### PR TITLE
proposal for 3 options

### DIFF
--- a/frigate/mqtt.py
+++ b/frigate/mqtt.py
@@ -3,13 +3,14 @@ import cv2
 import threading
 
 class MqttObjectPublisher(threading.Thread):
-    def __init__(self, client, topic_prefix, objects_parsed, detected_objects, best_person_frame):
+    def __init__(self, client, topic_prefix, objects_parsed, detected_objects, best_person_frame, label):
         threading.Thread.__init__(self)
         self.client = client
         self.topic_prefix = topic_prefix
         self.objects_parsed = objects_parsed
         self._detected_objects = detected_objects
         self.best_person_frame = best_person_frame
+        self.label = label
 
     def run(self):
         last_sent_payload = ""
@@ -24,7 +25,7 @@ class MqttObjectPublisher(threading.Thread):
 
             # add all the person scores in detected objects
             detected_objects = self._detected_objects.copy()
-            person_score = sum([obj['score'] for obj in detected_objects if obj['name'] == 'person'])
+            person_score = sum([obj['score'] for obj in detected_objects if obj['name'] == self.label])
             # if the person score is more than 100, set person to ON
             payload['person'] = 'ON' if int(person_score*100) > 100 else 'OFF'
 

--- a/frigate/mqtt.py
+++ b/frigate/mqtt.py
@@ -3,7 +3,7 @@ import cv2
 import threading
 
 class MqttObjectPublisher(threading.Thread):
-    def __init__(self, client, topic_prefix, objects_parsed, detected_objects, best_person_frame, label):
+    def __init__(self, client, topic_prefix, objects_parsed, detected_objects, best_person_frame, label, dedupe_snapshot_publish):
         threading.Thread.__init__(self)
         self.client = client
         self.topic_prefix = topic_prefix
@@ -11,9 +11,11 @@ class MqttObjectPublisher(threading.Thread):
         self._detected_objects = detected_objects
         self.best_person_frame = best_person_frame
         self.label = label
+        self.dedupe_snapshot_publish = dedupe_snapshot_publish
 
     def run(self):
         last_sent_payload = ""
+        last_sent_snapshot_time = 0
         while True:
 
             # initialize the payload
@@ -35,7 +37,11 @@ class MqttObjectPublisher(threading.Thread):
                 last_sent_payload = new_payload
                 self.client.publish(self.topic_prefix+'/objects', new_payload, retain=False)
                 # send the snapshot over mqtt as well
-                if not self.best_person_frame.best_frame is None:
+                if not self.best_person_frame.best_frame is None and not self.best_person_frame.best_person is None:
+                    snapshot_time = self.best_person_frame.best_person['frame_time']
+                    if self.dedupe_snapshot_publish and snapshot_time == last_sent_snapshot_time:
+                        continue
+                    last_sent_snapshot_time = snapshot_time
                     ret, jpg = cv2.imencode('.jpg', self.best_person_frame.best_frame)
                     if ret:
                         jpg_bytes = jpg.tobytes()

--- a/frigate/objects.py
+++ b/frigate/objects.py
@@ -38,11 +38,12 @@ class ObjectCleaner(threading.Thread):
 # Maintains the frame and person with the highest score from the most recent
 # motion event
 class BestPersonFrame(threading.Thread):
-    def __init__(self, objects_parsed, recent_frames, detected_objects):
+    def __init__(self, objects_parsed, recent_frames, detected_objects, label):
         threading.Thread.__init__(self)
         self.objects_parsed = objects_parsed
         self.recent_frames = recent_frames
         self.detected_objects = detected_objects
+        self.label = label
         self.best_person = None
         self.best_frame = None
 
@@ -55,7 +56,7 @@ class BestPersonFrame(threading.Thread):
 
             # make a copy of detected objects
             detected_objects = self.detected_objects.copy()
-            detected_people = [obj for obj in detected_objects if obj['name'] == 'person']
+            detected_people = [obj for obj in detected_objects if obj['name'] == self.label]
 
             # get the highest scoring person
             new_best_person = max(detected_people, key=lambda x:x['score'], default=self.best_person)

--- a/frigate/objects.py
+++ b/frigate/objects.py
@@ -38,12 +38,13 @@ class ObjectCleaner(threading.Thread):
 # Maintains the frame and person with the highest score from the most recent
 # motion event
 class BestPersonFrame(threading.Thread):
