### PR TITLE
lock libedgetpu1 to 15.0, update tflite_runtime

### DIFF
--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -17,6 +17,6 @@ RUN apt-get -qq update \
         libtiff5 \
         libdc1394-22 \
     ## Tensorflow lite
-    && pip3 install https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp38-cp38-linux_aarch64.whl \
+    && pip3 install https://github.com/google-coral/pycoral/releases/download/release-frogfish/tflite_runtime-2.5.0-cp38-cp38-linux_aarch64.whl \
     && rm -rf /var/lib/apt/lists/* \
     && (apt-get autoremove -y; apt-get autoclean -y)

--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -11,8 +11,8 @@ RUN apt-get -qq update \
         # VAAPI drivers for Intel hardware accel
         libva-drm2 libva2 i965-va-driver vainfo intel-media-va-driver \
         ## Tensorflow lite
-    && wget -q https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp38-cp38-linux_x86_64.whl \
-    && python3.8 -m pip install tflite_runtime-2.1.0.post1-cp38-cp38-linux_x86_64.whl \
-    && rm tflite_runtime-2.1.0.post1-cp38-cp38-linux_x86_64.whl \
+    && wget -q https://github.com/google-coral/pycoral/releases/download/release-frogfish/tflite_runtime-2.5.0-cp38-cp38-linux_x86_64.whl \
+    && python3.8 -m pip install tflite_runtime-2.5.0-cp38-cp38-linux_x86_64.whl \
+    && rm tflite_runtime-2.5.0-cp38-cp38-linux_x86_64.whl \
     && rm -rf /var/lib/apt/lists/* \
     && (apt-get autoremove -y; apt-get autoclean -y)

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -19,6 +19,6 @@ RUN apt-get -qq update \
         libaom0 \
         libx265-179 \
     ## Tensorflow lite
-    && pip3 install https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp38-cp38-linux_armv7l.whl \
+    && pip3 install https://github.com/google-coral/pycoral/releases/download/release-frogfish/tflite_runtime-2.5.0-cp38-cp38-linux_armv7l.whl \
     && rm -rf /var/lib/apt/lists/* \
     && (apt-get autoremove -y; apt-get autoclean -y)

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -23,7 +23,7 @@ RUN apt-get -qq update \
     && echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" > /etc/apt/sources.list.d/coral-edgetpu.list \
     && echo "libedgetpu1-max libedgetpu/accepted-eula select true" | debconf-set-selections \
     && apt-get -qq update && apt-get -qq install --no-install-recommends -y \
-        libedgetpu1-max \
+        libedgetpu1-max=15.0 \
     && rm -rf /var/lib/apt/lists/* /wheels \
     && (apt-get autoremove -y; apt-get autoclean -y)
 


### PR DESCRIPTION
This PR fixes issue #289 by locking libedgetpu1 to version 15.0, and also updating tflite_runtime to the compatible version 2.5.0.

As a future improvement, I would suggest specifying the tflite_runtime version and libedgetpu version in one place, perhaps in  Dockerfile.base