### PR TITLE
fix(web): fix CameraMap.jsx import of api after move to routes/

### DIFF
--- a/web/src/routes/CameraMap.jsx
+++ b/web/src/routes/CameraMap.jsx
@@ -5,7 +5,7 @@ import Heading from '../components/Heading';
 import Switch from '../components/Switch';
 import { route } from 'preact-router';
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks';
-import { useApiHost, useConfig } from './api';
+import { useApiHost, useConfig } from '../api';
 
 export default function CameraMasks({ camera, url }) {
   const { data: config } = useConfig();


### PR DESCRIPTION
Without this, build fails:

```
> frigate@ build /opt/frigate
> cross-env NODE_ENV=production SNOWPACK_MODE=production SNOWPACK_PUBLIC_API_HOST='' snowpack build

[snowpack] ! building source files...
[snowpack] ✔ build complete [7.40s]
[snowpack] ! building dependencies...
[snowpack] ✔ dependencies ready! [0.97s]
[snowpack] ! verifying build...
[snowpack] ✔ verification complete [0.02s]
[snowpack] ! writing build to disk...
[snowpack] ! optimizing build...
 > dist/routes/CameraMap.js: error: Could not resolve "./api.js"
    8 │ import {useApiHost, useConfig} from "./api.js";
      ╵                                     ~~~~~~~~~~

1 error
[snowpack] Build failed with 1 error:
dist/routes/CameraMap.js:8:36: error: Could not resolve "./api.js"
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! frigate@ build: `cross-env NODE_ENV=production SNOWPACK_MODE=production SNOWPACK_PUBLIC_API_HOST='' snowpack build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the frigate@ build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-02-09T08_06_47_924Z-debug.log
The command '/bin/sh -c npm install && npm run build' returned a non-zero code: 1
make: *** [Makefile:9: web] Error 1
```

cc @paularmstrong 