### PR TITLE
fix(logging): consistent error messages on MQTT connection issues

### DIFF
--- a/frigate/mqtt.py
+++ b/frigate/mqtt.py
@@ -82,13 +82,13 @@ def create_mqtt_client(config: FrigateConfig, camera_metrics):
         threading.current_thread().name = "mqtt"
         if rc != 0:
             if rc == 3:
-                logger.error("MQTT Server unavailable")
+                logger.error("Unable to connect to MQTT server: MQTT Server unavailable")
             elif rc == 4:
-                logger.error("MQTT Bad username or password")
+                logger.error("Unable to connect to MQTT server: MQTT Bad username or password")
             elif rc == 5:
-                logger.error("MQTT Not authorized")
+                logger.error("Unable to connect to MQTT server: MQTT Not authorized")
             else:
-                logger.error("Unable to connect to MQTT: Connection refused. Error code: " + str(rc))
+                logger.error("Unable to connect to MQTT server: Connection refused. Error code: " + str(rc))
             
         logger.info("MQTT connected")
         client.subscribe(f"{mqtt_config.topic_prefix}/#")


### PR DESCRIPTION
Hi @blakeblackshear 👋🏼 

Small change. It would be nice if these log messages were consistent so I can easily alert on them using a centralized logging platform like Loki or ELK.

Thanks!