### PR TITLE
Avoid "database is locked" errors using playhouse.sqliteq.SqliteQueueDatabase

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -9,7 +9,7 @@ import signal
 
 import yaml
 from peewee_migrate import Router
-from playhouse.sqlite_ext import SqliteExtDatabase
+from playhouse.sqliteq import SqliteQueueDatabase
 
 from frigate.config import FrigateConfig
 from frigate.const import RECORD_DIR, CLIPS_DIR, CACHE_DIR
@@ -112,7 +112,7 @@ class FrigateApp():
         self.detected_frames_queue = mp.Queue(maxsize=len(self.config.cameras.keys())*2)
 
     def init_database(self):
-        self.db = SqliteExtDatabase(self.config.database.path)
+        self.db = SqliteQueueDatabase(self.config.database.path)
 
         # Run migrations
         del(logging.getLogger('peewee_migrate').handlers[:])


### PR DESCRIPTION
I'm currently testing this change to avoid `database is locked` errors as discussed in https://github.com/blakeblackshear/frigate/discussions/389#discussioncomment-271204