### PR TITLE
Add RTMP and timestamp style to global config

### DIFF
--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -215,6 +215,12 @@ Frigate can re-stream your video feed as a RTMP feed for other applications such
 
 Some video feeds are not compatible with RTMP. If you are experiencing issues, check to make sure your camera feed is h264 with AAC audio. If your camera doesn't support a compatible format for RTMP, you can use the ffmpeg args to re-encode it on the fly at the expense of increased CPU utilization.
 
+```yaml
+rtmp:
+  # Optional: Enable the RTMP stream (default: True)
+  enabled: True
+```
+
 ## Timestamp style configuration
 
 For the debug view and snapshots it is possible to embed a timestamp in the feed. In some instances the default position obstructs important space, visibility or contrast is too low because of color or the datetime format does not match ones desire.
@@ -357,7 +363,7 @@ cameras:
 
     # Optional: RTMP re-stream configuration
     rtmp:
-      # Required: Enable the RTMP stream (default: True)
+      # Optional: Enable the RTMP stream (default: True)
       enabled: True
 
     # Optional: Live stream configuration for WebUI

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -233,3 +233,13 @@ birdseye:
   #   continuous - all cameras are included always
   mode: objects
 ```
+
+### `rtmp`
+
+Can be overridden at the camera level. See the [cameras configuration page](cameras.md) for more information about RTMP streaming.
+
+```yaml
+rtmp:
+  # Optional: Enable the RTMP stream (default: True)
+  enabled: True
+```

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -243,3 +243,34 @@ rtmp:
   # Optional: Enable the RTMP stream (default: True)
   enabled: True
 ```
+
+## `timestamp_style`
+
+Can be overridden at the camera level. See the [cameras configuration page](cameras.md) for more information about timestamp styling.
+
+```yaml
+# Optional: in-feed timestamp style configuration
+timestamp_style:
+  # Optional: Position of the timestamp (default: shown below)
+  #           "tl" (top left), "tr" (top right), "bl" (bottom left), "br" (bottom right)
+  position: "tl"
+  # Optional: Format specifier conform to the Python package "datetime" (default: shown below)
+  #           Additional Examples:
+  #             german: "%d.%m.%Y %H:%M:%S"
+  format: "%m/%d/%Y %H:%M:%S"
+  # Optional: Color of font
+  color:
+    # All Required when color is specified (default: shown below)
+    red: 255
+    green: 255
+    blue: 255
+  # Optional: Scale factor for font (default: shown below)
+  scale: 1.0
+  # Optional: Line thickness of font (default: shown below)
+  thickness: 2
+  # Optional: Effect of lettering (default: shown below)
+  #           None (No effect),
+  #           "solid" (solid background in inverse color of font)
+  #           "shadow" (shadow for font)
+  effect: None
+```

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -675,6 +675,9 @@ class FrigateConfig(BaseModel):
         default_factory=DetectConfig, title="Global object tracking configuration."
     )
     cameras: Dict[str, CameraConfig] = Field(title="Camera configuration.")
+    timestamp_style: TimestampStyleConfig = Field(
+        default_factory=TimestampStyleConfig, title="Global timestamp style configuration."
+    )
 
     @property
     def runtime_config(self) -> FrigateConfig:
@@ -695,6 +698,7 @@ class FrigateConfig(BaseModel):
                 "motion": ...,
                 "detect": ...,
                 "ffmpeg": ...,
+                "timestamp_style": ...,
             },
             exclude_unset=True,
         )

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -676,7 +676,8 @@ class FrigateConfig(BaseModel):
     )
     cameras: Dict[str, CameraConfig] = Field(title="Camera configuration.")
     timestamp_style: TimestampStyleConfig = Field(
-        default_factory=TimestampStyleConfig, title="Global timestamp style configuration."
+        default_factory=TimestampStyleConfig,
+        title="Global timestamp style configuration.",
     )
 
     @property

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -432,7 +432,7 @@ class CameraMqttConfig(BaseModel):
     )
 
 
