### PR TITLE
Use Recordings for Clips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ amd64_ffmpeg:
 	docker build --no-cache --pull --tag blakeblackshear/frigate-ffmpeg:1.2.0-amd64 --file docker/Dockerfile.ffmpeg.amd64 .
 
 nginx_frigate:
-	docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag blakeblackshear/frigate-nginx:1.0.1 --file docker/Dockerfile.nginx .
+	docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag blakeblackshear/frigate-nginx:1.0.2 --file docker/Dockerfile.nginx .
 
 amd64_frigate: version web
-	docker build --no-cache --tag frigate-base --build-arg ARCH=amd64 --build-arg FFMPEG_VERSION=1.1.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.1 --file docker/Dockerfile.base .
+	docker build --no-cache --tag frigate-base --build-arg ARCH=amd64 --build-arg FFMPEG_VERSION=1.1.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.2 --file docker/Dockerfile.base .
 	docker build --no-cache --tag frigate --file docker/Dockerfile.amd64 .
 
 amd64_all: amd64_wheels amd64_ffmpeg amd64_frigate
@@ -30,7 +30,7 @@ amd64nvidia_ffmpeg:
 	docker build --no-cache --pull --tag blakeblackshear/frigate-ffmpeg:1.2.0-amd64nvidia --file docker/Dockerfile.ffmpeg.amd64nvidia .
 
 amd64nvidia_frigate: version web
-	docker build --no-cache --tag frigate-base --build-arg ARCH=amd64nvidia --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.1 --file docker/Dockerfile.base .
+	docker build --no-cache --tag frigate-base --build-arg ARCH=amd64nvidia --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.2 --file docker/Dockerfile.base .
 	docker build --no-cache --tag frigate --file docker/Dockerfile.amd64nvidia .
 
 amd64nvidia_all: amd64nvidia_wheels amd64nvidia_ffmpeg amd64nvidia_frigate
@@ -42,7 +42,7 @@ aarch64_ffmpeg:
 	docker build --no-cache --pull --tag blakeblackshear/frigate-ffmpeg:1.2.0-aarch64 --file docker/Dockerfile.ffmpeg.aarch64 .
 
 aarch64_frigate: version web
-	docker build --no-cache --tag frigate-base --build-arg ARCH=aarch64 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.1 --file docker/Dockerfile.base .
+	docker build --no-cache --tag frigate-base --build-arg ARCH=aarch64 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.2 --file docker/Dockerfile.base .
 	docker build --no-cache --tag frigate --file docker/Dockerfile.aarch64 .
 
 armv7_all: armv7_wheels armv7_ffmpeg armv7_frigate
@@ -54,7 +54,7 @@ armv7_ffmpeg:
 	docker build --no-cache --pull --tag blakeblackshear/frigate-ffmpeg:1.2.0-armv7 --file docker/Dockerfile.ffmpeg.armv7 .
 
 armv7_frigate: version web
-	docker build --no-cache --tag frigate-base --build-arg ARCH=armv7 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.1 --file docker/Dockerfile.base .
+	docker build --no-cache --tag frigate-base --build-arg ARCH=armv7 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.2 --file docker/Dockerfile.base .
 	docker build --no-cache --tag frigate --file docker/Dockerfile.armv7 .
 
 armv7_all: armv7_wheels armv7_ffmpeg armv7_frigate

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ amd64_ffmpeg:
 	docker build --no-cache --pull --tag blakeblackshear/frigate-ffmpeg:1.2.0-amd64 --file docker/Dockerfile.ffmpeg.amd64 .
 
 nginx_frigate:
-	docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag blakeblackshear/frigate-nginx:1.0.0 --file docker/Dockerfile.nginx .
+	docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag blakeblackshear/frigate-nginx:1.0.1 --file docker/Dockerfile.nginx .
 
 amd64_frigate: version web
-	docker build --no-cache --tag frigate-base --build-arg ARCH=amd64 --build-arg FFMPEG_VERSION=1.1.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.0 --file docker/Dockerfile.base .
+	docker build --no-cache --tag frigate-base --build-arg ARCH=amd64 --build-arg FFMPEG_VERSION=1.1.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.1 --file docker/Dockerfile.base .
 	docker build --no-cache --tag frigate --file docker/Dockerfile.amd64 .
 
 amd64_all: amd64_wheels amd64_ffmpeg amd64_frigate
@@ -30,7 +30,7 @@ amd64nvidia_ffmpeg:
 	docker build --no-cache --pull --tag blakeblackshear/frigate-ffmpeg:1.2.0-amd64nvidia --file docker/Dockerfile.ffmpeg.amd64nvidia .
 
 amd64nvidia_frigate: version web
-	docker build --no-cache --tag frigate-base --build-arg ARCH=amd64nvidia --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.0 --file docker/Dockerfile.base .
+	docker build --no-cache --tag frigate-base --build-arg ARCH=amd64nvidia --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.1 --file docker/Dockerfile.base .
 	docker build --no-cache --tag frigate --file docker/Dockerfile.amd64nvidia .
 
 amd64nvidia_all: amd64nvidia_wheels amd64nvidia_ffmpeg amd64nvidia_frigate
@@ -42,7 +42,7 @@ aarch64_ffmpeg:
 	docker build --no-cache --pull --tag blakeblackshear/frigate-ffmpeg:1.2.0-aarch64 --file docker/Dockerfile.ffmpeg.aarch64 .
 
 aarch64_frigate: version web
-	docker build --no-cache --tag frigate-base --build-arg ARCH=aarch64 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.0 --file docker/Dockerfile.base .
+	docker build --no-cache --tag frigate-base --build-arg ARCH=aarch64 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.1 --file docker/Dockerfile.base .
 	docker build --no-cache --tag frigate --file docker/Dockerfile.aarch64 .
 
 armv7_all: armv7_wheels armv7_ffmpeg armv7_frigate
@@ -54,7 +54,7 @@ armv7_ffmpeg:
 	docker build --no-cache --pull --tag blakeblackshear/frigate-ffmpeg:1.2.0-armv7 --file docker/Dockerfile.ffmpeg.armv7 .
 
 armv7_frigate: version web
-	docker build --no-cache --tag frigate-base --build-arg ARCH=armv7 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.0 --file docker/Dockerfile.base .
+	docker build --no-cache --tag frigate-base --build-arg ARCH=armv7 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.1 --file docker/Dockerfile.base .
 	docker build --no-cache --tag frigate --file docker/Dockerfile.armv7 .
 
 armv7_all: armv7_wheels armv7_ffmpeg armv7_frigate

