### PR TITLE
Reduce docker image size and build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
 FROM ubuntu:16.04
 
 # Install system packages
-RUN apt-get -qq update && apt-get -qq install --no-install-recommends -y python3 \ 
+RUN apt-get -qq update && apt-get -qq install --no-install-recommends -y python3 \
  python3-dev \
  python-pil \
  python-lxml \
  python-tk \
  build-essential \
- cmake \ 
- git \ 
- libgtk2.0-dev \ 
- pkg-config \ 
- libavcodec-dev \ 
- libavformat-dev \ 
- libswscale-dev \ 
+ cmake \
+ git \
+ libgtk2.0-dev \
+ pkg-config \
+ libavcodec-dev \
+ libavformat-dev \
+ libswscale-dev \
  libtbb2 \
- libtbb-dev \ 
+ libtbb-dev \
  libjpeg-dev \
  libpng-dev \
  libtiff-dev \
@@ -36,9 +36,9 @@ RUN apt-get -qq update && apt-get -qq install --no-install-recommends -y python3
  libc++-dev \
  libc++abi-dev \
  build-essential \
- && rm -rf /var/lib/apt/lists/* 
+ && rm -rf /var/lib/apt/lists/*
 
-# Install core packages 
+# Install core packages
 RUN wget -q -O /tmp/get-pip.py --no-check-certificate https://bootstrap.pypa.io/get-pip.py && python3 /tmp/get-pip.py
 RUN  pip install -U pip \
  numpy \
@@ -72,7 +72,7 @@ RUN cd /usr/local/src/ \
  && rm 4.0.1.zip \
  && cd /usr/local/src/opencv-4.0.1/ \
  && mkdir build \
- && cd /usr/local/src/opencv-4.0.1/build \ 
+ && cd /usr/local/src/opencv-4.0.1/build \
  && cmake -D CMAKE_INSTALL_TYPE=Release -D CMAKE_INSTALL_PREFIX=/usr/local/ .. \
  && make -j4 \
  && make install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,21 +50,6 @@ RUN  pip install -U pip \
  paho-mqtt \
  PyYAML
 
-# Install tensorflow models object detection
-RUN GIT_SSL_NO_VERIFY=true git clone -q https://github.com/tensorflow/models /usr/local/lib/python3.5/dist-packages/tensorflow/models
-RUN wget -q -P /usr/local/src/ --no-check-certificate https://github.com/google/protobuf/releases/download/v3.5.1/protobuf-python-3.5.1.tar.gz
-
-# Download & build protobuf-python
-RUN cd /usr/local/src/ \
- && tar xf protobuf-python-3.5.1.tar.gz \
- && rm protobuf-python-3.5.1.tar.gz \
- && cd /usr/local/src/protobuf-3.5.1/ \
- && ./configure \
- && make \
- && make install \
- && ldconfig \
- && rm -rf /usr/local/src/protobuf-3.5.1/
-
 # Download & build OpenCV
 RUN wget -q -P /usr/local/src/ --no-check-certificate https://github.com/opencv/opencv/archive/4.0.1.zip
 RUN cd /usr/local/src/ \
@@ -96,10 +81,6 @@ RUN ln -s /python-tflite-source/edgetpu/test_data/coco_labels.txt /coco_labels.t
 # Minimize image size
 RUN (apt-get autoremove -y; \
      apt-get autoclean -y)
-
-# Set TF object detection available
-ENV PYTHONPATH "$PYTHONPATH:/usr/local/lib/python3.5/dist-packages/tensorflow/models/research:/usr/local/lib/python3.5/dist-packages/tensorflow/models/research/slim"
-RUN cd /usr/local/lib/python3.5/dist-packages/tensorflow/models/research && protoc object_detection/protos/*.proto --python_out=.
 
 WORKDIR /opt/frigate/
 ADD frigate frigate/

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,19 +82,20 @@ RUN cd /usr/local/src/ \
 RUN wget -q -O edgetpu_api.tar.gz --no-check-certificate http://storage.googleapis.com/cloud-iot-edge-pretrained-models/edgetpu_api.tar.gz
 
 RUN tar xzf edgetpu_api.tar.gz \
+  && rm -rf edgetpu_api.tar.gz \
   && cd python-tflite-source \
   && cp -p libedgetpu/libedgetpu_x86_64.so /lib/x86_64-linux-gnu/libedgetpu.so \
   && cp edgetpu/swig/compiled_so/_edgetpu_cpp_wrapper_x86_64.so edgetpu/swig/_edgetpu_cpp_wrapper.so \
   && cp edgetpu/swig/compiled_so/edgetpu_cpp_wrapper.py edgetpu/swig/ \
   && python3 setup.py develop --user
 
-# Minimize image size 
+# symlink the model and labels
+RUN ln -s /python-tflite-source/edgetpu/test_data/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite /mobilenet_ssd_v2_coco.tflite
+RUN ln -s /python-tflite-source/edgetpu/test_data/coco_labels.txt /coco_labels.txt
+
+# Minimize image size
 RUN (apt-get autoremove -y; \
      apt-get autoclean -y)
-
-# symlink the model and labels
-RUN ln -s /python-tflite-source/edgetpu/test_data/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite /frozen_inference_graph.pb
-RUN ln -s /python-tflite-source/edgetpu/test_data/coco_labels.txt /label_map.pbtext
 
 # Set TF object detection available
 ENV PYTHONPATH "$PYTHONPATH:/usr/local/lib/python3.5/dist-packages/tensorflow/models/research:/usr/local/lib/python3.5/dist-packages/tensorflow/models/research/slim"

--- a/frigate/object_detection.py
+++ b/frigate/object_detection.py
@@ -6,11 +6,6 @@ import numpy as np
 from edgetpu.detection.engine import DetectionEngine
 from . util import tonumpyarray
 
-# Path to frozen detection graph. This is the actual model that is used for the object detection.
-PATH_TO_CKPT = '/frozen_inference_graph.pb'
-# List of the strings that is used to add correct label for each box.
-PATH_TO_LABELS = '/label_map.pbtext'
-
 # Function to read labels from text files.
 def ReadLabelFile(file_path):
     with open(file_path, 'r') as f:
@@ -27,10 +22,11 @@ class PreppedQueueProcessor(threading.Thread):
         threading.Thread.__init__(self)
         self.cameras = cameras
         self.prepped_frame_queue = prepped_frame_queue
-        
-        # Load the edgetpu engine and labels
-        self.engine = DetectionEngine(PATH_TO_CKPT)
-        self.labels = ReadLabelFile(PATH_TO_LABELS)
+
+        # Load the edgetpu engine with the model used for object detection.
+        self.engine = DetectionEngine('/mobilenet_ssd_v2_coco.tflite')
+        # Load the strings used to add the correct label for each box.
+        self.labels = ReadLabelFile('/coco_labels.txt')
 
     def run(self):
         # process queue...

--- a/frigate/object_detection.py
+++ b/frigate/object_detection.py
@@ -57,7 +57,7 @@ class PreppedQueueProcessor(threading.Thread):
 
 # should this be a region class?
 class FramePrepper(threading.Thread):
-    def __init__(self, camera_name, shared_frame, frame_time, frame_ready, 
+    def __init__(self, camera_name, shared_frame, frame_time, frame_ready,
         frame_lock,
         region_size, region_x_offset, region_y_offset, region_threshold,
         prepped_frame_queue):
@@ -83,12 +83,12 @@ class FramePrepper(threading.Thread):
                 # if there isnt a frame ready for processing or it is old, wait for a new frame
                 if self.frame_time.value == frame_time or (now - self.frame_time.value) > 0.5:
                     self.frame_ready.wait()
-            
+
             # make a copy of the cropped frame
             with self.frame_lock:
                 cropped_frame = self.shared_frame[self.region_y_offset:self.region_y_offset+self.region_size, self.region_x_offset:self.region_x_offset+self.region_size].copy()
                 frame_time = self.frame_time.value
-            
+
             # convert to RGB
             cropped_frame_rgb = cv2.cvtColor(cropped_frame, cv2.COLOR_BGR2RGB)
             # Resize to 300x300 if needed

--- a/frigate/objects.py
+++ b/frigate/objects.py
@@ -2,7 +2,7 @@ import time
 import datetime
 import threading
 import cv2
-from object_detection.utils import visualization_utils as vis_util
+from . util import drawobjectbox
 
 class ObjectCleaner(threading.Thread):
     def __init__(self, objects_parsed, detected_objects):
@@ -70,27 +70,24 @@ class BestPersonFrame(threading.Thread):
             # if there is already a best_person
             else:
                 now = datetime.datetime.now().timestamp()
-                # if the new best person is a higher score than the current best person 
+                # if the new best person is a higher score than the current best person
                 # or the current person is more than 1 minute old, use the new best person
                 if new_best_person['score'] > self.best_person['score'] or (now - self.best_person['frame_time']) > 60:
                     self.best_person = new_best_person
-            
+
             # make a copy of the recent frames
             recent_frames = self.recent_frames.copy()
-            
-            if not self.best_person is None and self.best_person['frame_time'] in recent_frames:
-                best_frame = recent_frames[self.best_person['frame_time']]
-                best_frame = cv2.cvtColor(best_frame, cv2.COLOR_BGR2RGB)
-                # draw the bounding box on the frame
-                vis_util.draw_bounding_box_on_image_array(best_frame,
-                    self.best_person['ymin'],
-                    self.best_person['xmin'],
-                    self.best_person['ymax'],
-                    self.best_person['xmax'],
-                    color='red',
-                    thickness=2,
-                    display_str_list=["{}: {}%".format(self.best_person['name'],int(self.best_person['score']*100))],
-                    use_normalized_coordinates=False)
 
-                # convert back to BGR
-                self.best_frame = cv2.cvtColor(best_frame, cv2.COLOR_RGB2BGR)
+            if not self.best_person is None and self.best_person['frame_time'] in recent_frames:
+                self.best_frame = recent_frames[self.best_person['frame_time']]
+
+                label = "{}: {}%".format(self.best_person['name'], int(self.best_person['score'] * 100))
+                bounding_box = (
+                    self.best_person['xmin'],
+                    self.best_person['ymin'],
+                    self.best_person['xmax'],
+                    self.best_person['ymax']
+                )
+
+                # draw the bounding box on the frame
+                drawobjectbox(self.best_frame, label, bounding_box)

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -1,5 +1,25 @@
 import numpy as np
+import cv2
+
+LABEL_FONT = cv2.FONT_HERSHEY_PLAIN
+FONT_SCALE = 0.8
 
 # convert shared memory array into numpy array
 def tonumpyarray(mp_arr):
     return np.frombuffer(mp_arr.get_obj(), dtype=np.uint8)
+
+# draw a box with text in the upper left on the image
+def drawobjectbox(image, text, rect):
+    x1, y1, x2, y2 = rect
+
+    # draw the red bounding box
+    cv2.rectangle(image, (x1, y1), (x2, y2), (0, 0, 255), 2)
+
+    # get the size of the text
+    (text_width, text_height) = cv2.getTextSize(text, LABEL_FONT, FONT_SCALE, 1)[0]
+
+    # draw the text background with padding
+    cv2.rectangle(image, (x1, y1), (x1 + text_width + 8, y1 - text_height - 8), (0, 0, 255), cv2.FILLED)
+
+    # draw the text
+    cv2.putText(image, text, (x1 + 4, y1 - 4), LABEL_FONT, FONT_SCALE, (0, 0, 0), lineType=cv2.LINE_AA)


### PR DESCRIPTION
Switch to using the existing dependency on `cv2` to draw object boxes and labels instead of Tensorflow `object_detection.utils`. This facilitates removing tensorflow models and protobuf-python from the docker image, greatly reducing image build time and image size by ~1.3GB.

Also includes a few minor updates to the model and label file loading and trailing whitespace removal.