### PR TITLE
feat(web): auto-paginate events page

### DIFF
--- a/frigate/http.py
+++ b/frigate/http.py
@@ -55,7 +55,7 @@ def events_summary():
 
     if not has_clip is None:
         clauses.append((Event.has_clip == has_clip))
-    
+
     if not has_snapshot is None:
         clauses.append((Event.has_snapshot == has_snapshot))
 
@@ -160,8 +160,8 @@ def events():
     camera = request.args.get('camera')
     label = request.args.get('label')
     zone = request.args.get('zone')
-    after = request.args.get('after', type=int)
-    before = request.args.get('before', type=int)
+    after = request.args.get('after', type=float)
+    before = request.args.get('before', type=float)
     has_clip = request.args.get('has_clip', type=int)
     has_snapshot = request.args.get('has_snapshot', type=int)
     include_thumbnails = request.args.get('include_thumbnails', default=1, type=int)
@@ -186,7 +186,7 @@ def events():
 
     if not has_clip is None:
         clauses.append((Event.has_clip == has_clip))
-    
+
     if not has_snapshot is None:
         clauses.append((Event.has_snapshot == has_snapshot))
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3574,6 +3574,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
     },
+    "immer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
+    },
     "import-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "@snowpack/plugin-webpack": "^2.3.0",
     "autoprefixer": "^10.2.1",
     "cross-env": "^7.0.3",
+    "immer": "^8.0.1",
     "postcss": "^8.2.2",
     "postcss-cli": "^8.3.1",
     "preact": "^10.5.9",

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -7,36 +7,25 @@ import Event from './Event';
 import Events from './Events';
 import { Router } from 'preact-router';
 import Sidebar from './Sidebar';
