### PR TITLE
Make nms_threshold configurable

### DIFF
--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -43,6 +43,10 @@ Global object detection settings. These may also be defined at the camera level.
 detect:
   # Optional: Number of frames without a detection before frigate considers an object to be gone. (default: 5x the frame rate)
   max_disappeared: 25
+  # Optional: Non Maximum Suppression Threshold, maximum overlap between detections of each detected object type. (default: 0.4)
+  # Higher values mean only detections with a high amount of overlap will have lower confidence detections discarded.
+  # Low values mean more overlapping detections will be discarded as a smaller overlap is tolerated.
+  nms_threshold: 0.4
 ```
 
 ### `logger`

--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -287,6 +287,8 @@ cameras:
       enabled: True
       # Optional: Number of frames without a detection before frigate considers an object to be gone. (default: 5x the frame rate)
       max_disappeared: 25
+      # Optional: Non Maximum Suppression Threshold, maximum overlap between detections of each detected object type. (default: 0.4)
+      nms_threshold: 0.4
 
     # Optional: save clips configuration
     clips:

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -187,7 +187,12 @@ class MotionConfig:
         }
 
 
-GLOBAL_DETECT_SCHEMA = vol.Schema({"max_disappeared": int})
+GLOBAL_DETECT_SCHEMA = vol.Schema(
+    {
+        "max_disappeared": int,
+        vol.Required("nms_threshold", default=0.4): vol.All(float, vol.Range(min=0, max=1)),
+    }
+)
 DETECT_SCHEMA = GLOBAL_DETECT_SCHEMA.extend(
     {vol.Optional("enabled", default=True): bool}
 )
@@ -197,6 +202,7 @@ DETECT_SCHEMA = GLOBAL_DETECT_SCHEMA.extend(
 class DetectConfig:
     enabled: bool
     max_disappeared: int
+    nms_threshold: float
 
     @classmethod
     def build(cls, config, global_config, camera_fps) -> DetectConfig:
@@ -211,6 +217,7 @@ class DetectConfig:
         return {
             "enabled": self.enabled,
             "max_disappeared": self.max_disappeared,
+            "nms_threshold": self.nms_threshold,
         }
 
 

--- a/frigate/process_clip.py
+++ b/frigate/process_clip.py
@@ -111,6 +111,7 @@ class ProcessClip:
             "detection_frame": mp.Value("d", 0.0),
         }
         stop_event = mp.Event()
+        nms_threshold = self.camera_config.detect.nms_threshold
         model_shape = (self.config.model.height, self.config.model.width)
 
         process_frames(
@@ -128,6 +129,7 @@ class ProcessClip:
             object_filters,
             mask,
             stop_event,
+            nms_threshold,
             exit_on_empty=True,
         )
 

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -348,6 +348,7 @@ def track_camera(
     )
 
     object_tracker = ObjectTracker(config.detect)
+    nms_threshold = config.detect.nms_threshold
 
     frame_manager = SharedMemoryFrameManager()
 
@@ -365,6 +366,7 @@ def track_camera(
         objects_to_track,
         object_filters,
         detection_enabled,
+        nms_threshold,
         stop_event,
     )
 
@@ -436,6 +438,7 @@ def process_frames(
     object_filters,
     detection_enabled: mp.Value,
     stop_event,
+    nms_threshold,
     exit_on_empty: bool = False,
 ):
 
@@ -540,7 +543,7 @@ def process_frames(
                     for o in group
                 ]
                 confidences = [o[1] for o in group]
-                idxs = cv2.dnn.NMSBoxes(boxes, confidences, 0.5, 0.4)
+                idxs = cv2.dnn.NMSBoxes(boxes, confidences, 0.5, nms_threshold)
 
                 for index in idxs:
                     obj = group[index[0]]


### PR DESCRIPTION
This surfaces the `nms_threshold` which is passed to `NMSBoxes` up to the `detect` config block. This allows it to be set per camera.

I get a lot of near-duplicate detections (overlapping "boxes" in the detection) on my cameras and would like to be able to tweak the `nms_threshold` value to reduce them.

I mostly don't care how many people/cars/cats/etc are being detected so long as the recording is tagged with what type of object was seen and I can use that for automations based on events.

I haven't had a chance to build and test this on my own camera feeds yet so just marking this PR as a draft for now.