### PR TITLE
Improve restart from UI

### DIFF
--- a/frigate/mqtt.py
+++ b/frigate/mqtt.py
@@ -90,7 +90,7 @@ def create_mqtt_client(config: FrigateConfig, camera_metrics):
         client.publish(state_topic, payload, retain=True)
 
     def on_restart_command(client, userdata, message):
-        restart_frigate()
+        restart_frigate(client, mqtt_config.topic_prefix)
 
     def on_connect(client, userdata, flags, rc):
         threading.current_thread().name = "mqtt"

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -523,6 +523,7 @@ def restart_frigate(mqtt_client, topic_prefix):
 
     def on_publish(client,userdata,result):
         time.sleep(0.67)
+        logger.info("Restart requested.")
         os.kill(os.getpid(), signal.SIGTERM)
 
     mqtt_client.on_publish = on_publish

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -519,14 +519,14 @@ def clipped(obj, frame_shape):
         return False
 
 
-def restart_frigate(mqtt_client, topic_prefix, from_ui = 0):
+def restart_frigate(mqtt_client, topic_prefix):
 
     def on_publish(client,userdata,result):
         time.sleep(0.67)
         os.kill(os.getpid(), signal.SIGTERM)
 
     mqtt_client.on_publish = on_publish
-    mqtt_client.publish(f"{topic_prefix}/restarted", int(from_ui))
+    mqtt_client.publish(f"{topic_prefix}/restarted", 1)
 
 
 class EventsPerSecond:

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -523,12 +523,7 @@ def restart_frigate(mqtt_client, topic_prefix, from_ui = 0):
 
     def on_publish(client,userdata,result):
         time.sleep(0.67)
-        rc, docker = 1, "/usr/local/bin/docker"
-        if os.access(docker, os.X_OK) and os.path.isfile("/var/run/docker.sock"):
-            rc = sp.Popen(f"{docker} restart $(hostname)", shell=True).wait()
-        if rc:
-            # Sometimes you have to wait a long time like this
-            os.kill(os.getpid(), signal.SIGTERM)
+        os.kill(os.getpid(), signal.SIGTERM)
 
     mqtt_client.on_publish = on_publish
     mqtt_client.publish(f"{topic_prefix}/restarted", int(from_ui))

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -519,8 +519,19 @@ def clipped(obj, frame_shape):
         return False
 
 
-def restart_frigate():
-    os.kill(os.getpid(), signal.SIGTERM)
+def restart_frigate(mqtt_client, topic_prefix, from_ui = 0):
+
+    def on_publish(client,userdata,result):
+        time.sleep(0.67)
+        rc, docker = 1, "/usr/local/bin/docker"
+        if os.access(docker, os.X_OK) and os.path.isfile("/var/run/docker.sock"):
+            rc = sp.Popen(f"{docker} restart $(hostname)", shell=True).wait()
+        if rc:
+            # Sometimes you have to wait a long time like this
+            os.kill(os.getpid(), signal.SIGTERM)
+
+    mqtt_client.on_publish = on_publish
+    mqtt_client.publish(f"{topic_prefix}/restarted", int(from_ui))
 
 
 class EventsPerSecond:

--- a/web/src/AppBar.jsx
+++ b/web/src/AppBar.jsx
@@ -6,17 +6,14 @@ import AutoAwesomeIcon from './icons/AutoAwesome';
 import LightModeIcon from './icons/LightMode';
 import DarkModeIcon from './icons/DarkMode';
 import FrigateRestartIcon from './icons/FrigateRestart';
-import Dialog from './components/Dialog';
+import DialogRestart from './components/DialogRestart';
 import { useDarkMode } from './context';
 import { useCallback, useRef, useState } from 'preact/hooks';