-    def __init__(self, objects_parsed, recent_frames, detected_objects, label):
+    def __init__(self, objects_parsed, recent_frames, detected_objects, label, invalidate_seconds):
         threading.Thread.__init__(self)
         self.objects_parsed = objects_parsed
         self.recent_frames = recent_frames
         self.detected_objects = detected_objects
         self.label = label
+        self.invalidate_seconds = invalidate_seconds
         self.best_person = None
         self.best_frame = None
 
@@ -73,7 +74,7 @@ class BestPersonFrame(threading.Thread):
                 now = datetime.datetime.now().timestamp()
                 # if the new best person is a higher score than the current best person 
                 # or the current person is more than 1 minute old, use the new best person
-                if new_best_person['score'] > self.best_person['score'] or (now - self.best_person['frame_time']) > 60:
+                if new_best_person['score'] > self.best_person['score'] or (now - self.best_person['frame_time']) > self.invalidate_seconds:
                     self.best_person = new_best_person
             
             # make a copy of the recent frames

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -132,6 +132,7 @@ class Camera:
         self.mqtt_topic_prefix = '{}/{}'.format(mqtt_prefix, self.name)
         self.label = config.get('label', 'person')
         self.dedupe_snapshot_publish = config.get('dedupe_snapshot_publish', False)
+        self.best_person_invalidate_seconds = config.get('best_person_invalidate_seconds', 60)
 
         # create a numpy array for the current frame in initialize to zeros
         self.current_frame = np.zeros(self.frame_shape, np.uint8)
@@ -172,7 +173,7 @@ class Camera:
         self.frame_tracker.start()
 
         # start a thread to store the highest scoring recent person frame
-        self.best_person_frame = BestPersonFrame(self.objects_parsed, self.recent_frames, self.detected_objects, self.label)
+        self.best_person_frame = BestPersonFrame(self.objects_parsed, self.recent_frames, self.detected_objects, self.label, self.best_person_invalidate_seconds)
         self.best_person_frame.start()
 
         # start a thread to expire objects from the detected objects list

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -131,6 +131,7 @@ class Camera:
         self.mqtt_client = mqtt_client
         self.mqtt_topic_prefix = '{}/{}'.format(mqtt_prefix, self.name)
         self.label = config.get('label', 'person')
+        self.dedupe_snapshot_publish = config.get('dedupe_snapshot_publish', True)
 
         # create a numpy array for the current frame in initialize to zeros
         self.current_frame = np.zeros(self.frame_shape, np.uint8)
@@ -179,7 +180,7 @@ class Camera:
         self.object_cleaner.start()
 
         # start a thread to publish object scores (currently only person)
-        mqtt_publisher = MqttObjectPublisher(self.mqtt_client, self.mqtt_topic_prefix, self.objects_parsed, self.detected_objects, self.best_person_frame, self.label)
+        mqtt_publisher = MqttObjectPublisher(self.mqtt_client, self.mqtt_topic_prefix, self.objects_parsed, self.detected_objects, self.best_person_frame, self.label, self.dedupe_snapshot_publish)
         mqtt_publisher.start()
 
         # create a watchdog thread for capture process

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -131,7 +131,7 @@ class Camera:
         self.mqtt_client = mqtt_client
         self.mqtt_topic_prefix = '{}/{}'.format(mqtt_prefix, self.name)
         self.label = config.get('label', 'person')
-        self.dedupe_snapshot_publish = config.get('dedupe_snapshot_publish', True)
+        self.dedupe_snapshot_publish = config.get('dedupe_snapshot_publish', False)
 
         # create a numpy array for the current frame in initialize to zeros
         self.current_frame = np.zeros(self.frame_shape, np.uint8)


### PR DESCRIPTION
Hi any interest in supporting these options? Great experience setting up frigate and was able to validate operation very quickly. This request preserves current behavior by default and adds 3 options that allowed me to customize my system:

1) label argument per camera. Set a different label than 'person' which is the default label for the camera. I have all my external cameras in the default configuration and one internal camera that instead detects cats, I don't want it to fire events for people. If you're interested in taking this I can clean it up, for instance supporting a list of tags per camera; and variable name cleanup, lots of 'person' vars throughout.

2) deduping mqtt snapshots. I have a basic mqtt adapter to Discord and found the current implementation resending a selected snapshot often and creating many duplicates in my notification UI / discord channel. This option ensures all snapshots are new, no repeats in feed.

3) custom best frame expiration per camera. I have one external camera set to 15 seconds, my cat cam looking for 'cat' labels set to 5 minutes. Along with the deduping option, you get new snapshots really quickly if it converges to a high signal at which point you'll wait the specified refresh time. Made cameras feel very appropriate to their intended use cases.