-import { ApiHost, Config } from './context';
-import { useContext, useEffect, useState } from 'preact/hooks';
+import Api, { useConfig } from './api';
 
 export default function App() {
-  const apiHost = useContext(ApiHost);
-  const [config, setConfig] = useState(null);
-
-  useEffect(async () => {
-    const response = await fetch(`${apiHost}/api/config`);
-    const data = response.ok ? await response.json() : {};
-    setConfig(data);
-  }, []);
-
-  return !config ? (
+  const { data, status } = useConfig();
+  return !data ? (
     <div />
   ) : (
-    <Config.Provider value={config}>
-      <div className="md:flex flex-col md:flex-row md:min-h-screen w-full bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white">
-        <Sidebar />
-        <div className="flex-auto p-4 lg:pl-8 lg:pr-8 min-w-0">
-          <Router>
-            <CameraMap path="/cameras/:camera/editor" />
-            <Camera path="/cameras/:camera" />
-            <Event path="/events/:eventId" />
-            <Events path="/events" />
-            <Debug path="/debug" />
-            <Cameras default path="/" />
-          </Router>
-        </div>
+    <div className="md:flex flex-col md:flex-row md:min-h-screen w-full bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white">
+      <Sidebar />
+      <div className="flex-auto p-2 md:p-4 lg:pl-8 lg:pr-8 min-w-0">
+        <Router>
+          <CameraMap path="/cameras/:camera/editor" />
+          <Camera path="/cameras/:camera" />
+          <Event path="/events/:eventId" />
+          <Events path="/events" />
+          <Debug path="/debug" />
+          <Cameras default path="/" />
+        </Router>
       </div>
-    </Config.Provider>
+    </div>
   );
 }

--- a/web/src/Camera.jsx
+++ b/web/src/Camera.jsx
@@ -6,13 +6,13 @@ import Link from './components/Link';
 import Switch from './components/Switch';
 import { route } from 'preact-router';
 import { useCallback, useContext } from 'preact/hooks';
-import { ApiHost, Config } from './context';
+import { useApiHost, useConfig } from './api';
 
 export default function Camera({ camera, url }) {
-  const config = useContext(Config);
-  const apiHost = useContext(ApiHost);
+  const { data: config } = useConfig();
+  const apiHost = useApiHost();
 
-  if (!(camera in config.cameras)) {
+  if (!config) {
     return <div>{`No camera named ${camera}`}</div>;
   }
 

--- a/web/src/CameraMap.jsx
+++ b/web/src/CameraMap.jsx
@@ -5,11 +5,11 @@ import Heading from './components/Heading';
 import Switch from './components/Switch';
 import { route } from 'preact-router';
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks';
-import { ApiHost, Config } from './context';
+import { useApiHost, useConfig } from './api';
 
 export default function CameraMasks({ camera, url }) {
-  const config = useContext(Config);
-  const apiHost = useContext(ApiHost);
+  const { data: config } = useConfig();
+  const apiHost = useApiHost();
   const imageRef = useRef(null);
   const [imageScale, setImageScale] = useState(1);
   const [snap, setSnap] = useState(true);

--- a/web/src/Cameras.jsx
+++ b/web/src/Cameras.jsx
@@ -4,13 +4,12 @@ import CameraImage from './components/CameraImage';
 import Events from './Events';
 import Heading from './components/Heading';
 import { route } from 'preact-router';
-import { useContext } from 'preact/hooks';
-import { ApiHost, Config } from './context';
+import { useConfig } from './api';
 
 export default function Cameras() {
-  const config = useContext(Config);
+  const { data: config, status } = useConfig();
 
-  if (!config.cameras) {
+  if (!config) {
     return <p>loading…</p>;
   }
 

--- a/web/src/Debug.jsx
+++ b/web/src/Debug.jsx
@@ -3,25 +3,21 @@ import Box from './components/Box';
 import Button from './components/Button';
 import Heading from './components/Heading';
 import Link from './components/Link';
-import { ApiHost, Config } from './context';
+import { useConfig, useStats } from './api';
 import { Table, Tbody, Thead, Tr, Th, Td } from './components/Table';
-import { useCallback, useContext, useEffect, useState } from 'preact/hooks';
+import { useCallback, useEffect, useState } from 'preact/hooks';
 
 export default function Debug() {
-  const apiHost = useContext(ApiHost);
-  const config = useContext(Config);
-  const [stats, setStats] = useState({});
+  const config = useConfig();
+
   const [timeoutId, setTimeoutId] = useState(null);
 
-  const fetchStats = useCallback(async () => {
-    const statsResponse = await fetch(`${apiHost}/api/stats`);
-    const stats = statsResponse.ok ? await statsResponse.json() : {};
-    setStats(stats);
-    setTimeoutId(setTimeout(fetchStats, 1000));
-  }, [setStats]);
+  const forceUpdate = useCallback(async () => {
+    setTimeoutId(setTimeout(forceUpdate, 1000));
+  }, []);
 
   useEffect(() => {
-    fetchStats();
+    forceUpdate();
   }, []);
 
   useEffect(() => {
@@ -29,11 +25,13 @@ export default function Debug() {
       clearTimeout(timeoutId);
     };
   }, [timeoutId]);
+  const { data: stats, status } = useStats(null, timeoutId);
 
-  const { detectors, detection_fps, service, ...cameras } = stats;
-  if (!service) {
+  if (!stats) {
     return 'loading…';
   }
+
+  const { detectors, detection_fps, service, ...cameras } = stats;
 
   const detectorNames = Object.keys(detectors);
   const detectorDataKeys = Object.keys(detectors[detectorNames[0]]);

--- a/web/src/Event.jsx
+++ b/web/src/Event.jsx
@@ -1,20 +1,13 @@
 import { h, Fragment } from 'preact';
-import { ApiHost } from './context';
 import Box from './components/Box';
 import Heading from './components/Heading';
 import Link from './components/Link';
 import { Table, Thead, Tbody, Tfoot, Th, Tr, Td } from './components/Table';
-import { useContext, useEffect, useState } from 'preact/hooks';
+import { useApiHost, useEvent } from './api';
 
 export default function Event({ eventId }) {
-  const apiHost = useContext(ApiHost);
-  const [data, setData] = useState(null);
-
-  useEffect(async () => {
-    const response = await fetch(`${apiHost}/api/events/${eventId}`);
-    const data = response.ok ? await response.json() : null;
-    setData(data);
-  }, [apiHost, eventId]);
+  const apiHost = useApiHost();
+  const { data } = useEvent(eventId);
 
   if (!data) {
     return (
@@ -57,34 +50,36 @@ export default function Event({ eventId }) {
         />
       </Box>
 
-      <Table>
-        <Thead>
-          <Th>Key</Th>
-          <Th>Value</Th>
-        </Thead>
-        <Tbody>
-          <Tr>
-            <Td>Camera</Td>
-            <Td>
-              <Link href={`/cameras/${data.camera}`}>{data.camera}</Link>
-            </Td>
-          </Tr>
-          <Tr index={1}>
-            <Td>Timeframe</Td>
-            <Td>
-              {startime.toLocaleString()} – {endtime.toLocaleString()}
-            </Td>
-          </Tr>
-          <Tr>
-            <Td>Score</Td>
-            <Td>{(data.top_score * 100).toFixed(2)}%</Td>
-          </Tr>
-          <Tr index={1}>
-            <Td>Zones</Td>
-            <Td>{data.zones.join(', ')}</Td>
-          </Tr>
-        </Tbody>
-      </Table>
+      <Box>
+        <Table>
+          <Thead>
+            <Th>Key</Th>
+            <Th>Value</Th>
+          </Thead>
+          <Tbody>
+            <Tr>
+              <Td>Camera</Td>
+              <Td>
+                <Link href={`/cameras/${data.camera}`}>{data.camera}</Link>
+              </Td>
+            </Tr>
+            <Tr index={1}>
+              <Td>Timeframe</Td>
+              <Td>
+                {startime.toLocaleString()} – {endtime.toLocaleString()}
+              </Td>
+            </Tr>
+            <Tr>
+              <Td>Score</Td>
+              <Td>{(data.top_score * 100).toFixed(2)}%</Td>
+            </Tr>
+            <Tr index={1}>
+              <Td>Zones</Td>
+              <Td>{data.zones.join(', ')}</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      </Box>
     </div>
   );
 }

--- a/web/src/api/index.jsx
+++ b/web/src/api/index.jsx
@@ -1,0 +1,108 @@
+import { h, createContext } from 'preact';
+import produce from 'immer';
+import { useCallback, useContext, useEffect, useMemo, useRef, useReducer, useState } from 'preact/hooks';
+
+export const ApiHost = createContext(import.meta.env.SNOWPACK_PUBLIC_API_HOST || window.baseUrl || '');
+
+export const FetchStatus = {
+  NONE: 'none',
+  LOADING: 'loading',
+  LOADED: 'loaded',
+  ERROR: 'error',
+};
+
+const initialState = Object.freeze({
+  host: import.meta.env.SNOWPACK_PUBLIC_API_HOST || window.baseUrl || '',
+  queries: {},
+});
+export const Api = createContext(initialState);
+export default Api;
+
+function reducer(state, { type, payload, meta }) {
+  switch (type) {
+    case 'REQUEST': {
+      const { url, request } = payload;
+      const data = state.queries[url]?.data || null;
+      return produce(state, (draftState) => {
+        draftState.queries[url] = { status: FetchStatus.LOADING, data };
+      });
+    }
+
+    case 'RESPONSE': {
+      const { url, ok, data } = payload;
+      return produce(state, (draftState) => {
+        draftState.queries[url] = { status: ok ? FetchStatus.LOADED : FetchStatus.ERROR, data };
+      });
+    }
+
+    default:
+      return state;
+  }
+}
+
+export const ApiProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  return <Api.Provider value={{ state, dispatch }}>{children}</Api.Provider>;
+};
+
+function shouldFetch(state, url, forceRefetch = false) {
+  if (forceRefetch || !(url in state.queries)) {
+    return true;
+  }
+  const { status } = state.queries[url];
+
+  return status !== FetchStatus.LOADING && status !== FetchStatus.LOADED;
+}
+
+export function useFetch(url, forceRefetch) {
+  const { state, dispatch } = useContext(Api);
+
+  useEffect(() => {
+    if (!shouldFetch(state, url, forceRefetch)) {
+      return;
+    }
+
+    async function fetchConfig() {
+      await dispatch({ type: 'REQUEST', payload: { url } });
+      const response = await fetch(`${state.host}${url}`);
+      const data = await response.json();
+      await dispatch({ type: 'RESPONSE', payload: { url, ok: response.ok, data } });
+    }
+
+    fetchConfig();
+  }, [url, forceRefetch]);
+
+  if (!(url in state.queries)) {
+    return { data: null, status: FetchStatus.NONE };
+  }
+
+  const data = state.queries[url].data || null;
+  const status = state.queries[url].status;
+
+  return { data, status };
+}
+
+export function useApiHost() {
+  const { state, dispatch } = useContext(Api);
+  return state.host;
+}
+
+export function useEvents(searchParams, forceRefetch) {
+  const url = `/api/events${searchParams ? `?${searchParams.toString()}` : ''}`;
+  return useFetch(url, forceRefetch);
+}
+
+export function useEvent(eventId, forceRefetch) {
+  const url = `/api/events/${eventId}`;
+  return useFetch(url, forceRefetch);
+}
+
+export function useConfig(searchParams, forceRefetch) {
+  const url = `/api/config${searchParams ? `?${searchParams.toString()}` : ''}`;
+  return useFetch(url, forceRefetch);
+}
+
+export function useStats(searchParams, forceRefetch) {
+  const url = `/api/stats${searchParams ? `?${searchParams.toString()}` : ''}`;
+  return useFetch(url, forceRefetch);
+}

--- a/web/src/components/AutoUpdatingCameraImage.jsx
+++ b/web/src/components/AutoUpdatingCameraImage.jsx
@@ -1,6 +1,5 @@
 import { h } from 'preact';
 import CameraImage from './CameraImage';
-import { ApiHost, Config } from '../context';
 import { useCallback, useState } from 'preact/hooks';
 
 const MIN_LOAD_TIMEOUT_MS = 200;

--- a/web/src/components/Box.jsx
+++ b/web/src/components/Box.jsx
@@ -4,7 +4,7 @@ export default function Box({ children, className = '', hover = false, href, ...
   const Element = href ? 'a' : 'div';
   return (
     <Element
-      className={`bg-white dark:bg-gray-700 shadow-lg rounded-lg p-4 ${
+      className={`bg-white dark:bg-gray-700 shadow-lg rounded-lg p-2 lg:p-4 ${
         hover ? 'hover:bg-gray-300 hover:dark:bg-gray-500 dark:hover:text-gray-900 dark:hover:text-gray-900' : ''
       } ${className}`}
       href={href}

--- a/web/src/components/CameraImage.jsx
+++ b/web/src/components/CameraImage.jsx
@@ -1,10 +1,10 @@
 import { h } from 'preact';
-import { ApiHost, Config } from '../context';
+import { useApiHost, useConfig } from '../api';
 import { useCallback, useEffect, useContext, useMemo, useRef, useState } from 'preact/hooks';
 
 export default function CameraImage({ camera, onload, searchParams = '' }) {
-  const config = useContext(Config);
-  const apiHost = useContext(ApiHost);
+  const { data: config } = useConfig();
+  const apiHost = useApiHost();
   const [availableWidth, setAvailableWidth] = useState(0);
   const [loadedSrc, setLoadedSrc] = useState(null);
   const containerRef = useRef(null);

--- a/web/src/components/Table.jsx
+++ b/web/src/components/Table.jsx
@@ -6,12 +6,12 @@ export function Table({ children, className = '' }) {
   );
 }
 
-export function Thead({ children, className = '' }) {
-  return <thead className={`${className}`}>{children}</thead>;
+export function Thead({ children, className }) {
+  return <thead className={className}>{children}</thead>;
 }
 
-export function Tbody({ children, className = '' }) {
-  return <tbody className={`${className}`}>{children}</tbody>;
+export function Tbody({ children, className }) {
+  return <tbody className={className}>{children}</tbody>;
 }
 
 export function Tfoot({ children, className = '' }) {
@@ -19,13 +19,21 @@ export function Tfoot({ children, className = '' }) {
 }
 
 export function Tr({ children, className = '', index }) {
-  return <tr className={`${index % 2 ? 'bg-gray-200 dark:bg-gray-700' : ''} ${className}`}>{children}</tr>;
+  return <tr className={`${index % 2 ? 'bg-gray-200 dark:bg-gray-600' : ''} ${className}`}>{children}</tr>;
 }
 
-export function Th({ children, className = '' }) {
-  return <th className={`border-b-2 border-gray-400 p-4 text-left ${className}`}>{children}</th>;
+export function Th({ children, className = '', colspan }) {
+  return (
+    <th className={`border-b-2 border-gray-400 p-1 md:p-2 text-left ${className}`} colspan={colspan}>
+      {children}
+    </th>
+  );
 }
 
-export function Td({ children, className = '' }) {
-  return <td className={`p-4 ${className}`}>{children}</td>;
+export function Td({ children, className = '', colspan }) {
+  return (
+    <td className={`p-1 md:p-2 ${className}`} colspan={colspan}>
+      {children}
+    </td>
+  );
 }

--- a/web/src/context/index.js
+++ b/web/src/context/index.js
@@ -1,5 +1,0 @@
-import { createContext } from 'preact';
-
-export const Config = createContext({});
-
-export const ApiHost = createContext(import.meta.env.SNOWPACK_PUBLIC_API_HOST || window.baseUrl || '');

--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -1,9 +1,12 @@
 import App from './App';
+import { ApiProvider } from './api';
 import { h, render } from 'preact';
 import 'preact/devtools';
 import './index.css';
 
 render(
-  <App />,
+  <ApiProvider>
+    <App />
+  </ApiProvider>,
   document.getElementById('root')
 );


### PR DESCRIPTION
This ended up being a lot larger than originally imagined, because of the need to lump multiple things together.

# 1. Adds an `api` layer 
These custom hooks in `web/api/index.jsx` handle fetching data and retaining in-memory cache of the API requests, given the query parameters. They include a `forceRefetch` argument to allow replacing the cache with the results of a new call. If this parameter is not included (and is not unique since the last time it was used), the data will be reused from memory instead of attempting to query the API again.

This introduces a small dependency, `immer`, which allows us to ensure data stored is immutable and easy to update in the reducers.

# 2. Adds auto-pagination to the Events page
* Fixes a bug in the python HTTP API that prevented querying unique events using `before` and `after` timestamps
* Implements local state to the `Events` page using a reducer to track all events across paginated queries
* Uses an `IntersectionObserver` to watch the last row of the table to determine if it should attempt to fetch more events
* If the API returns fewer than the `limit` (hard-coded to 25, ~10kB JSON 🎉 ), assume we've reached the end of available events and stops looking for more

# 3. Adds top-level filters to Events page
* `<select>` dropdowns that update the page, clearing the current set of events displayed on change

closes blakeblackshear/frigate#648
closes blakeblackshear/frigate#601
closes blakeblackshear/frigate#650

Tested on Chrome, Firefox, and Safari (all latest)