### PR TITLE
Support for raspberry pi and new topic for MQTT

### DIFF
--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -1,0 +1,76 @@
+ARG PYARROW_IMAGE=kpine/raspberrypi-pyarrow-plasma:0.17.1
+fROM ${PYARROW_IMAGE} as pyarrow
+
+FROM balenalib/raspberrypi3-debian:buster-run
+
+# Add the Coral EdgeTPU repository
+RUN APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn apt-key adv --fetch-keys https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+ && echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" > /etc/apt/sources.list.d/coral-edgetpu.list \
+ && echo "libedgetpu1-max libedgetpu/accepted-eula select true" | debconf-set-selections
+
+RUN install_packages \
+      wget \
+      unzip \
+      python3 \
+      python3-pip \
+      python3-wheel \
+      ffmpeg \
+# opencv-python-headless dependencies
+      libatk1.0-0 \
+      libatlas3-base \
+      libavcodec58 \
+      libavformat58 \
+      libavutil56 \
+      libcairo-gobject2 \
+      libcairo2 \
+      libgdk-pixbuf2.0-0 \
+      libgtk-3-0 \
+      libilmbase23 \
+      libjasper1 \
+      libopenexr23 \
+      libpango-1.0-0 \
+      libpangocairo-1.0-0 \
+      libswscale5 \
+      libtiff5 \
+      libwebp6 \
+# Coral EdgeTPU dependencies
+      libedgetpu1-max=14.1 \
+# Frigate dependencies
+      python3-numpy \
+      python3-scipy \
+      python3-flask \
+      python3-paho-mqtt \
+      python3-yaml \
+      python3-matplotlib \
+ && rm -rf /var/lib/apt/lists/*
+
+# Python Arrow from Apache is a Frigate dependency, but Arrow does not support arm7, we require a
+# custom wheel.
+COPY --from=pyarrow /dist/*.whl /tmp/
+
+# opencv and other python packages not available in Debian Buster 4.1.1.26 is currently the latest
+# available piwheel build
+RUN python3 -m pip install --extra-index-url https://www.piwheels.org/simple \
+      opencv-python-headless==4.1.1.26 \
+      psutil \
+      imutils==0.5.* \
+      /tmp/*.whl \
+      https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp37-cp37m-linux_armv7l.whl \
+ && rm /tmp/*.whl
+
+# get model and labels
+ARG MODEL_REFS=7064b94dd5b996189242320359dbab8b52c94a84
+RUN wget -q https://github.com/google-coral/edgetpu/raw/$MODEL_REFS/test_data/ssd_mobilenet_v2_coco_quant_postprocess_edgetpu.tflite -O /edgetpu_model.tflite
+RUN wget -q https://github.com/google-coral/edgetpu/raw/$MODEL_REFS/test_data/coco_labels.txt -O /labelmap.txt
+RUN wget -q https://github.com/google-coral/edgetpu/raw/$MODEL_REFS/test_data/ssd_mobilenet_v2_coco_quant_postprocess.tflite -O /cpu_model.tflite
+RUN mkdir /cache
+RUN chmod 777 /cache
+# piwheels opencv build workaround: https://github.com/piwheels/packages/issues/59
+ENV LD_PRELOAD="/usr/lib/arm-linux-gnueabihf/libatomic.so.1"
+
+WORKDIR /opt/frigate/
+COPY frigate frigate/
+COPY detect_objects.py .
+COPY benchmark.py .
+
+CMD ["python3.7", "-u", "detect_objects.py"]

--- a/README.md
+++ b/README.md
@@ -161,6 +161,19 @@ Publishes `ON` or `OFF` and is designed to be used a as a binary sensor in HomeA
 Publishes a jpeg encoded frame of the detected object type. When the object is no longer detected, the highest confidence image is published or the original image
 is published again.
 
+### frigate/<camera_name>/<object_name>/event
+Publishes a jpeg encoded frame  as well as data of the detected object in the same message. The message will have the below format
+```json
+{
+   "image": "<BASE64 encoded image>",
+   "status": "ON/OFF", 
+   "label": "person",
+   "score" : 0.76354,
+   "start_time" : 1594298020.819046,
+   "id": "1594298020.819046-0"
+}
+```
+
 ### frigate/<camera_name>/events/start
 Message published at the start of any tracked object. JSON looks as follows:
 ```json

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -199,12 +199,12 @@ class CameraState():
                     obj_copy['frame'] = np.copy(self.current_frame)
                     self.best_objects[object_type] = obj_copy
                     for c in self.callbacks['snapshot']:
-                        c(self.name, self.best_objects[object_type])
+                        c(self.name, self.best_objects[object_type],"ON")
             else:
                 obj_copy['frame'] = np.copy(self.current_frame)
                 self.best_objects[object_type] = obj_copy
                 for c in self.callbacks['snapshot']:
-                    c(self.name, self.best_objects[object_type])
+                    c(self.name, self.best_objects[object_type],"ON")
         
         # update overall camera state for each object type
         obj_counter = Counter()
@@ -227,7 +227,7 @@ class CameraState():
             for c in self.callbacks['object_status']:
                 c(self.name, obj_name, 'OFF')
             for c in self.callbacks['snapshot']:
-                c(self.name, self.best_objects[obj_name])
+                c(self.name, self.best_objects[obj_name],"OFF")
 
 
 class TrackedObjectProcessor(threading.Thread):
@@ -254,7 +254,7 @@ class TrackedObjectProcessor(threading.Thread):
             self.client.publish(f"{self.topic_prefix}/{camera}/events/end", json.dumps(obj), retain=False)
             self.event_queue.put(('end', camera, obj))
         
-        def snapshot(camera, obj):
+        def snapshot(camera, obj,status):
             if not 'frame' in obj:
                 return
             best_frame = cv2.cvtColor(obj['frame'], cv2.COLOR_RGB2BGR)
@@ -272,7 +272,7 @@ class TrackedObjectProcessor(threading.Thread):
                 jpg_as_text = base64.b64encode(jpg).decode()
                 payload={
                         "image": jpg_as_text,
-                        "status":"OFF",
+                        "status": status,
                         "label":obj["label"],
                         "score": obj["score"],
                         "start_time" : obj["start_time"],


### PR DESCRIPTION
This adds support for raspberry pi. I had added a seperate docker file "Dockerfile.rpi" for raspberry pi build. 

Also added a new MQTT topic  "frigate/<camera_name>/<object_name>/event" Which publishes the image in base64 as well as the event details. This is useful while doing automation events where i need to avoid i am not able to relate the snapshot with the image. 