### PR TITLE
Adding a download link to the clip page

### DIFF
--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -61,6 +61,7 @@ export default function Event({ eventId }) {
             src={`${apiHost}/clips/${data.camera}-${eventId}.mp4`}
             controls
           />
+          <a href={`${apiHost}/clips/${data.camera}-${eventId}.mp4`} download>Download Clip</a>
         </Fragment>
       ) : (
         <p>No clip available</p>


### PR DESCRIPTION
Adding a download link to the clip page to allow downloads via iOS browsers.

Feature request that I opened: https://github.com/blakeblackshear/frigate/issues/1168