--- a/docker/Dockerfile.nginx
+++ b/docker/Dockerfile.nginx
@@ -23,6 +23,8 @@ RUN apt-get -yqq install --no-install-recommends curl \
     && curl -sL https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar -C /tmp/nginx -zx --strip-components=1 \
     && mkdir /tmp/nginx-vod-module \
     && curl -sL https://github.com/kaltura/nginx-vod-module/archive/refs/tags/${VOD_MODULE_VERSION}.tar.gz | tar -C /tmp/nginx-vod-module -zx --strip-components=1 \
+    # Patch MAX_CLIPS to allow more clips to be added than the default 128
+    && sed -i 's/MAX_CLIPS (128)/MAX_CLIPS (1080)/g' /tmp/nginx-vod-module/vod/media_set.h \
     && mkdir /tmp/nginx-rtmp-module \
     && curl -sL https://github.com/arut/nginx-rtmp-module/archive/refs/tags/v${RTMP_MODULE_VERSION}.tar.gz | tar -C /tmp/nginx-rtmp-module -zx --strip-components=1
 

--- a/docker/Dockerfile.nginx
+++ b/docker/Dockerfile.nginx
@@ -10,6 +10,7 @@ FROM base as build
 
 ARG NGINX_VERSION=1.18.0
 ARG VOD_MODULE_VERSION=1.28
+ARG SECURE_TOKEN_MODULE_VERSION=1.4
 ARG RTMP_MODULE_VERSION=1.2.1
 
 RUN cp /etc/apt/sources.list /etc/apt/sources.list~ \
@@ -25,6 +26,8 @@ RUN apt-get -yqq install --no-install-recommends curl \
     && curl -sL https://github.com/kaltura/nginx-vod-module/archive/refs/tags/${VOD_MODULE_VERSION}.tar.gz | tar -C /tmp/nginx-vod-module -zx --strip-components=1 \
     # Patch MAX_CLIPS to allow more clips to be added than the default 128
     && sed -i 's/MAX_CLIPS (128)/MAX_CLIPS (1080)/g' /tmp/nginx-vod-module/vod/media_set.h \
+    && mkdir /tmp/nginx-secure-token-module \
+    && curl -sL https://github.com/kaltura/nginx-secure-token-module/archive/refs/tags/${SECURE_TOKEN_MODULE_VERSION}.tar.gz | tar -C /tmp/nginx-secure-token-module -zx --strip-components=1 \
     && mkdir /tmp/nginx-rtmp-module \
     && curl -sL https://github.com/arut/nginx-rtmp-module/archive/refs/tags/v${RTMP_MODULE_VERSION}.tar.gz | tar -C /tmp/nginx-rtmp-module -zx --strip-components=1
 
@@ -36,6 +39,7 @@ RUN ./configure --prefix=/usr/local/nginx \
     --with-http_ssl_module \
     --with-threads \
     --add-module=../nginx-vod-module \
+    --add-module=../nginx-secure-token-module \
     --add-module=../nginx-rtmp-module \
     --with-cc-opt="-O3 -Wno-error=implicit-fallthrough"
 

