### PR TITLE
Add `record` to configuration docs

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -138,3 +138,19 @@ objects:
       # Optional: minimum decimal percentage for tracked object's computed score to be considered a true positive (default: shown below)
       threshold: 0.7
 ```
+
+### `record`
+
+Can be overridden at the camera level. 24/7 recordings can be enabled and are stored at `/media/frigate/recordings`. The folder structure for the recordings is `YYYY-MM/DD/HH/<camera_name>/MM.SS.mp4`. These recordings are written directly from your camera stream without re-encoding and are available in HomeAssistant's media browser. Each camera supports a configurable retention policy in the config.
+
+:::caution
+Previous versions of frigate included `-vsync drop` in input parameters. This is not compatible with FFmpeg's segment feature and must be removed from your input parameters if you have overrides set.
+:::
+
+```yaml
+record:
+  # Optional: Enable recording
+  enabled: False
+  # Optional: Number of days to retain
+  retain_days: 30
+```


### PR DESCRIPTION
Record was missing from the configuration docs. Added it in based on the other options show and the info under 24/7 recordings in the cameras docs.