### PR TITLE
Include details about stream passthrough

### DIFF
--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -38,6 +38,8 @@ cameras:
     fps: 5
 ```
 
+`width`, `height`, and `fps` are only used for the `detect` role. Other streams are passed through, so there is no need to specify the resolution.
+
 ## Masks & Zones
 
 ### Masks


### PR DESCRIPTION
Refs #1440

Indicate that width and height are only used for the detect role and so other streams for with other roles are passed through and resolution is not needed.