### PR TITLE
Add support for AMD Ryzen iGPU (fixes #311)

### DIFF
--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -9,7 +9,7 @@ RUN apt-get -qq update \
         # ffmpeg dependencies
         libgomp1 \
         # VAAPI drivers for Intel hardware accel
-        libva-drm2 libva2 i965-va-driver vainfo intel-media-va-driver \
+        libva-drm2 libva2 i965-va-driver vainfo intel-media-va-driver mesa-va-drivers \
         ## Tensorflow lite
     && wget -q https://github.com/google-coral/pycoral/releases/download/release-frogfish/tflite_runtime-2.5.0-cp38-cp38-linux_x86_64.whl \
     && python3.8 -m pip install tflite_runtime-2.5.0-cp38-cp38-linux_x86_64.whl \

--- a/docker/Dockerfile.ffmpeg.amd64
+++ b/docker/Dockerfile.ffmpeg.amd64
@@ -522,5 +522,5 @@ COPY --from=build /usr/local /usr/local/
 
 RUN \
 	apt-get update -y && \
-	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver && \
+	apt-get install -y --no-install-recommends libva-drm2 libva2 i965-va-driver mesa-va-drivers && \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This package will add support for the iGPU of AMD Ryzen and presumably a few more AMD cards.
See details of the package here: https://packages.ubuntu.com/focal/mesa-va-drivers

I can confirm that installing the package makes it work for Ryzen (see #311 )

According to https://wiki.debian.org/HardwareVideoAcceleration and https://nouveau.freedesktop.org/VideoAcceleration.html this should also add support for VAAPI using the open source Nvidia Nouveau driver.
I sadly don't have an Nvidia card to test this theory.