--- a/docker/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/rootfs/usr/local/nginx/conf/nginx.conf
@@ -71,6 +71,9 @@ http {
         location /vod/ {
             vod hls;
 
+            secure_token $args;
+			secure_token_types application/vnd.apple.mpegurl;
+
             add_header Access-Control-Allow-Headers '*';
             add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
             add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -83,15 +83,95 @@ cameras:
 
 ## Optional
 
-### `clips`
+### `database`
 
 ```yaml
-clips:
-  # Optional: Maximum length of time to retain video during long events. (default: shown below)
-  # NOTE: If an object is being tracked for longer than this amount of time, the cache
-  #       will begin to expire and the resulting clip will be the last x seconds of the event.
-  max_seconds: 300
-  # Optional: Retention settings for clips (default: shown below)
+database:
+  # The path to store the SQLite DB (default: shown below)
+  path: /media/frigate/frigate.db
+```
+
+### `model`
+
+```yaml
+# Optional: model modifications
+model:
+  # Required: Object detection model input width (default: shown below)
+  width: 320
+  # Required: Object detection model input height (default: shown below)
+  height: 320
+  # Optional: Label name modifications
+  labelmap:
+    2: vehicle # previously "car"
+```
+
+### `detectors`
+
+Check the [detectors configuration page](detectors.md) for a complete list of options.
+
+### `logger`
+
+```yaml
+# Optional: logger verbosity settings
+logger:
+  # Optional: Default log verbosity (default: shown below)
+  default: info
+  # Optional: Component specific logger overrides
+  logs:
+    frigate.event: debug
+```
+
+### `record`
+
+Can be overridden at the camera level. 24/7 recordings can be enabled and are stored at `/media/frigate/recordings`. The folder structure for the recordings is `YYYY-MM/DD/HH/<camera_name>/MM.SS.mp4`. These recordings are written directly from your camera stream without re-encoding and are available in Home Assistant's media browser. Each camera supports a configurable retention policy in the config.
+
+Clips are also created off of these recordings. Frigate chooses the largest matching retention value between the recording retention and the event retention when determining if a recording should be removed.
+
+These recordings will not be playable in the web UI or in Home Assistant's media browser unless your camera sends video as h264.
+
+:::caution
+Previous versions of frigate included `-vsync drop` in input parameters. This is not compatible with FFmpeg's segment feature and must be removed from your input parameters if you have overrides set.
+:::
+
+```yaml
+record:
+  # Optional: Enable recording (default: shown below)
+  enabled: False
+  # Optional: Number of days to retain (default: shown below)
+  retain_days: 0
+  # Optional: Event recording settings
+  events:
+    # Optional: Enable event recording retention settings (default: shown below)
+    enabled: False
+    # Optional: Maximum length of time to retain video during long events. (default: shown below)
+    # NOTE: If an object is being tracked for longer than this amount of time, the cache
+    #       will begin to expire and the resulting clip will be the last x seconds of the event unless retain_days under record is > 0.
+    max_seconds: 300
+    # Optional: Number of seconds before the event to include in the clips (default: shown below)
+    pre_capture: 5
+    # Optional: Number of seconds after the event to include in the clips (default: shown below)
+    post_capture: 5
+    # Optional: Objects to save clips for. (default: all tracked objects)
+    objects:
+      - person
+    # Optional: Restrict clips to objects that entered any of the listed zones (default: no required zones)
+    required_zones: []
+    # Optional: Retention settings for clips
+    retain:
+      # Required: Default retention days (default: shown below)
+      default: 10
+      # Optional: Per object retention days
+      objects:
+        person: 15
+```
+
+## `snapshots`
+
+Can be overridden at the camera level. Global snapshot retention settings.
+
+```yaml
+# Optional: Configuration for the jpg snapshots written to the clips directory for each event
+snapshots:
   retain:
     # Required: Default retention days (default: shown below)
     default: 10
@@ -101,6 +181,8 @@ clips:
 ```
 
 ### `ffmpeg`
+
+Can be overridden at the camera level.
 
 ```yaml
 ffmpeg:
@@ -143,22 +225,6 @@ objects:
       min_score: 0.5
       # Optional: minimum decimal percentage for tracked object's computed score to be considered a true positive (default: shown below)
       threshold: 0.7
-```
-
-### `record`
-
-Can be overridden at the camera level. 24/7 recordings can be enabled and are stored at `/media/frigate/recordings`. The folder structure for the recordings is `YYYY-MM/DD/HH/<camera_name>/MM.SS.mp4`. These recordings are written directly from your camera stream without re-encoding and are available in Home Assistant's media browser. Each camera supports a configurable retention policy in the config.
-
-:::caution
-Previous versions of frigate included `-vsync drop` in input parameters. This is not compatible with FFmpeg's segment feature and must be removed from your input parameters if you have overrides set.
-:::
-
-```yaml
-record:
-  # Optional: Enable recording
-  enabled: False
-  # Optional: Number of days to retain
-  retain_days: 30
 ```
 
 ### `birdseye`

--- a/docs/docs/usage/mqtt.md
+++ b/docs/docs/usage/mqtt.md
@@ -88,13 +88,13 @@ Topic to turn detection for a camera on and off. Expected values are `ON` and `O
 
 Topic with current state of detection for a camera. Published values are `ON` and `OFF`.
 
-### `frigate/<camera_name>/clips/set`
+### `frigate/<camera_name>/recordings/set`
 
-Topic to turn clips for a camera on and off. Expected values are `ON` and `OFF`.
+Topic to turn recordings for a camera on and off. Expected values are `ON` and `OFF`.
 
-### `frigate/<camera_name>/clips/state`
+### `frigate/<camera_name>/recordings/state`
 
-Topic with current state of clips for a camera. Published values are `ON` and `OFF`.
+Topic with current state of recordings for a camera. Published values are `ON` and `OFF`.
 
 ### `frigate/<camera_name>/snapshots/set`
 

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -23,7 +23,7 @@ from frigate.models import Event, Recordings
 from frigate.mqtt import create_mqtt_client, MqttSocketRelay
 from frigate.object_processing import TrackedObjectProcessor
 from frigate.output import output_frames
-from frigate.record import RecordingMaintainer
+from frigate.record import RecordingCleanup, RecordingMaintainer
 from frigate.stats import StatsEmitter, stats_init
 from frigate.video import capture_camera, track_camera
 from frigate.watchdog import FrigateWatchdog
@@ -301,6 +301,10 @@ class FrigateApp:
         self.recording_maintainer = RecordingMaintainer(self.config, self.stop_event)
         self.recording_maintainer.start()
 
+    def start_recording_cleanup(self):
+        self.recording_cleanup = RecordingCleanup(self.config, self.stop_event)
+        self.recording_cleanup.start()
+
     def start_stats_emitter(self):
         self.stats_emitter = StatsEmitter(
             self.config,
@@ -346,6 +350,7 @@ class FrigateApp:
         self.start_event_processor()
         self.start_event_cleanup()
         self.start_recording_maintainer()
+        self.start_recording_cleanup()
         self.start_stats_emitter()
         self.start_watchdog()
         # self.zeroconf = broadcast_zeroconf(self.config.mqtt.client_id)
@@ -372,6 +377,7 @@ class FrigateApp:
         self.event_processor.join()
         self.event_cleanup.join()
         self.recording_maintainer.join()
+        self.recording_cleanup.join()
         self.stats_emitter.join()
         self.frigate_watchdog.join()
         self.db.stop()

--- a/frigate/events.py
+++ b/frigate/events.py
@@ -1,20 +1,14 @@
 import datetime
-import json
 import logging
 import os
 import queue
-import subprocess as sp
 import threading
 import time
-from collections import defaultdict
 from pathlib import Path
 
-import psutil
-import shutil
-
-from frigate.config import FrigateConfig
-from frigate.const import RECORD_DIR, CLIPS_DIR, CACHE_DIR
-from frigate.models import Event
+from frigate.config import FrigateConfig, RecordConfig
+from frigate.const import CLIPS_DIR
+from frigate.models import Event, Recordings
 
 from peewee import fn
 
@@ -39,8 +33,16 @@ class EventProcessor(threading.Thread):
         if event_data["false_positive"]:
             return False
 
-        # if there are required zones and there is no overlap
-        required_zones = self.config.cameras[camera].clips.required_zones
+        record_config: RecordConfig = self.config.cameras[camera].record
+
+        # Recording clips is disabled
+        if not record_config.enabled or (
+            record_config.retain_days == 0 and not record_config.events.enabled
+        ):
+            return False
+
+        # If there are required zones and there is no overlap
+        required_zones = record_config.events.required_zones
         if len(required_zones) > 0 and not set(event_data["entered_zones"]) & set(
             required_zones
         ):
@@ -49,208 +51,65 @@ class EventProcessor(threading.Thread):
             )
             return False
 
-        return True
-
-    def refresh_cache(self):
-        cached_files = os.listdir(CACHE_DIR)
-
-        files_in_use = []
-        for process in psutil.process_iter():
-            try:
-                if process.name() != "ffmpeg":
-                    continue
-
-                flist = process.open_files()
-                if flist:
-                    for nt in flist:
-                        if nt.path.startswith(CACHE_DIR):
-                            files_in_use.append(nt.path.split("/")[-1])
-            except:
-                continue
-
-        for f in cached_files:
-            if f in files_in_use or f in self.cached_clips:
-                continue
-
-            basename = os.path.splitext(f)[0]
-            camera, date = basename.rsplit("-", maxsplit=1)
-            start_time = datetime.datetime.strptime(date, "%Y%m%d%H%M%S")
-
-            ffprobe_cmd = [
-                "ffprobe",
-                "-v",
-                "error",
-                "-show_entries",
-                "format=duration",
-                "-of",
-                "default=noprint_wrappers=1:nokey=1",
-                f"{os.path.join(CACHE_DIR, f)}",
-            ]
-            p = sp.run(ffprobe_cmd, capture_output=True)
-            if p.returncode == 0:
-                duration = float(p.stdout.decode().strip())
-            else:
-                logger.info(f"bad file: {f}")
-                os.remove(os.path.join(CACHE_DIR, f))
-                continue
-
-            self.cached_clips[f] = {
-                "path": f,
-                "camera": camera,
-                "start_time": start_time.timestamp(),
-                "duration": duration,
-            }
-
-        if len(self.events_in_process) > 0:
-            earliest_event = min(
-                self.events_in_process.values(), key=lambda x: x["start_time"]
-            )["start_time"]
-        else:
-            earliest_event = datetime.datetime.now().timestamp()
-
-        # if the earliest event is more tha max seconds ago, cap it
-        max_seconds = self.config.clips.max_seconds
-        earliest_event = max(
-            earliest_event,
-            datetime.datetime.now().timestamp() - self.config.clips.max_seconds,
-        )
-
-        for f, data in list(self.cached_clips.items()):
-            if earliest_event - 90 > data["start_time"] + data["duration"]:
-                del self.cached_clips[f]
-                logger.debug(f"Cleaning up cached file {f}")
-                os.remove(os.path.join(CACHE_DIR, f))
-
-        # if we are still using more than 90% of the cache, proactively cleanup
-        cache_usage = shutil.disk_usage("/tmp/cache")
-        while (
-            cache_usage.used / cache_usage.total > 0.9
-            and cache_usage.free < 200000000
-            and len(self.cached_clips) > 0
+        # If the required objects are not present
+        if (
+            record_config.events.objects is not None
+            and event_data["label"] not in record_config.events.objects
         ):
-            logger.warning("More than 90% of the cache is used.")
-            logger.warning(
-                "Consider increasing space available at /tmp/cache or reducing max_seconds in your clips config."
+            logger.debug(
+                f"Not creating clip for {event_data['id']} because it did not contain required objects"
             )
-            logger.warning("Proactively cleaning up the cache...")
-            oldest_clip = min(self.cached_clips.values(), key=lambda x: x["start_time"])
-            del self.cached_clips[oldest_clip["path"]]
-            os.remove(os.path.join(CACHE_DIR, oldest_clip["path"]))
-            cache_usage = shutil.disk_usage("/tmp/cache")
-
-    def create_clip(self, camera, event_data, pre_capture, post_capture):
-        # get all clips from the camera with the event sorted
-        sorted_clips = sorted(
-            [c for c in self.cached_clips.values() if c["camera"] == camera],
-            key=lambda i: i["start_time"],
-        )
-
-        # if there are no clips in the cache or we are still waiting on a needed file check every 5 seconds
-        wait_count = 0
-        while (
-            len(sorted_clips) == 0
-            or sorted_clips[-1]["start_time"] + sorted_clips[-1]["duration"]
-            < event_data["end_time"] + post_capture
-        ):
-            if wait_count > 4:
-                logger.warning(
-                    f"Unable to create clip for {camera} and event {event_data['id']}. There were no cache files for this event."
-                )
-                return False
-            logger.debug(f"No cache clips for {camera}. Waiting...")
-            time.sleep(5)
-            self.refresh_cache()
-            # get all clips from the camera with the event sorted
-            sorted_clips = sorted(
-                [c for c in self.cached_clips.values() if c["camera"] == camera],
-                key=lambda i: i["start_time"],
-            )
-            wait_count += 1
-
-        playlist_start = event_data["start_time"] - pre_capture
-        playlist_end = event_data["end_time"] + post_capture
-        playlist_lines = []
-        for clip in sorted_clips:
-            # clip ends before playlist start time, skip
-            if clip["start_time"] + clip["duration"] < playlist_start:
-                continue
-            # clip starts after playlist ends, finish
-            if clip["start_time"] > playlist_end:
-                break
-            playlist_lines.append(f"file '{os.path.join(CACHE_DIR,clip['path'])}'")
-            # if this is the starting clip, add an inpoint
-            if clip["start_time"] < playlist_start:
-                playlist_lines.append(
-                    f"inpoint {int(playlist_start-clip['start_time'])}"
-                )
-            # if this is the ending clip, add an outpoint
-            if clip["start_time"] + clip["duration"] > playlist_end:
-                playlist_lines.append(
-                    f"outpoint {int(playlist_end-clip['start_time'])}"
-                )
-
-        clip_name = f"{camera}-{event_data['id']}"
-        ffmpeg_cmd = [
-            "ffmpeg",
-            "-y",
-            "-protocol_whitelist",
-            "pipe,file",
-            "-f",
-            "concat",
-            "-safe",
-            "0",
-            "-i",
-            "-",
-            "-c",
-            "copy",
-            "-movflags",
-            "+faststart",
-            f"{os.path.join(CLIPS_DIR, clip_name)}.mp4",
-        ]
-
-        p = sp.run(
-            ffmpeg_cmd,
-            input="\n".join(playlist_lines),
-            encoding="ascii",
-            capture_output=True,
-        )
-        if p.returncode != 0:
-            logger.error(p.stderr)
             return False
+
         return True
+
+    def verify_clip(self, camera, end_time):
+        # check every 5 seconds for the last required recording
+        for _ in range(4):
+            recordings_count = (
+                Recordings.select()
+                .where(Recordings.camera == camera, Recordings.end_time > end_time)
+                .limit(1)
+                .count()
+            )
+            if recordings_count > 0:
+                return True
+            logger.debug(f"Missing recording for {camera} clip. Waiting...")
+            time.sleep(5)
+
+        logger.warning(
+            f"Unable to verify clip for {camera}. There were no recordings for this camera."
+        )
+        return False
 
     def run(self):
         while not self.stop_event.is_set():
             try:
                 event_type, camera, event_data = self.event_queue.get(timeout=10)
             except queue.Empty:
-                if not self.stop_event.is_set():
-                    self.refresh_cache()
+                # if not self.stop_event.is_set():
+                #     self.refresh_cache()
                 continue
 
             logger.debug(f"Event received: {event_type} {camera} {event_data['id']}")
-            self.refresh_cache()
+            # self.refresh_cache()
 
             if event_type == "start":
                 self.events_in_process[event_data["id"]] = event_data
 
             if event_type == "end":
-                clips_config = self.config.cameras[camera].clips
+                record_config: RecordConfig = self.config.cameras[camera].record
 
-                clip_created = False
-                if self.should_create_clip(camera, event_data):
-                    if clips_config.enabled and (
-                        clips_config.objects is None
-                        or event_data["label"] in clips_config.objects
-                    ):
-                        clip_created = self.create_clip(
-                            camera,
-                            event_data,
-                            clips_config.pre_capture,
-                            clips_config.post_capture,
-                        )
+                has_clip = self.should_create_clip(camera, event_data)
 
-                if clip_created or event_data["has_snapshot"]:
+                # Wait for recordings to be ready
+                if has_clip:
+                    has_clip = self.verify_clip(
+                        camera,
+                        event_data["end_time"] + record_config.events.post_capture,
+                    )
+
+                if has_clip or event_data["has_snapshot"]:
                     Event.create(
                         id=event_data["id"],
                         label=event_data["label"],
@@ -261,11 +120,12 @@ class EventProcessor(threading.Thread):
                         false_positive=event_data["false_positive"],
                         zones=list(event_data["entered_zones"]),
                         thumbnail=event_data["thumbnail"],
-                        has_clip=clip_created,
+                        has_clip=has_clip,
                         has_snapshot=event_data["has_snapshot"],
                     )
+
                 del self.events_in_process[event_data["id"]]
-                self.event_processed_queue.put((event_data["id"], camera, clip_created))
+                self.event_processed_queue.put((event_data["id"], camera, has_clip))
 
         logger.info(f"Exiting event processor...")
 

--- a/frigate/events.py
+++ b/frigate/events.py
@@ -87,12 +87,9 @@ class EventProcessor(threading.Thread):
             try:
                 event_type, camera, event_data = self.event_queue.get(timeout=10)
             except queue.Empty:
-                # if not self.stop_event.is_set():
-                #     self.refresh_cache()
                 continue
 
             logger.debug(f"Event received: {event_type} {camera} {event_data['id']}")
-            # self.refresh_cache()
 
             if event_type == "start":
                 self.events_in_process[event_data["id"]] = event_data

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -594,8 +594,6 @@ def recording_clip(camera, start_ts, end_ts):
         "-",
         "-c",
         "copy",
-        "-f",
-        "mp4",
         "-movflags",
         "+faststart",
         path,

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -187,6 +187,7 @@ def event_thumbnail(id):
 
 @bp.route("/events/<id>/snapshot.jpg")
 def event_snapshot(id):
+    download = request.args.get("download", type=bool)
     jpg_bytes = None
     try:
         event = Event.get(Event.id == id)
@@ -222,11 +223,17 @@ def event_snapshot(id):
 
     response = make_response(jpg_bytes)
     response.headers["Content-Type"] = "image/jpg"
+    if download:
+        response.headers[
+            "Content-Disposition"
+        ] = f"attachment; filename=snapshot-{id}.jpg"
     return response
 
 
 @bp.route("/events/<id>/clip.mp4")
 def event_clip(id):
+    download = request.args.get("download", type=bool)
+
     event: Event = Event.get(Event.id == id)
 
     if event is None:
@@ -246,7 +253,7 @@ def event_clip(id):
     return send_file(
         clip_path,
         mimetype="video/mp4",
-        as_attachment=True,
+        as_attachment=download,
         attachment_filename=f"{event.camera}_{start_ts}-{end_ts}.mp4",
     )
 
@@ -548,6 +555,8 @@ def recordings(camera_name):
 @bp.route("/<camera>/start/<int:start_ts>/end/<int:end_ts>/clip.mp4")
 @bp.route("/<camera>/start/<float:start_ts>/end/<float:end_ts>/clip.mp4")
 def recording_clip(camera, start_ts, end_ts):
+    download = request.args.get("download", type=bool)
+
     recordings = (
         Recordings.select()
         .where(
@@ -615,9 +624,10 @@ def recording_clip(camera, start_ts, end_ts):
 
     response = make_response(mp4_bytes)
     response.mimetype = "video/mp4"
-    response.headers[
-        "Content-Disposition"
-    ] = f"attachment; filename={camera}_{start_ts}-{end_ts}.mp4"
+    if download:
+        response.headers[
+            "Content-Disposition"
+        ] = f"attachment; filename={camera}_{start_ts}-{end_ts}.mp4"
     return response
 
 

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -553,6 +553,7 @@ def recording_clip(camera, start_ts, end_ts):
         .where(
             (Recordings.start_time.between(start_ts, end_ts))
             | (Recordings.end_time.between(start_ts, end_ts))
+            | ((start_ts > Recordings.start_time) & (end_ts < Recordings.end_time))
         )
         .where(Recordings.camera == camera)
         .order_by(Recordings.start_time.asc())
@@ -626,8 +627,9 @@ def vod_ts(camera, start_ts, end_ts):
     recordings = (
         Recordings.select()
         .where(
-            (Recordings.start_time.between(start_ts, end_ts))
-            | (Recordings.end_time.between(start_ts, end_ts))
+            Recordings.start_time.between(start_ts, end_ts)
+            | Recordings.end_time.between(start_ts, end_ts)
+            | ((start_ts > Recordings.start_time) & (end_ts < Recordings.end_time))
         )
         .where(Recordings.camera == camera)
         .order_by(Recordings.start_time.asc())

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -234,9 +234,9 @@ def event_snapshot(id):
 def event_clip(id):
     download = request.args.get("download", type=bool)
 
-    event: Event = Event.get(Event.id == id)
-
-    if event is None:
+    try:
+        event: Event = Event.get(Event.id == id)
+    except DoesNotExist:
         return "Event not found.", 404
 
     if not event.has_clip:
@@ -689,9 +689,9 @@ def vod_hour(year_month, day, hour, camera):
 
 @bp.route("/vod/event/<id>")
 def vod_event(id):
-    event: Event = Event.get(Event.id == id)
-
-    if event is None:
+    try:
+        event: Event = Event.get(Event.id == id)
+    except DoesNotExist:
         return "Event not found.", 404
 
     if not event.has_clip:

--- a/frigate/mqtt.py
+++ b/frigate/mqtt.py
@@ -21,22 +21,22 @@ logger = logging.getLogger(__name__)
 def create_mqtt_client(config: FrigateConfig, camera_metrics):
     mqtt_config = config.mqtt
 
-    def on_clips_command(client, userdata, message):
+    def on_recordings_command(client, userdata, message):
         payload = message.payload.decode()
-        logger.debug(f"on_clips_toggle: {message.topic} {payload}")
+        logger.debug(f"on_recordings_toggle: {message.topic} {payload}")
 
         camera_name = message.topic.split("/")[-3]
 
-        clips_settings = config.cameras[camera_name].clips
+        record_settings = config.cameras[camera_name].record
 
         if payload == "ON":
-            if not clips_settings.enabled:
-                logger.info(f"Turning on clips for {camera_name} via mqtt")
-                clips_settings.enabled = True
+            if not record_settings.enabled:
+                logger.info(f"Turning on recordings for {camera_name} via mqtt")
+                record_settings.enabled = True
         elif payload == "OFF":
-            if clips_settings.enabled:
-                logger.info(f"Turning off clips for {camera_name} via mqtt")
-                clips_settings.enabled = False
+            if record_settings.enabled:
+                logger.info(f"Turning off recordings for {camera_name} via mqtt")
+                record_settings.enabled = False
         else:
             logger.warning(f"Received unsupported value at {message.topic}: {payload}")
 
@@ -120,7 +120,7 @@ def create_mqtt_client(config: FrigateConfig, camera_metrics):
     # register callbacks
     for name in config.cameras.keys():
         client.message_callback_add(
-            f"{mqtt_config.topic_prefix}/{name}/clips/set", on_clips_command
+            f"{mqtt_config.topic_prefix}/{name}/recordings/set", on_recordings_command
         )
         client.message_callback_add(
             f"{mqtt_config.topic_prefix}/{name}/snapshots/set", on_snapshots_command
@@ -159,8 +159,8 @@ def create_mqtt_client(config: FrigateConfig, camera_metrics):
 
     for name in config.cameras.keys():
         client.publish(
-            f"{mqtt_config.topic_prefix}/{name}/clips/state",
-            "ON" if config.cameras[name].clips.enabled else "OFF",
+            f"{mqtt_config.topic_prefix}/{name}/recordings/state",
+            "ON" if config.cameras[name].record.enabled else "OFF",
             retain=True,
         )
         client.publish(

--- a/frigate/record.py
+++ b/frigate/record.py
@@ -3,6 +3,7 @@ import itertools
 import logging
 import os
 import random
+import shutil
 import string
 import subprocess as sp
 import threading
@@ -10,9 +11,11 @@ from pathlib import Path
 
 import psutil
 
+from peewee import JOIN
+
 from frigate.config import FrigateConfig
-from frigate.const import RECORD_DIR
-from frigate.models import Recordings
+from frigate.const import CACHE_DIR, RECORD_DIR
+from frigate.models import Event, Recordings
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +48,10 @@ class RecordingMaintainer(threading.Thread):
     def move_files(self):
         recordings = [
             d
-            for d in os.listdir(RECORD_DIR)
-            if os.path.isfile(os.path.join(RECORD_DIR, d)) and d.endswith(".mp4")
+            for d in os.listdir(CACHE_DIR)
+            if os.path.isfile(os.path.join(CACHE_DIR, d))
+            and d.endswith(".mp4")
+            and not d.startswith("tmp_clip")
         ]
 
         files_in_use = []
@@ -57,7 +62,7 @@ class RecordingMaintainer(threading.Thread):
                 flist = process.open_files()
                 if flist:
                     for nt in flist:
-                        if nt.path.startswith(RECORD_DIR):
+                        if nt.path.startswith(CACHE_DIR):
                             files_in_use.append(nt.path.split("/")[-1])
             except:
                 continue
@@ -66,6 +71,7 @@ class RecordingMaintainer(threading.Thread):
             if f in files_in_use:
                 continue
 
+            cache_path = os.path.join(CACHE_DIR, f)
             basename = os.path.splitext(f)[0]
             camera, date = basename.rsplit("-", maxsplit=1)
             start_time = datetime.datetime.strptime(date, "%Y%m%d%H%M%S")
@@ -78,7 +84,7 @@ class RecordingMaintainer(threading.Thread):
                 "format=duration",
                 "-of",
                 "default=noprint_wrappers=1:nokey=1",
-                f"{os.path.join(RECORD_DIR, f)}",
+                f"{cache_path}",
             ]
             p = sp.run(ffprobe_cmd, capture_output=True)
             if p.returncode == 0:
@@ -86,7 +92,7 @@ class RecordingMaintainer(threading.Thread):
                 end_time = start_time + datetime.timedelta(seconds=duration)
             else:
                 logger.info(f"bad file: {f}")
-                os.remove(os.path.join(RECORD_DIR, f))
+                Path(cache_path).unlink(missing_ok=True)
                 continue
 
             directory = os.path.join(
@@ -99,7 +105,7 @@ class RecordingMaintainer(threading.Thread):
             file_name = f"{start_time.strftime('%M.%S.mp4')}"
             file_path = os.path.join(directory, file_name)
 
-            os.rename(os.path.join(RECORD_DIR, f), file_path)
+            shutil.move(cache_path, file_path)
 
             rand_id = "".join(
                 random.choices(string.ascii_lowercase + string.digits, k=6)
@@ -113,7 +119,135 @@ class RecordingMaintainer(threading.Thread):
                 duration=duration,
             )
 
+    def expire_recordings(self):
+        event_recordings = Recordings.select(
+            Recordings.id.alias("recording_id"),
+            Recordings.camera,
+            Recordings.path,
+            Recordings.end_time,
+            Event.id.alias("event_id"),
+            Event.label,
+        ).join(
+            Event,
+            on=(
+                (Recordings.camera == Event.camera)
+                & (
+                    (Recordings.start_time.between(Event.start_time, Event.end_time))
+                    | (Recordings.end_time.between(Event.start_time, Event.end_time))
+                ),
+            ),
+        )
+
+        retain = {}
+        for recording in event_recordings:
+            # Set default to delete
+            if recording.path not in retain:
+                retain[recording.path] = False
+
+            # Handle deleted cameras that still have recordings and events
+            if recording.camera in self.config.cameras:
+                record_config = self.config.cameras[recording.camera].record
+            else:
+                record_config = self.config.record
+
+            # Check event retention and set to True if within window
+            expire_days_event = (
+                0
+                if not record_config.events.enabled
+                else record_config.events.retain.objects.get(
+                    recording.event.label, record_config.events.retain.default
+                )
+            )
+            expire_before_event = (
+                datetime.datetime.now() - datetime.timedelta(days=expire_days_event)
+            ).timestamp()
+            if recording.end_time >= expire_before_event:
+                retain[recording.path] = True
+
+            # Check recording retention and set to True if within window
+            expire_days_record = record_config.retain_days
+            expire_before_record = (
+                datetime.datetime.now() - datetime.timedelta(days=expire_days_record)
+            ).timestamp()
+            if recording.end_time > expire_before_record:
+                retain[recording.path] = True
+
+        # Actually expire recordings
+        for path, keep in retain.items():
+            if not keep:
+                Path(path).unlink(missing_ok=True)
+                Recordings.delete_by_id(recording.recording_id)
+
+        # Update Event
+        event_no_recordings = (
+            Event.select()
+            .join(
+                Recordings,
+                JOIN.LEFT_OUTER,
+                on=(
+                    (Recordings.camera == Event.camera)
+                    & (
+                        (
+                            Recordings.start_time.between(
+                                Event.start_time, Event.end_time
+                            )
+                        )
+                        | (
+                            Recordings.end_time.between(
+                                Event.start_time, Event.end_time
+                            )
+                        )
+                    ),
+                ),
+            )
+            .where(Recordings.id.is_null())
+        )
+        update = Event.update(has_clip=False).where(Event.id << event_no_recordings)
+        update.execute()
+
+        event_paths = list(retain.keys())
+
+        # Handle deleted cameras
+        no_camera_recordings: Recordings = Recordings.select().where(
+            Recordings.camera.not_in(list(self.config.cameras.keys())),
+            Recordings.path.not_in(event_paths),
+        )
+
+        for recording in no_camera_recordings:
+            expire_days = self.config.record.retain_days
+            expire_before = (
+                datetime.datetime.now() - datetime.timedelta(days=expire_days)
+            ).timestamp()
+            if recording.end_time >= expire_before:
+                Path(recording.path).unlink(missing_ok=True)
+                Recordings.delete_by_id(recording.id)
+
+        # When deleting recordings without events, we have to keep at LEAST the configured max clip duration
+        for camera, config in self.config.cameras.items():
+            min_end = (
+                datetime.datetime.now()
+                - datetime.timedelta(seconds=config.record.events.max_seconds)
+            ).timestamp()
+            recordings: Recordings = Recordings.select().where(
+                Recordings.camera == camera,
+                Recordings.path.not_in(event_paths),
+                Recordings.end_time < min_end,
+            )
+
+            for recording in recordings:
+                expire_days = config.record.retain_days
+                expire_before = (
+                    datetime.datetime.now() - datetime.timedelta(days=expire_days)
+                ).timestamp()
+                if recording.end_time >= expire_before:
+                    Path(recording.path).unlink(missing_ok=True)
+                    Recordings.delete_by_id(recording.id)
+
     def expire_files(self):
+        default_expire = (
+            datetime.datetime.now().timestamp()
+            - SECONDS_IN_DAY * self.config.record.retain_days
+        )
         delete_before = {}
         for name, camera in self.config.cameras.items():
             delete_before[name] = (
@@ -122,19 +256,22 @@ class RecordingMaintainer(threading.Thread):
             )
 
         for p in Path("/media/frigate/recordings").rglob("*.mp4"):
-            if not p.parent.name in delete_before:
+            # Ignore files that have a record in the recordings DB
+            if Recordings.select().where(Recordings.path == str(p)).count():
                 continue
-            if p.stat().st_mtime < delete_before[p.parent.name]:
-                Recordings.delete().where(Recordings.path == str(p)).execute()
+            if p.stat().st_mtime < delete_before.get(p.parent.name, default_expire):
                 p.unlink(missing_ok=True)
 
     def run(self):
-        for counter in itertools.cycle(range(60)):
-            if self.stop_event.wait(10):
+        # only expire events every 10 minutes, but check for new files every 5 seconds
+        for counter in itertools.cycle(range(120)):
+            if self.stop_event.wait(5):
                 logger.info(f"Exiting recording maintenance...")
                 break
 
-            # only expire events every 10 minutes, but check for new files every 10 seconds
+            if counter % 12 == 0:
+                self.expire_recordings()
+
             if counter == 0:
                 self.expire_files()
                 remove_empty_directories(RECORD_DIR)

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -198,7 +198,6 @@ class TestConfig(unittest.TestCase):
         assert len(back_camera.objects.filters["person"].raw_mask) == 1
 
     def test_default_input_args(self):
-
         config = {
             "mqtt": {"host": "mqtt"},
             "cameras": {

--- a/web/src/api/__tests__/mqtt.test.jsx
+++ b/web/src/api/__tests__/mqtt.test.jsx
@@ -107,12 +107,12 @@ describe('MqttProvider', () => {
     );
   });
 
-  test('prefills the clips/detect/snapshots state from config', async () => {
+  test('prefills the recordings/detect/snapshots state from config', async () => {
     jest.spyOn(Date, 'now').mockReturnValue(123456);
     const config = {
       cameras: {
-        front: { name: 'front', detect: { enabled: true }, clips: { enabled: false }, snapshots: { enabled: true } },
-        side: { name: 'side', detect: { enabled: false }, clips: { enabled: false }, snapshots: { enabled: false } },
+        front: { name: 'front', detect: { enabled: true }, record: { enabled: false }, snapshots: { enabled: true } },
+        side: { name: 'side', detect: { enabled: false }, record: { enabled: false }, snapshots: { enabled: false } },
       },
     };
     render(
@@ -122,10 +122,10 @@ describe('MqttProvider', () => {
     );
     await screen.findByTestId('data');
     expect(screen.getByTestId('front/detect/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"ON"}');
-    expect(screen.getByTestId('front/clips/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"OFF"}');
+    expect(screen.getByTestId('front/recordings/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"OFF"}');
     expect(screen.getByTestId('front/snapshots/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"ON"}');
     expect(screen.getByTestId('side/detect/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"OFF"}');
-    expect(screen.getByTestId('side/clips/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"OFF"}');
+    expect(screen.getByTestId('side/recordings/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"OFF"}');
     expect(screen.getByTestId('side/snapshots/state')).toHaveTextContent('{"lastUpdate":123456,"payload":"OFF"}');
   });
 });

--- a/web/src/api/mqtt.jsx
+++ b/web/src/api/mqtt.jsx
@@ -41,8 +41,8 @@ export function MqttProvider({
 
   useEffect(() => {
     Object.keys(config.cameras).forEach((camera) => {
-      const { name, clips, detect, snapshots } = config.cameras[camera];
-      dispatch({ topic: `${name}/clips/state`, payload: clips.enabled ? 'ON' : 'OFF' });
+      const { name, record, detect, snapshots } = config.cameras[camera];
+      dispatch({ topic: `${name}/recordings/state`, payload: record.enabled ? 'ON' : 'OFF' });
       dispatch({ topic: `${name}/detect/state`, payload: detect.enabled ? 'ON' : 'OFF' });
       dispatch({ topic: `${name}/snapshots/state`, payload: snapshots.enabled ? 'ON' : 'OFF' });
     });
@@ -101,12 +101,12 @@ export function useDetectState(camera) {
   return { payload, send, connected };
 }
 
-export function useClipsState(camera) {
+export function useRecordingsState(camera) {
   const {
     value: { payload },
     send,
     connected,
-  } = useMqtt(`${camera}/clips/state`, `${camera}/clips/set`);
+  } = useMqtt(`${camera}/recordings/state`, `${camera}/recordings/set`);
   return { payload, send, connected };
 }
 

--- a/web/src/routes/Cameras.jsx
+++ b/web/src/routes/Cameras.jsx
@@ -5,7 +5,7 @@ import CameraImage from '../components/CameraImage';
 import ClipIcon from '../icons/Clip';
 import MotionIcon from '../icons/Motion';
 import SnapshotIcon from '../icons/Snapshot';
-import { useDetectState, useClipsState, useSnapshotsState } from '../api/mqtt';
+import { useDetectState, useRecordingsState, useSnapshotsState } from '../api/mqtt';
 import { useConfig, FetchStatus } from '../api';
 import { useMemo } from 'preact/hooks';
 
@@ -25,7 +25,7 @@ export default function Cameras() {
 
 function Camera({ name, conf }) {
   const { payload: detectValue, send: sendDetect } = useDetectState(name);
-  const { payload: clipValue, send: sendClips } = useClipsState(name);
+  const { payload: recordValue, send: sendRecordings } = useRecordingsState(name);
   const { payload: snapshotValue, send: sendSnapshots } = useSnapshotsState(name);
   const href = `/cameras/${name}`;
   const buttons = useMemo(() => {
@@ -46,11 +46,11 @@ function Camera({ name, conf }) {
         },
       },
       {
-        name: `Toggle clips ${clipValue === 'ON' ? 'off' : 'on'}`,
+        name: `Toggle recordings ${recordValue === 'ON' ? 'off' : 'on'}`,
         icon: ClipIcon,
-        color: clipValue === 'ON' ? 'blue' : 'gray',
+        color: recordValue === 'ON' ? 'blue' : 'gray',
         onClick: () => {
-          sendClips(clipValue === 'ON' ? 'OFF' : 'ON');
+          sendRecordings(recordValue === 'ON' ? 'OFF' : 'ON');
         },
       },
       {
@@ -62,7 +62,7 @@ function Camera({ name, conf }) {
         },
       },
     ],
-    [detectValue, sendDetect, clipValue, sendClips, snapshotValue, sendSnapshots]
+    [detectValue, sendDetect, recordValue, sendRecordings, snapshotValue, sendSnapshots]
   );
 
   return (

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -115,8 +115,8 @@ export default function Event({ eventId }) {
             options={{
               sources: [
                 {
-                  src: `${apiHost}/clips/${data.camera}-${eventId}.mp4`,
-                  type: 'video/mp4',
+                  src: `${apiHost}/vod/event/${eventId}/index.m3u8`,
+                  type: 'application/vnd.apple.mpegurl',
                 },
               ],
               poster: data.has_snapshot
@@ -127,7 +127,7 @@ export default function Event({ eventId }) {
             onReady={(player) => {}}
           />
           <div className="text-center">
-            <Button className="mx-2" color="blue" href={`${apiHost}/clips/${data.camera}-${eventId}.mp4`} download>
+            <Button className="mx-2" color="blue" href={`${apiHost}/api/events/${eventId}/clip.mp4`} download>
               <Clip className="w-6" /> Download Clip
             </Button>
             <Button className="mx-2" color="blue" href={`${apiHost}/clips/${data.camera}-${eventId}.jpg`} download>

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -127,10 +127,20 @@ export default function Event({ eventId }) {
             onReady={(player) => {}}
           />
           <div className="text-center">
-            <Button className="mx-2" color="blue" href={`${apiHost}/api/events/${eventId}/clip.mp4`} download>
+            <Button
+              className="mx-2"
+              color="blue"
+              href={`${apiHost}/api/events/${eventId}/clip.mp4?download=true`}
+              download
+            >
               <Clip className="w-6" /> Download Clip
             </Button>
-            <Button className="mx-2" color="blue" href={`${apiHost}/clips/${data.camera}-${eventId}.jpg`} download>
+            <Button
+              className="mx-2"
+              color="blue"
+              href={`${apiHost}/api/events/${eventId}/snapshot.jpg?download=true`}
+              download
+            >
               <Snapshot className="w-6" /> Download Snapshot
             </Button>
           </div>

--- a/web/src/routes/__tests__/Cameras.test.jsx
+++ b/web/src/routes/__tests__/Cameras.test.jsx
@@ -51,13 +51,13 @@ describe('Cameras Route', () => {
 
   test('buttons toggle detect, clips, and snapshots', async () => {
     const sendDetect = jest.fn();
-    const sendClips = jest.fn();
+    const sendRecordings = jest.fn();
     const sendSnapshots = jest.fn();
     jest.spyOn(Mqtt, 'useDetectState').mockImplementation(() => {
       return { payload: 'ON', send: sendDetect };
     });
-    jest.spyOn(Mqtt, 'useClipsState').mockImplementation(() => {
-      return { payload: 'OFF', send: sendClips };
+    jest.spyOn(Mqtt, 'useRecordingsState').mockImplementation(() => {
+      return { payload: 'OFF', send: sendRecordings };
     });
     jest.spyOn(Mqtt, 'useSnapshotsState').mockImplementation(() => {
       return { payload: 'ON', send: sendSnapshots };
@@ -72,11 +72,11 @@ describe('Cameras Route', () => {
     fireEvent.click(screen.getAllByLabelText('Toggle snapshots off')[0]);
     expect(sendSnapshots).toHaveBeenCalledWith('OFF');
 
-    fireEvent.click(screen.getAllByLabelText('Toggle clips on')[0]);
-    expect(sendClips).toHaveBeenCalledWith('ON');
+    fireEvent.click(screen.getAllByLabelText('Toggle recordings on')[0]);
+    expect(sendRecordings).toHaveBeenCalledWith('ON');
 
     expect(sendDetect).toHaveBeenCalledTimes(1);
     expect(sendSnapshots).toHaveBeenCalledTimes(1);
-    expect(sendClips).toHaveBeenCalledTimes(1);
+    expect(sendRecordings).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This removes the somewhat duplicative separate clips/recordings functionality and combines them. This allows us to not create duplicate clips for different event labels, and also opens the door to be able to export arbitrary clips based on recordings.

It merges the current clips configuration into the new-style config so there will be no breaking changes, but a warning will be printed out. The `clips` role in the FFMPEG config is also deprecated.

Currently still a WIP but mostly functional.