### PR TITLE
0.2.1 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Access the mjpeg stream at `http://localhost:5000/<camera_name>` and the best pe
 ```
 camera:
   - name: Camera Last Person
-    platform: generic
-    still_image_url: http://<ip>:5000/<camera_name>/best_person.jpg
+    platform: mqtt
+    topic: frigate/<camera_name>/snapshot
 
 binary_sensor:
   - name: Camera Person
@@ -71,6 +71,26 @@ binary_sensor:
     value_template: '{{ value_json.person }}'
     device_class: motion
     availability_topic: "frigate/available"
+
+automation:
+  - alias: Alert me if a person is detected while armed away
+    trigger: 
+      platform: state
+      entity_id: binary_sensor.camera_person
+      from: 'off'
+      to: 'on'
+    condition:
+      - condition: state
+        entity_id: alarm_control_panel.home_alarm
+        state: armed_away
+    action:
+      - service: notify.user_telegram
+        data:
+          message: "A person was detected."
+          data:
+            photo:
+              - url: http://<ip>:5000/<camera_name>/best_person.jpg
+                caption: A person was detected.
 ```
 
 ## Tips

--- a/config/config.yml
+++ b/config/config.yml
@@ -48,10 +48,21 @@ cameras:
     #   - yuv420p
 
     ################
+    # FFmpeg log level. Default is "panic". https://ffmpeg.org/ffmpeg.html#Generic-options
+    ################
+    # ffmpeg_log_level: panic
+
+    ################
     # Optional custom input args. Some cameras may need custom ffmpeg params to work reliably. Specifying
     # these will replace the default input params.
     ################
     # ffmpeg_input_args: []
+
+    ################
+    # Optional custom output args. Some cameras may need custom ffmpeg params to work reliably. Specifying
+    # these will replace the default output params.
+    ################
+    # ffmpeg_output_args: []
     
     regions:
       - size: 350

--- a/config/config.yml
+++ b/config/config.yml
@@ -46,6 +46,12 @@ cameras:
     #   - /dev/dri/renderD128
     #   - -hwaccel_output_format
     #   - yuv420p
+
+    ################
+    # Optional custom input args. Some cameras may need custom ffmpeg params to work reliably. Specifying
+    # these will replace the default input params.
+    ################
+    # ffmpeg_input_args: []
     
     regions:
       - size: 350

--- a/frigate/mqtt.py
+++ b/frigate/mqtt.py
@@ -1,13 +1,15 @@
 import json
+import cv2
 import threading
 
 class MqttObjectPublisher(threading.Thread):
-    def __init__(self, client, topic_prefix, objects_parsed, detected_objects):
+    def __init__(self, client, topic_prefix, objects_parsed, detected_objects, best_person_frame):
         threading.Thread.__init__(self)
         self.client = client
         self.topic_prefix = topic_prefix
         self.objects_parsed = objects_parsed
         self._detected_objects = detected_objects
+        self.best_person_frame = best_person_frame
 
     def run(self):
         last_sent_payload = ""
@@ -31,3 +33,9 @@ class MqttObjectPublisher(threading.Thread):
             if new_payload != last_sent_payload:
                 last_sent_payload = new_payload
                 self.client.publish(self.topic_prefix+'/objects', new_payload, retain=False)
+                # send the snapshot over mqtt as well
+                if not self.best_person_frame.best_frame is None:
+                    ret, jpg = cv2.imencode('.jpg', self.best_person_frame.best_frame)
+                    if ret:
+                        jpg_bytes = jpg.tobytes()
+                        self.client.publish(self.topic_prefix+'/snapshot', jpg_bytes, retain=True)

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -121,6 +121,7 @@ class Camera:
         self.recent_frames = {}
         self.rtsp_url = get_rtsp_url(self.config['rtsp'])
         self.take_frame = self.config.get('take_frame', 1)
+        self.ffmpeg_log_level = self.config.get('ffmpeg_log_level', 'panic')
         self.ffmpeg_hwaccel_args = self.config.get('ffmpeg_hwaccel_args', [])
         self.ffmpeg_input_args = self.config.get('ffmpeg_input_args', [
             '-avoid_negative_ts', 'make_zero', 
@@ -132,6 +133,10 @@ class Camera:
             '-rtsp_transport', 'tcp', 
             '-stimeout', '5000000', 
             '-use_wallclock_as_timestamps', '1'
+        ])
+        self.ffmpeg_output_args = self.config.get('ffmpeg_output_args', [
+            '-f', 'rawvideo',
+            '-pix_fmt', 'rgb24'
         ])
         self.regions = self.config['regions']
         self.frame_shape = get_frame_shape(self.rtsp_url)
@@ -231,17 +236,16 @@ class Camera:
     
     def start_ffmpeg(self):
         ffmpeg_global_args = [
-            '-hide_banner', '-loglevel', 'panic'
+            '-hide_banner', '-loglevel', self.ffmpeg_log_level
         ]
 
         ffmpeg_cmd = (['ffmpeg'] +
             ffmpeg_global_args +
             self.ffmpeg_hwaccel_args +
             self.ffmpeg_input_args +
-            ['-i', self.rtsp_url,
-            '-f', 'rawvideo',
-            '-pix_fmt', 'rgb24',
-            'pipe:'])
+            ['-i', self.rtsp_url] +
+            self.ffmpeg_output_args +
+            ['pipe:'])
 
         print(" ".join(ffmpeg_cmd))
         

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -73,8 +73,8 @@ class CameraWatchdog(threading.Thread):
             # wait a bit before checking
             time.sleep(10)
 
-            if (datetime.datetime.now().timestamp() - self.camera.frame_time.value) > 2:
-                print("last frame is more than 2 seconds old, restarting camera capture...")
+            if (datetime.datetime.now().timestamp() - self.camera.frame_time.value) > 10:
+                print("last frame is more than 10 seconds old, restarting camera capture...")
                 self.camera.start_or_restart_capture()
                 time.sleep(5)
 

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -175,7 +175,7 @@ class Camera:
         self.object_cleaner.start()
 
         # start a thread to publish object scores (currently only person)
-        mqtt_publisher = MqttObjectPublisher(self.mqtt_client, self.mqtt_topic_prefix, self.objects_parsed, self.detected_objects)
+        mqtt_publisher = MqttObjectPublisher(self.mqtt_client, self.mqtt_topic_prefix, self.objects_parsed, self.detected_objects, self.best_person_frame)
         mqtt_publisher.start()
 
         # create a watchdog thread for capture process


### PR DESCRIPTION
New image available at `blakeblackshear/frigate:0.2.1-beta`

- Push best person images over MQTT for more realtime updates in homeassistant
- Attempt to gracefully terminate the ffmpeg process before killing
- Tweak the default input params to discard corrupt frames and ignore timestamps in the video feed
- Increase the watchdog timeout to 10 seconds
- Allow `ffmpeg_input_args`, `ffmpeg_output_args`, and `ffmpeg_log_level` to be passed in the config for customization