### PR TITLE
mqtt: support TLS with self-signed certs

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -45,6 +45,11 @@ mqtt:
   # NOTE: Environment variables that begin with 'FRIGATE_' may be referenced in {}.
   #       eg. password: '{FRIGATE_MQTT_PASSWORD}'
   password: password
+  # Optional: tls_ca_certs for enabling TLS using self-signed certs (default: None)
+  tls_ca_certs: /path/to/ca.crt
+  # Optional: tls_insecure (true/false) for enabling TLS verification of
+  # the server hostname in the server certificate (default: None)
+  tls_insecure: false
   # Optional: interval in seconds for publishing stats (default: shown below)
   stats_interval: 60
 ```

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -55,6 +55,8 @@ MQTT_SCHEMA = vol.Schema(
         vol.Optional("stats_interval", default=60): int,
         vol.Inclusive("user", "auth"): str,
         vol.Inclusive("password", "auth"): str,
+        vol.Optional("tls_ca_certs"): str,
+        vol.Optional("tls_insecure"): bool,
     }
 )
 
@@ -68,6 +70,8 @@ class MqttConfig:
     stats_interval: int
     user: Optional[str]
     password: Optional[str]
+    tls_ca_certs: Optional[str]
+    tls_insecure: Optional[bool]
 
     @classmethod
     def build(cls, config) -> MqttConfig:
@@ -79,6 +83,8 @@ class MqttConfig:
             config["stats_interval"],
             config.get("user"),
             config.get("password"),
+            config.get("tls_ca_certs"),
+            config.get("tls_insecure"),
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/frigate/mqtt.py
+++ b/frigate/mqtt.py
@@ -116,6 +116,10 @@ def create_mqtt_client(config: FrigateConfig, camera_metrics):
             f"{mqtt_config.topic_prefix}/{name}/detect/set", on_detect_command
         )
 
+    if not mqtt_config.tls_ca_certs is None:
+        client.tls_set(mqtt_config.tls_ca_certs)
+    if not mqtt_config.tls_insecure is None:
+        client.tls_insecure_set(mqtt_config.tls_insecure)
     if not mqtt_config.user is None:
         client.username_pw_set(mqtt_config.user, password=mqtt_config.password)
     try:


### PR DESCRIPTION
(Fixed version of PR  #1069)

Please consider this PR. I've added support for MQTT to use TLS with self-signed certs. I tested it locally and it works with my MQTT config.

Thanks,
Benjamin