### PR TITLE
Include thumbnail in final MQTT event payload

### DIFF
--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -451,7 +451,7 @@ class TrackedObjectProcessor(threading.Thread):
             event_data = obj.to_dict(include_thumbnail=True)
             event_data['has_snapshot'] = False
             if not obj.false_positive:
-                message = { 'before': obj.previous, 'after': obj.to_dict(), 'type': 'end' }
+                message = { 'before': obj.previous, 'after': event_data, 'type': 'end' }
                 self.client.publish(f"{self.topic_prefix}/events", json.dumps(message), retain=False)
                 # write snapshot to disk if enabled
                 if snapshot_config.enabled and self.should_save_snapshot(camera, obj):


### PR DESCRIPTION
For users of only the MQTT API, there's no convenient way to know if you've received the "best" snapshot for a given event since there's no delivery ordering/timing guarantees from MQTT across the different topics or additional metadata in the `../snapshots` payload apart from the JPEG encoded image to tell you if you should be expecting another "better" image or if you've already received it.

This makes it difficult for consumers to acquire a thumbnail for a given event without interacting with the HTTP API. Since it seems like the event data already has a thumbnail that is generated but then discarded, this change just re-uses it in the 'end' event.