### PR TITLE
Listen on both ipv4 and ipv6 in nginx

### DIFF
--- a/docker/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/rootfs/usr/local/nginx/conf/nginx.conf
@@ -45,6 +45,7 @@ http {
 
     server {
         listen 5000;
+        listen [::]:5000;
 
         # vod settings
         vod_base_url '';
@@ -196,7 +197,7 @@ http {
 
 rtmp {
     server {
-        listen 1935;
+        listen [::]:1935;
         chunk_size 4096;
         allow publish 127.0.0.1;
         deny publish all;


### PR DESCRIPTION
For environments that are dual-stack, the current config will only listen on ipv4. Adding an extra listen directive should allow connections to be served on both ipv4 & ipv6.

I couldn't figure out how to do this with a single `listen` directive. In theory, a single `[::]:5000 ipv6only=off` should work, but trying that on my local enviroment, ipv4 clients were unable to connect. A mystery.