### PR TITLE
Fix Makefile to ignore gpg signatures in commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 default_target: amd64_frigate
 
-COMMIT_HASH := $(shell git log -1 --pretty=format:"%h")
+COMMIT_HASH := $(shell git log -1 --pretty=format:"%h"|tail -1)
 
 version:
 	echo "VERSION='0.8.0-$(COMMIT_HASH)'" > frigate/version.py


### PR DESCRIPTION
Without this change, I cannot build docker image as I sign all commits by default:

```
echo "VERSION='0.8.0-gpg: Signature made Wed 13 Jan 2021 05:42:34 PM CET gpg:                using RSA key C9A6BD07A7089CE56CDF6125FD55B9BD5687D8FF gpg: Good signature from "Patrick Dec
at <pdecat@gmail.com>" [ultimate] Primary key fingerprint: 9779 4ADD 33EA 00D3 2389  8608 A811 66D9 F225 BAF8      Subkey fingerprint: C9A6 BD07 A708 9CE5 6CDF  6125 FD55 B9BD 5687 D8FF
 0eed173'" > frigate/version.py                                                                                                                                                          
/bin/sh: 1: cannot open pdecat@gmail.com: No such file                                      
make: *** [Makefile:6: version] Error 2                                                     
```