### PR TITLE
fix(web): ensure button bg colors show in prod builds

### DIFF
--- a/web/src/components/Button.jsx
+++ b/web/src/components/Button.jsx
@@ -2,12 +2,18 @@ import { h } from 'preact';
 
 const noop = () => {};
 
+const BUTTON_COLORS = {
+  blue: { normal: 'bg-blue-500', hover: 'hover:bg-blue-400' },
+  red: { normal: 'bg-red-500', hover: 'hover:bg-red-400' },
+  green: { normal: 'bg-green-500', hover: 'hover:bg-green-400' },
+};
+
 export default function Button({ children, className, color = 'blue', onClick, size, ...attrs }) {
   return (
     <div
       role="button"
       tabindex="0"
-      className={`rounded bg-${color}-500 text-white pl-4 pr-4 pt-2 pb-2 font-bold shadow hover:bg-${color}-400 hover:shadow-lg cursor-pointer ${className}`}
+      className={`rounded ${BUTTON_COLORS[color].normal} text-white pl-4 pr-4 pt-2 pb-2 font-bold shadow ${BUTTON_COLORS[color].hover} hover:shadow-lg cursor-pointer ${className}`}
       onClick={onClick || noop}
       {...attrs}
     >


### PR DESCRIPTION
## Problem

Button background colors do not show in production builds of the web UI

<img width="864" alt="Screen Shot 2021-01-18 at 9 31 49 AM" src="https://user-images.githubusercontent.com/33297/104947143-2496bd80-5970-11eb-91de-816561682c10.png">

## Solution

Postcss / Tailwindcss plugin purges too many classnames because they are constructed at runtime and not visible at build time. This change ensures that the classnames are visible in static source, allowing purgecss to find them and not remove too many from the production css build