-import { useRestart } from './api/mqtt';
 
 export default function AppBar() {
   const [showMoreMenu, setShowMoreMenu] = useState(false);
-  const [showDialog, setShowDialog] = useState(false);
-  const [showDialogWait, setShowDialogWait] = useState(false);
+  const [showDialogRestart, setShowDialogRestart] = useState(false);
   const { setDarkMode } = useDarkMode();
-  const { send: sendRestart } = useRestart();
 
   const handleSelectDarkMode = useCallback(
     (value, label) => {
@@ -36,16 +33,6 @@ export default function AppBar() {
     setShowMoreMenu(false);
   }, [setShowMoreMenu]);
 
-  const handleClickRestartDialog = useCallback(() => {
-    setShowDialog(false);
-    setShowDialogWait(true);
-    sendRestart();
-  }, [setShowDialog]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const handleDismissRestartDialog = useCallback(() => {
-    setShowDialog(false);
-  }, [setShowDialog]);
-
   const handleRestart = useCallback(() => {
     setShowMoreMenu(false);
     setShowDialog(true);
@@ -63,24 +50,8 @@ export default function AppBar() {
           <MenuSeparator />
           <MenuItem icon={FrigateRestartIcon} label="Restart Frigate" onSelect={handleRestart} />
         </Menu>
-      ) : null},
-      {showDialog ? (
-        <Dialog
-          onDismiss={handleDismissRestartDialog}
-          title="Restart Frigate"
-          text="Are you sure?"
-          actions={[
-            { text: 'Yes', color: 'red', onClick: handleClickRestartDialog },
-            { text: 'Cancel', onClick: handleDismissRestartDialog },
-          ]}
-        />
-      ) : null},
-      {showDialogWait ? (
-        <Dialog
-          title="Restart in progress"
-          text="Please wait a few seconds for the restart to complete before reloading the page."
-        />
       ) : null}
+      <DialogRestart showDialog={showDialogRestart} setShowDialog={setShowDialogRestart} />
     </Fragment>
   );
 }

--- a/web/src/AppBar.jsx
+++ b/web/src/AppBar.jsx
@@ -36,7 +36,7 @@ export default function AppBar() {
   const handleRestart = useCallback(() => {
     setShowMoreMenu(false);
     setShowDialog(true);
-  }, [setShowDialog]);
+  }, [showDialogRestart]);
 
   return (
     <Fragment>

--- a/web/src/AppBar.jsx
+++ b/web/src/AppBar.jsx
@@ -35,7 +35,7 @@ export default function AppBar() {
 
   const handleRestart = useCallback(() => {
     setShowMoreMenu(false);
-    setShowDialog(true);
+    setShowDialogRestart(true);
   }, [showDialogRestart]);
 
   return (

--- a/web/src/AppBar.jsx
+++ b/web/src/AppBar.jsx
@@ -51,7 +51,7 @@ export default function AppBar() {
           <MenuItem icon={FrigateRestartIcon} label="Restart Frigate" onSelect={handleRestart} />
         </Menu>
       ) : null}
-      <DialogRestart showDialog={showDialogRestart} setShowDialog={setShowDialogRestart} />
+      <DialogRestart show={showDialogRestart} setShow={setShowDialogRestart} />
     </Fragment>
   );
 }

--- a/web/src/api/mqtt.jsx
+++ b/web/src/api/mqtt.jsx
@@ -124,6 +124,6 @@ export function useRestart() {
     value: { payload },
     send,
     connected,
-  } = useMqtt('restart', 'restart');
+  } = useMqtt('restarted', 'restart');
   return { payload, send, connected };
 }

