### PR TITLE
Add support for NGINX VOD Module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,11 @@ amd64_wheels:
 amd64_ffmpeg:
 	docker build --tag blakeblackshear/frigate-ffmpeg:1.1.0-amd64 --file docker/Dockerfile.ffmpeg.amd64 .
 
+nginx:
+	docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag blakeblackshear/frigate-nginx:1.0.0 --file docker/Dockerfile.nginx .
+
 amd64_frigate: version web
-	docker build --tag frigate-base --build-arg ARCH=amd64 --build-arg FFMPEG_VERSION=1.1.0 --build-arg WHEELS_VERSION=1.0.3 --file docker/Dockerfile.base .
+	docker build --tag frigate-base --build-arg ARCH=amd64 --build-arg FFMPEG_VERSION=1.1.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.0 --file docker/Dockerfile.base .
 	docker build --tag frigate --file docker/Dockerfile.amd64 .
 
 amd64_all: amd64_wheels amd64_ffmpeg amd64_frigate

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ amd64_wheels:
 amd64_ffmpeg:
 	docker build --tag blakeblackshear/frigate-ffmpeg:1.1.0-amd64 --file docker/Dockerfile.ffmpeg.amd64 .
 
-nginx:
+nginx_frigate:
 	docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag blakeblackshear/frigate-nginx:1.0.0 --file docker/Dockerfile.nginx .
 
 amd64_frigate: version web

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ amd64_ffmpeg:
 	docker build --tag blakeblackshear/frigate-ffmpeg:1.1.0-amd64 --file docker/Dockerfile.ffmpeg.amd64 .
 
 nginx_frigate:
-	docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag blakeblackshear/frigate-nginx:1.0.0 --file docker/Dockerfile.nginx .
+	docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag blakeblackshear/frigate-nginx:1.0.0 --file docker/Dockerfile.nginx .
 
 amd64_frigate: version web
 	docker build --tag frigate-base --build-arg ARCH=amd64 --build-arg FFMPEG_VERSION=1.1.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.0 --file docker/Dockerfile.base .

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ amd64nvidia_ffmpeg:
 	docker build --tag blakeblackshear/frigate-ffmpeg:1.0.0-amd64nvidia --file docker/Dockerfile.ffmpeg.amd64nvidia .
 
 amd64nvidia_frigate: version web
-	docker build --tag frigate-base --build-arg ARCH=amd64nvidia --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --file docker/Dockerfile.base .
+	docker build --tag frigate-base --build-arg ARCH=amd64nvidia --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.0 --file docker/Dockerfile.base .
 	docker build --tag frigate --file docker/Dockerfile.amd64nvidia .
 
 amd64nvidia_all: amd64nvidia_wheels amd64nvidia_ffmpeg amd64nvidia_frigate
@@ -42,7 +42,7 @@ aarch64_ffmpeg:
 	docker build --tag blakeblackshear/frigate-ffmpeg:1.0.0-aarch64 --file docker/Dockerfile.ffmpeg.aarch64 .
 
 aarch64_frigate: version web
-	docker build --tag frigate-base --build-arg ARCH=aarch64 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --file docker/Dockerfile.base .
+	docker build --tag frigate-base --build-arg ARCH=aarch64 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.0 --file docker/Dockerfile.base .
 	docker build --tag frigate --file docker/Dockerfile.aarch64 .
 
 armv7_all: armv7_wheels armv7_ffmpeg armv7_frigate
@@ -54,7 +54,7 @@ armv7_ffmpeg:
 	docker build --tag blakeblackshear/frigate-ffmpeg:1.0.0-armv7 --file docker/Dockerfile.ffmpeg.armv7 .
 
 armv7_frigate: version web
-	docker build --tag frigate-base --build-arg ARCH=armv7 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --file docker/Dockerfile.base .
+	docker build --tag frigate-base --build-arg ARCH=armv7 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.0 --file docker/Dockerfile.base .
 	docker build --tag frigate --file docker/Dockerfile.armv7 .
 
 armv7_all: armv7_wheels armv7_ffmpeg armv7_frigate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "5000:5000"
       - "5001:5001"
       - "8080:8080"
-    command: /bin/sh -c "sudo service nginx start; while sleep 1000; do :; done"
+    command: /bin/sh -c "sudo /usr/local/nginx/sbin/nginx; while sleep 1000; do :; done"
   mqtt:
     container_name: mqtt
     image: eclipse-mosquitto:1.6

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,8 +1,10 @@
 ARG ARCH=amd64
 ARG WHEELS_VERSION
 ARG FFMPEG_VERSION
