### PR TITLE
make max_disappeared optional with default value

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -126,7 +126,7 @@ class RuntimeMotionConfig(MotionConfig):
 
 class DetectConfig(BaseModel):
     enabled: bool = Field(default=True, title="Detection Enabled.")
-    max_disappeared: int = Field(
+    max_disappeared: Optional[int] = Field(
         title="Maximum number of frames the object can dissapear before detection ends."
     )
 
@@ -732,8 +732,11 @@ class FrigateConfig(BaseModel):
                 )
 
             # Default detect configuration
-            if camera_config.detect is None:
-                max_disappeared = (camera_config.fps or 5) * 5
+            max_disappeared = (camera_config.fps or 5) * 5
+            if camera_config.detect:
+                if camera_config.detect.max_disappeared is None:
+                    camera_config.detect.max_disappeared = max_disappeared
+            else:
                 camera_config.detect = DetectConfig(max_disappeared=max_disappeared)
 
             # Default live configuration

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -425,6 +425,33 @@ class TestConfig(unittest.TestCase):
         assert len(ffmpeg_cmds) == 1
         assert not "clips" in ffmpeg_cmds[0]["roles"]
 
+    def test_max_disappeared_default(self):
+        config = {
+            "mqtt": {"host": "mqtt"},
+            "cameras": {
+                "back": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {
+                                "path": "rtsp://10.0.0.1:554/video",
+                                "roles": ["detect"],
+                            },
+                        ]
+                    },
+                    "height": 1080,
+                    "width": 1920,
+                    "detect": {"enabled": True},
+                }
+            },
+        }
+
+        frigate_config = FrigateConfig(**config)
+        assert config == frigate_config.dict(exclude_unset=True)
+
+        runtime_config = frigate_config.runtime_config
+        ffmpeg_cmds = runtime_config.cameras["back"].ffmpeg_cmds
+        assert runtime_config.cameras["back"].detect.max_disappeared == 5 * 5
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Updated to make the max_disappeared an option property under the detect config section and still assume a default value. Is this the right approach based on what you do elsewhere? I plan to add a unit test before merging.