### PR TITLE
Set titles for forked processes

### DIFF
--- a/docker/Dockerfile.wheels
+++ b/docker/Dockerfile.wheels
@@ -32,7 +32,8 @@ RUN pip3 wheel --wheel-dir=/wheels \
     paho-mqtt \
     PyYAML \
     matplotlib \
-    click
+    click \
+    setproctitle
 
 FROM scratch
 

--- a/docker/Dockerfile.wheels.aarch64
+++ b/docker/Dockerfile.wheels.aarch64
@@ -42,7 +42,8 @@ RUN pip3 wheel --wheel-dir=/wheels \
     paho-mqtt \
     PyYAML \
     matplotlib \
-    click
+    click \
+    setproctitle
 
 FROM scratch
 

--- a/frigate/edgetpu.py
+++ b/frigate/edgetpu.py
@@ -8,6 +8,7 @@ import threading
 import signal
 from abc import ABC, abstractmethod
 from multiprocessing.connection import Connection
+from setproctitle import setproctitle
 from typing import Dict
 
 import numpy as np
@@ -110,6 +111,7 @@ def run_detector(name: str, detection_queue: mp.Queue, out_events: Dict[str, mp.
     threading.current_thread().name = f"detector:{name}"
     logger = logging.getLogger(f"detector.{name}")
     logger.info(f"Starting detection process: {os.getpid()}")
+    setproctitle(f"frigate.detector.{name}")
     listen()
 
     stop_event = mp.Event()

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -6,6 +6,7 @@ import signal
 import queue
 import multiprocessing as mp
 from logging import handlers
+from setproctitle import setproctitle
 
 
 def listener_configurer():
@@ -31,6 +32,7 @@ def log_process(log_queue):
     signal.signal(signal.SIGINT, receiveSignal)
 
     threading.current_thread().name = f"logger"
+    setproctitle("frigate.logger")
     listener_configurer()
     while True:
         if stop_event.is_set() and log_queue.empty():

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -13,6 +13,7 @@ import signal
 import threading
 import time
 from collections import defaultdict
+from setproctitle import setproctitle
 from typing import Dict, List
 
 import cv2
@@ -249,6 +250,7 @@ def track_camera(name, config: CameraConfig, model_shape, detection_queue, resul
     signal.signal(signal.SIGINT, receiveSignal)
 
     threading.current_thread().name = f"process:{name}"
+    setproctitle(f"frigate.process:{name}")
     listen()
 
     frame_queue = process_info['frame_queue']


### PR DESCRIPTION
To assist with debugging performance issues, set the title of forked processes to `frigate.process_name` using `setproctitle()`

**Before:**

```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root       410  0.2  0.0   4244  3540 pts/0    Ss   19:40   0:00 bash
root       577  0.0  0.0   6044  3020 pts/0    R+   19:40   0:00  \_ ps auxf
root         1 21.3  0.1 1726176 102004 ?      Ssl  19:40   0:03 python3 -u -m frigate
root        18  0.0  0.0  16420  1172 ?        Ss   19:40   0:00 nginx: master process /usr/sbin/nginx
nobody      19  9.9  0.0  18580  5304 ?        S    19:40   0:01  \_ nginx: worker process
root        44  0.0  0.0 1141068 58172 ?       S    19:40   0:00 python3 -u -m frigate
root        47  2.0  0.0  14516 10928 ?        R    19:40   0:00 /usr/bin/python3 -c from multiprocessing.resource_tracker import main;main(49)
root        48 51.8  0.1 1372980 86168 ?       Sl   19:40   0:07 python3 -u -m frigate
root        51  0.6  0.1 1357336 74356 ?       Sl   19:40   0:00 python3 -u -m frigate
root        53  0.6  0.1 1357336 74360 ?       Sl   19:40   0:00 python3 -u -m frigate
root        55  6.3  0.1 2087608 77392 ?       Sl   19:40   0:00 python3 -u -m frigate
root        57  0.7  0.1 1357336 74356 ?       Sl   19:40   0:00 python3 -u -m frigate
root        58  0.6  0.1 1357336 74360 ?       Sl   19:40   0:00 python3 -u -m frigate
root        59  0.5  0.1 1357336 74360 ?       Sl   19:40   0:00 python3 -u -m frigate
root        60  0.6  0.1 1357340 74364 ?       Sl   19:40   0:00 python3 -u -m frigate
root        61  0.6  0.1 1357176 74332 ?       Sl   19:40   0:00 python3 -u -m frigate
root        62  0.6  0.1 1357340 74368 ?       Sl   19:40   0:00 python3 -u -m frigate
root        63  0.6  0.1 1357340 74432 ?       Sl   19:40   0:00 python3 -u -m frigate
root        64  0.6  0.1 1357176 74272 ?       Sl   19:40   0:00 python3 -u -m frigate
root        65  0.5  0.1 1357180 74340 ?       Sl   19:40   0:00 python3 -u -m frigate
root        66  0.6  0.1 1357340 74436 ?       Sl   19:40   0:00 python3 -u -m frigate
root        67  1.0  0.1 1502520 68820 ?       Sl   19:40   0:00 python3 -u -m frigate
```

**After:**

```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root       710  1.0  0.0   4244  3400 pts/0    Ss   19:21   0:00 bash
root       717  0.0  0.0   6044  2920 pts/0    R+   19:21   0:00  \_ ps auxf
root         1 11.7  0.1 2610948 106160 ?      Ssl  19:20   0:06 python3 -u -m frigate
root        19  0.0  0.0  16420  1164 ?        Ss   19:20   0:00 nginx: master process /usr/sbin/nginx
nobody      20 14.3  0.0  18712  5668 ?        R    19:20   0:08  \_ nginx: worker process
root        45  0.0  0.0 1141052 58288 ?       S    19:20   0:00 frigate.logger
root        48  2.5  0.0  14516 10976 ?        S    19:20   0:01 /usr/bin/python3 -c from multiprocessing.resource_tracker import main;main(49)
root        49 82.5  0.1 1373076 86024 ?       Sl   19:20   0:47 frigate.detector:coral1
root        52  0.9  0.1 1357324 74516 ?       Rl   19:20   0:00 frigate.process:drivenorth
root        54  0.8  0.1 1357324 74516 ?       Sl   19:20   0:00 frigate.process:bridge
root        57  5.4  0.1 2088056 77872 ?       Sl   19:20   0:03 frigate.process:barnleft
root        58  6.1  0.1 2087600 77332 ?       Sl   19:20   0:03 frigate.process:barnright
root        59  0.9  0.1 1357328 74520 ?       Sl   19:20   0:00 frigate.process:workshop
root        60  0.9  0.1 1357328 74528 ?       Sl   19:20   0:00 frigate.process:shed
root        61  0.9  0.1 1357328 74596 ?       Sl   19:20   0:00 frigate.process:drivewest
root        62  0.8  0.1 1357168 74500 ?       Sl   19:20   0:00 frigate.process:driveeast
root        63  0.8  0.1 1357328 74596 ?       Sl   19:20   0:00 frigate.process:logssouth
root        64  0.8  0.1 1357332 74592 ?       Sl   19:20   0:00 frigate.process:logsnorth
root        65  0.8  0.1 1357168 74496 ?       Sl   19:20   0:00 frigate.process:utility
root        66  0.8  0.1 1357168 74508 ?       Sl   19:20   0:00 frigate.process:rear
root        67  0.9  0.1 1357332 74608 ?       Sl   19:20   0:00 frigate.process:polewoods
```

I don't think the per-camera routines which fork ffmpeg can be named as they are threads.