### PR TITLE
Detectors with native edgetpu (Coral Dev Board)

### DIFF
--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -30,6 +30,15 @@ detectors:
     device: usb:1
 ```
 
+Native Coral (Dev Board):
+
+```yaml
+detectors:
+  coral:
+    type: edgetpu
+    device: ''
+```
+
 Multiple PCIE/M.2 Corals:
 
 ```yaml
@@ -40,15 +49,6 @@ detectors:
   coral2:
     type: edgetpu
     device: pci:1
-```
-
-Native Corals (Dev Board):
-
-```yaml
-detectors:
-  coral:
-    type: edgetpu
-    device: ''
 ```
 
 Mixing Corals:

--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -42,6 +42,15 @@ detectors:
     device: pci:1
 ```
 
+Native Corals (Dev Board):
+
+```yaml
+detectors:
+  coral:
+    type: edgetpu
+    device: ''
+```
+
 Mixing Corals:
 
 ```yaml


### PR DESCRIPTION
Based on findings in [issue-1161](https://github.com/blakeblackshear/frigate/issues/1161), documentation updated with how to get Frigate to run and use the edgetpu on a Coral Dev Board.