### PR TITLE
Update labelmap.txt to include `truck`

### DIFF
--- a/labelmap.txt
+++ b/labelmap.txt
@@ -5,7 +5,7 @@
 4  airplane
 5  bus
 6  train
-7  car
+7  truck
 8  boat
 9  traffic light
 10  fire hydrant


### PR DESCRIPTION
Restore unique `truck` label from COCO labels.

@blakeblackshear - not sure whether this was intentional (if not, feel free to just reject this PR!), but it looks like the labels in the repo here already *include* the documentation's example edit of `7 truck` --> `7 car`. The example confused me for a bit when I was looking at the [list of available objects](https://blakeblackshear.github.io/frigate/configuration/objects) and couldn't find `truck` :) 