+ARG NGINX_VERSION
 FROM blakeblackshear/frigate-wheels:${WHEELS_VERSION}-${ARCH} as wheels
 FROM blakeblackshear/frigate-ffmpeg:${FFMPEG_VERSION}-${ARCH} as ffmpeg
+FROM blakeblackshear/frigate-nginx:${NGINX_VERSION} as nginx
 FROM frigate-web as web
 
 FROM ubuntu:20.04
@@ -18,16 +20,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install packages for apt repo
 RUN apt-get -qq update \
     && apt-get upgrade -y \
-    && apt-get -qq install --no-install-recommends -y \
-    gnupg wget unzip tzdata nginx libnginx-mod-rtmp \
-    && apt-get -qq install --no-install-recommends -y \
-    python3-pip \
+    && apt-get -qq install --no-install-recommends -y gnupg wget unzip tzdata libxml2 \
+    && apt-get -qq install --no-install-recommends -y python3-pip \
     && pip3 install -U /wheels/*.whl \
     && APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn apt-key adv --fetch-keys https://packages.cloud.google.com/apt/doc/apt-key.gpg \
     && echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" > /etc/apt/sources.list.d/coral-edgetpu.list \
     && echo "libedgetpu1-max libedgetpu/accepted-eula select true" | debconf-set-selections \
-    && apt-get -qq update && apt-get -qq install --no-install-recommends -y \
-    libedgetpu1-max=15.0 \
+    && apt-get -qq update && apt-get -qq install --no-install-recommends -y libedgetpu1-max=15.0 \
     && rm -rf /var/lib/apt/lists/* /wheels \
     && (apt-get autoremove -y; apt-get autoclean -y)
 
@@ -39,7 +38,8 @@ RUN pip3 install \
     gevent \
     gevent-websocket
 
-COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY --from=nginx /usr/local/nginx/ /usr/local/nginx/
+COPY nginx/nginx.conf /usr/local/nginx/conf/nginx.conf
 
 # get model and labels
 COPY labelmap.txt /labelmap.txt

--- a/docker/Dockerfile.nginx
+++ b/docker/Dockerfile.nginx
@@ -1,0 +1,46 @@
+FROM ubuntu:20.04 AS base
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get -yqq update && \
+    apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+    apt-get autoremove -y && \
+    apt-get clean -y
+
+FROM base as build
+
+ARG NGINX_VERSION=1.18.0
+ARG VOD_MODULE_VERSION=1.28
+ARG RTMP_MODULE_VERSION=1.2.1
+
+RUN cp /etc/apt/sources.list /etc/apt/sources.list~ \
+    && sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list \
+    && apt-get update
+
+RUN apt-get -yqq build-dep nginx
+
+RUN apt-get -yqq install --no-install-recommends curl \
+    && mkdir /tmp/nginx \
+    && curl -sL https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar -C /tmp/nginx -zx --strip-components=1 \
+    && mkdir /tmp/nginx-vod-module \
+    && curl -sL https://github.com/kaltura/nginx-vod-module/archive/refs/tags/${VOD_MODULE_VERSION}.tar.gz | tar -C /tmp/nginx-vod-module -zx --strip-components=1 \
+    && mkdir /tmp/nginx-rtmp-module \
+    && curl -sL https://github.com/arut/nginx-rtmp-module/archive/refs/tags/v${RTMP_MODULE_VERSION}.tar.gz | tar -C /tmp/nginx-rtmp-module -zx --strip-components=1
+
+WORKDIR /tmp/nginx
+
+RUN ./configure --prefix=/usr/local/nginx \
+    --with-file-aio \
+    --with-http_sub_module \
+    --with-http_ssl_module \
+    --with-threads \
+    --add-module=../nginx-vod-module \
+    --add-module=../nginx-rtmp-module \
+    --with-cc-opt="-O3 -Wno-error=implicit-fallthrough"
+
+RUN make && make install
+RUN rm -rf /usr/local/nginx/html /usr/local/nginx/conf/*.default
+
+FROM base
+COPY --from=build /usr/local/nginx /usr/local/nginx
+ENTRYPOINT ["/usr/local/nginx/sbin/nginx"]
+CMD ["-g", "daemon off;"]

--- a/docs/docs/usage/api.md
+++ b/docs/docs/usage/api.md
@@ -125,26 +125,26 @@ Sample response:
         "total": 1000,
         "used": 700,
         "free": 300,
-        "mnt_type": "ext4",
+        "mnt_type": "ext4"
       },
       "/media/frigate/recordings": {
         "total": 1000,
         "used": 700,
         "free": 300,
-        "mnt_type": "ext4",
+        "mnt_type": "ext4"
       },
       "/tmp/cache": {
         "total": 256,
         "used": 100,
         "free": 156,
-        "mnt_type": "tmpfs",
+        "mnt_type": "tmpfs"
       },
       "/dev/shm": {
         "total": 256,
         "used": 100,
         "free": 156,
-        "mnt_type": "tmpfs",
-      },
+        "mnt_type": "tmpfs"
+      }
     }
   }
 }
@@ -210,3 +210,7 @@ Video clip for the given camera and event id.
 ### `/clips/<camera>-<id>.jpg`
 
 JPG snapshot for the given camera and event id.
+
+### `/vod/<year>-<month>/<day>/<hour>/<camera>/master.m3u8`
+
+HTTP Live Streaming Video on Demand URL for the specified hour and camera. Can be viewed in an application like VLC.

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -316,7 +316,11 @@ class FrigateApp:
         server = pywsgi.WSGIServer(
             ("127.0.0.1", 5001), self.flask_app, handler_class=WebSocketHandler
         )
-        server.serve_forever()
+
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            pass
 
         self.stop()
 

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -35,7 +35,7 @@ def log_process(log_queue):
     while True:
         try:
             record = log_queue.get(timeout=5)
-        except queue.Empty:
+        except (queue.Empty, KeyboardInterrupt):
             continue
         logger = logging.getLogger(record.name)
         logger.handle(record)

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,9 +3,6 @@ worker_processes  1;
 error_log  /usr/local/nginx/logs/error.log warn;
 pid        /var/run/nginx.pid;
 
-# load_module "modules/ngx_rtmp_module.so";
-# load_module "modules/ngx_http_vod_module.so";
-
 events {
     worker_connections  1024;
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,23 +1,24 @@
 worker_processes  1;
 
-error_log  /var/log/nginx/error.log warn;
+error_log  /usr/local/nginx/logs/error.log warn;
 pid        /var/run/nginx.pid;
 
-load_module "modules/ngx_rtmp_module.so";
+# load_module "modules/ngx_rtmp_module.so";
+# load_module "modules/ngx_http_vod_module.so";
 
 events {
     worker_connections  1024;
 }
 
 http {
-    include       /etc/nginx/mime.types;
+    include       mime.types;
     default_type  application/octet-stream;
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                         '$status $body_bytes_sent "$http_referer" '
                         '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  /usr/local/nginx/logs/access.log  main;
 
     sendfile        on;
 
@@ -36,6 +37,39 @@ http {
 
     server {
         listen 5000;
+
+        # vod settings
+        vod_mode mapped;
+        vod_max_mapping_response_size 1m;
+        vod_upstream_location /api;
+        vod_last_modified 'Sun, 19 Nov 2000 08:52:00 GMT';
+        vod_last_modified_types *;
+
+        # vod caches
+        vod_metadata_cache metadata_cache 512m;
+        vod_response_cache response_cache 128m;
+        vod_mapping_cache mapping_cache 5m;
+
+        # gzip manifests
+        gzip on;
+        gzip_types application/vnd.apple.mpegurl;
+
+        # file handle caching / aio
+        open_file_cache          max=1000 inactive=5m;
+        open_file_cache_valid    2m;
+        open_file_cache_min_uses 1;
+        open_file_cache_errors   on;
+        aio on;
+
+        location /vod/ {
+            vod hls;
+
+            add_header Access-Control-Allow-Headers '*';
+            add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+            add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+            add_header Access-Control-Allow-Origin '*';
+            expires 100d;
+        }
 
         location /stream/ {
             add_header 'Cache-Control' 'no-cache';

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-service nginx start
+/usr/local/nginx/sbin/nginx
 exec python3 -u -m frigate


### PR DESCRIPTION
This adds support for viewing recordings as a "video on demand". It can be tested by loading the stream URL into [this demo site](http://players.akamai.com/players/hlsjs) or VLC.

The VOD stream format currently follows the recording directory format - i.e.: http://localhost:5000/vod/2021-05/17/20/{camera}/master.m3u8

This first version is obviously limited to an hour's worth of recordings based on the current recording file structure. We can expand it later by modifying the `vod` function in `http.py`. Regardless, The Home Assistant integration can be updated to use this new URL to allow Media Browser recordings of entire hour long segments without having to use FFMPEG to combine the videos. The Web UI can also use this along with something like `videojs` to build a recording playback page. I left the `/recordings` directive in tact for backwards compatibility until things switch over.