### PR TITLE
fix(web): set default path to cameras view

### DIFF
--- a/web/snowpack.config.js
+++ b/web/snowpack.config.js
@@ -26,6 +26,7 @@ module.exports = {
     sourcemap: false,
   },
   buildOptions: {
+    baseUrl: '/foobar/',
     sourcemap: true,
   },
 };

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -33,7 +33,7 @@ export default function App() {
             <Event path="/events/:eventId" />
             <Events path="/events" />
             <Debug path="/debug" />
-            <Cameras path="/" />
+            <Cameras default path="/" />
           </Router>
         </div>
       </div>


### PR DESCRIPTION
Problem: With hassio ingress, the default view doesn't show anything

Solution: Setting `default` attribute to the `Cameras` view and preact-router will fall back on this when another route does not match.