### PR TITLE
Purge best object upon expiration to fix incorrect MQTT snapshots

### DIFF
--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -512,6 +512,7 @@ class CameraState:
                 c(self.name, obj_name, 0)
             for c in self.callbacks["snapshot"]:
                 c(self.name, self.best_objects[obj_name], frame_time)
+                del self.best_objects[obj_name]
 
         # cleanup thumbnail frame cache
         current_thumb_frames = {


### PR DESCRIPTION
While using solely MQTT events and snapshots to interact with Frigate, I've noticed that in certain situations, the snapshot that is published when an event ends is that of a previous detection rather than the most recent one. From what I can tell, this is the series of events that leads to this:

1. Start frigate
2. Detection of Alice with score 0.75 populates `best_objects['person']` with tracked object at T=x
3. Alice leaves frame, object is considered expired and we publish a snapshot to MQTT from `best_objects['person']` of Alice
4. If Bob enters the frame with a score less than that of Alice and T <= x + `camera_config.best_image_timeout`, we do not update `best_objects['person']` since `is_better_thumbnail` returns False
5. Bob leaves frame, object is considered expired and we publish a snapshot to MQTT from `best_objects['person']`, but in this situation, the best object still refers to Alice, so we see the previous snapshot again

This problem is unique to the MQTT based snapshots since the HTTP API based snapshots are generated on the 'end' event and always refer the object that was removed from the frame.