### PR TITLE
Update advanced.md to move `type:` to its own line

### DIFF
--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -99,7 +99,8 @@ detectors:
   # Required: name of the detector
   coral:
     # Required: type of the detector
-    # Valid values are 'edgetpu' (requires device property below) and 'cpu'. type: edgetpu
+    # Valid values are 'edgetpu' (requires device property below) and 'cpu'.
+    type: edgetpu
     # Optional: device name as defined here: https://coral.ai/docs/edgetpu/multiple-edgetpu/#using-the-tensorflow-lite-python-api
     device: usb
     # Optional: num_threads value passed to the tflite.Interpreter (default: shown below)


### PR DESCRIPTION
Type was stuck on the comment line. Added a line break to move it onto its own line so it's visible.