### PR TITLE
Devcontainer Setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "context": "..",
   "dockerComposeFile": "../docker-compose.yml",
   "service": "dev",
-  "workspaceFolder": "/workspace",
+  "workspaceFolder": "/opt/frigate",
   "shutdownAction": "stopCompose",
   "extensions": [
     "ms-python.python",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,37 +1,26 @@
-version: '3'
+version: "3"
 services:
   dev:
-    container_name: core-dev
+    container_name: frigate-dev
     user: vscode
     build:
       context: .
-      dockerfile: docker/Dockerfile.core.dev
-    volumes:
-      - /etc/localtime:/etc/localtime:ro
-      - .:/workspace:cached
-    command: /bin/sh -c "while sleep 1000; do :; done"
-  frigate:
-    container_name: frigate
-    privileged: true
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.amd64
-      # dockerfile: docker/Dockerfile.core.dev
+      dockerfile: docker/Dockerfile.dev
     devices:
       - /dev/bus/usb:/dev/bus/usb
       - /dev/dri:/dev/dri # for intel hwaccel, needs to be updated for your hardware
     volumes:
       - /etc/localtime:/etc/localtime:ro
+      - .:/opt/frigate:cached
       - ./config/config.yml:/config/config.yml:ro
       - ./debug:/media/frigate
-      - ./frigate:/opt/frigate/frigate:cached
-      - ./migrations:/opt/frigate/migrations:cached
     ports:
-      - '5000:5000'
-      - '1935:1935'
-    command: /bin/sh -c "service nginx start; while sleep 1000; do :; done"
+      - "5000:5000"
+      - "5001:5001"
+      - "8080:8080"
+    command: /bin/sh -c "sudo service nginx start; while sleep 1000; do :; done"
   mqtt:
     container_name: mqtt
-    image: eclipse-mosquitto
+    image: eclipse-mosquitto:1.6
     ports:
-      - '1883:1883'
+      - "1883:1883"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - ./config/config.yml:/config/config.yml:ro
       - ./debug:/media/frigate
     ports:
+      - "1935:1935"
       - "5000:5000"
       - "5001:5001"
       - "8080:8080"

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -14,6 +14,15 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
-RUN apt-get install -y git
+RUN apt-get install -y git curl vim
 
 RUN pip3 install pylint black
+
+# Install Node 14
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+    && apt-get install -y nodejs
+
+# Install MQTT CLI
+RUN wget -q https://github.com/hivemq/mqtt-cli/releases/download/v4.6.0/mqtt-cli-4.6.0.deb \
+    && apt-get install -y ./mqtt-cli-4.6.0.deb \
+    && rm mqtt-cli-4.6.0.deb

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -21,8 +21,3 @@ RUN pip3 install pylint black
 # Install Node 14
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -y nodejs
-
-# Install MQTT CLI
-RUN wget -q https://github.com/hivemq/mqtt-cli/releases/download/v4.6.0/mqtt-cli-4.6.0.deb \
-    && apt-get install -y ./mqtt-cli-4.6.0.deb \
-    && rm mqtt-cli-4.6.0.deb

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -41,12 +41,15 @@ Fork [blakeblackshear/frigate-hass-integration](https://github.com/blakeblackshe
 ### Setup
 
 #### 1. Build the docker container locally with the appropriate make command
+
 For x86 machines, use `make amd64_frigate`
 
 #### 2. Create a local config file for testing
+
 Place the file at `config/config.yml` in the root of the repo.
 
 Here is an example, but modify for your needs:
+
 ```yaml
 mqtt:
   host: mqtt
@@ -69,15 +72,22 @@ cameras:
 These input args tell ffmpeg to read the mp4 file in an infinite loop. You can use any valid ffmpeg input here.
 
 #### 3. Gather some mp4 files for testing
+
 Create and place these files in a `debug` folder in the root of the repo. This is also where clips and recordings will be created if you enable them in your test config. Update your config from step 2 above to point at the right file. You can check the `docker-compose.yml` file in the repo to see how the volumes are mapped.
 
 #### 4. Open the repo with Visual Studio Code
+
 Upon opening, you should be prompted to open the project in a remote container. This will build a container on top of the base frigate container with all the development dependencies installed. This ensures everyone uses a consistent development environment without the need to install any dependencies on your host machine.
 
 #### 5. Run frigate from the command line
-VSCode will start the docker compose file for you and you will be able to see 3 containers listed when running `docker ps`. To run frigate with your modified code, run `docker exec -it frigate /bin/bash` from the command line to get a prompt inside the container. Then run `python3 -m frigate` to start.
+
+VSCode will start the docker compose file for you and open a terminal window connected to `frigate-dev`.
+
+- Run `python3 -m frigate` to start the backend.
+- In a separate terminal window inside VS Code, change into the `web` directory and run `npm install && npm start` to start the frontend.
 
 #### 6. Teardown
+
 After closing VSCode, you may still have containers running. To close everything down, just run `docker-compose down -v` to cleanup all containers.
 
 ## Web Interface


### PR DESCRIPTION
Made a few changes:
- `eclipse-mosquitto:2.x` no longer allows anonymous connections by default, so using `1.6`
- Installed Node 14 in the dev container and mounted the entire frigate directory to `opt/frigate` to allow frontend and core development out of the same container.
- Removed the unnecessary Frigate service as the dev service can now run Frigate and the Frontend itself.