### PR TITLE
warning for dev board incompatibility post-0.9.x

### DIFF
--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -31,6 +31,7 @@ detectors:
 ```
 
 ### Native Coral (Dev Board)
+_warning: may have [compatibility issues](https://github.com/blakeblackshear/frigate/issues/1706) after `v0.9.x`_
 
 ```yaml
 detectors:


### PR DESCRIPTION
Hoped to investigate this with my dev board at some point. In the meantime, added a warning for others who may experience it when upgrading to the new stable release.