### PR TITLE
fix(app): reduce JPEG quality to drastically improve size

### DIFF
--- a/frigate/http.py
+++ b/frigate/http.py
@@ -236,7 +236,7 @@ def best(camera_name, label):
         width = int(height*best_frame.shape[1]/best_frame.shape[0])
 
         best_frame = cv2.resize(best_frame, dsize=(width, height), interpolation=cv2.INTER_AREA)
-        ret, jpg = cv2.imencode('.jpg', best_frame)
+        ret, jpg = cv2.imencode('.jpg', best_frame, [int(cv2.IMWRITE_JPEG_QUALITY), 70])
         response = make_response(jpg.tobytes())
         response.headers['Content-Type'] = 'image/jpg'
         return response
@@ -283,7 +283,7 @@ def latest_frame(camera_name):
 
         frame = cv2.resize(frame, dsize=(width, height), interpolation=cv2.INTER_AREA)
 
-        ret, jpg = cv2.imencode('.jpg', frame)
+        ret, jpg = cv2.imencode('.jpg', frame, [int(cv2.IMWRITE_JPEG_QUALITY), 70])
         response = make_response(jpg.tobytes())
         response.headers['Content-Type'] = 'image/jpg'
         return response
@@ -301,6 +301,6 @@ def imagestream(detected_frames_processor, camera_name, fps, height, draw_option
         width = int(height*frame.shape[1]/frame.shape[0])
         frame = cv2.resize(frame, dsize=(width, height), interpolation=cv2.INTER_LINEAR)
 
-        ret, jpg = cv2.imencode('.jpg', frame)
+        ret, jpg = cv2.imencode('.jpg', frame, [int(cv2.IMWRITE_JPEG_QUALITY), 70])
         yield (b'--frame\r\n'
             b'Content-Type: image/jpeg\r\n\r\n' + jpg.tobytes() + b'\r\n\r\n')


### PR DESCRIPTION
**Problem:** Images returned from the python app that are 654x338 pixels are coming out at about 84KiBs. This is really high for typically JPEG images.

**Solution:** You can reduce the quality to 70% and typically not notice any artifacts appearing. This drops my images down to about 31KiB for the same image.

> Probably won't come through at all, but I took screenshot comparisons to avoid GitHub changing compression after uploading to their CND 🤷🏻 
<img width="537" alt="Screen Shot 2021-01-31 at 3 08 08 PM" src="https://user-images.githubusercontent.com/33297/106400952-54b17800-63d6-11eb-9a8c-74ae0469b0dc.png">
<img width="662" alt="Screen Shot 2021-01-31 at 3 08 46 PM" src="https://user-images.githubusercontent.com/33297/106400954-567b3b80-63d6-11eb-8ba6-b5275f312711.png">


