### PR TITLE
Fix docker-compose syntax for mounting USB devices

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -40,8 +40,9 @@ services:
     restart: unless-stopped
     privileged: true
     image: blakeblackshear/frigate:0.8.0-beta2-amd64
-    volumes:
+    devices:
       - /dev/bus/usb:/dev/bus/usb
+    volumes:
       - /etc/localtime:/etc/localtime:ro
       - <path_to_config>:/config
       - <path_to_directory_for_clips>:/media/frigate/clips


### PR DESCRIPTION
Mounting a device as a volume returns the error: `creating device nodes caused: mkdir /var/lib/docker/overlay2/b8[...]3ee8f/merged/dev/bus/usb: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type`