### PR TITLE
Add nginx sub_filter to fix resources from /dist with HA ingress

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -124,6 +124,7 @@ http {
 
             sub_filter 'href="/' 'href="$http_x_ingress_path/';
             sub_filter 'url(/' 'url($http_x_ingress_path/';
+            sub_filter '"/dist/' '"$http_x_ingress_path/dist/';
             sub_filter '"/js/' '"$http_x_ingress_path/js/';
             sub_filter '<body>' '<body><script>window.baseUrl="$http_x_ingress_path";</script>';
             sub_filter_types text/css application/javascript;


### PR DESCRIPTION
Without this change, web UI was no longer working with HA ingress (404 on `/dist/index.L2DpzrKZtzyV.js`).