### PR TITLE
Add support for non-RTSP protocols (RTMP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <a href='https://ko-fi.com/P5P7XGO9' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://az743702.vo.msecnd.net/cdn/kofi4.png?v=2' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
-# Frigate - Realtime Object Detection for RTSP Cameras
+# Frigate - Realtime Object Detection for RTSP/RTMP Cameras
 **Note:** This version requires the use of a [Google Coral USB Accelerator](https://coral.withgoogle.com/products/accelerator/)
 
-Uses OpenCV and Tensorflow to perform realtime object detection locally for RTSP cameras. Designed for integration with HomeAssistant or others via MQTT.
+Uses OpenCV and Tensorflow to perform realtime object detection locally for RTSP/RTMP cameras. Designed for integration with HomeAssistant or others via MQTT.
 
 - Leverages multiprocessing and threads heavily with an emphasis on realtime over processing every frame
 - Allows you to define specific regions (squares) in the image to look for objects

--- a/config/config.yml
+++ b/config/config.yml
@@ -23,6 +23,12 @@ cameras:
 
 
     ################
+    ## Optional URL format. Specifying this will override the default RTSP URL format.
+    ## Some cameras support the RTMP protocol which may give better performance. 
+    ################
+    # urlformat: rtmp://{host}:{port}{path}&user={user}&password={password}
+
+    ################
     ## Optional mask. Must be the same dimensions as your video feed.
     ## The mask works by looking at the bottom center of the bounding box for the detected
     ## person in the image. If that pixel in the mask is a black pixel, it ignores it as a
@@ -69,6 +75,29 @@ cameras:
     # these will replace the default output params.
     ################
     # ffmpeg_output_args: []
+
+
+    ################
+    ## RTMP supports all RTSP arguments
+    ## The RTMP config uses different ffmpeg arguments to make it compatible with frigate.
+    ################
+
+    rtmp:
+      user: viewer
+      host: 10.0.10.11
+      port: 1935
+      # values that begin with a "$" will be replaced with environment variable
+      password: $RTSP_PASSWORD
+      path: /cam/realmonitor?channel=1&subtype=2    
+
+    rtmp:
+      user: viewer
+      host: 10.0.10.12
+      port: 1935
+      # values that begin with a "$" will be replaced with environment variable
+      password: $RTSP_PASSWORD
+      path: /cam/realmonitor?channel=1&subtype=2    
+      urlformat: rtmp://{host}:{port}{path}&user={user}&password={password}
     
     regions:
       - size: 350

--- a/config/config.yml
+++ b/config/config.yml
@@ -7,20 +7,90 @@ mqtt:
   # password: password # Optional -- Uncomment for use
 
 cameras:
-  back:
+  backyard:
     rtsp:
+      # The camera URL protocol is determined by the key (`rtsp`) above unless overridden by `urlformat`
       user: viewer
       host: 10.0.10.10
       port: 554
       # values that begin with a "$" will be replaced with environment variable
       password: $RTSP_PASSWORD
       path: /cam/realmonitor?channel=1&subtype=2
-
-    ################
-    ## Optional URL format. Specifying this will override the default RTSP URL format.
-    ## Some cameras support the RTMP protocol which may give better performance. 
-    ################
-    # urlformat: rtmp://{host}:{port}{path}&user={user}&password={password}
+      regions:
+        - size: 350
+          x_offset: 0
+          y_offset: 300
+          min_person_area: 5000
+          threshold: 0.5
+        - size: 400
+          x_offset: 350
+          y_offset: 250
+          min_person_area: 2000
+          threshold: 0.5
+        - size: 400
+          x_offset: 750
+          y_offset: 250
+          min_person_area: 2000
+          threshold: 0.5      
+  front_yard:      
+    rtmp:
+      user: viewer
+      host: 10.0.10.11
+      port: 1935
+      # values that begin with a "$" will be replaced with environment variable
+      password: $RTMP_PASSWORD
+      path: /cam/realmonitor?channel=1&subtype=2   
+      ffmpeg_input_args:
+        - -avoid_negative_ts
+        - make_zero
+        - -fflags
+        - nobuffer
+        - -flags
+        - low_delay
+        - -strict
+        - experimental
+        - -fflags
+        - +genpts+discardcorrupt
+        - -vsync
+        - drop
+        - -use_wallclock_as_timestamps
+        - '1'
+      regions:
+        - size: 350
+          x_offset: 0
+          y_offset: 300
+          min_person_area: 5000
+          threshold: 0.5            
+  garage:
+    rtmp:
+      user: viewer
+      host: 10.0.10.12
+      port: 1935
+      # values that begin with a "$" will be replaced with environment variable
+      password: $CUSTOM_PASSWORD
+      path: /cam/realmonitor?channel=1&subtype=2    
+      urlformat: rtmp://{host}:{port}{path}&user={user}&password={password}
+      ffmpeg_input_args:
+        - -avoid_negative_ts
+        - make_zero
+        - -fflags
+        - nobuffer
+        - -flags
+        - low_delay
+        - -strict
+        - experimental
+        - -fflags
+        - +genpts+discardcorrupt
+        - -vsync
+        - drop
+        - -use_wallclock_as_timestamps
+        - '1'            
+      regions:
+      - size: 350
+        x_offset: 0
+        y_offset: 300
+        min_person_area: 5000
+        threshold: 0.5       
 
     ################
     ## Optional mask. Must be the same dimensions as your video feed.
@@ -37,7 +107,7 @@ cameras:
     # custom framerates. A value of 1 tells frigate to look at every frame, 2 every 2nd frame, 
     # 3 every 3rd frame, etc.
     ################
-    take_frame: 1
+    # take_frame: 1
 
     ################
     # Optional hardware acceleration parameters for ffmpeg. If your hardware supports it, it can
@@ -70,42 +140,8 @@ cameras:
     ################
     # ffmpeg_output_args: []
 
-
     ################
-    ## RTMP supports all RTSP arguments
-    ## The RTMP config uses different ffmpeg arguments to make it compatible with frigate.
+    ## Optional URL format. Specifying this will override the default protocol URL format.
+    ## Some cameras support the RTMP protocol which may give better performance. 
     ################
-
-    rtmp:
-      user: viewer
-      host: 10.0.10.11
-      port: 1935
-      # values that begin with a "$" will be replaced with environment variable
-      password: $RTSP_PASSWORD
-      path: /cam/realmonitor?channel=1&subtype=2    
-
-    rtmp:
-      user: viewer
-      host: 10.0.10.12
-      port: 1935
-      # values that begin with a "$" will be replaced with environment variable
-      password: $RTSP_PASSWORD
-      path: /cam/realmonitor?channel=1&subtype=2    
-      urlformat: rtmp://{host}:{port}{path}&user={user}&password={password}
-    
-    regions:
-      - size: 350
-        x_offset: 0
-        y_offset: 300
-        min_person_area: 5000
-        threshold: 0.5
-      - size: 400
-        x_offset: 350
-        y_offset: 250
-        min_person_area: 2000
-        threshold: 0.5
-      - size: 400
-        x_offset: 750
-        y_offset: 250
-        min_person_area: 2000
-        threshold: 0.5
+    # urlformat: rtmp://{host}:{port}{path}&user={user}&password={password}

--- a/config/config.yml
+++ b/config/config.yml
@@ -15,12 +15,6 @@ cameras:
       # values that begin with a "$" will be replaced with environment variable
       password: $RTSP_PASSWORD
       path: /cam/realmonitor?channel=1&subtype=2
-      ################
-      ## Optional URL format. Specifying this will override the default RTSP URL format.
-      ## Some cameras support the RTMP protocol which may give better performance. 
-      ################
-      # urlformat: rtmp://{host}:{port}{path}&user={user}&password={password}
-
 
     ################
     ## Optional URL format. Specifying this will override the default RTSP URL format.

--- a/config/config.yml
+++ b/config/config.yml
@@ -67,7 +67,7 @@ cameras:
       host: 10.0.10.12
       port: 1935
       # values that begin with a "$" will be replaced with environment variable
-      password: $CUSTOM_PASSWORD
+      password: $RTMP_PASSWORD
       path: /cam/realmonitor?channel=1&subtype=2    
       urlformat: rtmp://{host}:{port}{path}&user={user}&password={password}
       ffmpeg_input_args:
@@ -90,7 +90,22 @@ cameras:
         x_offset: 0
         y_offset: 300
         min_person_area: 5000
-        threshold: 0.5       
+        threshold: 0.5    
+  garden:
+    http:
+      # Example of a theoretical camera that uses HTTP for streaming instead of RTSP/RTMP
+      user: viewer
+      host: 10.0.10.13
+      port: 1234
+      # values that begin with a "$" will be replaced with environment variable
+      password: $CUSTOM_PASSWORD
+      path: /cam/5          
+      regions:
+      - size: 350
+        x_offset: 0
+        y_offset: 300
+        min_person_area: 5000
+        threshold: 0.5              
 
     ################
     ## Optional mask. Must be the same dimensions as your video feed.

--- a/config/config.yml
+++ b/config/config.yml
@@ -92,7 +92,7 @@ cameras:
         min_person_area: 5000
         threshold: 0.5    
   garden:
-    http:
+    https:
       # Example of a theoretical camera that uses HTTP for streaming instead of RTSP/RTMP
       user: viewer
       host: 10.0.10.13

--- a/config/config.yml
+++ b/config/config.yml
@@ -3,8 +3,8 @@ web_port: 5000
 mqtt:
   host: mqtt.server.com
   topic_prefix: frigate
-#  user: username # Optional -- Uncomment for use
-#  password: password # Optional -- Uncomment for use
+  # user: username # Optional -- Uncomment for use
+  # password: password # Optional -- Uncomment for use
 
 cameras:
   back:
@@ -15,6 +15,12 @@ cameras:
       # values that begin with a "$" will be replaced with environment variable
       password: $RTSP_PASSWORD
       path: /cam/realmonitor?channel=1&subtype=2
+      ################
+      ## Optional URL format. Specifying this will override the default RTSP URL format.
+      ## Some cameras support the RTMP protocol which may give better performance. 
+      ################
+      # urlformat: rtmp://{host}:{port}{path}&user={user}&password={password}
+
 
     ################
     ## Optional mask. Must be the same dimensions as your video feed.

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -4,7 +4,6 @@ import datetime
 import cv2
 import threading
 import ctypes
-import logging
 import multiprocessing as mp
 import subprocess as sp
 import numpy as np

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -157,7 +157,7 @@ class Camera:
             print('No valid camera config found.')
 
         self.take_frame = self.config.get('take_frame', 1)
-        self.ffmpeg_log_level = self.config.get('ffmpeg_log_level', 'info')
+        self.ffmpeg_log_level = self.config.get('ffmpeg_log_level', 'panic')
         self.ffmpeg_hwaccel_args = self.config.get('ffmpeg_hwaccel_args', [])
 
         self.ffmpeg_output_args = self.config.get('ffmpeg_output_args', [

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -58,9 +58,9 @@ def get_frame_shape(rtsp_url):
 def get_rtsp_url(rtsp_config):
     if (rtsp_config['password'].startswith('$')):
         rtsp_config['password'] = os.getenv(rtsp_config['password'][1:])
-    return 'rtsp://{}:{}@{}:{}{}'.format(rtsp_config['user'], 
-        rtsp_config['password'], rtsp_config['host'], rtsp_config['port'],
-        rtsp_config['path'])
+    urlformat = rtsp_config.get('urlformat', 'rtsp://{user}:{password}@{host}:{port}{path}')
+    return urlformat.format(host=rtsp_config['host'], port=rtsp_config['port'], 
+        path=rtsp_config['path'], user=rtsp_config['user'], password=rtsp_config['password'])
 
 class CameraWatchdog(threading.Thread):
     def __init__(self, camera):


### PR DESCRIPTION
Lifted most of the work from https://github.com/blakeblackshear/frigate/pull/65/ and improved on it.

- Adds support for non-`RTSP` protocols.
- Adds support for custom URL formatters for when they don't match a convention
- Adds example on how to add `RTMP` with `ffmpeg`
- Adds example on how to add a (theoretical) `https` camera endpoint