### PR TITLE
Remove misplaced comma in Header

### DIFF
--- a/web/src/AppBar.jsx
+++ b/web/src/AppBar.jsx
@@ -63,7 +63,7 @@ export default function AppBar() {
           <MenuSeparator />
           <MenuItem icon={FrigateRestartIcon} label="Restart Frigate" onSelect={handleRestart} />
         </Menu>
-      ) : null},
+      ) : null}
       {showDialog ? (
         <Dialog
           onDismiss={handleDismissRestartDialog}
@@ -74,7 +74,7 @@ export default function AppBar() {
             { text: 'Cancel', onClick: handleDismissRestartDialog },
           ]}
         />
-      ) : null},
+      ) : null}
       {showDialogWait ? (
         <Dialog
           title="Restart in progress"


### PR DESCRIPTION
Removed comma from AppBar.js, this was causing the main window to be pulled down behind the scenes, hence the vertical scrollbar was allways visible on homepage.

![comma](https://i.ibb.co/JRQpYRZ/Skjermbilde-2021-08-22-123706.png)