### PR TITLE
feat(web): use new websockets endpoint as mqtt bridge

### DIFF
--- a/frigate/http.py
+++ b/frigate/http.py
@@ -43,7 +43,7 @@ class MqttBackend():
             json_message = json.loads(message)
             json_message = {
                 'topic': f"{self.topic_prefix}/{json_message['topic']}",
-                'payload': json_message.get['payload'],
+                'payload': json_message['payload'],
                 'retain': json_message.get('retain', False)
             }
         except:
@@ -73,7 +73,7 @@ class MqttBackend():
                 except:
                     logger.debug("Removing websocket client due to a closed connection.")
                     self.clients.remove(client)
-        
+
         self.mqtt_client.message_callback_add(f"{self.topic_prefix}/#", send)
 
     def start(self):

--- a/web/config/setupTests.js
+++ b/web/config/setupTests.js
@@ -15,10 +15,4 @@ Object.defineProperty(window, 'matchMedia', {
 
 window.fetch = () => Promise.resolve();
 
-beforeEach(() => {
-  jest.spyOn(window, 'fetch').mockImplementation(async (url, opts = {}) => {
-    throw new Error(`Unexpected fetch to ${url}, ${JSON.stringify(opts)}`);
-  });
-});
-
 jest.mock('../src/env');

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -16,6 +16,7 @@
   <body>
     <div id="root" class="z-0"></div>
     <div id="menus" class="z-0"></div>
+    <div id="tooltips" class="z-0"></div>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script type="module" src="/dist/index.js"></script>
   </body>

--- a/web/src/api/__tests__/mqtt.test.jsx
+++ b/web/src/api/__tests__/mqtt.test.jsx
@@ -1,0 +1,109 @@
+import { h } from 'preact';
+import { Mqtt, MqttProvider, useMqtt } from '../mqtt';
+import { useCallback, useContext } from 'preact/hooks';
+import { fireEvent, render, screen } from '@testing-library/preact';
+
+function Test() {
+  const { state } = useContext(Mqtt);
+  return state.__connected ? (
+    <div data-testid="data">
+      {Object.keys(state).map((key) => (
+        <div data-testid={key}>{JSON.stringify(state[key])}</div>
+      ))}
+    </div>
+  ) : null;
+}
+
+const TEST_URL = 'ws://test-foo:1234/ws';
+
+describe('MqttProvider', () => {
+  let createWebsocket, wsClient;
+  beforeEach(() => {
+    wsClient = {
+      close: jest.fn(),
+      send: jest.fn(),
+    };
+    createWebsocket = jest.fn((url) => {
+      wsClient.args = [url];
+      return new Proxy(
+        {},
+        {
+          get(target, prop, receiver) {
+            return wsClient[prop];
+          },
+          set(target, prop, value) {
+            wsClient[prop] = typeof value === 'function' ? jest.fn(value) : value;
+            if (prop === 'onopen') {
+              wsClient[prop]();
+            }
+            return true;
+          },
+        }
+      );
+    });
+  });
+
+  test('connects to the mqtt server', async () => {
+    render(
+      <MqttProvider createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
+        <Test />
+      </MqttProvider>
+    );
+    await screen.findByTestId('data');
+    expect(wsClient.args).toEqual([TEST_URL]);
+    expect(screen.getByTestId('__connected')).toHaveTextContent('true');
+  });
+
+  test('receives data through useMqtt', async () => {
+    function Test() {
+      const {
+        value: { payload, retain },
+        connected,
+      } = useMqtt('tacos');
+      return connected ? (
+        <div>
+          <div data-testid="payload">{JSON.stringify(payload)}</div>
+          <div data-testid="retain">{JSON.stringify(retain)}</div>
+        </div>
+      ) : null;
+    }
+
+    const { rerender } = render(
+      <MqttProvider createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
+        <Test />
+      </MqttProvider>
+    );
+    await screen.findByTestId('payload');
+    wsClient.onmessage({
+      data: JSON.stringify({ topic: 'tacos', payload: JSON.stringify({ yes: true }), retain: false }),
+    });
+    rerender(
+      <MqttProvider createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
+        <Test />
+      </MqttProvider>
+    );
+    expect(screen.getByTestId('payload')).toHaveTextContent('{"yes":true}');
+    expect(screen.getByTestId('retain')).toHaveTextContent('false');
+  });
+
+  test('can send values through useMqtt', async () => {
+    function Test() {
+      const { send, connected } = useMqtt('tacos');
+      const handleClick = useCallback(() => {
+        send({ yes: true });
+      }, [send]);
+      return connected ? <button onClick={handleClick}>click me</button> : null;
+    }
+
+    render(
+      <MqttProvider createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
+        <Test />
+      </MqttProvider>
+    );
+    await screen.findByRole('button');
+    fireEvent.click(screen.getByRole('button'));
+    await expect(wsClient.send).toHaveBeenCalledWith(
+      JSON.stringify({ topic: 'tacos', payload: JSON.stringify({ yes: true }) })
+    );
+  });
+});

--- a/web/src/api/__tests__/mqtt.test.jsx
+++ b/web/src/api/__tests__/mqtt.test.jsx
@@ -45,7 +45,7 @@ describe('MqttProvider', () => {
 
   test('connects to the mqtt server', async () => {
     render(
-      <MqttProvider createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
+      <MqttProvider config={mockConfig} createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
         <Test />
       </MqttProvider>
     );
@@ -69,7 +69,7 @@ describe('MqttProvider', () => {
     }
 
     const { rerender } = render(
-      <MqttProvider createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
+      <MqttProvider config={mockConfig} createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
         <Test />
       </MqttProvider>
     );
@@ -78,7 +78,7 @@ describe('MqttProvider', () => {
       data: JSON.stringify({ topic: 'tacos', payload: JSON.stringify({ yes: true }), retain: false }),
     });
     rerender(
-      <MqttProvider createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
+      <MqttProvider config={mockConfig} createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
         <Test />
       </MqttProvider>
     );
@@ -96,7 +96,7 @@ describe('MqttProvider', () => {
     }
 
     render(
-      <MqttProvider createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
+      <MqttProvider config={mockConfig} createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
         <Test />
       </MqttProvider>
     );
@@ -106,4 +106,30 @@ describe('MqttProvider', () => {
       JSON.stringify({ topic: 'tacos', payload: JSON.stringify({ yes: true }) })
     );
   });
+
+  test('prefills the clips/detect/snapshots state from config', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(123456);
+    const config = {
+      cameras: {
+        front: { name: 'front', detect: { enabled: true }, clips: { enabled: false }, snapshots: { enabled: true } },
+        side: { name: 'side', detect: { enabled: false }, clips: { enabled: false }, snapshots: { enabled: false } },
+      },
+    };
+    render(
+      <MqttProvider config={config} createWebsocket={createWebsocket} mqttUrl={TEST_URL}>
+        <Test />
+      </MqttProvider>
+    );
+    await screen.findByTestId('data');
+    expect(screen.getByTestId('front/detect/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"ON"}');
+    expect(screen.getByTestId('front/clips/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"OFF"}');
+    expect(screen.getByTestId('front/snapshots/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"ON"}');
+    expect(screen.getByTestId('side/detect/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"OFF"}');
+    expect(screen.getByTestId('side/clips/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"OFF"}');
+    expect(screen.getByTestId('side/snapshots/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"OFF"}');
+  });
 });
+
+const mockConfig = {
+  cameras: {},
+};

--- a/web/src/api/baseUrl.js
+++ b/web/src/api/baseUrl.js
@@ -1,2 +1,2 @@
 import { API_HOST } from '../env';
-export const baseUrl = API_HOST || window.baseUrl || '';
+export const baseUrl = API_HOST || window.baseUrl || `${window.location.protocol}//${window.location.host}`;

--- a/web/src/api/index.jsx
+++ b/web/src/api/index.jsx
@@ -1,5 +1,6 @@
 import { baseUrl } from './baseUrl';
 import { h, createContext } from 'preact';
+import { MqttProvider } from './mqtt';
 import produce from 'immer';
 import { useContext, useEffect, useReducer } from 'preact/hooks';
 
@@ -41,7 +42,11 @@ function reducer(state, { type, payload, meta }) {
 
 export const ApiProvider = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
-  return <Api.Provider value={{ state, dispatch }}>{children}</Api.Provider>;
+  return (
+    <Api.Provider value={{ state, dispatch }}>
+      <MqttProvider>{children}</MqttProvider>
+    </Api.Provider>
+  );
 };
 
 function shouldFetch(state, url, fetchId = null) {

--- a/web/src/api/index.jsx
+++ b/web/src/api/index.jsx
@@ -40,14 +40,19 @@ function reducer(state, { type, payload, meta }) {
   }
 }
 
-export const ApiProvider = ({ children }) => {
+export function ApiProvider({ children }) {
   const [state, dispatch] = useReducer(reducer, initialState);
   return (
     <Api.Provider value={{ state, dispatch }}>
-      <MqttProvider>{children}</MqttProvider>
+      <MqttWithConfig>{children}</MqttWithConfig>
     </Api.Provider>
   );
-};
+}
+
+function MqttWithConfig({ children }) {
+  const { data, status } = useConfig();
+  return status === FetchStatus.LOADED ? <MqttProvider config={data}>{children}</MqttProvider> : children;
+}
 
 function shouldFetch(state, url, fetchId = null) {
   if ((fetchId && url in state.queries && state.queries[url].fetchId !== fetchId) || !(url in state.queries)) {

--- a/web/src/api/mqtt.jsx
+++ b/web/src/api/mqtt.jsx
@@ -1,0 +1,78 @@
+import { h, createContext } from 'preact';
+import { baseUrl } from './baseUrl';
+import produce from 'immer';
+import { useCallback, useContext, useEffect, useRef, useReducer } from 'preact/hooks';
+
+const initialState = Object.freeze({ __connected: false });
+export const Mqtt = createContext({ state: initialState, connection: null });
+
+const defaultCreateWebsocket = (url) => new WebSocket(url);
+
+function reducer(state, { topic, payload, retain }) {
+  switch (topic) {
+    case '__CLIENT_CONNECTED':
+      return produce(state, (draftState) => {
+        draftState.__connected = true;
+      });
+
+    default:
+      return produce(state, (draftState) => {
+        let parsedPayload = payload;
+        try {
+          parsedPayload = payload && JSON.parse(payload);
+        } catch (e) {}
+        draftState[topic] = {
+          lastUpdate: Date.now(),
+          payload: parsedPayload,
+          retain,
+        };
+      });
+  }
+}
+
+export function MqttProvider({
+  children,
+  createWebsocket = defaultCreateWebsocket,
+  mqttUrl = `${baseUrl.replace(/^https?:/, 'ws:')}/ws`,
+}) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const wsRef = useRef();
+
+  useEffect(
+    () => {
+      const ws = createWebsocket(mqttUrl);
+      ws.onopen = () => {
+        dispatch({ topic: '__CLIENT_CONNECTED' });
+      };
+
+      ws.onmessage = (event) => {
+        dispatch(JSON.parse(event.data));
+      };
+
+      wsRef.current = ws;
+
+      return () => {
+        ws.close(3000, 'Provider destroyed');
+      };
+    },
+    // Forces reconnecting
+    [state.__reconnectAttempts, mqttUrl] // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  return <Mqtt.Provider value={{ state, ws: wsRef.current }}>{children}</Mqtt.Provider>;
+}
+
+export function useMqtt(topic) {
+  const { state, ws } = useContext(Mqtt);
+
+  const value = state[topic] || { payload: null };
+
+  const send = useCallback(
+    (payload) => {
+      ws.send(JSON.stringify({ topic, payload: typeof payload !== 'string' ? JSON.stringify(payload) : payload }));
+    },
+    [ws, topic]
+  );
+
+  return { value, send, connected: state.__connected };
+}

--- a/web/src/components/Button.jsx
+++ b/web/src/components/Button.jsx
@@ -1,4 +1,6 @@
-import { h } from 'preact';
+import { h, Fragment } from 'preact';
+import Tooltip from './Tooltip';
+import { useCallback, useRef, useState } from 'preact/hooks';
 
 const ButtonColors = {
   blue: {
@@ -21,6 +23,13 @@ const ButtonColors = {
       'text-green-500 border-2 border-green-500 hover:bg-green-500 hover:bg-opacity-20 focus:bg-green-500 focus:bg-opacity-40 active:bg-green-500 active:bg-opacity-40',
     text:
       'text-green-500 hover:bg-green-500 hover:bg-opacity-20 focus:bg-green-500 focus:bg-opacity-40 active:bg-green-500 active:bg-opacity-40',
+  },
+  gray: {
+    contained: 'bg-gray-500 focus:bg-gray-400 active:bg-gray-600 ring-gray-300',
+    outlined:
+      'text-gray-500 border-2 border-gray-500 hover:bg-gray-500 hover:bg-opacity-20 focus:bg-gray-500 focus:bg-opacity-40 active:bg-gray-500 active:bg-opacity-40',
+    text:
+      'text-gray-500 hover:bg-gray-500 hover:bg-opacity-20 focus:bg-gray-500 focus:bg-opacity-40 active:bg-gray-500 active:bg-opacity-40',
   },
   disabled: {
     contained: 'bg-gray-400',
@@ -52,6 +61,9 @@ export default function Button({
   type = 'contained',
   ...attrs
 }) {
+  const [hovered, setHovered] = useState(false);
+  const ref = useRef();
+
   let classes = `whitespace-nowrap flex items-center space-x-1 ${className} ${ButtonTypes[type]} ${
     ButtonColors[disabled ? 'disabled' : color][type]
   } font-sans inline-flex font-bold uppercase text-xs px-2 py-2 rounded outline-none focus:outline-none ring-opacity-50 transition-shadow transition-colors ${
@@ -62,18 +74,32 @@ export default function Button({
     classes = classes.replace(/(?:focus|active|hover):[^ ]+/g, '');
   }
 
+  const handleMousenter = useCallback((event) => {
+    setHovered(true);
+  }, []);
+
+  const handleMouseleave = useCallback((event) => {
+    setHovered(false);
+  }, []);
+
   const Element = href ? 'a' : 'div';
 
   return (
-    <Element
-      role="button"
-      aria-disabled={disabled ? 'true' : 'false'}
-      tabindex="0"
-      className={classes}
-      href={href}
-      {...attrs}
-    >
-      {children}
-    </Element>
+    <Fragment>
+      <Element
+        role="button"
+        aria-disabled={disabled ? 'true' : 'false'}
+        tabindex="0"
+        className={classes}
+        href={href}
+        ref={ref}
+        onmouseenter={handleMousenter}
+        onmouseleave={handleMouseleave}
+        {...attrs}
+      >
+        {children}
+      </Element>
+      {hovered && attrs['aria-label'] ? <Tooltip text={attrs['aria-label']} relativeTo={ref} /> : null}
+    </Fragment>
   );
 }

--- a/web/src/components/Card.jsx
+++ b/web/src/components/Card.jsx
@@ -9,6 +9,7 @@ export default function Box({
   elevated = true,
   header,
   href,
+  icons = [],
   media = null,
   ...props
 }) {
@@ -26,14 +27,20 @@ export default function Box({
           <div className="p-4 pb-2">{header ? <Heading size="base">{header}</Heading> : null}</div>
         </Element>
       ) : null}
-      {buttons.length || content ? (
-        <div className="pl-4 pb-2">
+      {buttons.length || content || icons.length ? (
+        <div className="px-4 pb-2">
           {content || null}
           {buttons.length ? (
             <div className="flex space-x-4 -ml-2">
               {buttons.map(({ name, href }) => (
                 <Button key={name} href={href} type="text">
                   {name}
+                </Button>
+              ))}
+              <div class="flex-grow" />
+              {icons.map(({ name, icon: Icon, ...props }) => (
+                <Button aria-label={name} className="rounded-full" key={name} type="text" {...props}>
+                  <Icon className="w-6" />
                 </Button>
               ))}
             </div>

--- a/web/src/components/Tooltip.jsx
+++ b/web/src/components/Tooltip.jsx
@@ -1,0 +1,61 @@
+import { h } from 'preact';
+import { createPortal } from 'preact/compat';
+import { useEffect, useRef, useState } from 'preact/hooks';
+
+const TIP_SPACE = 20;
+
+export default function Tooltip({ relativeTo, text }) {
+  const [position, setPosition] = useState({ top: -Infinity, left: -Infinity });
+  const portalRoot = document.getElementById('tooltips');
+  const ref = useRef();
+
+  useEffect(() => {
+    if (ref && ref.current && relativeTo && relativeTo.current) {
+      const windowWidth = window.innerWidth;
+      const {
+        x: relativeToX,
+        y: relativeToY,
+        width: relativeToWidth,
+        height: relativeToHeight,
+      } = relativeTo.current.getBoundingClientRect();
+      const { width: tipWidth, height: tipHeight } = ref.current.getBoundingClientRect();
+
+      const left = relativeToX + Math.round(relativeToWidth / 2) + window.scrollX;
+      const top = relativeToY + Math.round(relativeToHeight / 2) + window.scrollY;
+
+      let newTop = top - TIP_SPACE - tipHeight;
+      let newLeft = left - Math.round(tipWidth / 2);
+      // too far right
+      if (newLeft + tipWidth + TIP_SPACE > windowWidth - window.scrollX) {
+        newLeft = left - tipWidth - TIP_SPACE;
+        newTop = top - Math.round(tipHeight / 2);
+      }
+      // too far left
+      else if (newLeft < TIP_SPACE + window.scrollX) {
+        newLeft = left + TIP_SPACE;
+        newTop = top - Math.round(tipHeight / 2);
+      }
+      // too close to top
+      else if (newTop <= TIP_SPACE + window.scrollY) {
+        newTop = top + tipHeight + TIP_SPACE;
+      }
+
+      setPosition({ left: newLeft, top: newTop });
+    }
+  }, [relativeTo, ref]);
+
+  const tooltip = (
+    <div
+      role="tooltip"
+      className={`shadow max-w-lg absolute pointer-events-none bg-gray-900 dark:bg-gray-200 bg-opacity-80 rounded px-2 py-1 transition-opacity duration-200 opacity-0 text-gray-100 dark:text-gray-900 text-sm ${
+        position.top >= 0 ? 'opacity-100' : ''
+      }`}
+      ref={ref}
+      style={position.top >= 0 ? position : null}
+    >
+      {text}
+    </div>
+  );
+
+  return portalRoot ? createPortal(tooltip, portalRoot) : tooltip;
+}

--- a/web/src/components/__tests__/Toolltip.test.jsx
+++ b/web/src/components/__tests__/Toolltip.test.jsx
@@ -1,0 +1,115 @@
+import { h, createRef } from 'preact';
+import Tooltip from '../Tooltip';
+import { render, screen } from '@testing-library/preact';
+
+describe('Tooltip', () => {
+  test('renders in a relative position', async () => {
+    jest
+      .spyOn(window.HTMLElement.prototype, 'getBoundingClientRect')
+      // relativeTo
+      .mockReturnValueOnce({
+        x: 100,
+        y: 100,
+        width: 50,
+        height: 10,
+      })
+      // tooltip
+      .mockReturnValueOnce({ width: 40, height: 15 });
+
+    const ref = createRef();
+    render(
+      <div>
+        <div ref={ref} />
+        <Tooltip relativeTo={ref} text="hello" />
+      </div>
+    );
+
+    const tooltip = await screen.findByRole('tooltip');
+    const style = window.getComputedStyle(tooltip);
+    expect(style.left).toEqual('105px');
+    expect(style.top).toEqual('70px');
+  });
+
+  test('if too far right, renders to the left', async () => {
+    window.innerWidth = 1024;
+    jest
+      .spyOn(window.HTMLElement.prototype, 'getBoundingClientRect')
+      // relativeTo
+      .mockReturnValueOnce({
+        x: 1000,
+        y: 100,
+        width: 24,
+        height: 10,
+      })
+      // tooltip
+      .mockReturnValueOnce({ width: 50, height: 15 });
+
+    const ref = createRef();
+    render(
+      <div>
+        <div ref={ref} />
+        <Tooltip relativeTo={ref} text="hello" />
+      </div>
+    );
+
+    const tooltip = await screen.findByRole('tooltip');
+    const style = window.getComputedStyle(tooltip);
+    expect(style.left).toEqual('942px');
+    expect(style.top).toEqual('97px');
+  });
+
+  test('if too far left, renders to the right', async () => {
+    jest
+      .spyOn(window.HTMLElement.prototype, 'getBoundingClientRect')
+      // relativeTo
+      .mockReturnValueOnce({
+        x: 0,
+        y: 100,
+        width: 24,
+        height: 10,
+      })
+      // tooltip
+      .mockReturnValueOnce({ width: 50, height: 15 });
+
+    const ref = createRef();
+    render(
+      <div>
+        <div ref={ref} />
+        <Tooltip relativeTo={ref} text="hello" />
+      </div>
+    );
+
+    const tooltip = await screen.findByRole('tooltip');
+    const style = window.getComputedStyle(tooltip);
+    expect(style.left).toEqual('32px');
+    expect(style.top).toEqual('97px');
+  });
+
+  test('if too close to top, renders to the bottom', async () => {
+    window.scrollY = 90;
+    jest
+      .spyOn(window.HTMLElement.prototype, 'getBoundingClientRect')
+      // relativeTo
+      .mockReturnValueOnce({
+        x: 100,
+        y: 100,
+        width: 24,
+        height: 10,
+      })
+      // tooltip
+      .mockReturnValueOnce({ width: 50, height: 15 });
+
+    const ref = createRef();
+    render(
+      <div>
+        <div ref={ref} />
+        <Tooltip relativeTo={ref} text="hello" />
+      </div>
+    );
+
+    const tooltip = await screen.findByRole('tooltip');
+    const style = window.getComputedStyle(tooltip);
+    expect(style.left).toEqual('87px');
+    expect(style.top).toEqual('160px');
+  });
+});

--- a/web/src/icons/Clip.jsx
+++ b/web/src/icons/Clip.jsx
@@ -1,0 +1,13 @@
+import { h } from 'preact';
+import { memo } from 'preact/compat';
+
+export function Clip({ className = '' }) {
+  return (
+    <svg className={`fill-current ${className}`} viewBox="0 0 24 24">
+      <path d="M0 0h24v24H0z" fill="none" />
+      <path d="M18 3v2h-2V3H8v2H6V3H4v18h2v-2h2v2h8v-2h2v2h2V3h-2zM8 17H6v-2h2v2zm0-4H6v-2h2v2zm0-4H6V7h2v2zm10 8h-2v-2h2v2zm0-4h-2v-2h2v2zm0-4h-2V7h2v2z" />
+    </svg>
+  );
+}
+
+export default memo(Clip);

--- a/web/src/icons/Motion.jsx
+++ b/web/src/icons/Motion.jsx
@@ -1,0 +1,12 @@
+import { h } from 'preact';
+import { memo } from 'preact/compat';
+
+export function Motion({ className = '' }) {
+  return (
+    <svg className={`fill-current ${className}`} viewBox="0 0 24 24">
+      <path d="M13.5 5.5c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zM9.8 8.9L7 23h2.1l1.8-8 2.1 2v6h2v-7.5l-2.1-2 .6-3C14.8 12 16.8 13 19 13v-2c-1.9 0-3.5-1-4.3-2.4l-1-1.6c-.4-.6-1-1-1.7-1-.3 0-.5.1-.8.1L6 8.3V13h2V9.6l1.8-.7" />
+    </svg>
+  );
+}
+
+export default memo(Motion);

--- a/web/src/icons/Snapshot.jsx
+++ b/web/src/icons/Snapshot.jsx
@@ -1,0 +1,14 @@
+import { h } from 'preact';
+import { memo } from 'preact/compat';
+
+export function Snapshot({ className = '' }) {
+  return (
+    <svg className={`fill-current ${className}`} viewBox="0 0 24 24">
+      <path d="M0 0h24v24H0z" fill="none" />
+      <circle cx="12" cy="12" r="3.2" />
+      <path d="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z" />
+    </svg>
+  );
+}
+
+export default memo(Snapshot);

--- a/web/src/routes/Cameras.jsx
+++ b/web/src/routes/Cameras.jsx
@@ -2,6 +2,10 @@ import { h } from 'preact';
 import ActivityIndicator from '../components/ActivityIndicator';
 import Card from '../components/Card';
 import CameraImage from '../components/CameraImage';
+import ClipIcon from '../icons/Clip';
+import MotionIcon from '../icons/Motion';
+import SnapshotIcon from '../icons/Snapshot';
+import { useDetectState, useClipsState, useSnapshotsState } from '../api/mqtt';
 import { useConfig, FetchStatus } from '../api';
 import { useMemo } from 'preact/hooks';
 
@@ -20,8 +24,42 @@ export default function Cameras() {
 }
 
 function Camera({ name }) {
+  const { payload: detectValue, send: sendDetect } = useDetectState(name);
+  const { payload: clipValue, send: sendClips } = useClipsState(name);
+  const { payload: snapshotValue, send: sendSnapshots } = useSnapshotsState(name);
   const href = `/cameras/${name}`;
   const buttons = useMemo(() => [{ name: 'Events', href: `/events?camera=${name}` }], [name]);
+  const icons = useMemo(
+    () => [
+      {
+        name: `Toggle detect ${detectValue === 'ON' ? 'off' : 'on'}`,
+        icon: MotionIcon,
+        color: detectValue === 'ON' ? 'blue' : 'gray',
+        onClick: () => {
+          sendDetect(detectValue === 'ON' ? 'OFF' : 'ON');
+        },
+      },
+      {
+        name: `Toggle clips ${clipValue === 'ON' ? 'off' : 'on'}`,
+        icon: ClipIcon,
+        color: clipValue === 'ON' ? 'blue' : 'gray',
+        onClick: () => {
+          sendClips(clipValue === 'ON' ? 'OFF' : 'ON');
+        },
+      },
+      {
+        name: `Toggle snapshots ${snapshotValue === 'ON' ? 'off' : 'on'}`,
+        icon: SnapshotIcon,
+        color: snapshotValue === 'ON' ? 'blue' : 'gray',
+        onClick: () => {
+          sendSnapshots(snapshotValue === 'ON' ? 'OFF' : 'ON');
+        },
+      },
+    ],
+    [detectValue, sendDetect, clipValue, sendClips, snapshotValue, sendSnapshots]
+  );
 
-  return <Card buttons={buttons} href={href} header={name} media={<CameraImage camera={name} stretch />} />;
+  return (
+    <Card buttons={buttons} href={href} header={name} icons={icons} media={<CameraImage camera={name} stretch />} />
+  );
 }

--- a/web/src/routes/Debug.jsx
+++ b/web/src/routes/Debug.jsx
@@ -14,7 +14,7 @@ export default function Debug() {
   const { data: config } = useConfig();
 
   const {
-    value: { stats },
+    value: { payload: stats },
   } = useMqtt('stats');
   const { data: initialStats } = useStats();
 

--- a/web/src/routes/Debug.jsx
+++ b/web/src/routes/Debug.jsx
@@ -1,36 +1,24 @@
-import { h } from 'preact';
+import { h, Fragment } from 'preact';
 import ActivityIndicator from '../components/ActivityIndicator';
 import Button from '../components/Button';
 import Heading from '../components/Heading';
 import Link from '../components/Link';
+import { useMqtt } from '../api/mqtt';
 import { useConfig, useStats } from '../api';
 import { Table, Tbody, Thead, Tr, Th, Td } from '../components/Table';
-import { useCallback, useEffect, useState } from 'preact/hooks';
+import { useCallback } from 'preact/hooks';
 
 const emptyObject = Object.freeze({});
 
 export default function Debug() {
-  const config = useConfig();
+  const { data: config } = useConfig();
 
-  const [timeoutId, setTimeoutId] = useState(null);
-  const { data: stats } = useStats(null, timeoutId);
+  const {
+    value: { stats },
+  } = useMqtt('stats');
+  const { data: initialStats } = useStats();
 
-  const forceUpdate = useCallback(() => {
-    const timeoutId = setTimeout(forceUpdate, 1000);
-    setTimeoutId(timeoutId);
-  }, []);
-
-  useEffect(() => {
-    forceUpdate();
-  }, [forceUpdate]);
-
-  useEffect(() => {
-    return () => {
-      clearTimeout(timeoutId);
-    };
-  }, [timeoutId]);
-
-  const { detectors, service, detection_fps, ...cameras } = stats || emptyObject;
+  const { detectors, service = {}, detection_fps, ...cameras } = stats || initialStats || emptyObject;
 
   const detectorNames = Object.keys(detectors || emptyObject);
   const detectorDataKeys = Object.keys(detectors ? detectors[detectorNames[0]] : emptyObject);
@@ -44,61 +32,69 @@ export default function Debug() {
     copy();
   }, [config]);
 
-  return stats === null ? (
-    <ActivityIndicator />
-  ) : (
+  return (
     <div className="space-y-4">
       <Heading>
         Debug <span className="text-sm">{service.version}</span>
       </Heading>
 
-      <div data-testid="detectors" className="min-w-0 overflow-auto">
-        <Table className="w-full">
-          <Thead>
-            <Tr>
-              <Th>detector</Th>
-              {detectorDataKeys.map((name) => (
-                <Th>{name.replace('_', ' ')}</Th>
-              ))}
-            </Tr>
-          </Thead>
-          <Tbody>
-            {detectorNames.map((detector, i) => (
-              <Tr index={i}>
-                <Td>{detector}</Td>
-                {detectorDataKeys.map((name) => (
-                  <Td key={`${name}-${detector}`}>{detectors[detector][name]}</Td>
+      {!detectors ? (
+        <div>
+          <ActivityIndicator />
+        </div>
+      ) : (
+        <Fragment>
+          <div data-testid="detectors" className="min-w-0 overflow-auto">
+            <Table className="w-full">
+              <Thead>
+                <Tr>
+                  <Th>detector</Th>
+                  {detectorDataKeys.map((name) => (
+                    <Th>{name.replace('_', ' ')}</Th>
+                  ))}
+                </Tr>
+              </Thead>
+              <Tbody>
+                {detectorNames.map((detector, i) => (
+                  <Tr index={i}>
+                    <Td>{detector}</Td>
+                    {detectorDataKeys.map((name) => (
+                      <Td key={`${name}-${detector}`}>{detectors[detector][name]}</Td>
+                    ))}
+                  </Tr>
                 ))}
-              </Tr>
-            ))}
-          </Tbody>
-        </Table>
-      </div>
+              </Tbody>
+            </Table>
+          </div>
 
-      <div data-testid="cameras" className="min-w-0 overflow-auto">
-        <Table className="w-full">
-          <Thead>
-            <Tr>
-              <Th>camera</Th>
-              {cameraDataKeys.map((name) => (
-                <Th>{name.replace('_', ' ')}</Th>
-              ))}
-            </Tr>
-          </Thead>
-          <Tbody>
-            {cameraNames.map((camera, i) => (
-              <Tr index={i}>
-                <Td>
-                  <Link href={`/cameras/${camera}`}>{camera}</Link>
-                </Td>
-                {cameraDataKeys.map((name) => (
-                  <Td key={`${name}-${camera}`}>{cameras[camera][name]}</Td>
+          <div data-testid="cameras" className="min-w-0 overflow-auto">
+            <Table className="w-full">
+              <Thead>
+                <Tr>
+                  <Th>camera</Th>
+                  {cameraDataKeys.map((name) => (
+                    <Th>{name.replace('_', ' ')}</Th>
+                  ))}
+                </Tr>
+              </Thead>
+              <Tbody>
+                {cameraNames.map((camera, i) => (
+                  <Tr index={i}>
+                    <Td>
+                      <Link href={`/cameras/${camera}`}>{camera}</Link>
+                    </Td>
+                    {cameraDataKeys.map((name) => (
+                      <Td key={`${name}-${camera}`}>{cameras[camera][name]}</Td>
+                    ))}
+                  </Tr>
                 ))}
-              </Tr>
-            ))}
-          </Tbody>
-        </Table>
-      </div>
+              </Tbody>
+            </Table>
+          </div>
+
+          <p>Debug stats update automatically every {config.mqtt.stats_interval} seconds.</p>
+        </Fragment>
+      )}
 
       <div className="relative">
         <Heading size="sm">Config</Heading>

--- a/web/src/routes/StyleGuide.jsx
+++ b/web/src/routes/StyleGuide.jsx
@@ -25,6 +25,7 @@ export default function StyleGuide() {
         <Button>Default</Button>
         <Button color="red">Danger</Button>
         <Button color="green">Save</Button>
+        <Button color="gray">Gray</Button>
         <Button disabled>Disabled</Button>
       </div>
       <div className="flex space-x-4 mb-4">
@@ -34,6 +35,9 @@ export default function StyleGuide() {
         </Button>
         <Button color="green" type="text">
           Save
+        </Button>
+        <Button color="gray" type="text">
+          Gray
         </Button>
         <Button disabled type="text">
           Disabled
@@ -46,6 +50,9 @@ export default function StyleGuide() {
         </Button>
         <Button color="green" type="outlined">
           Save
+        </Button>
+        <Button color="gray" type="outlined">
+          Gray
         </Button>
         <Button disabled type="outlined">
           Disabled

--- a/web/src/routes/__tests__/Cameras.test.jsx
+++ b/web/src/routes/__tests__/Cameras.test.jsx
@@ -1,8 +1,9 @@
 import { h } from 'preact';
 import * as Api from '../../api';
-import Cameras from '../Cameras';
 import * as CameraImage from '../../components/CameraImage';
-import { render, screen } from '@testing-library/preact';
+import * as Mqtt from '../../api/mqtt';
+import Cameras from '../Cameras';
+import { fireEvent, render, screen } from '@testing-library/preact';
 
 describe('Cameras Route', () => {
   let useConfigMock;
@@ -19,6 +20,7 @@ describe('Cameras Route', () => {
     }));
     jest.spyOn(Api, 'useApiHost').mockImplementation(() => 'http://base-url.local:5000');
     jest.spyOn(CameraImage, 'default').mockImplementation(() => <div data-testid="camera-image" />);
+    jest.spyOn(Mqtt, 'useMqtt').mockImplementation(() => ({ value: { payload: 'OFF' }, send: jest.fn() }));
   });
 
   test('shows an ActivityIndicator if not yet loaded', async () => {
@@ -37,5 +39,36 @@ describe('Cameras Route', () => {
 
     expect(screen.queryByText('side')).toBeInTheDocument();
     expect(screen.queryByText('side').closest('a')).toHaveAttribute('href', '/cameras/side');
+  });
+
+  test('buttons toggle detect, clips, and snapshots', async () => {
+    const sendDetect = jest.fn();
+    const sendClips = jest.fn();
+    const sendSnapshots = jest.fn();
+    jest.spyOn(Mqtt, 'useDetectState').mockImplementation(() => {
+      return { payload: 'ON', send: sendDetect };
+    });
+    jest.spyOn(Mqtt, 'useClipsState').mockImplementation(() => {
+      return { payload: 'OFF', send: sendClips };
+    });
+    jest.spyOn(Mqtt, 'useSnapshotsState').mockImplementation(() => {
+      return { payload: 'ON', send: sendSnapshots };
+    });
+
+    render(<Cameras />);
+
+    fireEvent.click(screen.getAllByLabelText('Toggle detect off')[0]);
+    expect(sendDetect).toHaveBeenCalledWith('OFF');
+    expect(sendDetect).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getAllByLabelText('Toggle snapshots off')[0]);
+    expect(sendSnapshots).toHaveBeenCalledWith('OFF');
+
+    fireEvent.click(screen.getAllByLabelText('Toggle clips on')[0]);
+    expect(sendClips).toHaveBeenCalledWith('ON');
+
+    expect(sendDetect).toHaveBeenCalledTimes(1);
+    expect(sendSnapshots).toHaveBeenCalledTimes(1);
+    expect(sendClips).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/routes/__tests__/Debug.test.jsx
+++ b/web/src/routes/__tests__/Debug.test.jsx
@@ -1,10 +1,11 @@
 import { h } from 'preact';
 import * as Api from '../../api';
+import * as Mqtt from '../../api/mqtt';
 import Debug from '../Debug';
 import { render, screen } from '@testing-library/preact';
 
 describe('Debug Route', () => {
-  let useStatsMock;
+  let useStatsMock, useMqttMock;
 
   beforeEach(() => {
     jest.spyOn(Api, 'useConfig').mockImplementation(() => ({
@@ -16,10 +17,14 @@ describe('Debug Route', () => {
           front: { name: 'front', objects: { track: ['taco', 'cat', 'dog'] } },
           side: { name: 'side', objects: { track: ['taco', 'cat', 'dog'] } },
         },
+        mqtt: {
+          stats_interva: 60,
+        },
       },
       status: 'loaded',
     }));
-    useStatsMock = jest.spyOn(Api, 'useStats').mockImplementation(() => statsMock);
+    useStatsMock = jest.spyOn(Api, 'useStats').mockImplementation(() => ({ data: statsMock }));
+    useMqttMock = jest.spyOn(Mqtt, 'useMqtt').mockImplementation(() => ({ value: { payload: null } }));
   });
 
   test('shows an ActivityIndicator if stats are null', async () => {
@@ -43,29 +48,31 @@ describe('Debug Route', () => {
     expect(screen.queryByRole('button', { name: 'Copy to Clipboard' })).toBeInTheDocument();
   });
 
-  test('updates the stats on a timeout', async () => {
-    jest.spyOn(window, 'setTimeout').mockReturnValue(123);
-    render(<Debug />);
-    expect(useStatsMock).toHaveBeenCalledWith(null, null);
-    jest.advanceTimersByTime(1001);
-    expect(useStatsMock).toHaveBeenCalledWith(null, 123);
-    expect(useStatsMock).toHaveBeenCalledTimes(2);
+  test('updates the stats from  mqtt', async () => {
+    const { rerender } = render(<Debug />);
+    expect(useMqttMock).toHaveBeenCalledWith('stats');
+    useMqttMock.mockReturnValue({
+      value: {
+        payload: { ...statsMock, detectors: { coral: { ...statsMock.detectors.coral, inference_speed: 42.4242 } } },
+      },
+    });
+    rerender(<Debug />);
+
+    expect(screen.queryByText('42.4242')).toBeInTheDocument();
   });
 });
 
 const statsMock = {
-  data: {
+  detection_fps: 0.0,
+  detectors: { coral: { detection_start: 0.0, inference_speed: 8.94, pid: 52 } },
+  front: { camera_fps: 5.0, capture_pid: 64, detection_fps: 0.0, pid: 54, process_fps: 0.0, skipped_fps: 0.0 },
+  side: {
+    camera_fps: 6.9,
+    capture_pid: 71,
     detection_fps: 0.0,
-    detectors: { coral: { detection_start: 0.0, inference_speed: 8.94, pid: 52 } },
-    front: { camera_fps: 5.0, capture_pid: 64, detection_fps: 0.0, pid: 54, process_fps: 0.0, skipped_fps: 0.0 },
-    side: {
-      camera_fps: 6.9,
-      capture_pid: 71,
-      detection_fps: 0.0,
-      pid: 60,
-      process_fps: 0.0,
-      skipped_fps: 0.0,
-    },
-    service: { uptime: 34812, version: '0.8.1-d376f6b' },
+    pid: 60,
+    process_fps: 0.0,
+    skipped_fps: 0.0,
   },
+  service: { uptime: 34812, version: '0.8.1-d376f6b' },
 };


### PR DESCRIPTION
Enables watching MQTT state via the new websockets implementation

* Fixes a bug in the send value in the /ws endpoint
* Changes the Debug view to watch the MQTT stats value
* Pre-fills the local MQTT state via the config
* Adds toggles to the main page for detect, clips, and snapshots
* Adds tooltips for use with icon-only buttons, etc
