### PR TITLE
Wait on stop event when possible

### DIFF
--- a/frigate/edgetpu.py
+++ b/frigate/edgetpu.py
@@ -154,10 +154,7 @@ def run_detector(
         out_np = np.ndarray((20, 6), dtype=np.float32, buffer=out_shm.buf)
         outputs[name] = {"shm": out_shm, "np": out_np}
 
-    while True:
-        if stop_event.is_set():
-            break
-
+    while not stop_event.is_set():
         try:
             connection_id = detection_queue.get(timeout=5)
         except queue.Empty:

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -706,11 +706,7 @@ class TrackedObjectProcessor(threading.Thread):
         return self.camera_states[camera].get_current_frame(draw_options)
 
     def run(self):
-        while True:
-            if self.stop_event.is_set():
-                logger.info(f"Exiting object processor...")
-                break
-
+        while not self.stop_event.is_set():
             try:
                 (
                     camera,
@@ -769,3 +765,5 @@ class TrackedObjectProcessor(threading.Thread):
             while not self.event_processed_queue.empty():
                 event_id, camera = self.event_processed_queue.get()
                 self.camera_states[camera].finished(event_id)
+
+        logger.info(f"Exiting object processor...")

--- a/frigate/record.py
+++ b/frigate/record.py
@@ -1,4 +1,5 @@
 import datetime
+import itertools
 import json
 import logging
 import os
@@ -119,19 +120,14 @@ class RecordingMaintainer(threading.Thread):
                 p.unlink(missing_ok=True)
 
     def run(self):
-        counter = 0
-        self.expire_files()
-        while True:
-            if self.stop_event.is_set():
+        for counter in itertools.cycle(range(60)):
+            if self.stop_event.wait(10):
                 logger.info(f"Exiting recording maintenance...")
                 break
 
             # only expire events every 10 minutes, but check for new files every 10 seconds
-            time.sleep(10)
-            counter = counter + 1
-            if counter > 60:
+            if counter == 0:
                 self.expire_files()
                 remove_empty_directories(RECORD_DIR)
-                counter = 0
 
             self.move_files()

--- a/frigate/stats.py
+++ b/frigate/stats.py
@@ -94,12 +94,9 @@ class StatsEmitter(threading.Thread):
 
     def run(self):
         time.sleep(10)
-        while True:
-            if self.stop_event.is_set():
-                logger.info(f"Exiting watchdog...")
-                break
+        while not self.stop_event.wait(self.config.mqtt.stats_interval):
             stats = stats_snapshot(self.stats_tracking)
             self.mqtt_client.publish(
                 f"{self.topic_prefix}/stats", json.dumps(stats), retain=False
             )
-            time.sleep(self.config.mqtt.stats_interval)
+        logger.info(f"Exiting watchdog...")

--- a/frigate/watchdog.py
+++ b/frigate/watchdog.py
@@ -17,14 +17,7 @@ class FrigateWatchdog(threading.Thread):
 
     def run(self):
         time.sleep(10)
-        while True:
-            # wait a bit before checking
-            time.sleep(10)
-
-            if self.stop_event.is_set():
-                logger.info(f"Exiting watchdog...")
-                break
-
+        while not self.stop_event.wait(10):
             now = datetime.datetime.now().timestamp()
 
             # check the detection processes
@@ -38,3 +31,5 @@ class FrigateWatchdog(threading.Thread):
                 elif not detector.detect_process.is_alive():
                     logger.info("Detection appears to have stopped. Exiting frigate...")
                     os.kill(os.getpid(), signal.SIGTERM)
+
+        logger.info(f"Exiting watchdog...")


### PR DESCRIPTION
Generally eliminate the `while True` loops while waiting for a stop
event and prefer to condition the loops on if the stop event is set,
blocking on that where it makes sense.  This generally comes in 3
flavors.  First and simplest, when there is a sleep and the stop event
is the only thing the loop blocks on, instead do a check using
`stop_event.wait(timeout)` to instead block on the stop event for the
designated amount of time. Second, when there is a different event that
is blocking in the loop, condition the loop on `stop_event.is_set()`
rather than breaking when it is set. Finally, when there is a separate
internal condition that requires a counter, have the loop iterate over
the counter and use `if stop_event.wait(timeout)` internal to the loop.