### PR TITLE
Added Healthcheck to Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Example docker-compose:
       - "5000:5000"
     environment:
       FRIGATE_RTSP_PASSWORD: "password"
+    healthcheck:
+      test: ["CMD", "wget" , "-q", "-O-", "http://localhost:5000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 3m
 ```
 
 A `config.yml` file must exist in the `config` directory. See example [here](config/config.example.yml) and device specific info can be found [here](docs/DEVICES.md).


### PR DESCRIPTION
Frigate provides an HTTP server that can be used to detect if frigate is running or not. Using the docker-compose "healthcheck" feature we can set automations to restart the service if it stops working.