### PR TITLE
Change 'theme-color' From Red

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -11,7 +11,8 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#3b82f7" />
     <meta name="msapplication-TileColor" content="#3b82f7" />
-    <meta name="theme-color" content="#ff0000" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#111827" media="(prefers-color-scheme: dark)" />
   </head>
   <body>
     <div id="root" class="z-0"></div>

--- a/web/public/site.webmanifest
+++ b/web/public/site.webmanifest
@@ -13,7 +13,7 @@
             "type": "image/png"
         }
     ],
-    "theme_color": "#ff0000",
-    "background_color": "#ff0000",
+    "theme_color": "#ffffff",
+    "background_color": "#ffffff",
     "display": "standalone"
 }


### PR DESCRIPTION
Currently the theme-color is set to '#ff0000' causing the status bar on mobile to be red. This PR set's the theme color to '#ffffff' if the device prefers light mode and '#111827' (bg-grey-900) if the device prefers dark mode. It also changes the theme_color and background_color to white in the manifest file. 

Unfortunately this does not dynamically change the theme-color when selecting light or dark mode in the UI, but this is just a quick fix. 