### PR TITLE
Move event-view to events table.

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -28,7 +28,6 @@ export default function App() {
                   <AsyncRoute path="/cameras/:camera/editor" getComponent={Routes.getCameraMap} />
                   <AsyncRoute path="/cameras/:camera" getComponent={Routes.getCamera} />
                   <AsyncRoute path="/birdseye" getComponent={Routes.getBirdseye} />
-                  <AsyncRoute path="/events/:eventId" getComponent={Routes.getEvent} />
                   <AsyncRoute path="/events" getComponent={Routes.getEvents} />
                   <AsyncRoute path="/recording/:camera/:date?/:hour?/:seconds?" getComponent={Routes.getRecording} />
                   <AsyncRoute path="/debug" getComponent={Routes.getDebug} />

--- a/web/src/api/index.jsx
+++ b/web/src/api/index.jsx
@@ -51,7 +51,7 @@ function reducer(state, { type, payload, meta }) {
 
           // Splice the deleted index.
           draftState.queries[url].data.splice(removeIndex, 1);
-          draftState.queries[url].deleted = totDeleted + 1;
+          draftState.queries[url].deletedId = eventId;
         });
       });
     }
@@ -111,9 +111,9 @@ export function useFetch(url, fetchId) {
 
   const data = state.queries[url].data || null;
   const status = state.queries[url].status;
-  const deleted = state.queries[url].deleted || 0;
+  const deletedId = state.queries[url].deletedId || 0;
 
-  return { data, status, deleted };
+  return { data, status, deletedId };
 }
 
 export function useDelete() {

--- a/web/src/api/index.jsx
+++ b/web/src/api/index.jsx
@@ -39,18 +39,6 @@ function reducer(state, { type, payload, meta }) {
 
       return produce(state, (draftState) => {
         Object.keys(draftState.queries).map((url, index) => {
-          // If data has no array length then just return state.
-          if (!('data' in draftState.queries[url]) || !draftState.queries[url].data.length) return state;
-
-          //Find the index to remove
-          const removeIndex = draftState.queries[url].data.map((event) => event.id).indexOf(eventId);
-          if (removeIndex === -1) return state;
-
-          // We need to keep track of deleted items, This will be used to re-calculate "ReachEnd" for auto load new events. Events.jsx
-          const totDeleted = state.queries[url].deleted || 0;
-
-          // Splice the deleted index.
-          draftState.queries[url].data.splice(removeIndex, 1);
           draftState.queries[url].deletedId = eventId;
         });
       });

--- a/web/src/api/index.jsx
+++ b/web/src/api/index.jsx
@@ -18,7 +18,7 @@ const initialState = Object.freeze({
 
 const Api = createContext(initialState);
 
-function reducer(state, { type, payload, meta }) {
+function reducer(state, { type, payload }) {
   switch (type) {
     case 'REQUEST': {
       const { url, fetchId } = payload;
@@ -36,9 +36,8 @@ function reducer(state, { type, payload, meta }) {
     }
     case 'DELETE': {
       const { eventId } = payload;
-
       return produce(state, (draftState) => {
-        Object.keys(draftState.queries).map((url, index) => {
+        Object.keys(draftState.queries).map((url) => {
           draftState.queries[url].deletedId = eventId;
         });
       });

--- a/web/src/components/Dialog.jsx
+++ b/web/src/components/Dialog.jsx
@@ -19,7 +19,7 @@ export default function Dialog({ actions = [], portalRootID = 'dialogs', title, 
       <div
         data-testid="scrim"
         key="scrim"
-        className="absolute inset-0 z-10 flex justify-center items-center bg-black bg-opacity-40"
+        className="fixed bg-fixed inset-0 z-10 flex justify-center items-center bg-black bg-opacity-40"
       >
         <div
           role="modal"

--- a/web/src/icons/Close.jsx
+++ b/web/src/icons/Close.jsx
@@ -1,0 +1,13 @@
+import { h } from 'preact';
+import { memo } from 'preact/compat';
+
+export function Close({ className = '' }) {
+  return (
+    <svg className={`fill-current ${className}`} viewBox="0 0 24 24">
+      <path d="M0 0h24v24H0z" fill="none" />
+      <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z" />
+    </svg>
+  );
+}
+
+export default memo(Close);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -38,7 +38,3 @@ Could not find a proper tailwind css.
 .outer-max-width {
   max-width: 60%;
 }
-.aspect-ratio-box {
-  padding-top: calc(9 / 16 * 100%);
-  padding-bottom: 20%;
-}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -29,3 +29,16 @@
 .jsmpeg canvas {
   position: static !important;
 }
+
+/*
+Event.js
+Maintain aspect ratio and scale down the video container
+Could not find a proper tailwind css.
+*/
+.outer-max-width {
+  max-width: 60%;
+}
+.aspect-ratio-box {
+  padding-top: calc(9 / 16 * 100%);
+  padding-bottom: 20%;
+}

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -82,12 +82,11 @@ export default function Event({ eventId, close }) {
           />
         ) : null}
       </div>
-
-      {data.has_clip ? (
-        <Fragment>
-          <div className="outer-max-width m-auto">
-            <div className="aspect-ratio-box w-full relative">
-              <div className="absolute w-full top-10 left-0">
+      <div className="outer-max-width m-auto">
+        <div className="aspect-ratio-box w-full relative">
+          <div className="absolute w-full top-10 left-0">
+            {data.has_clip ? (
+              <Fragment>
                 <VideoPlayer
                   options={{
                     sources: [
@@ -103,23 +102,23 @@ export default function Event({ eventId, close }) {
                   seekOptions={{ forward: 10, back: 5 }}
                   onReady={(player) => {}}
                 />
-              </div>
-            </div>
+              </Fragment>
+            ) : (
+              <Fragment>
+                <Heading size="sm">{data.has_snapshot ? 'Best Image' : 'Thumbnail'}</Heading>
+                <img
+                  src={
+                    data.has_snapshot
+                      ? `${apiHost}/clips/${data.camera}-${eventId}.jpg`
+                      : `data:image/jpeg;base64,${data.thumbnail}`
+                  }
+                  alt={`${data.label} at ${(data.top_score * 100).toFixed(1)}% confidence`}
+                />
+              </Fragment>
+            )}
           </div>
-        </Fragment>
-      ) : (
-        <Fragment>
-          <Heading size="sm">{data.has_snapshot ? 'Best Image' : 'Thumbnail'}</Heading>
-          <img
-            src={
-              data.has_snapshot
-                ? `${apiHost}/clips/${data.camera}-${eventId}.jpg`
-                : `data:image/jpeg;base64,${data.thumbnail}`
-            }
-            alt={`${data.label} at ${(data.top_score * 100).toFixed(1)}% confidence`}
-          />
-        </Fragment>
-      )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -21,7 +21,7 @@ export default function Event({ eventId, close, scrollIntoView }) {
   useEffect(() => {
     // Call Events.js scroll when this event has been mounted.
     scrollIntoView(eventId);
-  }, [scrollIntoView]);
+  }, [scrollIntoView, eventId]);
 
   const handleClickDelete = () => {
     setShowDialog(true);

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -1,19 +1,15 @@
 import { h, Fragment } from 'preact';
 import { useCallback, useState } from 'preact/hooks';
-import { route } from 'preact-router';
 import ActivityIndicator from '../components/ActivityIndicator';
 import Button from '../components/Button';
 import Clip from '../icons/Clip';
-import ArrowDown from '../icons/ArrowDropdown';
 import Menu from '../icons/Menu';
 import Delete from '../icons/Delete';
 import Snapshot from '../icons/Snapshot';
 import Dialog from '../components/Dialog';
 import Heading from '../components/Heading';
-import Link from '../components/Link';
 import VideoPlayer from '../components/VideoPlayer';
 import { FetchStatus, useApiHost, useEvent, useDelete } from '../api';
-import { Table, Thead, Tbody, Th, Tr, Td } from '../components/Table';
 
 export default function Event({ eventId, close }) {
   const apiHost = useApiHost();
@@ -49,9 +45,7 @@ export default function Event({ eventId, close }) {
     return <ActivityIndicator />;
   }
 
-  const startime = new Date(data.start_time * 1000);
-  const endtime = new Date(data.end_time * 1000);
-
+  console.log(data);
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-6 gap-4">
@@ -61,10 +55,6 @@ export default function Event({ eventId, close }) {
           </Button>
           <Button color="blue" href={`${apiHost}/api/events/${eventId}/snapshot.jpg?download=true`} download>
             <Snapshot className="w-6" /> Download Snapshot
-          </Button>
-          <Button className="self-start" onClick={() => setShowDetails(!showDetails)}>
-            <ArrowDown className="w-6" />
-            {`${showDetails ? 'Hide event Details' : 'View event Details'}`}
           </Button>
         </div>
         <div class="col-end-10 col-span-2 space-x-4">
@@ -93,35 +83,6 @@ export default function Event({ eventId, close }) {
           />
         ) : null}
       </div>
-
-      <Table class="w-full">
-        <Thead>
-          <Th>Key</Th>
-          <Th>Value</Th>
-        </Thead>
-        <Tbody>
-          <Tr>
-            <Td>Camera</Td>
-            <Td>
-              <Link href={`/cameras/${data.camera}`}>{data.camera}</Link>
-            </Td>
-          </Tr>
-          <Tr index={1}>
-            <Td>Timeframe</Td>
-            <Td>
-              {startime.toLocaleString()} – {endtime.toLocaleString()}
-            </Td>
-          </Tr>
-          <Tr>
-            <Td>Score</Td>
-            <Td>{(data.top_score * 100).toFixed(2)}%</Td>
-          </Tr>
-          <Tr index={1}>
-            <Td>Zones</Td>
-            <Td>{data.zones.join(', ')}</Td>
-          </Tr>
-        </Tbody>
-      </Table>
 
       {data.has_clip ? (
         <Fragment>

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -1,5 +1,5 @@
 import { h, Fragment } from 'preact';
-import { useCallback, useState, useEffect, useRef } from 'preact/hooks';
+import { useCallback, useState, useEffect } from 'preact/hooks';
 import ActivityIndicator from '../components/ActivityIndicator';
 import Button from '../components/Button';
 import Clip from '../icons/Clip';
@@ -113,7 +113,7 @@ export default function Event({ eventId, close, scrollRef }) {
                       : `data:image/jpeg;base64,${data.thumbnail}`,
                   }}
                   seekOptions={{ forward: 10, back: 5 }}
-                  onReady={(player) => {}}
+                  onReady={() => {}}
                 />
               </Fragment>
             ) : (

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -3,7 +3,7 @@ import { useCallback, useState, useEffect } from 'preact/hooks';
 import ActivityIndicator from '../components/ActivityIndicator';
 import Button from '../components/Button';
 import Clip from '../icons/Clip';
-import Menu from '../icons/Menu';
+import Close from '../icons/Close';
 import Delete from '../icons/Delete';
 import Snapshot from '../icons/Snapshot';
 import Dialog from '../components/Dialog';
@@ -70,7 +70,7 @@ export default function Event({ eventId, close, scrollRef }) {
             <Delete className="w-6" /> Delete event
           </Button>
           <Button color="gray" className="self-start" onClick={() => close()}>
-            <Menu className="w-6" /> Close
+            <Close className="w-6" /> Close
           </Button>
         </div>
         {showDialog ? (

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -1,5 +1,5 @@
 import { h, Fragment } from 'preact';
-import { useCallback, useState, useEffect } from 'preact/hooks';
+import { useCallback, useState, useEffect, useRef } from 'preact/hooks';
 import ActivityIndicator from '../components/ActivityIndicator';
 import Button from '../components/Button';
 import Clip from '../icons/Clip';
@@ -11,7 +11,7 @@ import Heading from '../components/Heading';
 import VideoPlayer from '../components/VideoPlayer';
 import { FetchStatus, useApiHost, useEvent, useDelete } from '../api';
 
-export default function Event({ eventId, close, scrollIntoView }) {
+export default function Event({ eventId, close, scrollRef }) {
   const apiHost = useApiHost();
   const { data, status } = useEvent(eventId);
   const [showDialog, setShowDialog] = useState(false);
@@ -20,8 +20,15 @@ export default function Event({ eventId, close, scrollIntoView }) {
 
   useEffect(() => {
     // Call Events.js scroll when this event has been mounted.
-    scrollIntoView(eventId);
-  }, [scrollIntoView, eventId]);
+    // scrollIntoView(eventId);
+    scrollToElement();
+  }, [data]);
+
+  const scrollToElement = useCallback(() => {
+    if (scrollRef && scrollRef[eventId]) {
+      scrollRef[eventId].scrollIntoView();
+    }
+  }, [scrollRef]);
 
   const handleClickDelete = () => {
     setShowDialog(true);

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -4,6 +4,8 @@ import { route } from 'preact-router';
 import ActivityIndicator from '../components/ActivityIndicator';
 import Button from '../components/Button';
 import Clip from '../icons/Clip';
+import ArrowDown from '../icons/ArrowDropdown';
+import Menu from '../icons/Menu';
 import Delete from '../icons/Delete';
 import Snapshot from '../icons/Snapshot';
 import Dialog from '../components/Dialog';
@@ -13,7 +15,7 @@ import VideoPlayer from '../components/VideoPlayer';
 import { FetchStatus, useApiHost, useEvent, useDelete } from '../api';
 import { Table, Thead, Tbody, Th, Tr, Td } from '../components/Table';
 
-export default function Event({ eventId }) {
+export default function Event({ eventId, close }) {
   const apiHost = useApiHost();
   const { data, status } = useEvent(eventId);
   const [showDialog, setShowDialog] = useState(false);
@@ -40,7 +42,6 @@ export default function Event({ eventId }) {
     if (success) {
       setDeleteStatus(FetchStatus.LOADED);
       setShowDialog(false);
-      route('/events', true);
     }
   }, [eventId, setShowDialog, setDeleteEvent]);
 
@@ -53,13 +54,27 @@ export default function Event({ eventId }) {
 
   return (
     <div className="space-y-4">
-      <div className="flex">
-        <Heading className="flex-grow">
-          {data.camera} {data.label} <span className="text-sm">{startime.toLocaleString()}</span>
-        </Heading>
-        <Button className="self-start" color="red" onClick={handleClickDelete}>
-          <Delete className="w-6" /> Delete event
-        </Button>
+      <div className="grid grid-cols-6 gap-4">
+        <div class="col-start-1 col-end-8 md:space-x-4">
+          <Button color="blue" href={`${apiHost}/api/events/${eventId}/clip.mp4?download=true`} download>
+            <Clip className="w-6" /> Download Clip
+          </Button>
+          <Button color="blue" href={`${apiHost}/api/events/${eventId}/snapshot.jpg?download=true`} download>
+            <Snapshot className="w-6" /> Download Snapshot
+          </Button>
+          <Button className="self-start" onClick={() => setShowDetails(!showDetails)}>
+            <ArrowDown className="w-6" />
+            {`${showDetails ? 'Hide event Details' : 'View event Details'}`}
+          </Button>
+        </div>
+        <div class="col-end-10 col-span-2 space-x-4">
+          <Button color="gray" className="self-start" onClick={() => close()}>
+            <Menu className="w-6" /> Close
+          </Button>
+          <Button className="self-start" color="red" onClick={handleClickDelete}>
+            <Delete className="w-6" /> Delete event
+          </Button>
+        </div>
         {showDialog ? (
           <Dialog
             onDismiss={handleDismissDeleteDialog}
@@ -110,39 +125,26 @@ export default function Event({ eventId }) {
 
       {data.has_clip ? (
         <Fragment>
-          <Heading size="lg">Clip</Heading>
-          <VideoPlayer
-            options={{
-              sources: [
-                {
-                  src: `${apiHost}/vod/event/${eventId}/index.m3u8`,
-                  type: 'application/vnd.apple.mpegurl',
-                },
-              ],
-              poster: data.has_snapshot
-                ? `${apiHost}/clips/${data.camera}-${eventId}.jpg`
-                : `data:image/jpeg;base64,${data.thumbnail}`,
-            }}
-            seekOptions={{ forward: 10, back: 5 }}
-            onReady={(player) => {}}
-          />
-          <div className="text-center">
-            <Button
-              className="mx-2"
-              color="blue"
-              href={`${apiHost}/api/events/${eventId}/clip.mp4?download=true`}
-              download
-            >
-              <Clip className="w-6" /> Download Clip
-            </Button>
-            <Button
-              className="mx-2"
-              color="blue"
-              href={`${apiHost}/api/events/${eventId}/snapshot.jpg?download=true`}
-              download
-            >
-              <Snapshot className="w-6" /> Download Snapshot
-            </Button>
+          <div className="outer-max-width m-auto">
+            <div className="aspect-ratio-box w-full relative">
+              <div className="absolute w-full top-10 left-0">
+                <VideoPlayer
+                  options={{
+                    sources: [
+                      {
+                        src: `${apiHost}/vod/event/${eventId}/index.m3u8`,
+                        type: 'application/vnd.apple.mpegurl',
+                      },
+                    ],
+                    poster: data.has_snapshot
+                      ? `${apiHost}/clips/${data.camera}-${eventId}.jpg`
+                      : `data:image/jpeg;base64,${data.thumbnail}`,
+                  }}
+                  seekOptions={{ forward: 10, back: 5 }}
+                  onReady={(player) => {}}
+                />
+              </div>
+            </div>
           </div>
         </Fragment>
       ) : (

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -92,41 +92,39 @@ export default function Event({ eventId, close, scrollRef }) {
         ) : null}
       </div>
       <div className="outer-max-width m-auto">
-        <div className="aspect-ratio-box w-full relative">
-          <div className="absolute w-full top-10 left-0">
-            {data.has_clip ? (
-              <Fragment>
-                <Heading size="lg">Clip</Heading>
-                <VideoPlayer
-                  options={{
-                    sources: [
-                      {
-                        src: `${apiHost}/vod/event/${eventId}/index.m3u8`,
-                        type: 'application/vnd.apple.mpegurl',
-                      },
-                    ],
-                    poster: data.has_snapshot
-                      ? `${apiHost}/clips/${data.camera}-${eventId}.jpg`
-                      : `data:image/jpeg;base64,${data.thumbnail}`,
-                  }}
-                  seekOptions={{ forward: 10, back: 5 }}
-                  onReady={() => {}}
-                />
-              </Fragment>
-            ) : (
-              <Fragment>
-                <Heading size="sm">{data.has_snapshot ? 'Best Image' : 'Thumbnail'}</Heading>
-                <img
-                  src={
-                    data.has_snapshot
-                      ? `${apiHost}/clips/${data.camera}-${eventId}.jpg`
-                      : `data:image/jpeg;base64,${data.thumbnail}`
-                  }
-                  alt={`${data.label} at ${(data.top_score * 100).toFixed(1)}% confidence`}
-                />
-              </Fragment>
-            )}
-          </div>
+        <div className="w-full pt-5 relative pb-20">
+          {data.has_clip ? (
+            <Fragment>
+              <Heading size="lg">Clip</Heading>
+              <VideoPlayer
+                options={{
+                  sources: [
+                    {
+                      src: `${apiHost}/vod/event/${eventId}/index.m3u8`,
+                      type: 'application/vnd.apple.mpegurl',
+                    },
+                  ],
+                  poster: data.has_snapshot
+                    ? `${apiHost}/clips/${data.camera}-${eventId}.jpg`
+                    : `data:image/jpeg;base64,${data.thumbnail}`,
+                }}
+                seekOptions={{ forward: 10, back: 5 }}
+                onReady={() => {}}
+              />
+            </Fragment>
+          ) : (
+            <Fragment>
+              <Heading size="sm">{data.has_snapshot ? 'Best Image' : 'Thumbnail'}</Heading>
+              <img
+                src={
+                  data.has_snapshot
+                    ? `${apiHost}/clips/${data.camera}-${eventId}.jpg`
+                    : `data:image/jpeg;base64,${data.thumbnail}`
+                }
+                alt={`${data.label} at ${(data.top_score * 100).toFixed(1)}% confidence`}
+              />
+            </Fragment>
+          )}
         </div>
       </div>
     </div>

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -86,9 +86,10 @@ export default function Event({ eventId, close }) {
 
       {data.has_clip ? (
         <Fragment>
+          <Heading size="lg">Clip</Heading>
           <div className="outer-max-width m-auto">
             <div className="aspect-ratio-box w-full relative">
-              <div className="absolute w-full top-10 left-0">
+              <div className="absolute w-full top-0 left-0">
                 <VideoPlayer
                   options={{
                     sources: [
@@ -106,6 +107,14 @@ export default function Event({ eventId, close }) {
                 />
               </div>
             </div>
+          </div>
+          <div className="flex space-x-4 justify-center">
+            <Button color="blue" href={`${apiHost}/api/events/${eventId}/clip.mp4?download=true`} download>
+              <Clip className="w-6" /> Download Clip
+            </Button>
+            <Button color="blue" href={`${apiHost}/api/events/${eventId}/snapshot.jpg?download=true`} download>
+              <Snapshot className="w-6" /> Download Snapshot
+            </Button>
           </div>
         </Fragment>
       ) : (

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -66,11 +66,11 @@ export default function Event({ eventId, close, scrollRef }) {
           </Button>
         </div>
         <div class="col-end-10 col-span-2 space-x-4">
-          <Button color="gray" className="self-start" onClick={() => close()}>
-            <Menu className="w-6" /> Close
-          </Button>
           <Button className="self-start" color="red" onClick={handleClickDelete}>
             <Delete className="w-6" /> Delete event
+          </Button>
+          <Button color="gray" className="self-start" onClick={() => close()}>
+            <Menu className="w-6" /> Close
           </Button>
         </div>
         {showDialog ? (

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -1,5 +1,5 @@
 import { h, Fragment } from 'preact';
-import { useCallback, useState } from 'preact/hooks';
+import { useCallback, useState, useEffect } from 'preact/hooks';
 import ActivityIndicator from '../components/ActivityIndicator';
 import Button from '../components/Button';
 import Clip from '../icons/Clip';
@@ -11,12 +11,17 @@ import Heading from '../components/Heading';
 import VideoPlayer from '../components/VideoPlayer';
 import { FetchStatus, useApiHost, useEvent, useDelete } from '../api';
 
-export default function Event({ eventId, close }) {
+export default function Event({ eventId, close, scrollIntoView }) {
   const apiHost = useApiHost();
   const { data, status } = useEvent(eventId);
   const [showDialog, setShowDialog] = useState(false);
   const [deleteStatus, setDeleteStatus] = useState(FetchStatus.NONE);
   const setDeleteEvent = useDelete();
+
+  useEffect(() => {
+    // Call Events.js scroll when this event has been mounted.
+    scrollIntoView(eventId);
+  }, []);
 
   const handleClickDelete = () => {
     setShowDialog(true);

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -45,7 +45,6 @@ export default function Event({ eventId, close }) {
     return <ActivityIndicator />;
   }
 
-  console.log(data);
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-6 gap-4">
@@ -107,14 +106,6 @@ export default function Event({ eventId, close }) {
                 />
               </div>
             </div>
-          </div>
-          <div className="flex space-x-4 justify-center">
-            <Button color="blue" href={`${apiHost}/api/events/${eventId}/clip.mp4?download=true`} download>
-              <Clip className="w-6" /> Download Clip
-            </Button>
-            <Button color="blue" href={`${apiHost}/api/events/${eventId}/snapshot.jpg?download=true`} download>
-              <Snapshot className="w-6" /> Download Snapshot
-            </Button>
           </div>
         </Fragment>
       ) : (

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -85,7 +85,6 @@ export default function Event({ eventId, close }) {
 
       {data.has_clip ? (
         <Fragment>
-          <Heading size="lg">Clip</Heading>
           <div className="outer-max-width m-auto">
             <div className="aspect-ratio-box w-full relative">
               <div className="absolute w-full top-0 left-0">

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -20,8 +20,8 @@ export default function Event({ eventId, close, scrollIntoView }) {
 
   useEffect(() => {
     // Call Events.js scroll when this event has been mounted.
-    () => scrollIntoView(eventId);
-  }, []);
+    scrollIntoView(eventId);
+  }, [scrollIntoView]);
 
   const handleClickDelete = () => {
     setShowDialog(true);

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -15,20 +15,17 @@ export default function Event({ eventId, close, scrollRef }) {
   const apiHost = useApiHost();
   const { data, status } = useEvent(eventId);
   const [showDialog, setShowDialog] = useState(false);
+  const [shouldScroll, setShouldScroll] = useState(true);
   const [deleteStatus, setDeleteStatus] = useState(FetchStatus.NONE);
   const setDeleteEvent = useDelete();
 
   useEffect(() => {
-    // Call Events.js scroll when this event has been mounted.
-    // scrollIntoView(eventId);
-    scrollToElement();
-  }, [data]);
-
-  const scrollToElement = useCallback(() => {
-    if (scrollRef && scrollRef[eventId]) {
+    // Scroll event into view when component has been mounted.
+    if (shouldScroll && scrollRef && scrollRef[eventId]) {
       scrollRef[eventId].scrollIntoView();
+      setShouldScroll(false);
     }
-  }, [scrollRef]);
+  }, [data, scrollRef, eventId, shouldScroll]);
 
   const handleClickDelete = () => {
     setShowDialog(true);

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -87,7 +87,7 @@ export default function Event({ eventId, close }) {
         <Fragment>
           <div className="outer-max-width m-auto">
             <div className="aspect-ratio-box w-full relative">
-              <div className="absolute w-full top-0 left-0">
+              <div className="absolute w-full top-10 left-0">
                 <VideoPlayer
                   options={{
                     sources: [

--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -20,7 +20,7 @@ export default function Event({ eventId, close, scrollIntoView }) {
 
   useEffect(() => {
     // Call Events.js scroll when this event has been mounted.
-    scrollIntoView(eventId);
+    () => scrollIntoView(eventId);
   }, []);
 
   const handleClickDelete = () => {
@@ -92,6 +92,7 @@ export default function Event({ eventId, close, scrollIntoView }) {
           <div className="absolute w-full top-10 left-0">
             {data.has_clip ? (
               <Fragment>
+                <Heading size="lg">Clip</Heading>
                 <VideoPlayer
                   options={{
                     sources: [

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -136,7 +136,7 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
 
   const viewEventById = (eventId) => (
     <Tr className="border-b-1">
-      <Td colspan="8">
+      <Td colSpan="8">
         <Event eventId={eventId} close={() => setViewEvent(null)} />
       </Td>
     </Tr>

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -73,7 +73,7 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
   const [searchString, setSearchString] = useState(`${defaultSearchString(limit)}&${initialSearchParams.toString()}`);
   const { data, status, deletedId } = useEvents(searchString);
 
-  let scrollToRef = {};
+  const scrollToRef = {};
   useEffect(() => {
     if (data && !(searchString in searchStrings)) {
       dispatch({ type: 'APPEND_EVENTS', payload: data, meta: { searchString } });

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -80,7 +80,6 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
     }
 
     if (data && Array.isArray(data) && data.length + deleted < limit) {
-      console.log('reached end');
       dispatch({ type: 'REACHED_END', meta: { searchString } });
     }
   }, [data, limit, searchString, searchStrings, deleted]);

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -36,6 +36,7 @@ const reducer = (state = initialState, action) => {
       return produce(state, (draftState) => {
         draftState.searchStrings[searchString] = true;
         draftState.events.push(...payload);
+        draftState.deleted = 0;
       });
     }
 
@@ -71,6 +72,10 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
   const [viewEvent, setViewEvent] = useState(null);
   const [searchString, setSearchString] = useState(`${defaultSearchString(limit)}&${initialSearchParams.toString()}`);
   const { data, status, deletedId } = useEvents(searchString);
+  console.log('deleted', deleted);
+  console.log('deletedId', deletedId);
+  console.log('limit', limit);
+  console.log('data.length', data && data.length);
 
   let scrollToRef = {};
   useEffect(() => {
@@ -79,13 +84,16 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
     }
 
     if (data && Array.isArray(data) && data.length + deleted < limit) {
+      console.log('reached end');
       dispatch({ type: 'REACHED_END', meta: { searchString } });
     }
+  }, [data, limit, searchString, searchStrings, deleted]);
 
+  useEffect(() => {
     if (deletedId) {
       dispatch({ type: 'DELETE_EVENT', deletedId });
     }
-  }, [data, limit, searchString, searchStrings, deleted, deletedId]);
+  }, [deletedId]);
 
   const [entry, setIntersectNode] = useIntersectionObserver();
 
@@ -214,9 +222,7 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
                     {viewEvent === id ? (
                       <Tr className="border-b-1">
                         <Td colspan="8">
-                          <div>
-                            <Event eventId={viewEvent} close={() => setViewEvent(null)} />
-                          </div>
+                          <Event eventId={viewEvent} close={() => setViewEvent(null)} />
                         </Td>
                       </Tr>
                     ) : null}

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -88,12 +88,6 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
     }
   }, [data, limit, searchString, searchStrings, deleted, deletedId]);
 
-  // useEffect(() => {
-  //   if (deletedId) {
-  //     dispatch({ type: 'DELETE_EVENT', deletedId });
-  //   }
-  // }, [deletedId]);
-
   const [entry, setIntersectNode] = useIntersectionObserver();
 
   useEffect(() => {

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -128,6 +128,13 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
   };
   const searchParams = useMemo(() => new URLSearchParams(searchString), [searchString]);
 
+  const viewEventById = (eventId) => (
+    <Tr className="border-b-1">
+      <Td colspan="8">
+        <Event eventId={eventId} close={() => setViewEvent(null)} />
+      </Td>
+    </Tr>
+  );
   return (
     <div className="space-y-4 w-full">
       <Heading>Events</Heading>
@@ -215,13 +222,7 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
                       <Td>{start.toLocaleTimeString()}</Td>
                       <Td>{end.toLocaleTimeString()}</Td>
                     </Tr>
-                    {viewEvent === id ? (
-                      <Tr className="border-b-1">
-                        <Td colspan="8">
-                          <Event eventId={viewEvent} close={() => setViewEvent(null)} />
-                        </Td>
-                      </Tr>
-                    ) : null}
+                    {viewEvent === id ? viewEventById(viewEvent) : null}
                   </Fragment>
                 );
               }

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -72,10 +72,6 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
   const [viewEvent, setViewEvent] = useState(null);
   const [searchString, setSearchString] = useState(`${defaultSearchString(limit)}&${initialSearchParams.toString()}`);
   const { data, status, deletedId } = useEvents(searchString);
-  console.log('deleted', deleted);
-  console.log('deletedId', deletedId);
-  console.log('limit', limit);
-  console.log('data.length', data && data.length);
 
   let scrollToRef = {};
   useEffect(() => {

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -80,6 +80,7 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
     }
 
     if (data && Array.isArray(data) && data.length + deleted < limit) {
+      console.log('reached end');
       dispatch({ type: 'REACHED_END', meta: { searchString } });
     }
   }, [data, limit, searchString, searchStrings, deleted]);
@@ -127,12 +128,6 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
 
     //Set event id to be rendered.
     setViewEvent(id);
-  };
-
-  // Called from the mounted event.js to prevent
-  // race condition between scollIntoView and if component has been mounted.
-  const scrollIntoView = (id) => {
-    if (id in scrollToRef) scrollToRef[id].scrollIntoView();
   };
 
   const searchParams = useMemo(() => new URLSearchParams(searchString), [searchString]);
@@ -224,7 +219,7 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
                     {viewEvent === id ? (
                       <Tr className="border-b-1">
                         <Td colSpan="8">
-                          <Event scrollIntoView={scrollIntoView} eventId={id} close={() => setViewEvent(null)} />
+                          <Event eventId={id} close={() => setViewEvent(null)} scrollRef={scrollToRef} />
                         </Td>
                       </Tr>
                     ) : null}

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -128,19 +128,16 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
 
     //Set event id to be rendered.
     setViewEvent(id);
+  };
 
-    //scroll the event into view
+  // Called from the mounted event.js to prevent
+  // race condition between scollIntoView and if component has been mounted.
+  const scrollIntoView = (id) => {
     if (id in scrollToRef) scrollToRef[id].scrollIntoView();
   };
+
   const searchParams = useMemo(() => new URLSearchParams(searchString), [searchString]);
 
-  const viewEventById = (eventId) => (
-    <Tr className="border-b-1">
-      <Td colSpan="8">
-        <Event eventId={eventId} close={() => setViewEvent(null)} />
-      </Td>
-    </Tr>
-  );
   return (
     <div className="space-y-4 w-full">
       <Heading>Events</Heading>
@@ -163,10 +160,7 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
           </Thead>
           <Tbody>
             {events.map(
-              (
-                { camera, id, label, start_time: startTime, end_time: endTime, thumbnail, top_score: score, zones },
-                i
-              ) => {
+              ({ camera, id, label, start_time: startTime, end_time: endTime, top_score: score, zones }, i) => {
                 const start = new Date(parseInt(startTime * 1000, 10));
                 const end = new Date(parseInt(endTime * 1000, 10));
                 const ref = i === events.length - 1 ? lastCellRef : undefined;
@@ -228,7 +222,13 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
                       <Td>{start.toLocaleTimeString()}</Td>
                       <Td>{end.toLocaleTimeString()}</Td>
                     </Tr>
-                    {viewEvent === id ? viewEventById(viewEvent) : null}
+                    {viewEvent === id ? (
+                      <Tr className="border-b-1">
+                        <Td colSpan="8">
+                          <Event scrollIntoView={scrollIntoView} eventId={id} close={() => setViewEvent(null)} />
+                        </Td>
+                      </Tr>
+                    ) : null}
                   </Fragment>
                 );
               }
@@ -236,7 +236,7 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
           </Tbody>
           <Tfoot>
             <Tr>
-              <Td className="text-center p-4" colspan="8">
+              <Td className="text-center p-4" colSpan="8">
                 {status === FetchStatus.LOADING ? <ActivityIndicator /> : reachedEnd ? 'No more events' : null}
               </Td>
             </Tr>

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -121,10 +121,16 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
     },
     [limit, pathname, setSearchString]
   );
+
   const viewEventHandler = (id) => {
+    //Toggle event view
     if (viewEvent === id) return setViewEvent(null);
-    if (id in scrollToRef) scrollToRef[id].scrollIntoView();
+
+    //Set event id to be rendered.
     setViewEvent(id);
+
+    //scroll the event into view
+    if (id in scrollToRef) scrollToRef[id].scrollIntoView();
   };
   const searchParams = useMemo(() => new URLSearchParams(searchString), [searchString]);
 

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -82,13 +82,17 @@ export default function Events({ path: pathname, limit = API_LIMIT } = {}) {
     if (data && Array.isArray(data) && data.length + deleted < limit) {
       dispatch({ type: 'REACHED_END', meta: { searchString } });
     }
-  }, [data, limit, searchString, searchStrings, deleted]);
 
-  useEffect(() => {
     if (deletedId) {
       dispatch({ type: 'DELETE_EVENT', deletedId });
     }
-  }, [deletedId]);
+  }, [data, limit, searchString, searchStrings, deleted, deletedId]);
+
+  // useEffect(() => {
+  //   if (deletedId) {
+  //     dispatch({ type: 'DELETE_EVENT', deletedId });
+  //   }
+  // }, [deletedId]);
 
   const [entry, setIntersectNode] = useIntersectionObserver();
 

--- a/web/src/routes/__tests__/Event.test.jsx
+++ b/web/src/routes/__tests__/Event.test.jsx
@@ -16,12 +16,12 @@ describe('Event Route', () => {
 
   test('shows an ActivityIndicator if not yet loaded', async () => {
     useEventMock.mockReturnValueOnce(() => ({ status: 'loading' }));
-    render(<Event eventId={mockEvent.id} scrollIntoView={mockEvent.scrollIntoView} />);
+    render(<Event eventId={mockEvent.id} />);
     expect(screen.queryByLabelText('Loading…')).toBeInTheDocument();
   });
 
   test('shows cameras', async () => {
-    render(<Event eventId={mockEvent.id} scrollIntoView={mockEvent.scrollIntoView} />);
+    render(<Event eventId={mockEvent.id} />);
 
     expect(screen.queryByLabelText('Loading…')).not.toBeInTheDocument();
 
@@ -33,7 +33,7 @@ describe('Event Route', () => {
 
   test('does not render a video if there is no clip', async () => {
     useEventMock.mockReturnValue({ data: { ...mockEvent, has_clip: false }, status: 'loaded' });
-    render(<Event eventId={mockEvent.id} scrollIntoView={mockEvent.scrollIntoView} />);
+    render(<Event eventId={mockEvent.id} />);
 
     expect(screen.queryByText('Clip')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Video Player')).not.toBeInTheDocument();
@@ -43,7 +43,7 @@ describe('Event Route', () => {
 
   test('shows the thumbnail if no snapshot available', async () => {
     useEventMock.mockReturnValue({ data: { ...mockEvent, has_clip: false, has_snapshot: false }, status: 'loaded' });
-    render(<Event eventId={mockEvent.id} scrollIntoView={mockEvent.scrollIntoView} />);
+    render(<Event eventId={mockEvent.id} />);
 
     expect(screen.queryByText('Best Image')).not.toBeInTheDocument();
     expect(screen.queryByText('Thumbnail')).toBeInTheDocument();
@@ -66,5 +66,4 @@ const mockEvent = {
   top_score: 0.8203125,
   zones: ['front_patio'],
   thumbnail: '/9j/4aa...',
-  scrollIntoView: jest.fn(),
 };

--- a/web/src/routes/__tests__/Event.test.jsx
+++ b/web/src/routes/__tests__/Event.test.jsx
@@ -16,12 +16,12 @@ describe('Event Route', () => {
 
   test('shows an ActivityIndicator if not yet loaded', async () => {
     useEventMock.mockReturnValueOnce(() => ({ status: 'loading' }));
-    render(<Event eventId={mockEvent.id} />);
+    render(<Event eventId={mockEvent.id} scrollIntoView={mockEvent.scrollIntoView} />);
     expect(screen.queryByLabelText('Loading…')).toBeInTheDocument();
   });
 
   test('shows cameras', async () => {
-    render(<Event eventId={mockEvent.id} />);
+    render(<Event eventId={mockEvent.id} scrollIntoView={mockEvent.scrollIntoView} />);
 
     expect(screen.queryByLabelText('Loading…')).not.toBeInTheDocument();
 
@@ -33,7 +33,7 @@ describe('Event Route', () => {
 
   test('does not render a video if there is no clip', async () => {
     useEventMock.mockReturnValue({ data: { ...mockEvent, has_clip: false }, status: 'loaded' });
-    render(<Event eventId={mockEvent.id} />);
+    render(<Event eventId={mockEvent.id} scrollIntoView={mockEvent.scrollIntoView} />);
 
     expect(screen.queryByText('Clip')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Video Player')).not.toBeInTheDocument();
@@ -43,7 +43,7 @@ describe('Event Route', () => {
 
   test('shows the thumbnail if no snapshot available', async () => {
     useEventMock.mockReturnValue({ data: { ...mockEvent, has_clip: false, has_snapshot: false }, status: 'loaded' });
-    render(<Event eventId={mockEvent.id} />);
+    render(<Event eventId={mockEvent.id} scrollIntoView={mockEvent.scrollIntoView} />);
 
     expect(screen.queryByText('Best Image')).not.toBeInTheDocument();
     expect(screen.queryByText('Thumbnail')).toBeInTheDocument();
@@ -66,4 +66,5 @@ const mockEvent = {
   top_score: 0.8203125,
   zones: ['front_patio'],
   thumbnail: '/9j/4aa...',
+  scrollIntoView: jest.fn(),
 };


### PR DESCRIPTION
Event viewer will open below the table row when clicking the image instead of opening new page. 
This will also resolve #1465 #1594 as the scroll position will not change. 

Brief overview:
- New event table row is open when clicking the event image. 
- It will automatically scroll the event into view.
- Scaled down the videoplayer, but ratio is maintained.
- Removed event details as its already in the events table.
- Moved the delete reducer from api to Events.js
- Added fixed position for the delete Dialog.
- Removed Event route.

Tested on Chrome, Firefox, Edge with 1000+ events.

**Note!**
Im currently trying to trace down some performance issue. When i scroll down large amount of events (700+), i notice the browser get slugish. This is also noticable in 0.9.0 without this mod, and probably 0.8.4 (not tested), but it became more noticable now as the event view is loaded from the same page events.js. 

Im not sure if this is only related to docker dev? I will update when i get more info.

![event_view](https://i.ibb.co/gP45nWR/event-view.png)
