### PR TITLE
Fix error in the docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You see multiple bounding boxes because it draws bounding boxes from all frames 
 Run the container with
 ```bash
 docker run --rm \
--name blakeblackshear/frigate:stable \
+--name frigate \
 --privileged \
 --shm-size=512m \ # should work for a 2-3 cameras
 -v /dev/bus/usb:/dev/bus/usb \


### PR DESCRIPTION
I have very little experience with Docker, but it seems the command in the README has two mistakes in it:

- unknown shorthand flag: 'n' in -name
- docker: Error response from daemon: Invalid container name (blakeblackshear/frigate:stable), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed.

I am running Docker version 19.03.13-ce, build 4484c46d9d on Arch linux.