### PR TITLE
Nginx Permissions Error

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,4 @@
+user root;
 worker_processes  1;
 
 error_log  /var/log/nginx/error.log warn;


### PR DESCRIPTION
Running via docker on QNAP/synology there might be additional ACLs provided by their respective linux flavors that cause a 403 when trying to view clips/recordings from the UI. Forcing nginx to run as root solves this on my QNAP.