### PR TITLE
Run docker as none root user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ nginx_frigate:
 	docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag blakeblackshear/frigate-nginx:1.0.2 --file docker/Dockerfile.nginx .
 
 amd64_frigate: version web
-	docker build --no-cache --tag frigate-base --build-arg ARCH=amd64 --build-arg FFMPEG_VERSION=1.1.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.2 --file docker/Dockerfile.base .
+	docker build --no-cache --tag frigate-base --build-arg ARCH=amd64 --build-arg OVERLAY_ARCH=amd64 --build-arg FFMPEG_VERSION=1.1.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.2 --file docker/Dockerfile.base .
 	docker build --no-cache --tag frigate --file docker/Dockerfile.amd64 .
 
 amd64_all: amd64_wheels amd64_ffmpeg amd64_frigate
@@ -30,7 +30,7 @@ amd64nvidia_ffmpeg:
 	docker build --no-cache --pull --tag blakeblackshear/frigate-ffmpeg:1.2.0-amd64nvidia --file docker/Dockerfile.ffmpeg.amd64nvidia .
 
 amd64nvidia_frigate: version web
-	docker build --no-cache --tag frigate-base --build-arg ARCH=amd64nvidia --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.2 --file docker/Dockerfile.base .
+	docker build --no-cache --tag frigate-base --build-arg ARCH=amd64nvidia --build-arg OVERLAY_ARCH=amd64 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.2 --file docker/Dockerfile.base .
 	docker build --no-cache --tag frigate --file docker/Dockerfile.amd64nvidia .
 
 amd64nvidia_all: amd64nvidia_wheels amd64nvidia_ffmpeg amd64nvidia_frigate
@@ -42,7 +42,7 @@ aarch64_ffmpeg:
 	docker build --no-cache --pull --tag blakeblackshear/frigate-ffmpeg:1.2.0-aarch64 --file docker/Dockerfile.ffmpeg.aarch64 .
 
 aarch64_frigate: version web
-	docker build --no-cache --tag frigate-base --build-arg ARCH=aarch64 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.2 --file docker/Dockerfile.base .
+	docker build --no-cache --tag frigate-base --build-arg ARCH=aarch64 --build-arg OVERLAY_ARCH=aarch64 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.2 --file docker/Dockerfile.base .
 	docker build --no-cache --tag frigate --file docker/Dockerfile.aarch64 .
 
 armv7_all: armv7_wheels armv7_ffmpeg armv7_frigate
@@ -54,7 +54,7 @@ armv7_ffmpeg:
 	docker build --no-cache --pull --tag blakeblackshear/frigate-ffmpeg:1.2.0-armv7 --file docker/Dockerfile.ffmpeg.armv7 .
 
 armv7_frigate: version web
