### PR TITLE
docs: add contributing docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,32 +2,4 @@
 
 This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
 
-## Installation
-
-```console
-yarn install
-```
-
-## Local Development
-
-```console
-yarn start
-```
-
-This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
-
-## Build
-
-```console
-yarn build
-```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-## Deployment
-
-```console
-GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+For installation and contributing instructions, please follow the [Contributing Docs](https://blakeblackshear.github.io/frigate/contributing).

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -1,0 +1,131 @@
+---
+id: contributing
+title: Contributing
+---
+
+## Getting the source
+
+### Core, Web, Docker, and Documentation
+
+This repository holds the main Frigate application and all of its dependencies.
+
+Fork [blakeblackshear/frigate](https://github.com/blakeblackshear/frigate.git) to your own GitHub profile, then clone the forked repo to your local machine.
+
+From here, follow the guides for:
+
+- [Core](#core)
+- [Web Interface](#web-interface)
+- [Documentation](#documentation)
+
+### Frigate Home Assistant Addon
+
+This repository holds the Home Assistant Addon, for use with Home Assistant OS and compatible installations. It is the piece that allows you to run Frigate from your Home Assistant Supervisor tab.
+
+Fork [blakeblackshear/frigate-hass-addons](https://github.com/blakeblackshear/frigate-hass-addons) to your own Github profile, then clone the forked repo to your local machine.
+
+### Frigate Home Assistant Integration
+
+This repository holds the custom integration that allows your Home Assistant installation to automatically create entities for your Frigate instance, whether you run that with the [addon](#frigate-home-assistant-addon) or in a separate Docker instance.
+
+Fork [blakeblackshear/frigate-hass-integration](https://github.com/blakeblackshear/frigate-hass-integration) to your own GitHub profile, then clone the forked repo to your local machine.
+
+## Core
+
+### Prerequisites
+
+- [Frigate source code](#frigate-core-web-and-docs)
+- GNU make
+- Docker
+
+## Web Interface
+
+### Prerequisites
+
+- [Frigate source code](#frigate-core-web-and-docs)
+- All [core](#core) prerequisites _or_ another running Frigate instance locally available
+- Node.js 14
+
+### Making changes
+
+#### 1. Set up a Frigate instance
+
+The Web UI requires an instance of Frigate to interact with for all of its data. You can either run an instance locally (recommended) or attach to a separate instance accessible on your network.
+
+To run the local instance, follow the [core](#core) development instructions.
+
+If you won't be making any changes to the Frigate HTTP API, you can attach the web development server to any Frigate instance on your network. Skip this step and go to [3a](#3a-run-the-development-server-against-a-non-local-instance).
+
+#### 2. Install dependencies
+
+```console
+cd web && npm install
+```
+
+#### 3. Run the development server
+
+```console
+cd web && npm run start
+```
+
+#### 3a. Run the development server against a non-local instance
+
+To run the development server against a non-local instance, you will need to provide an environment variable, `SNOWPACK_PUBLIC_API_HOST` that tells the web application how to connect to the Frigate API:
+
+```console
+cd web && SNOWPACK_PUBLIC_API_HOST=http://<ip-address-to-your-frigate-instance>:5000 npm run start
+```
+
+#### 4. Making changes
+
+The Web UI is built using [Snowpack](https://www.snowpack.dev/), [Preact](https://preactjs.com), and [Tailwind CSS](https://tailwindcss.com).
+
+Light guidelines and advice:
+
+- Avoid adding more dependencies. The web UI intends to be lightweight and fast to load.
+- Do not make large sweeping changes. [Open a discussion on GitHub](https://github.com/blakeblackshear/frigate/discussions/new) for any large or architectural ideas.
+- Ensure `lint` passes. This command will ensure basic conformance to styles, applying as many automatic fixes as possible, including Prettier formatting.
+
+```console
+npm run lint
+```
+
+- Add to unit tests and ensure they pass. As much as possible, you should strive to _increase_ test coverage whenever making changes. This will help ensure features do not accidentally become broken in the future.
+
+```console
+npm run test
+```
+
+- Test in different browsers. Firefox, Chrome, and Safari all have different quirks that make them unique targets to interact with.
+
+## Documentation
+
+### Prerequisites
+
+- [Frigate source code](#frigate-core-web-and-docs)
+- Node.js 14
+
+### Making changes
+
+#### 1. Installation
+
+```console
+npm run install
+```
+
+#### 2. Local Development
+
+```console
+npm run start
+```
+
+This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
+
+The docs are built using [Docusaurus v2](https://v2.docusaurus.io). Please refer to the Docusaurus docs for more information on how to modify Frigate's documentation.
+
+#### 3. Build (optional)
+
+```console
+npm run build
+```
+
+This command generates static content into the `build` directory and can be served using any static contents hosting service.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -10,5 +10,6 @@ module.exports = {
       'configuration/advanced',
     ],
     Usage: ['usage/home-assistant', 'usage/web', 'usage/api', 'usage/mqtt'],
+    Development: ['contributing'],
   },
 };

--- a/web/README.md
+++ b/web/README.md
@@ -1,8 +1,3 @@
 # Frigate Web UI
 
-## Development
-
-1. Build the docker images in the root of the repository `make amd64_all` (or appropriate for your system)
-2. Create a config file in `config/`
-3. Run the container: `docker run --rm --name frigate --privileged -v $PWD/config:/config:ro -v /etc/localtime:/etc/localtime:ro -p 5000:5000 frigate`
-4. Run the dev ui: `cd web && npm run start`
+For installation and contributing instructions, please follow the [Contributing Docs](https://blakeblackshear.github.io/frigate/contributing).

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "start": "cross-env SNOWPACK_PUBLIC_API_HOST=http://localhost:5000 snowpack dev",
+    "start:custom": "snowpack dev",
     "prebuild": "rimraf build",
     "build": "snowpack build"
   },


### PR DESCRIPTION
Hoping to get more people involved, I wanted to make sure it was written out how to get things running. I intentionally left the *Core* section blank, as I'm not familiar with the recommended way to go about it. I have some roundabout steps that I take, but maybe there are easier bits.

![localhost_3000_frigate_contributing](https://user-images.githubusercontent.com/33297/107822002-40ed0680-6d32-11eb-9edd-106fdee838a8.png)
