### PR TITLE
tmpfs support

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -45,6 +45,14 @@ class FrigateApp():
             else:
                 logger.debug(f"Skipping directory: {d}")
     
+    def create_cache_tmpfs(self):
+        tmpfs_size = self.config.cache_tmpfs_size
+        if tmpfs_size is not None and tmpfs_size.strip():
+             logger.info(f"Creating tmpfs of size {tmpfs_size}")
+             rc = os.system(f"mount -t tmpfs -o size={tmpfs_size} tmpfs /tmp/cache")
+             if rc != 0:
+                 logger.error(f"Failed to create tmpfs, error code: {rc}")
+
     def init_logger(self):
         self.log_process = mp.Process(target=log_process, args=(self.log_queue,), name='log_process')
         self.log_process.daemon = True
@@ -180,6 +188,7 @@ class FrigateApp():
                 sys.exit(1)
             self.check_config()
             self.set_log_levels()
+            self.create_cache_tmpfs()
             self.init_queues()
             self.init_database()
             self.init_mqtt()

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -206,7 +206,8 @@ FRIGATE_CONFIG_SCHEMA = vol.Schema(
         },
         vol.Optional('ffmpeg', default={}): GLOBAL_FFMPEG_SCHEMA,
         vol.Optional('objects', default={}): OBJECTS_SCHEMA,
-        vol.Required('cameras', default={}): CAMERAS_SCHEMA
+        vol.Required('cameras', default={}): CAMERAS_SCHEMA,
+        vol.Optional('cache_tmpfs_size', default=None): str
     }
 )
 
@@ -761,6 +762,7 @@ class FrigateConfig():
         self._save_clips = SaveClipsConfig(config['save_clips'])
         self._cameras = { name: CameraConfig(name, c, config) for name, c in config['cameras'].items() }
         self._logger = LoggerConfig(config['logger'])
+        self._cache_tmpfs_size = config['cache_tmpfs_size']
 
     def _sub_env_vars(self, config):
         frigate_env_vars = {k: v for k, v in os.environ.items() if k.startswith('FRIGATE_')}
@@ -813,3 +815,7 @@ class FrigateConfig():
     @property
     def cameras(self) -> Dict[str, CameraConfig]:
         return self._cameras
+
+    @property
+    def cache_tmpfs_size(self):
+        return self._cache_tmpfs_size


### PR DESCRIPTION
This pull requests add support for creating tmpfs via configuration, e.g.

```
cache_tmpfs_size: 100m
```

This allows usage of tmpfs when using frigate as hass add-on.

See blakeblackshear/frigate-hass-addons#6
