### PR TITLE
reduce navbar padding / height

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -23,7 +23,7 @@ export default function App() {
           ) : (
             <div className="flex flex-row min-h-screen w-full bg-white dark:bg-gray-900 text-gray-900 dark:text-white">
               <Sidebar />
-              <div className="w-full flex-auto p-2 mt-24 px-4 min-w-0">
+              <div className="w-full flex-auto p-2 mt-16 px-4 min-w-0">
                 <Router>
                   <AsyncRoute path="/cameras/:camera/editor" getComponent={Routes.getCameraMap} />
                   <AsyncRoute path="/cameras/:camera" getComponent={Routes.getCamera} />

--- a/web/src/components/AppBar.jsx
+++ b/web/src/components/AppBar.jsx
@@ -37,13 +37,13 @@ export default function AppBar({ title: Title, overflowRef, onOverflowClick }) {
 
   return (
     <div
-      className={`w-full border-b border-gray-200 dark:border-gray-700 flex items-center align-middle p-4 space-x-2 fixed left-0 right-0 z-10 bg-white dark:bg-gray-900 transform transition-all duration-200 ${
+      className={`w-full border-b border-gray-200 dark:border-gray-700 flex items-center align-middle p-2  fixed left-0 right-0 z-10 bg-white dark:bg-gray-900 transform transition-all duration-200 ${
         !show ? '-translate-y-full' : 'translate-y-0'
       } ${!atZero ? 'shadow-sm' : ''}`}
       data-testid="appbar"
     >
       <div className="lg:hidden">
-        <Button color="black" className="rounded-full w-12 h-12" onClick={handleShowDrawer} type="text">
+        <Button color="black" className="rounded-full w-10 h-10" onClick={handleShowDrawer} type="text">
           <MenuIcon className="w-10 h-10" />
         </Button>
       </div>
@@ -54,7 +54,7 @@ export default function AppBar({ title: Title, overflowRef, onOverflowClick }) {
             <Button
               aria-label="More options"
               color="black"
-              className="rounded-full w-12 h-12"
+              className="rounded-full w-9 h-9"
               onClick={onOverflowClick}
               type="text"
             >

--- a/web/src/components/NavigationDrawer.jsx
+++ b/web/src/components/NavigationDrawer.jsx
@@ -22,7 +22,7 @@ export default function NavigationDrawer({ children, header }) {
         onClick={handleDismiss}
       >
         {header ? (
-          <div className="flex-shrink-0 p-5 flex flex-row items-center justify-between border-b border-gray-200 dark:border-gray-700">
+          <div className="flex-shrink-0 p-2 flex flex-row items-center justify-between border-b border-gray-200 dark:border-gray-700">
             {header}
           </div>
         ) : null}


### PR DESCRIPTION
Note! Header will not look good without PR #1586 

- Reduced padding for the header-bar, this creates more space to play with as it was pretty huge.
- Fixed navbar frigate logo alignment, header-bar and main logo did not align propely when scrolling.