### PR TITLE
Reuse shared memory segments

### DIFF
--- a/frigate/edgetpu.py
+++ b/frigate/edgetpu.py
@@ -116,8 +116,7 @@ def run_detector(detection_queue, out_events: Dict[str, mp.Event], avg_speed, st
     
     while True:
         connection_id = detection_queue.get()
-        input_frame = frame_manager.get(connection_id, (1,300,300,3))
-
+        input_frame = frame_manager.get((1,300,300,3), name=connection_id)
         if input_frame is None:
             continue
 


### PR DESCRIPTION
Some more profiling showed that a significant amount of CPU time was being used closing shared memory segments.
This PR refactors the SharedMemoryFrameManager to reuse existing segments whenever possible.

In addition to reducing cpu usage (presumably via syscalls to close the fd for the shmem segment), it also should improve cache hits. In the future, it may be worth considering locking the shared memory segment so it can't be swapped out, but I don't know if this can be achieved in python.

Honestly though, I haven't seen that much of a performance change with this patch, but this is probably because my system isn't bottlenecked, perhaps I can try increasing the frame rate more now, or reducing some of the thresholds.


The code refactoring is significant:

1) the interface for create() is now a nameless write (ie, the name gets returned to you, instead of you getting to assign the name). as a result, the framemanager keeps track of "slots" or indexes rather than names. a tuple of <index, frame> is returned, the index is what you need to pass to get() or close()

2) delete() isn't necessary anymore, since pages are reused.

3) the usage status of the frame is located in the first byte of the buffer. if it set to 1, the frame is in use. calling close sets this bit to 0, freeing the frame for reuse by create()


currently this breaks the interface defined in the abstract FrameManager class, and this PR currently makes no attempt to fix the DictionaryFrameManager class. As far as I can tell, this only affects the process_clip.py script.