### PR TITLE
Http event snapshot 404

### DIFF
--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -30,6 +30,15 @@ detectors:
     device: usb:1
 ```
 
+Native Coral (Dev Board):
+
+```yaml
+detectors:
+  coral:
+    type: edgetpu
+    device: ''
+```
+
 Multiple PCIE/M.2 Corals:
 
 ```yaml
@@ -40,15 +49,6 @@ detectors:
   coral2:
     type: edgetpu
     device: pci:1
-```
-
-Native Corals (Dev Board):
-
-```yaml
-detectors:
-  coral:
-    type: edgetpu
-    device: ''
 ```
 
 Mixing Corals:

--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -42,6 +42,15 @@ detectors:
     device: pci:1
 ```
 
+Native Corals (Dev Board):
+
+```yaml
+detectors:
+  coral:
+    type: edgetpu
+    device: ''
+```
+
 Mixing Corals:
 
 ```yaml

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -86,7 +86,8 @@ def create_app(frigate_config, database: SqliteDatabase, stats_tracking, detecte
 
     @app.before_request
     def _db_connect():
-        database.connect()
+        if database.is_closed():
+            database.connect()
 
     @app.teardown_request
     def _db_close(exc):

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -214,6 +214,9 @@ def event_snapshot(id):
     except:
         return "Event not found", 404
 
+    if jpg_bytes is None:
+        return "Event not found", 404
+
     response = make_response(jpg_bytes)
     response.headers['Content-Type'] = 'image/jpg'
     return response


### PR DESCRIPTION
While developing a custom application that utilizes the frigate api, I noticed that requests to the snapshot endpoint for missing event ids would cause a 500 response, and occasionally even require frigate to be restarted.  

You can reproduce this issue by requesting a url like this:
http://localhost:5000/api/events/INVALIDEVENT/snapshot.jpg

Which results in these errors in my log:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/flask_sockets.py", line 40, in __call__
    handler, values = adapter.match()
  File "/usr/local/lib/python3.8/dist-packages/werkzeug/routing.py", line 1945, in match
    raise NotFound()
werkzeug.exceptions.NotFound: 404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/gevent/pywsgi.py", line 999, in handle_one_response
    self.run_application()
  File "/usr/local/lib/python3.8/dist-packages/geventwebsocket/handler.py", line 87, in run_application
    return super(WebSocketHandler, self).run_application()
  File "/usr/local/lib/python3.8/dist-packages/gevent/pywsgi.py", line 945, in run_application
    self.result = self.application(self.environ, self.start_response)
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 2464, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.8/dist-packages/flask_sockets.py", line 48, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 2450, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1867, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.8/dist-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.8/dist-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1948, in full_dispatch_request
    rv = self.preprocess_request()
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 2242, in preprocess_request
    rv = func()
  File "/opt/frigate/frigate/http.py", line 89, in _db_connect
    database.connect()
  File "/usr/local/lib/python3.8/dist-packages/peewee.py", line 3061, in connect
    raise OperationalError('Connection already opened.')
peewee.OperationalError: Connection already opened.
2021-06-26T23:24:32Z {'REMOTE_ADDR': '127.0.0.1', 'REMOTE_PORT': '50198', 'HTTP_HOST': '192.168.0.10', (hidden keys: 24)} failed with OperationalError
```


I traced it down to two issues.

First, it some part of the error handling in the api was causing `_db_connect` to be called again mid-request.  This raised an error because the database connection was already open.  Checking `database.is_closed()` seems like a good safety measure.  Unfortunately I'm not familiar enough with flask to know why _db_connect was called twice.

Second, in the `event_snapshot` endpoint, `jpg_bytes` remains `None` if the image is not on the filesystem and not being tracked.  I've added a check before calling `make_response`, and returning 404 if `jpg_bytes` is still `None`.