### PR TITLE
Print out mask file read failure

### DIFF
--- a/frigate/video.py
+++ b/frigate/video.py
@@ -190,7 +190,7 @@ def track_camera(name, config, global_objects_config, frame_queue, frame_shape, 
     # load in the mask for object detection
     if 'mask' in config:
         mask = cv2.imread("/config/{}".format(config['mask']), cv2.IMREAD_GRAYSCALE)
-        if img.size == 0:
+        if mask.size == 0:
             print(f"Failed to read mask file")
     else:
         mask = None

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -191,7 +191,7 @@ def track_camera(name, config, global_objects_config, frame_queue, frame_shape, 
     if 'mask' in config:
         mask = cv2.imread("/config/{}".format(config['mask']), cv2.IMREAD_GRAYSCALE)
         if mask.size == 0:
-            print(f"Failed to read mask file")
+            print("Failed to read mask file")
     else:
         mask = None
 

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -190,6 +190,8 @@ def track_camera(name, config, global_objects_config, frame_queue, frame_shape, 
     # load in the mask for object detection
     if 'mask' in config:
         mask = cv2.imread("/config/{}".format(config['mask']), cv2.IMREAD_GRAYSCALE)
+        if img.size == 0:
+            print(f"Failed to read mask file")
     else:
         mask = None
 

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -192,6 +192,7 @@ def track_camera(name, config, global_objects_config, frame_queue, frame_shape, 
         mask = cv2.imread("/config/{}".format(config['mask']), cv2.IMREAD_GRAYSCALE)
         if mask.size == 0:
             print("Failed to read mask file")
+            mask = None
     else:
         mask = None
 


### PR DESCRIPTION
Added print statement when mask file could not be read. Spent some time trying to work out why a mask wasn't being applied, until I found that the filename was incorrect.