### PR TITLE
Set modal top postion to window_padding

### DIFF
--- a/web/src/components/RelativeModal.jsx
+++ b/web/src/components/RelativeModal.jsx
@@ -79,7 +79,7 @@ export default function RelativeModal({
       }
       // too close to bottom
       if (top + menuHeight > windowHeight - WINDOW_PADDING + window.scrollY) {
-        newTop = relativeToY - menuHeight;
+        newTop = WINDOW_PADDING;
       }
 
       if (top <= WINDOW_PADDING + window.scrollY) {


### PR DESCRIPTION
If the `RelativeModal` height exceeds the current `windowHeight` , it will position the modal top position wrong and will not be visible.

**Example:**
if you add all the objects in tracking, this will make the `Label` window height of close to 3000px, (depends on the screen resolution) and since the current calculation is:

RelativeModal.jsx
```js
// too close to bottom
if (top + menuHeight > windowHeight - WINDOW_PADDING + window.scrollY) {
   newTop = relativeToY - menuHeight;
}
```
the modal top position will be ~ `-3000px` and not visible on the page. 

I just assigned the **newTop** to WINDOW_PADDING which fix the issue. 
Tested with diffrente window size.


![2021-07-05_21-26-05.jpg](https://imgshare.io/images/2021/07/05/2021-07-05_21-26-05.jpg)

![2021-07-05_21-04-02.jpg](https://imgshare.io/images/2021/07/05/2021-07-05_21-04-02.jpg)