### PR TITLE
Fix errors when using amd64nvidia Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ amd64nvidia_wheels:
 	docker build --tag blakeblackshear/frigate-wheels:amd64nvidia --file docker/Dockerfile.wheels .
 
 amd64nvidia_ffmpeg:
-	docker build --tag blakeblackshear/frigate-ffmpeg:amd64nvidia --file docker/Dockerfile.ffmpeg.amd64 .
+	docker build --tag blakeblackshear/frigate-ffmpeg:amd64nvidia --file docker/Dockerfile.ffmpeg.amd64nvidia .
 
 amd64nvidia_frigate:
 	docker build --tag frigate-base --build-arg ARCH=amd64nvidia --file docker/Dockerfile.base .

--- a/docker/Dockerfile.amd64nvidia
+++ b/docker/Dockerfile.amd64nvidia
@@ -31,7 +31,6 @@ ENV CUDA_VERSION 11.1.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cuda-cudart-11-1=11.1.74-1 \
     cuda-compat-11-1 \
-    libnvidia-decode-455 \
     && ln -s cuda-11.1 /usr/local/cuda && \
     rm -rf /var/lib/apt/lists/*
 
@@ -44,5 +43,5 @@ ENV LD_LIBRARY_PATH /usr/local/cuda/lib64
 
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 ENV NVIDIA_REQUIRE_CUDA "cuda>=11.1 brand=tesla,driver>=418,driver<419 brand=tesla,driver>=440,driver<441 brand=tesla,driver>=450,driver<451"

--- a/docker/Dockerfile.amd64nvidia
+++ b/docker/Dockerfile.amd64nvidia
@@ -31,6 +31,7 @@ ENV CUDA_VERSION 11.1.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cuda-cudart-11-1=11.1.74-1 \
     cuda-compat-11-1 \
+    libnvidia-decode-455 \
     && ln -s cuda-11.1 /usr/local/cuda && \
     rm -rf /var/lib/apt/lists/*
 
@@ -39,7 +40,7 @@ RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
     echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
-ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+ENV LD_LIBRARY_PATH /usr/local/cuda/lib64
 
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all

--- a/docker/Dockerfile.amd64nvidia
+++ b/docker/Dockerfile.amd64nvidia
@@ -39,7 +39,7 @@ RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
     echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
-ENV LD_LIBRARY_PATH /usr/local/cuda/lib64
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all


### PR DESCRIPTION
Ran into a few issues trying to use the `amd64nvidia` Dockerfiles: 
* Wrong ffmpeg Dockerfile used from Makefile
* Missing Nvidia runtime libs in final frigate image.

These changes seem to get things working smoothly for me.