--- a/web/src/components/Dialog.jsx
+++ b/web/src/components/Dialog.jsx
@@ -28,7 +28,7 @@ export default function Dialog({ actions = [], portalRootID = 'dialogs', title, 
           }`}
         >
           <div className="p-4">
-            <Heading size="lg">{title}</Heading>
+            <Heading size="lg" className="mb-4">{title}</Heading>
             <p>{text}</p>
           </div>
           <div className="p-2 flex justify-start flex-row-reverse space-x-2">

--- a/web/src/components/DialogRestart.jsx
+++ b/web/src/components/DialogRestart.jsx
@@ -1,11 +1,9 @@
 import { h, Fragment } from 'preact';
 import { useCallback, useEffect, useState } from 'preact/hooks';
 import Dialog from './Dialog';
-import { useApiHost } from '../api';
 import { useRestart } from '../api/mqtt';
 
 export default function DialogRestart({ show, setShow }) {
-  const apiHost = useApiHost();
   const { payload: detectRestarted = null, send: sendRestart } = useRestart();
   const [dialogTitle, setDialogTitle] = useState('Restart in progress');
 
@@ -22,8 +20,8 @@ export default function DialogRestart({ show, setShow }) {
     await delay(3456);
     while (true) {
       try {
-        const response = await fetch(`${apiHost}/api/config`, { method: 'GET' });
-        if (await response.status == 200)
+        const response = await fetch('/api/config', { method: 'GET' });
+        if (await response.status === 200)
           window.location.reload();
       }
       catch (e) {}

--- a/web/src/components/DialogRestart.jsx
+++ b/web/src/components/DialogRestart.jsx
@@ -13,11 +13,12 @@ export default function DialogRestart({ show, setShow }) {
         setDialogTitle('Server-initiated startup');
       setShow(false);
     }
-  }, [detectRestarted]);
+  }, [detectRestarted]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const waitPlease = async () => {
     const delay = ms => new Promise(res => setTimeout(res, ms));
     await delay(3456);
+    /* eslint-disable no-constant-condition */
     while (true) {
       try {
         const response = await fetch('/api/config', { method: 'GET' });
@@ -33,11 +34,11 @@ export default function DialogRestart({ show, setShow }) {
     sendRestart();
     setShow(false);
     waitPlease();
-  });
+  }, [show]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleDismiss = useCallback(() => {
     setShow(false);
-  });
+  }, [show]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Fragment>

--- a/web/src/components/DialogRestart.jsx
+++ b/web/src/components/DialogRestart.jsx
@@ -52,7 +52,7 @@ export default function DialogRestart({ show, setShow }) {
             { text: 'Cancel', onClick: handleDismiss } ]}
         />
       ) : detectRestarted != null && (
-        <Dialog title={dialogTitle} text="This page should refresh as soon as the server is up and running." />
+        <Dialog title={dialogTitle} text="This page should refresh as soon as the server is up and running…" />
       )}
     </Fragment>
   );

--- a/web/src/components/DialogRestart.jsx
+++ b/web/src/components/DialogRestart.jsx
@@ -1,0 +1,63 @@
+import { h, Fragment } from 'preact';
+import { useCallback, useEffect, useState } from 'preact/hooks';
+import Dialog from './Dialog';
+import { useApiHost } from '../api';
+import { useRestart } from '../api/mqtt';
+
+export default function DialogRestart({ showDialog, setShowDialog }) {
+  const apiHost = useApiHost();
+  const { payload: detectRestarted = null, send: sendRestart } = useRestart();
+  const [dialogTitle, setDialogTitle] = useState("Restart in progress");
+  const [showDialogWait, setShowDialogWait] = useState(false);
+
+  useEffect(() => {
+    if (detectRestarted != null && Number.isInteger(detectRestarted)) {
+      if (!detectRestarted)
+        setDialogTitle("Server-initiated startup");
+      setShowDialog(false);
+      setShowDialogWait(true);
+    }
+  }, [detectRestarted]);
+
+  const waitPlease = async () => {
+    const delay = ms => new Promise(res => setTimeout(res, ms));
+    await delay(3456);
+    while (true) {
+      try {
+        const response = await fetch(`${apiHost}/api/config`, { method: 'GET' });
+        if (await response.status == 200)
+          window.location.reload();
+      }
+      catch (e) {}
+      await delay(987);
+    }
+  };
+
+  const handleClick = useCallback(() => {
+    sendRestart();
+    setShowDialog(false);
+    waitPlease();
+  });
+
+  const handleDismiss = useCallback(() => {
+    setShowDialog(false);
+    setShowDialogWait(false);
+  });
+
+  return (
+    <Fragment>
+      {showDialog ? (
+        <Dialog
+          onDismiss={handleDismiss}
+          title="Restart Frigate"
+          text="Are you sure?"
+          actions={[
+            { text: 'Yes', color: 'red', onClick: handleClick },
+            { text: 'Cancel', onClick: handleDismiss } ]}
+        />
+      ) : detectRestarted != null && (
+        <Dialog title={dialogTitle} text="This page should refresh as soon as the server is up and running." />
+      )}
+    </Fragment>
+  );
+}

--- a/web/src/components/DialogRestart.jsx
+++ b/web/src/components/DialogRestart.jsx
@@ -4,18 +4,16 @@ import Dialog from './Dialog';
 import { useApiHost } from '../api';
 import { useRestart } from '../api/mqtt';
 
-export default function DialogRestart({ showDialog, setShowDialog }) {
+export default function DialogRestart({ show, setShow }) {
   const apiHost = useApiHost();
   const { payload: detectRestarted = null, send: sendRestart } = useRestart();
-  const [dialogTitle, setDialogTitle] = useState("Restart in progress");
-  const [showDialogWait, setShowDialogWait] = useState(false);
+  const [dialogTitle, setDialogTitle] = useState('Restart in progress');
 
   useEffect(() => {
     if (detectRestarted != null && Number.isInteger(detectRestarted)) {
       if (!detectRestarted)
-        setDialogTitle("Server-initiated startup");
-      setShowDialog(false);
-      setShowDialogWait(true);
+        setDialogTitle('Server-initiated startup');
+      setShow(false);
     }
   }, [detectRestarted]);
 
@@ -35,18 +33,17 @@ export default function DialogRestart({ showDialog, setShowDialog }) {
 
   const handleClick = useCallback(() => {
     sendRestart();
-    setShowDialog(false);
+    setShow(false);
     waitPlease();
   });
 
   const handleDismiss = useCallback(() => {
-    setShowDialog(false);
-    setShowDialogWait(false);
+    setShow(false);
   });
 
   return (
     <Fragment>
-      {showDialog ? (
+      {show ? (
         <Dialog
           onDismiss={handleDismiss}
           title="Restart Frigate"


### PR DESCRIPTION
The "Restart in progress" dialog is now displayed at the request of the server rather than by the UI.

And then provide a cleaner code.

During my tests I realized that sometimes I had to wait.
<details><summary>Almost 2 minutes sometimes:</summary>
<p>

```
[2021-07-12 14:12:31] peewee_migrate                 INFO    : There is nothing to migrate
[2021-07-12 14:12:31] frigate.mqtt                   INFO    : MQTT connected
[2021-07-12 14:12:31] detector.coral                 INFO    : Starting detection process: 218
[2021-07-12 14:12:31] frigate.app                    INFO    : Output process started: 220
[2021-07-12 14:12:31] ws4py                          INFO    : Using epoll
[2021-07-12 14:12:31] frigate.edgetpu                INFO    : Attempting to load TPU as usb
[2021-07-12 14:12:31] frigate.app                    INFO    : Camera processor started for camera_name_1: 223
[2021-07-12 14:12:33] frigate.edgetpu                INFO    : TPU found
[2021-07-12 14:12:31] frigate.app                    INFO    : Capture process started for camera_name_1: 226
[2021-07-12 14:12:31] ws4py                          INFO    : Using epoll
[2021-07-12 14:15:28] ws4py                          INFO    : Managing websocket [Local => 127.0.0.1:5002 | Remote => 127.0.0.1:43920]
[2021-07-12 14:15:36] frigate.app                    INFO    : Stopping...
[2021-07-12 14:15:36] ws4py                          INFO    : Closing all websockets with [1001] 'Server is shutting down'
[2021-07-12 14:15:36] frigate.record                 INFO    : Exiting recording maintenance...
[2021-07-12 14:15:36] frigate.events                 INFO    : Exiting event cleanup...
[2021-07-12 14:15:36] frigate.stats                  INFO    : Exiting watchdog...
[2021-07-12 14:15:36] frigate.watchdog               INFO    : Exiting watchdog...
[2021-07-12 14:15:36] frigate.object_processing      INFO    : Exiting object processor...
[2021-07-12 14:15:42] frigate.events                 INFO    : Exiting event processor...
[2021-07-12 14:15:42] peewee.sqliteq                 INFO    : writer received shutdown request, exiting.
[2021-07-12 14:15:42] root                           INFO    : Waiting for detection process to exit gracefully...
[cmd] python3 exited 0
/usr/lib/python3.8/multiprocessing/resource_tracker.py:216: UserWarning: resource_tracker: There appear to be 3 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
[cont-finish.d] executing container finish scripts...
[cont-finish.d] done.
[s6-finish] waiting for services.
[s6-finish] sending all processes the TERM signal.
[s6-finish] sending all processes the KILL signal and exiting.
[s6-init] making user provided files available at /var/run/s6/etc...exited 0.
[s6-init] ensuring user provided files have correct perms...exited 0.
[fix-attrs.d] applying ownership & permissions fixes...
[fix-attrs.d] done.
[cont-init.d] executing container initialization scripts...
[cont-init.d] done.
[services.d] starting services
[services.d] done.
Starting migrations
[2021-07-12 14:17:28] peewee_migrate                 INFO    : Starting migrations
There is nothing to migrate
[2021-07-12 14:17:28] peewee_migrate                 INFO    : There is nothing to migrate
[2021-07-12 14:17:28] frigate.mqtt                   INFO    : MQTT connected
[2021-07-12 14:17:28] detector.coral                 INFO    : Starting detection process: 218
[2021-07-12 14:17:28] frigate.app                    INFO    : Output process started: 220
[2021-07-12 14:17:28] ws4py                          INFO    : Using epoll
[2021-07-12 14:17:28] frigate.app                    INFO    : Camera processor started for camera_name_1: 225
[2021-07-12 14:17:28] frigate.app                    INFO    : Capture process started for camera_name_1: 229
[2021-07-12 14:17:28] ws4py                          INFO    : Using epoll
[2021-07-12 14:17:28] frigate.edgetpu                INFO    : Attempting to load TPU as usb
[2021-07-12 14:17:31] frigate.edgetpu                INFO    : TPU found
```
</p>
</details>

If there are no other less restrictive solutions, perhaps the following should be considered?

```python
    def on_publish(client,userdata,result):
        time.sleep(0.67)
        rc, docker = 1, "/usr/local/bin/docker"
        logger.info("Restart requested.")
        if os.access(docker, os.X_OK) and os.path.isfile("/var/run/docker.sock"):
            rc = sp.Popen(f"{docker} restart $(hostname)", shell=True).wait()
        if rc:
            os.kill(os.getpid(), signal.SIGTERM)
```
