### PR TITLE
Fix Logger during shutdown

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,8 @@
 {
   "name": "Frigate Dev",
-  "context": "..",
   "dockerComposeFile": "../docker-compose.yml",
   "service": "dev",
   "workspaceFolder": "/opt/frigate",
-  "shutdownAction": "stopCompose",
   "extensions": [
     "ms-python.python",
     "visualstudioexptteam.vscodeintellicode",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ services:
       - .:/opt/frigate:cached
       - ./config/config.yml:/config/config.yml:ro
       - ./debug:/media/frigate
+      - type: tmpfs # Optional: 1GB of memory, reduces SSD/SD Card wear
+        target: /tmp/cache
+        tmpfs:
+          size: 1000000000
     ports:
       - "1935:1935"
       - "5000:5000"

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -13,7 +13,9 @@ from collections import deque
 def listener_configurer():
     root = logging.getLogger()
     console_handler = logging.StreamHandler()
-    formatter = logging.Formatter("%(name)-30s %(levelname)-8s: %(message)s")
+    formatter = logging.Formatter(
+        "[%(asctime)s] %(name)-30s %(levelname)-8s: %(message)s", "%Y-%m-%d %H:%M:%S"
+    )
     console_handler.setFormatter(formatter)
     root.addHandler(console_handler)
     root.setLevel(logging.INFO)
@@ -27,20 +29,10 @@ def root_configurer(queue):
 
 
 def log_process(log_queue):
-    stop_event = mp.Event()
-
-    def receiveSignal(signalNumber, frame):
-        stop_event.set()
-
-    signal.signal(signal.SIGTERM, receiveSignal)
-    signal.signal(signal.SIGINT, receiveSignal)
-
     threading.current_thread().name = f"logger"
     setproctitle("frigate.logger")
     listener_configurer()
     while True:
-        if stop_event.is_set() and log_queue.empty():
-            break
         try:
             record = log_queue.get(timeout=5)
         except queue.Empty:


### PR DESCRIPTION
Since the logger is a daemon process we can allow it to just die with the main thread instead of listening for SIGINT or SIGTERM. This allows us to continue logging during shutdown.

Also adds datetime to the log output.