### PR TITLE
feat(nginx): enable gzip compression and cache control for static files

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -23,6 +23,12 @@ http {
 
     keepalive_timeout  65;
 
+    gzip on;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css application/json application/x-javascript application/javascript text/javascript image/svg+xml image/x-icon image/bmp image/png image/gif image/jpeg image/jpg;
+    gzip_proxied no-cache no-store private expired auth;
+    gzip_vary on;
+
     upstream frigate_api {
       server localhost:5001;
       keepalive 1024;
@@ -98,6 +104,7 @@ http {
 
         location /api/ {
             add_header 'Access-Control-Allow-Origin' '*';
+            add_header Cache-Control "no-store";
             proxy_pass http://frigate_api/;
             proxy_pass_request_headers on;
             proxy_set_header Host $host;
@@ -105,13 +112,23 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+
         location / {
+            add_header Cache-Control "no-cache";
+
+            location ~* \.(?:js|css|svg|ico|png)$ {
+                access_log off;
+                expires 1y;
+                add_header Cache-Control "public";
+            }
+
             sub_filter 'href="/' 'href="$http_x_ingress_path/';
             sub_filter 'url(/' 'url($http_x_ingress_path/';
             sub_filter '"/js/' '"$http_x_ingress_path/js/';
             sub_filter '<body>' '<body><script>window.baseUrl="$http_x_ingress_path";</script>';
             sub_filter_types text/css application/javascript;
             sub_filter_once off;
+
             root /opt/frigate/web;
             try_files $uri $uri/ /index.html;
         }


### PR DESCRIPTION
Before (without images, transfer size = **116kB**)
<img width="1392" alt="1-after" src="https://user-images.githubusercontent.com/33297/106300518-71e61b00-620b-11eb-8b23-27fd248e3112.png">

After (without images, transfer size = **52kB**)
<img width="1392" alt="Screen Shot 2021-01-29 at 8 22 34 AM" src="https://user-images.githubusercontent.com/33297/106300688-a8239a80-620b-11eb-8019-bf820dc3f640.png">

Closes blakeblackshear/frigate#653
