### PR TITLE
Mjpeg doco

### DIFF
--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -410,10 +410,12 @@ The input and output parameters need to be adjusted for MJPEG cameras
         - '1'
 ```
 
+Note that mjpeg cameras require encoding the video into h264 for clips, recording, and rtmp roles. This will use significantly more CPU than if the cameras supported h264 feeds directly.
 ```yaml
       output_args:
         record: -f segment -segment_time 60 -segment_format mp4 -reset_timestamps 1 -strftime 1 -c:v libx264 -an
         clips: -f segment -segment_time 60 -segment_format mp4 -reset_timestamps 1 -strftime 1 -c:v libx264 -an
+        rtmp: -c:v libx264 -an -f flv
 ```
 
 ### RTMP Cameras

--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -388,6 +388,34 @@ cameras:
 
 ## Camera specific configuration
 
+### MJPEG Cameras
+
+The input parameters need to be adjusted for MJPEG cameras
+
+```yaml
+      input_args:
+        - -avoid_negative_ts
+        - make_zero
+        - -fflags
+        - nobuffer
+        - -flags
+        - low_delay
+        - -strict
+        - experimental
+        - -fflags
+        - +genpts+discardcorrupt
+        - -r
+        - '3'
+        - -use_wallclock_as_timestamps
+        - '1'
+```
+
+```yaml
+      output_args:
+        record: -f segment -segment_time 60 -segment_format mp4 -reset_timestamps 1 -strftime 1 -c:v libx264 -an
+        clips: -f segment -segment_time 60 -segment_format mp4 -reset_timestamps 1 -strftime 1 -c:v libx264 -an
+```
+
 ### RTMP Cameras
 
 The input parameters need to be adjusted for RTMP cameras

--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -405,7 +405,7 @@ The input and output parameters need to be adjusted for MJPEG cameras
         - -fflags
         - +genpts+discardcorrupt
         - -r
-        - '3'
+        - '3'  # <---- adjust depending on your desired frame rate from the mjpeg image
         - -use_wallclock_as_timestamps
         - '1'
 ```

--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -390,7 +390,7 @@ cameras:
 
 ### MJPEG Cameras
 
-The input parameters need to be adjusted for MJPEG cameras
+The input and output parameters need to be adjusted for MJPEG cameras
 
 ```yaml
       input_args:


### PR DESCRIPTION
Adds an MJPEG example to the doco.  These parameters were derived from a post in the Home Assistant community forum to support reading from zoneminder MJPEG APIs but work for my native MJPEG camera.