### PR TITLE
mqtt: support TLS with self-signed certs

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -47,6 +47,11 @@ mqtt:
   # NOTE: Environment variables that begin with 'FRIGATE_' may be referenced in {}.
   #       eg. password: '{FRIGATE_MQTT_PASSWORD}'
   password: password
+  # Optional: tls_ca_certs for enabling TLS using self-signed certs (default: None)
+  tls_ca_certs: /path/to/ca.crt
+  # Optional: tls_insecure_set (true/false) for enabling TLS verification of
+  # the server hostname in the server certificate (default: None)
+  tls_ca_certs: false
   # Optional: interval in seconds for publishing stats (default: shown below)
   stats_interval: 60
 ```

--- a/frigate/mqtt.py
+++ b/frigate/mqtt.py
@@ -104,6 +104,10 @@ def create_mqtt_client(config: FrigateConfig, camera_metrics):
         client.message_callback_add(f"{mqtt_config.topic_prefix}/{name}/snapshots/set", on_snapshots_command)
         client.message_callback_add(f"{mqtt_config.topic_prefix}/{name}/detect/set", on_detect_command)
 
+    if not mqtt_config.tls_ca_certs is None:
+        client.tls_set(mqtt_config.tls_ca_certs)
+    if not mqtt_config.tls_insecure_set is None:
+        client.tls_insecure_set(mqtt_config.tls_insecure_set)
     if not mqtt_config.user is None:
         client.username_pw_set(mqtt_config.user, password=mqtt_config.password)
     try:


### PR DESCRIPTION
Hi,
Please consider this PR which adds some options to the MQTT YAML config to enable TLS with self-signed certs.

I have not been able to test this because my RPi docker isn't able to build (armv7_all) even at ToT.
 
Thanks,
Benjamin