### PR TITLE
docs: include available objects in documentation

### DIFF
--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -116,24 +116,3 @@ model:
   # Required: width of the trained model
   width: 320
 ```
-
-## Custom Models
-
-Models for both CPU and EdgeTPU (Coral) are bundled in the image. You can use your own models with volume mounts:
-
-- CPU Model: `/cpu_model.tflite`
-- EdgeTPU Model: `/edgetpu_model.tflite`
-- Labels: `/labelmap.txt`
-
-You also need to update the model width/height in the config if they differ from the defaults.
-
-### Customizing the Labelmap
-
-The labelmap can be customized to your needs. A common reason to do this is to combine multiple object types that are easily confused when you don't need to be as granular such as car/truck. You must retain the same number of labels, but you can change the names. To change:
-
-- Download the [COCO labelmap](https://dl.google.com/coral/canned_models/coco_labels.txt)
-- Modify the label names as desired. For example, change `7 truck` to `7 car`
-- Mount the new file at `/labelmap.txt` in the container with an additional volume
-  ```
-  -v ./config/labelmap.txt:/labelmap.txt
-  ```

--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -41,9 +41,11 @@ cameras:
 ## Masks & Zones
 
 ### Masks
+
 Masks are used to ignore initial detection in areas of your camera's field of view.
 
 There are two types of masks available:
+
 - **Motion masks**: Motion masks are used to prevent unwanted types of motion from triggering detection. Try watching the video feed with `Motion Boxes` enabled to see what may be regularly detected as motion. For example, you want to mask out your timestamp, the sky, rooftops, etc. Keep in mind that this mask only prevents motion from being detected and does not prevent objects from being detected if object detection was started due to motion in unmasked areas. Motion is also used during object tracking to refine the object detection area in the next frame. Over masking will make it more difficult for objects to be tracked. To see this effect, create a mask, and then watch the video feed with `Motion Boxes` enabled again.
 - **Object filter masks**: Object filter masks are used to filter out false positives for a given object type. These should be used to filter any areas where it is not possible for an object of that type to be. The bottom center of the detected object's bounding box is evaluated against the mask. If it is in a masked area, it is assumed to be a false positive. For example, you may want to mask out rooftops, walls, the sky, treetops for people. For cars, masking locations other than the street or your driveway will tell frigate that anything in your yard is a false positive.
 
@@ -102,6 +104,8 @@ zones:
 
 ## Objects
 
+For a list of available objects, see the [objects documentation](./objects.mdx).
+
 ```yaml
 # Optional: Camera level object filters config.
 objects:
@@ -109,7 +113,7 @@ objects:
     - person
     - car
   # Optional: mask to prevent all object types from being detected in certain areas (default: no mask)
-  # Checks based on the bottom center of the bounding box of the object. 
+  # Checks based on the bottom center of the bounding box of the object.
   # NOTE: This mask is COMBINED with the object type specific mask below
   mask: 0,0,1000,0,1000,200,0,200
   filters:
@@ -368,7 +372,7 @@ cameras:
         - person
         - car
       # Optional: mask to prevent all object types from being detected in certain areas (default: no mask)
-      # Checks based on the bottom center of the bounding box of the object. 
+      # Checks based on the bottom center of the bounding box of the object.
       # NOTE: This mask is COMBINED with the object type specific mask below
       mask: 0,0,1000,0,1000,200,0,200
       filters:
@@ -406,6 +410,7 @@ ffmpeg:
 ```
 
 ### Reolink 410/520 (possibly others)
+
 Several users have reported success with the rtmp video from Reolink cameras.
 
 ```yaml
@@ -426,7 +431,6 @@ ffmpeg:
     - -use_wallclock_as_timestamps
     - '1'
 ```
-
 
 ### Blue Iris RTSP Cameras
 

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -117,7 +117,7 @@ ffmpeg:
 
 ### `objects`
 
-Can be overridden at the camera level
+Can be overridden at the camera level. For a list of available objects, see the [objects documentation](./objects.mdx).
 
 ```yaml
 objects:

--- a/docs/docs/configuration/objects.mdx
+++ b/docs/docs/configuration/objects.mdx
@@ -1,0 +1,36 @@
+---
+id: objects
+title: Default available objects
+sidebar_label: Available objects
+---
+
+import labels from '../../../labelmap.txt';
+
+By default, Frigate includes the following object models from the Google Coral test data.
+
+<ul>
+  {labels.split('\n').map((label) => (
+    <li>{label.replace(/^\d+\s+/, '')}</li>
+  ))}
+</ul>
+
+## Custom Models
+
+Models for both CPU and EdgeTPU (Coral) are bundled in the image. You can use your own models with volume mounts:
+
+- CPU Model: `/cpu_model.tflite`
+- EdgeTPU Model: `/edgetpu_model.tflite`
+- Labels: `/labelmap.txt`
+
+You also need to update the model width/height in the config if they differ from the defaults.
+
+### Customizing the Labelmap
+
+The labelmap can be customized to your needs. A common reason to do this is to combine multiple object types that are easily confused when you don't need to be as granular such as car/truck. You must retain the same number of labels, but you can change the names. To change:
+
+- Download the [COCO labelmap](https://dl.google.com/coral/canned_models/coco_labels.txt)
+- Modify the label names as desired. For example, change `7 truck` to `7 car`
+- Mount the new file at `/labelmap.txt` in the container with an additional volume
+  ```
+  -v ./config/labelmap.txt:/labelmap.txt
+  ```

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   title: 'Frigate',
   tagline: 'NVR With Realtime Object Detection for IP Cameras',
@@ -11,7 +13,7 @@ module.exports = {
   themeConfig: {
     algolia: {
       apiKey: '81ec882db78f7fed05c51daf973f0362',
-      indexName: 'frigate'
+      indexName: 'frigate',
     },
     navbar: {
       title: 'Frigate',
@@ -56,6 +58,7 @@ module.exports = {
       copyright: `Copyright © ${new Date().getFullYear()} Blake Blackshear`,
     },
   },
+  plugins: [path.resolve(__dirname, 'plugins', 'raw-loader')],
   presets: [
     [
       '@docusaurus/preset-classic',

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9864,6 +9864,27 @@
         "unpipe": "1.0.0"
       }
     },
+    "raw-loader": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
+      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
     "@docusaurus/preset-classic": "2.0.0-alpha.70",
     "@mdx-js/react": "^1.6.21",
     "clsx": "^1.1.1",
+    "raw-loader": "^4.0.2",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },

--- a/docs/plugins/raw-loader.js
+++ b/docs/plugins/raw-loader.js
@@ -1,0 +1,12 @@
+module.exports = function (context, options) {
+  return {
+    name: 'labelmap',
+    configureWebpack(config, isServer, utils) {
+      return {
+        module: {
+          rules: [{ test: /\.txt$/, use: 'raw-loader' }],
+        },
+      };
+    },
+  };
+};

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -7,6 +7,7 @@ module.exports = {
       'configuration/optimizing',
       'configuration/detectors',
       'configuration/false_positives',
+      'configuration/objects',
       'configuration/advanced',
     ],
     Usage: ['usage/home-assistant', 'usage/web', 'usage/api', 'usage/mqtt'],


### PR DESCRIPTION
An issue that comes up frequently: "What objects can I track?"

This imports the labelmap it into a documentation page for easy viewing and searchign.