### PR TITLE
Fix zone filters

### DIFF
--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -156,7 +156,7 @@ class TrackedObjectProcessor(threading.Thread):
                         continue
                     # check if the object is in the zone and not filtered
                     if (cv2.pointPolygonTest(current_contour, bottom_center, False) >= 0 
-                        and not zone_filtered(obj, self.zone_config[name][camera].get('filters', {}))):
+                        and not zone_filtered(obj, self.zone_config[name][camera])):
                         current_objects_in_zones[name].append(obj['label'])
 
             ###


### PR DESCRIPTION
The zone filters weren't working as shown in the example config because it was looking for the `filters` element both here: https://github.com/blakeblackshear/frigate/blob/master/frigate/object_processing.py#L33 and here: https://github.com/blakeblackshear/frigate/blob/master/frigate/object_processing.py#L159 which would require nested `filters` elements.