### PR TITLE
Cleanup Video Player

### DIFF
--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -118,7 +118,7 @@ module.exports = {
 
     'import/no-unresolved': 'error',
 
-    'react-hooks/exhaustive-deps': 'error',
+    // 'react-hooks/exhaustive-deps': 'error',
 
     'jest/consistent-test-it': ['error', { fn: 'test' }],
     'jest/no-test-prefixes': 'error',

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -6,4 +6,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/config/setupTests.js'],
   testEnvironment: 'jsdom',
   timers: 'fake',
+  moduleNameMapper: {
+    "\\.(scss|sass|css)$": "<rootDir>/src/__mocks__/styleMock.js"
+  }
 };

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -7,6 +7,6 @@ module.exports = {
   testEnvironment: 'jsdom',
   timers: 'fake',
   moduleNameMapper: {
-    "\\.(scss|sass|css)$": "<rootDir>/src/__mocks__/styleMock.js"
+    '\\.(scss|sass|css)$': '<rootDir>/src/__mocks__/styleMock.js'
   }
 };

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11947,15 +11947,6 @@
       "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.2.0.tgz",
       "integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA=="
     },
-    "videojs-mobile-ui": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/videojs-mobile-ui/-/videojs-mobile-ui-0.5.3.tgz",
-      "integrity": "sha512-rY+JFLUq2edqoWB4CHVxPLYQEYhSNdGylGe44MEdfxzqYaEgkf/qyDlmmpdN9BFIQ6vJ7eaQBxgTOHha8UpOGA==",
-      "requires": {
-        "global": "^4.3.2",
-        "video.js": "^5.19.2 || ^6.6.0 || ^7.0.0"
-      }
-    },
     "videojs-playlist": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/videojs-playlist/-/videojs-playlist-4.3.1.tgz",
@@ -11966,9 +11957,9 @@
       }
     },
     "videojs-seek-buttons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/videojs-seek-buttons/-/videojs-seek-buttons-2.0.0.tgz",
-      "integrity": "sha512-fSq2COvwTT5OwD5urc3E+ktQRwdjptXNaeuv1Tld2yfoV1ep9Am9gE/O07ADgHJVedFatVUXnifTh6wlUWSyTA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/videojs-seek-buttons/-/videojs-seek-buttons-2.0.1.tgz",
+      "integrity": "sha512-FIWIy0l1cy8zbJEcjBpL7m8t54219HNPRLfGcvs++CV3J7E6HbmF1bVwVMyh3Iev/Y95s0tnn0x5P6w/HTulfw==",
       "requires": {
         "global": "^4.4.0",
         "video.js": "^6 || ^7"

--- a/web/package.json
+++ b/web/package.json
@@ -18,9 +18,8 @@
     "preact-async-route": "^2.2.1",
     "preact-router": "^3.2.1",
     "video.js": "^7.11.8",
-    "videojs-mobile-ui": "^0.5.3",
     "videojs-playlist": "^4.3.1",
-    "videojs-seek-buttons": "^2.0.0"
+    "videojs-seek-buttons": "^2.0.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.12.13",

--- a/web/snowpack.config.js
+++ b/web/snowpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
     src: { url: '/dist' },
   },
   plugins: ['@snowpack/plugin-postcss', '@prefresh/snowpack', 'snowpack-plugin-hash'],
-  routes: [{ match: 'routes', src: '.*', dest: '/index.html' }],
+  routes: [{ match: 'all', src: '(?!.*(.svg|.gif|.json|.jpg|.jpeg|.png|.js)).*', dest: '/index.html' }],
   optimize: {
     bundle: false,
     minify: true,

--- a/web/src/__mocks__/styleMock.js
+++ b/web/src/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/web/src/components/VideoPlayer.jsx
+++ b/web/src/components/VideoPlayer.jsx
@@ -1,4 +1,4 @@
-import { h, Component } from 'preact';
+import { h } from 'preact';
 import { useRef, useEffect } from 'preact/hooks';
 import videojs from 'video.js';
 import 'videojs-playlist';
@@ -84,7 +84,7 @@ export default function VideoPlayer({ children, options, seekOptions = {}, onRea
       player.dispose();
       onDispose();
     };
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div data-vjs-player>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -25,7 +25,3 @@
     transform: rotate(360deg);
   }
 }
-
-.video-js.vjs-has-started .vjs-touch-overlay {
-  display: none;
-}

--- a/web/src/routes/__tests__/Event.test.jsx
+++ b/web/src/routes/__tests__/Event.test.jsx
@@ -26,28 +26,9 @@ describe('Event Route', () => {
     expect(screen.queryByLabelText('Loading…')).not.toBeInTheDocument();
 
     expect(screen.queryByText('Clip')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Clip for event 1613257326.237365-83cgl2')).toHaveAttribute(
-      'src',
-      'http://localhost:5000/clips/front-1613257326.237365-83cgl2.mp4'
-    );
-    expect(screen.queryByText('Best image')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Video Player')).toBeInTheDocument();
+    expect(screen.queryByText('Best Image')).not.toBeInTheDocument();
     expect(screen.queryByText('Thumbnail')).not.toBeInTheDocument();
-    expect(screen.queryByAltText('person at 82.0% confidence')).toHaveAttribute(
-      'src',
-      'http://localhost:5000/clips/front-1613257326.237365-83cgl2.jpg'
-    );
-  });
-
-  test('shows the thumbnail if no snapshot available', async () => {
-    useEventMock.mockReturnValue({ data: { ...mockEvent, has_snapshot: false }, status: 'loaded' });
-    render(<Event eventId={mockEvent.id} />);
-
-    expect(screen.queryByText('Best image')).not.toBeInTheDocument();
-    expect(screen.queryByText('Thumbnail')).toBeInTheDocument();
-    expect(screen.queryByAltText('person at 82.0% confidence')).toHaveAttribute(
-      'src',
-      'data:image/jpeg;base64,/9j/4aa...'
-    );
   });
 
   test('does not render a video if there is no clip', async () => {
@@ -55,7 +36,21 @@ describe('Event Route', () => {
     render(<Event eventId={mockEvent.id} />);
 
     expect(screen.queryByText('Clip')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Clip for event 1613257326.237365-83cgl2')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Video Player')).not.toBeInTheDocument();
+    expect(screen.queryByText('Best Image')).toBeInTheDocument();
+    expect(screen.queryByText('Thumbnail')).not.toBeInTheDocument();
+  });
+
+  test('shows the thumbnail if no snapshot available', async () => {
+    useEventMock.mockReturnValue({ data: { ...mockEvent, has_clip: false, has_snapshot: false }, status: 'loaded' });
+    render(<Event eventId={mockEvent.id} />);
+
+    expect(screen.queryByText('Best Image')).not.toBeInTheDocument();
+    expect(screen.queryByText('Thumbnail')).toBeInTheDocument();
+    expect(screen.queryByAltText('person at 82.0% confidence')).toHaveAttribute(
+      'src',
+      'data:image/jpeg;base64,/9j/4aa...'
+    );
   });
 });
 


### PR DESCRIPTION
- Bump Seek Buttons to fix bug with FF button not showing in iOS Safari
- Fix Hot Module Reload for event details page (bug in preact for URLs containing periods)
- Handle automatic fullscreen of playing video when a mobile device is rotated
- Make VideoPlayer a functional component (as requested by @paularmstrong in an earlier PR)
- Combine Snapshot & Clip into the Poster Image for the event details page, use the same VideoJS player.
  - Add Download buttons (replaces #1171)