-class CameraRtmpConfig(BaseModel):
+class RtmpConfig(BaseModel):
     enabled: bool = Field(default=True, title="RTMP restreaming enabled.")
 
 
@@ -454,8 +454,8 @@ class CameraConfig(BaseModel):
     record: RecordConfig = Field(
         default_factory=RecordConfig, title="Record configuration."
     )
-    rtmp: CameraRtmpConfig = Field(
-        default_factory=CameraRtmpConfig, title="RTMP restreaming configuration."
+    rtmp: RtmpConfig = Field(
+        default_factory=RtmpConfig, title="RTMP restreaming configuration."
     )
     live: CameraLiveConfig = Field(
         default_factory=CameraLiveConfig, title="Live playback settings."
@@ -656,6 +656,9 @@ class FrigateConfig(BaseModel):
     snapshots: SnapshotsConfig = Field(
         default_factory=SnapshotsConfig, title="Global snapshots configuration."
     )
+    rtmp: RtmpConfig = Field(
+        default_factory=RtmpConfig, title="Global RTMP restreaming configuration."
+    )
     birdseye: BirdseyeConfig = Field(
         default_factory=BirdseyeConfig, title="Birdseye configuration."
     )
@@ -687,6 +690,7 @@ class FrigateConfig(BaseModel):
             include={
                 "record": ...,
                 "snapshots": ...,
+                "rtmp": ...,
                 "objects": ...,
                 "motion": ...,
                 "detect": ...,

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -883,7 +883,7 @@ class TestConfig(unittest.TestCase):
         assert runtime_config.cameras["back"].snapshots.bounding_box == False
         assert runtime_config.cameras["back"].snapshots.height == 150
         assert runtime_config.cameras["back"].snapshots.enabled
-    
+
     def test_global_rtmp(self):
 
         config = {
@@ -908,7 +908,7 @@ class TestConfig(unittest.TestCase):
         runtime_config = frigate_config.runtime_config
         assert runtime_config.cameras["back"].rtmp.enabled
 
-    def test_default_snapshots(self):
+    def test_default_rtmp(self):
 
         config = {
             "mqtt": {"host": "mqtt"},
@@ -931,7 +931,7 @@ class TestConfig(unittest.TestCase):
         runtime_config = frigate_config.runtime_config
         assert runtime_config.cameras["back"].rtmp.enabled
 
-    def test_global_snapshots_merge(self):
+    def test_global_rtmp_merge(self):
 
         config = {
             "mqtt": {"host": "mqtt"},
@@ -1033,6 +1033,7 @@ class TestConfig(unittest.TestCase):
         runtime_config = frigate_config.runtime_config
         assert runtime_config.cameras["back"].timestamp_style.position == "bl"
         assert runtime_config.cameras["back"].timestamp_style.scale == 1.5
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -883,6 +883,80 @@ class TestConfig(unittest.TestCase):
         assert runtime_config.cameras["back"].snapshots.bounding_box == False
         assert runtime_config.cameras["back"].snapshots.height == 150
         assert runtime_config.cameras["back"].snapshots.enabled
+    
+    def test_global_rtmp(self):
+
+        config = {
+            "mqtt": {"host": "mqtt"},
+            "rtmp": {"enabled": True},
+            "cameras": {
+                "back": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {
+                                "path": "rtsp://10.0.0.1:554/video",
+                                "roles": ["detect"],
+                            },
+                        ]
+                    },
+                }
+            },
+        }
+        frigate_config = FrigateConfig(**config)
+        assert config == frigate_config.dict(exclude_unset=True)
+
+        runtime_config = frigate_config.runtime_config
+        assert runtime_config.cameras["back"].rtmp.enabled
+
+    def test_default_snapshots(self):
+
+        config = {
+            "mqtt": {"host": "mqtt"},
+            "cameras": {
+                "back": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {
+                                "path": "rtsp://10.0.0.1:554/video",
+                                "roles": ["detect"],
+                            },
+                        ]
+                    }
+                }
+            },
+        }
+        frigate_config = FrigateConfig(**config)
+        assert config == frigate_config.dict(exclude_unset=True)
+
+        runtime_config = frigate_config.runtime_config
+        assert runtime_config.cameras["back"].rtmp.enabled
+
+    def test_global_snapshots_merge(self):
+
+        config = {
+            "mqtt": {"host": "mqtt"},
+            "rtmp": {"enabled": False},
+            "cameras": {
+                "back": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {
+                                "path": "rtsp://10.0.0.1:554/video",
+                                "roles": ["detect"],
+                            },
+                        ]
+                    },
+                    "rtmp": {
+                        "enabled": True,
+                    },
+                }
+            },
+        }
+        frigate_config = FrigateConfig(**config)
+        assert config == frigate_config.dict(exclude_unset=True)
+
+        runtime_config = frigate_config.runtime_config
+        assert runtime_config.cameras["back"].rtmp.enabled
 
 
 if __name__ == "__main__":

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -958,6 +958,81 @@ class TestConfig(unittest.TestCase):
         runtime_config = frigate_config.runtime_config
         assert runtime_config.cameras["back"].rtmp.enabled
 
