### PR TITLE
Convert config to Pydantic

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -36,8 +36,8 @@ RUN apt-get -qq update \
 
 RUN pip3 install \
     peewee_migrate \
+    pydantic \
     zeroconf \
-    voluptuous\
     ws4py
 
 COPY --from=nginx /usr/local/nginx/ /usr/local/nginx/

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -272,7 +272,14 @@ def events():
 
 @bp.route("/config")
 def config():
-    return jsonify(current_app.frigate_config.to_dict())
+    return jsonify(current_app.frigate_config.dict())
+
+
+@bp.route("/config/schema")
+def config_schema():
+    return current_app.response_class(
+        current_app.frigate_config.schema_json(), mimetype="application/json"
+    )
 
 
 @bp.route("/version")

--- a/frigate/motion.py
+++ b/frigate/motion.py
@@ -2,6 +2,7 @@ import cv2
 import imutils
 import numpy as np
 from frigate.config import MotionConfig
+from frigate.util import create_mask
 
 
 class MotionDetector:
@@ -18,7 +19,7 @@ class MotionDetector:
         self.motion_frame_count = 0
         self.frame_counter = 0
         resized_mask = cv2.resize(
-            config.mask,
+            create_mask(frame_shape, config.mask),
             dsize=(self.motion_frame_size[1], self.motion_frame_size[0]),
             interpolation=cv2.INTER_LINEAR,
         )

--- a/frigate/motion.py
+++ b/frigate/motion.py
@@ -2,7 +2,6 @@ import cv2
 import imutils
 import numpy as np
 from frigate.config import MotionConfig
-from frigate.util import create_mask
 
 
 class MotionDetector:
@@ -19,7 +18,7 @@ class MotionDetector:
         self.motion_frame_count = 0
         self.frame_counter = 0
         resized_mask = cv2.resize(
-            create_mask(frame_shape, config.mask),
+            config.mask,
             dsize=(self.motion_frame_size[1], self.motion_frame_size[0]),
             interpolation=cv2.INTER_LINEAR,
         )

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -319,7 +319,7 @@ class CameraState:
     def __init__(self, name, config, frame_manager):
         self.name = name
         self.config = config
-        self.camera_config: CameraConfig = config.cameras[name]
+        self.camera_config = config.cameras[name]
         self.frame_manager = frame_manager
         self.best_objects: Dict[str, TrackedObject] = {}
         self.object_counts = defaultdict(int)
@@ -329,7 +329,6 @@ class CameraState:
         self._current_frame = np.zeros(self.camera_config.frame_shape_yuv, np.uint8)
         self.current_frame_lock = threading.Lock()
         self.current_frame_time = 0.0
-        self.motion_mask = self.camera_config.motion.mask
         self.motion_boxes = []
         self.regions = []
         self.previous_frame_id = None
@@ -391,7 +390,7 @@ class CameraState:
                 cv2.drawContours(frame_copy, [zone.contour], -1, zone.color, thickness)
 
         if draw_options.get("mask"):
-            mask_overlay = np.where(self.motion_mask == [0])
+            mask_overlay = np.where(self.camera_config.motion_mask == [0])
             frame_copy[mask_overlay] = [0, 0, 0]
 
         if draw_options.get("motion_boxes"):

--- a/frigate/output.py
+++ b/frigate/output.py
@@ -21,7 +21,7 @@ from ws4py.server.wsgirefserver import (
 from ws4py.server.wsgiutils import WebSocketWSGIApplication
 from ws4py.websocket import WebSocket
 
-from frigate.config import FrigateConfig
+from frigate.config import BirdseyeModeEnum, FrigateConfig
 from frigate.util import SharedMemoryFrameManager, copy_yuv_to_position, get_yuv_crop
 
 logger = logging.getLogger(__name__)
@@ -173,13 +173,16 @@ class BirdsEyeFrameManager:
         )
 
     def camera_active(self, object_box_count, motion_box_count):
-        if self.mode == "continuous":
+        if self.mode == BirdseyeModeEnum.continuous:
             return True
 
-        if self.mode == "motion" and object_box_count + motion_box_count > 0:
+        if (
+            self.mode == BirdseyeModeEnum.motion
+            and object_box_count + motion_box_count > 0
+        ):
             return True
 
-        if self.mode == "objects" and object_box_count > 0:
+        if self.mode == BirdseyeModeEnum.objects and object_box_count > 0:
             return True
 
     def update_frame(self):

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 import datetime
 import hashlib
 import json
@@ -18,6 +19,29 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+
+def deep_merge(dct1: dict, dct2: dict, override=False) -> dict:
+    """
+    :param dct1: First dict to merge
+    :param dct2: Second dict to merge
+    :param override: if same key exists in both dictionaries, should override? otherwise ignore. (default=True)
+    :return: The merge dictionary
+    """
+    merged = copy.deepcopy(dct1)
+    for k, v2 in dct2.items():
+        if k in merged:
+            v1 = merged[k]
+            if isinstance(v1, dict) and isinstance(v2, collections.Mapping):
+                merged[k] = deep_merge(v1, v2, override)
+            elif isinstance(v1, list) and isinstance(v2, list):
+                merged[k] = v1 + v2
+            else:
+                if override:
+                    merged[k] = copy.deepcopy(v2)
+        else:
+            merged[k] = copy.deepcopy(v2)
+    return merged
 
 
 def draw_timestamp(


### PR DESCRIPTION
This converts the config to use [Pydantic](https://pydantic-docs.helpmanual.io/). The benefit here is validation inside the same models you use for configuration. I have also removed all side effects from the configuration settings. Calling `config.dict(exclude_unset=True)` will return the configuration dictionary exactly as it was parsed. This will enable editing from the frontend in the future.

All side-effects have thus been moved to `config.runtime_config` which returns a new config object that is used by the application runtime.