### PR TITLE
Performance: Use cv2.bitwise_and instead of numpy.where

### DIFF
--- a/frigate/motion.py
+++ b/frigate/motion.py
@@ -48,7 +48,7 @@ class MotionDetector():
 
             # black out everything in the avg_delta where there isnt motion in the current frame
             avg_delta_image = cv2.convertScaleAbs(self.avg_delta)
-            avg_delta_image[np.where(current_thresh==[0])] = [0]
+            avg_delta_image = cv2.bitwise_and(avg_delta_image, current_thresh)
 
             # then look for deltas above the threshold, but only in areas where there is a delta
             # in the current frame. this prevents deltas from previous frames from being included


### PR DESCRIPTION
Some profiling was showing that a lot of CPU usage was coming from motion.py::detect

It seems that the line causing the most usage was from line 51 in motion.py. numpy.where() is being used to zero out a mask, which appears to be computationally expensive. Since cv2.THRESH_BINARY is being used to generate the threshold mask, cv2.bitwise_and should be sufficient (and much faster) to generate the masked out `avg_delta_image`.

This change reduces CPU usage by about 10% on my old Haswell-EP machine, I believe without compromising any functionality.