-	docker build --no-cache --tag frigate-base --build-arg ARCH=armv7 --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.2 --file docker/Dockerfile.base .
+	docker build --no-cache --tag frigate-base --build-arg ARCH=armv7 --build-arg OVERLAY_ARCH=armhf --build-arg FFMPEG_VERSION=1.0.0 --build-arg WHEELS_VERSION=1.0.3 --build-arg NGINX_VERSION=1.0.2 --file docker/Dockerfile.base .
 	docker build --no-cache --tag frigate --file docker/Dockerfile.armv7 .
 
 armv7_all: armv7_wheels armv7_ffmpeg armv7_frigate

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -19,10 +19,6 @@ RUN apt-get -qq update \
     && rm -rf /var/lib/apt/lists/* \
     && (apt-get autoremove -y; apt-get autoclean -y)
 
-# s6-overlay
-ADD https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-aarch64-installer /tmp/
-RUN chmod +x /tmp/s6-overlay-aarch64-installer && /tmp/s6-overlay-aarch64-installer /
-
 ENTRYPOINT ["/init"]
 
 CMD ["python3", "-u", "-m", "frigate"]

--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -19,10 +19,6 @@ RUN apt-get -qq update \
     && rm -rf /var/lib/apt/lists/* \
     && (apt-get autoremove -y; apt-get autoclean -y)
 
-# s6-overlay
-ADD https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-amd64-installer /tmp/
-RUN chmod +x /tmp/s6-overlay-amd64-installer && /tmp/s6-overlay-amd64-installer /
-
 ENTRYPOINT ["/init"]
 
 CMD ["python3", "-u", "-m", "frigate"]

--- a/docker/Dockerfile.amd64nvidia
+++ b/docker/Dockerfile.amd64nvidia
@@ -42,10 +42,6 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 ENV NVIDIA_REQUIRE_CUDA "cuda>=11.1 brand=tesla,driver>=418,driver<419 brand=tesla,driver>=440,driver<441 brand=tesla,driver>=450,driver<451"
 
-# s6-overlay
-ADD https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-amd64-installer /tmp/
-RUN chmod +x /tmp/s6-overlay-amd64-installer && /tmp/s6-overlay-amd64-installer /
-
 ENTRYPOINT ["/init"]
 
 CMD ["python3", "-u", "-m", "frigate"]

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -21,10 +21,6 @@ RUN apt-get -qq update \
     && rm -rf /var/lib/apt/lists/* \
     && (apt-get autoremove -y; apt-get autoclean -y)
 
-# s6-overlay
-ADD https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-armhf-installer /tmp/
-RUN chmod +x /tmp/s6-overlay-armhf-installer && /tmp/s6-overlay-armhf-installer /
-
 ENTRYPOINT ["/init"]
 
 CMD ["python3", "-u", "-m", "frigate"]

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -10,6 +10,8 @@ FROM frigate-web as web
 FROM ubuntu:20.04
 LABEL maintainer "blakeb@blakeshome.com"
 
+ARG OVERLAY_ARCH=amd64
+
 COPY --from=ffmpeg /usr/local /usr/local/
 
 COPY --from=wheels /wheels/. /wheels/
@@ -48,6 +50,14 @@ ADD frigate frigate/
 ADD migrations migrations/
 
 COPY --from=web /opt/frigate/build web/
+
+# s6-overlay
+ADD https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-${OVERLAY_ARCH}-installer /tmp/
+RUN chmod +x /tmp/s6-overlay-${OVERLAY_ARCH}-installer && \
+    /tmp/s6-overlay-${OVERLAY_ARCH}-installer / && \
+    useradd -u 1000 -U -d /config -s /bin/false frigate && \
+    usermod -G users frigate && \
+    mv /usr/bin/with-contenv /usr/bin/with-contenvb
 
 COPY docker/rootfs/ /
 

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -55,8 +55,9 @@ COPY --from=web /opt/frigate/build web/
 ADD https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-${OVERLAY_ARCH}-installer /tmp/
 RUN chmod +x /tmp/s6-overlay-${OVERLAY_ARCH}-installer && \
     /tmp/s6-overlay-${OVERLAY_ARCH}-installer / && \
+    groupadd -g 109 render && \
     useradd -u 1000 -U -d /config -s /bin/false frigate && \
-    usermod -G users frigate && \
+    usermod -G users,render,video,plugdev frigate && \
     mv /usr/bin/with-contenv /usr/bin/with-contenvb
 
 COPY docker/rootfs/ /

--- a/docker/rootfs/etc/cont-init.d/01-envfile
+++ b/docker/rootfs/etc/cont-init.d/01-envfile
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+if [[ "$(ls /var/run/s6/container_environment/ | xargs)" == *"FILE__"* ]]; then
+  for FILENAME in /var/run/s6/container_environment/*; do
+    if [[ "${FILENAME##*/}" == "FILE__"* ]]; then
+      SECRETFILE=$(cat ${FILENAME})
+      if [[ -f ${SECRETFILE} ]]; then
+        FILESTRIP=${FILENAME//FILE__/}
+        cat ${SECRETFILE} > ${FILESTRIP}
+        echo "[env-init] ${FILESTRIP##*/} set from ${FILENAME##*/}"
+      else
+        echo "[env-init] cannot find secret in ${FILENAME##*/}"
+      fi
+    fi
+  done
+fi

--- a/docker/rootfs/etc/cont-init.d/10-adduser
+++ b/docker/rootfs/etc/cont-init.d/10-adduser
@@ -1,0 +1,12 @@
+#!/usr/bin/with-contenv bash
+
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+groupmod -o -g "$PGID" frigate
+usermod -o -u "$PUID" frigate
+
+chown -R frigate:frigate /opt/frigate/frigate
+chown -R frigate:frigate /opt/frigate/migrations
+chown -R frigate:frigate /opt/frigate/web
+chown -R frigate:frigate /usr/local/nginx

--- a/docker/rootfs/usr/bin/with-contenv
+++ b/docker/rootfs/usr/bin/with-contenv
@@ -1,0 +1,7 @@
+#! /bin/bash
+if [[ -f /var/run/s6/container_environment/UMASK ]] && [[ "$(pwdx $$)" =~ "/run/s6/services/" ]]; then
+  umask $(cat /var/run/s6/container_environment/UMASK)
+  exec /usr/bin/with-contenvb "$@"
+else
+  exec /usr/bin/with-contenvb "$@"
+fi

--- a/docker/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/rootfs/usr/local/nginx/conf/nginx.conf
@@ -71,6 +71,9 @@ http {
         location /vod/ {
             vod hls;
 
+            secure_token $args;
+            secure_token_types application/vnd.apple.mpegurl;
+
             add_header Access-Control-Allow-Headers '*';
             add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
             add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
@@ -120,6 +123,11 @@ http {
 
             autoindex on;
             root /media/frigate;
+        }
+
+        location /cache/ {
+                internal; # This tells nginx it's not accessible from the outside
+                alias /tmp/cache/;
         }
 
         location /recordings/ {

--- a/docker/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/rootfs/usr/local/nginx/conf/nginx.conf
@@ -1,8 +1,8 @@
 daemon off;
 worker_processes  1;
-
+user frigate;
 error_log  /usr/local/nginx/logs/error.log warn;
-pid        /var/run/nginx.pid;
+pid        /usr/local/nginx/nginx.pid;
 
 events {
     worker_connections  1024;
@@ -71,9 +71,6 @@ http {
         location /vod/ {
             vod hls;
 
-            secure_token $args;
-			secure_token_types application/vnd.apple.mpegurl;
-
             add_header Access-Control-Allow-Headers '*';
             add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
             add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
@@ -123,11 +120,6 @@ http {
 
             autoindex on;
             root /media/frigate;
-        }
-
-        location /cache/ {
-                internal; # This tells nginx it's not accessible from the outside
-                alias /tmp/cache/;
         }
 
         location /recordings/ {

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -57,6 +57,8 @@ services:
       - "1935:1935" # RTMP feeds
     environment:
       FRIGATE_RTSP_PASSWORD: "password"
+      PUID: 1000 # uid for frigate process
+      PGID: 1000 # gid for frigate process
 ```
 
 If you can't use docker compose, you can run the container with something similar to this:
@@ -72,6 +74,8 @@ docker run -d \
   -v <path_to_config_file>:/config/config.yml:ro \
   -v /etc/localtime:/etc/localtime:ro \
   -e FRIGATE_RTSP_PASSWORD='password' \
+  -e PUID=1000 \
+  -e PGID=1000 \
   -p 5000:5000 \
   -p 1935:1935 \
   blakeblackshear/frigate:<specify_version_tag>

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -81,6 +81,14 @@ docker run -d \
   blakeblackshear/frigate:<specify_version_tag>
 ```
 
+**Note:** You will need to add a udev rule to fix the permissions of the /dev/bus/usb device permissions:
+
+```
+sudo echo -e "SUBSYSTEM=="usb",ATTRS{idVendor}=="1a6e",GROUP="plugdev",MODE="0770"\nSUBSYSTEM=="usb",ATTRS{idVendor}=="18d1",GROUP="plugdev",MODE="0770" \n" >> /etc/udev/rules.d/99-coral-frigate.rules
+
+udevadm control --reload
+```
+
 ### Calculating shm-size
 
 The default shm-size of 64m is fine for setups with 3 or less 1080p cameras. If frigate is exiting with "Bus error" messages, it could be because you have too many high resolution cameras and you need to specify a higher shm size.


### PR DESCRIPTION
This would allow to run the docker container as a none root user. By default user 'frigate' with uid/gid: 1000/1000 is used, and can be set in the environment fields. 