### PR TITLE
Recordings Table

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -13,7 +13,7 @@ import numpy as np
 import voluptuous as vol
 import yaml
 
-from frigate.const import RECORD_DIR, CLIPS_DIR, CACHE_DIR
+from frigate.const import BASE_DIR, RECORD_DIR, CLIPS_DIR, CACHE_DIR
 from frigate.util import create_mask
 
 logger = logging.getLogger(__name__)
@@ -873,7 +873,7 @@ class CameraConfig:
 FRIGATE_CONFIG_SCHEMA = vol.Schema(
     {
         vol.Optional("database", default={}): {
-            vol.Optional("path", default=os.path.join(CLIPS_DIR, "frigate.db")): str
+            vol.Optional("path", default=os.path.join(BASE_DIR, "frigate.db")): str
         },
         vol.Optional("model", default={"width": 320, "height": 320}): {
             vol.Required("width"): int,

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -1,3 +1,4 @@
-CLIPS_DIR = "/media/frigate/clips"
-RECORD_DIR = "/media/frigate/recordings"
+BASE_DIR = "/media/frigate"
+CLIPS_DIR = f"{BASE_DIR}/clips"
+RECORD_DIR = f"{BASE_DIR}/recordings"
 CACHE_DIR = "/tmp/cache"

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -567,7 +567,7 @@ def recordings(camera_name):
 @bp.route("/vod/<year_month>/<day>/<hour>/<camera>")
 def vod(year_month, day, hour, camera):
     start_date = datetime.strptime(f"{year_month}-{day} {hour}", "%Y-%m-%d %H")
-    end_date = start_date + timedelta(hours=1)
+    end_date = start_date + timedelta(hours=1) - timedelta(milliseconds=1)
     start_ts = start_date.timestamp()
     end_ts = end_date.timestamp()
 

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -564,19 +564,12 @@ def recordings(camera_name):
     )
 
 
-@bp.route("/vod/<path:path>")
-def vod(path):
-    # Make sure we actually have recordings
-    if not os.path.isdir(f"{RECORD_DIR}/{path}"):
-        return "Recordings not found.", 404
-
-    # Break up path
-    parts = path.split("/")
-    start_date = datetime.strptime(f"{parts[0]}-{parts[1]} {parts[2]}", "%Y-%m-%d %H")
+@bp.route("/vod/<year_month>/<day>/<hour>/<camera>")
+def vod(year_month, day, hour, camera):
+    start_date = datetime.strptime(f"{year_month}-{day} {hour}", "%Y-%m-%d %H")
     end_date = start_date + timedelta(hours=1)
     start_ts = start_date.timestamp()
     end_ts = end_date.timestamp()
-    camera = parts[3]
 
     # Select all recordings where either the start or end dates fall in the requested hour
     recordings = (

--- a/frigate/models.py
+++ b/frigate/models.py
@@ -1,3 +1,4 @@
+from numpy import unique
 from peewee import *
 from playhouse.sqlite_ext import *
 
@@ -14,3 +15,12 @@ class Event(Model):
     thumbnail = TextField()
     has_clip = BooleanField(default=True)
     has_snapshot = BooleanField(default=True)
+
+
+class Recordings(Model):
+    id = CharField(null=False, primary_key=True, max_length=30)
+    camera = CharField(index=True, max_length=20)
+    path = CharField(unique=True)
+    start_time = DateTimeField()
+    end_time = DateTimeField()
+    duration = FloatField()

--- a/migrations/003_create_recordings_table.py
+++ b/migrations/003_create_recordings_table.py
@@ -20,24 +20,8 @@ Some examples (model - class or model name)::
     > migrator.add_default(model, field_name, default)
 
 """
-
-from concurrent.futures import as_completed, ThreadPoolExecutor
-import datetime as dt
 import peewee as pw
-from decimal import ROUND_HALF_EVEN
-import random
-import string
-import os
-import subprocess as sp
-import glob
-import re
 
-try:
-    import playhouse.postgres_ext as pw_pext
-except ImportError:
-    pass
-
-from frigate.const import RECORD_DIR
 from frigate.models import Recordings
 
 SQL = pw.SQL
@@ -46,62 +30,14 @@ SQL = pw.SQL
 def migrate(migrator, database, fake=False, **kwargs):
     migrator.create_model(Recordings)
 
-    def backfill():
+    def add_index():
         # First add the index here, because there is a bug in peewee_migrate
         # when trying to create an multi-column index in the same migration
         # as the table: https://github.com/klen/peewee_migrate/issues/19
         Recordings.add_index("start_time", "end_time")
         Recordings.create_table()
 
-        # Backfill existing recordings
-        files = glob.glob(f"{RECORD_DIR}/*/*/*/*/*.mp4")
-
-        def probe(path):
-            ffprobe_cmd = [
-                "ffprobe",
-                "-v",
-                "error",
-                "-show_entries",
-                "format=duration",
-                "-of",
-                "default=noprint_wrappers=1:nokey=1",
-                path,
-            ]
-            p = sp.run(ffprobe_cmd, capture_output=True)
-            if p.returncode == 0:
-                return float(p.stdout.decode().strip())
-            else:
-                os.remove(path)
-                return 0
-
-        with ThreadPoolExecutor() as executor:
-            future_to_path = {executor.submit(probe, path): path for path in files}
-            for future in as_completed(future_to_path):
-                path = future_to_path[future]
-                duration = future.result()
-                rand_id = "".join(
-                    random.choices(string.ascii_lowercase + string.digits, k=6)
-                )
-                search = re.search(
-                    r".+/(\d{4}[-]\d{2})/(\d{2})/(\d{2})/(.+)/(\d{2})\.(\d{2}).mp4",
-                    path,
-                )
-                if not search:
-                    return False
-                date = f"{search.group(1)}-{search.group(2)} {search.group(3)}:{search.group(5)}:{search.group(6)}"
-                start = dt.datetime.strptime(date, "%Y-%m-%d %H:%M:%S")
-                end = start + dt.timedelta(seconds=duration)
-
-                Recordings.create(
-                    id=f"{start.timestamp()}-{rand_id}",
-                    camera=search.group(4),
-                    path=path,
-                    start_time=start.timestamp(),
-                    end_time=end.timestamp(),
-                    duration=duration,
-                )
-
-    migrator.python(backfill)
+    migrator.python(add_index)
 
 
 def rollback(migrator, database, fake=False, **kwargs):

--- a/migrations/003_create_recordings_table.py
+++ b/migrations/003_create_recordings_table.py
@@ -1,0 +1,108 @@
+"""Peewee migrations -- 003_create_recordings_table.py.
+
+Some examples (model - class or model name)::
+
+    > Model = migrator.orm['model_name']            # Return model in current state by name
+
+    > migrator.sql(sql)                             # Run custom SQL
+    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.create_model(Model)                  # Create a model (could be used as decorator)
+    > migrator.remove_model(model, cascade=True)    # Remove a model
+    > migrator.add_fields(model, **fields)          # Add fields to a model
+    > migrator.change_fields(model, **fields)       # Change fields
+    > migrator.remove_fields(model, *field_names, cascade=True)
+    > migrator.rename_field(model, old_field_name, new_field_name)
+    > migrator.rename_table(model, new_table_name)
+    > migrator.add_index(model, *col_names, unique=False)
+    > migrator.drop_index(model, *col_names)
+    > migrator.add_not_null(model, *field_names)
+    > migrator.drop_not_null(model, *field_names)
+    > migrator.add_default(model, field_name, default)
+
+"""
+
+from concurrent.futures import as_completed, ThreadPoolExecutor
+import datetime as dt
+import peewee as pw
+from decimal import ROUND_HALF_EVEN
+import random
+import string
+import os
+import subprocess as sp
+import glob
+import re
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+from frigate.const import RECORD_DIR
+from frigate.models import Recordings
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.create_model(Recordings)
+
+    def backfill():
+        # First add the index here, because there is a bug in peewee_migrate
+        # when trying to create an multi-column index in the same migration
+        # as the table: https://github.com/klen/peewee_migrate/issues/19
+        Recordings.add_index("start_time", "end_time")
+        Recordings.create_table()
+
+        # Backfill existing recordings
+        files = glob.glob(f"{RECORD_DIR}/*/*/*/*/*.mp4")
+
+        def probe(path):
+            ffprobe_cmd = [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                path,
+            ]
+            p = sp.run(ffprobe_cmd, capture_output=True)
+            if p.returncode == 0:
+                return float(p.stdout.decode().strip())
+            else:
+                os.remove(path)
+                return 0
+
+        with ThreadPoolExecutor() as executor:
+            future_to_path = {executor.submit(probe, path): path for path in files}
+            for future in as_completed(future_to_path):
+                path = future_to_path[future]
+                duration = future.result()
+                rand_id = "".join(
+                    random.choices(string.ascii_lowercase + string.digits, k=6)
+                )
+                search = re.search(
+                    r".+/(\d{4}[-]\d{2})/(\d{2})/(\d{2})/(.+)/(\d{2})\.(\d{2}).mp4",
+                    path,
+                )
+                if not search:
+                    return False
+                date = f"{search.group(1)}-{search.group(2)} {search.group(3)}:{search.group(5)}:{search.group(6)}"
+                start = dt.datetime.strptime(date, "%Y-%m-%d %H:%M:%S")
+                end = start + dt.timedelta(seconds=duration)
+
+                Recordings.create(
+                    id=f"{start.timestamp()}-{rand_id}",
+                    camera=search.group(4),
+                    path=path,
+                    start_time=start.timestamp(),
+                    end_time=end.timestamp(),
+                    duration=duration,
+                )
+
+    migrator.python(backfill)
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.remove_model(Recordings)

--- a/web/src/components/RecordingPlaylist.jsx
+++ b/web/src/components/RecordingPlaylist.jsx
@@ -85,7 +85,11 @@ export function EventCard({ camera, event, delay }) {
   const start = fromUnixTime(event.start_time);
   const end = fromUnixTime(event.end_time);
   const duration = addSeconds(new Date(0), differenceInSeconds(end, start));
-  const seconds = Math.max(differenceInSeconds(start, startOfHour(start)) - delay - 10, 0);
+  const position = differenceInSeconds(start, startOfHour(start));
+  const offset = Object.entries(delay)
+    .map(([p, d]) => (position > p ? d : 0))
+    .reduce((p, c) => p + c);
+  const seconds = Math.max(position - offset - 10, 0);
   return (
     <Link className="" href={`/recording/${camera}/${format(start, 'yyyy-MM-dd')}/${format(start, 'HH')}/${seconds}`}>
       <div className="flex flex-row mb-2">

--- a/web/src/components/RecordingPlaylist.jsx
+++ b/web/src/components/RecordingPlaylist.jsx
@@ -88,7 +88,7 @@ export function EventCard({ camera, event, delay }) {
   const position = differenceInSeconds(start, startOfHour(start));
   const offset = Object.entries(delay)
     .map(([p, d]) => (position > p ? d : 0))
-    .reduce((p, c) => p + c);
+    .reduce((p, c) => p + c, 0);
   const seconds = Math.max(position - offset - 10, 0);
   return (
     <Link className="" href={`/recording/${camera}/${format(start, 'yyyy-MM-dd')}/${format(start, 'HH')}/${seconds}`}>


### PR DESCRIPTION
This adds a table to keep track of recordings. This unlocks the following:

- Store the video duration that was already calculated in the recordings maintainer to be used in the VOD mapping.
- Allows us to set an offset to guarantee the VOD starts at the top of the hour, and ends right at the end of the hour.
  - Useful for people who have overridden the default 60 second recording segment length.
- Allows calculating offsets at specific times in the VOD when recordings are missing.
  - Better matching of events to recording when Frigate has restarted within the hour.
  - Enables us to delete recordings without overlapping events in the future, but still have them line up in the recordings UI.