+    def test_global_timestamp_style(self):
+
+        config = {
+            "mqtt": {"host": "mqtt"},
+            "timestamp_style": {"position": "bl", "scale": 1.5},
+            "cameras": {
+                "back": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {
+                                "path": "rtsp://10.0.0.1:554/video",
+                                "roles": ["detect"],
+                            },
+                        ]
+                    },
+                }
+            },
+        }
+        frigate_config = FrigateConfig(**config)
+        assert config == frigate_config.dict(exclude_unset=True)
+
+        runtime_config = frigate_config.runtime_config
+        assert runtime_config.cameras["back"].timestamp_style.position == "bl"
+        assert runtime_config.cameras["back"].timestamp_style.scale == 1.5
+
+    def test_default_timestamp_style(self):
+
+        config = {
+            "mqtt": {"host": "mqtt"},
+            "cameras": {
+                "back": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {
+                                "path": "rtsp://10.0.0.1:554/video",
+                                "roles": ["detect"],
+                            },
+                        ]
+                    }
+                }
+            },
+        }
+        frigate_config = FrigateConfig(**config)
+        assert config == frigate_config.dict(exclude_unset=True)
+
+        runtime_config = frigate_config.runtime_config
+        assert runtime_config.cameras["back"].timestamp_style.position == "tl"
+        assert runtime_config.cameras["back"].timestamp_style.scale == 1.0
+
+    def test_global_timestamp_style_merge(self):
+
+        config = {
+            "mqtt": {"host": "mqtt"},
+            "rtmp": {"enabled": False},
+            "timestamp_style": {"position": "br", "scale": 2.0},
+            "cameras": {
+                "back": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {
+                                "path": "rtsp://10.0.0.1:554/video",
+                                "roles": ["detect"],
+                            },
+                        ]
+                    },
+                    "timestamp_style": {"position": "bl", "scale": 1.5},
+                }
+            },
+        }
+        frigate_config = FrigateConfig(**config)
+        assert config == frigate_config.dict(exclude_unset=True)
+
+        runtime_config = frigate_config.runtime_config
+        assert runtime_config.cameras["back"].timestamp_style.position == "bl"
+        assert runtime_config.cameras["back"].timestamp_style.scale == 1.5
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
This PR adds the ability to define `rtmp` and `timestamp_style` configs globally (as top-level maps), in addition to overriding them per camera.

I have updated the docs and added tests, but haven't been able to get the tests running locally... Something due to my dev environment, but as far as I can tell, they should be fine.

Closes #1656 and #1671.