### PR TITLE
Add passthrough information for PCIe Coral TPU

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -118,6 +118,7 @@ services:
     shm_size: "64mb" # update for your cameras based on calculation above
     devices:
       - /dev/bus/usb:/dev/bus/usb # passes the USB Coral, needs to be modified for other versions
+      - /dev/apex_0:/dev/apex_0 # passes a PCIe Coral, follow driver instructions here https://coral.ai/docs/m2/get-started/#2a-on-linux
       - /dev/dri/renderD128 # for intel hwaccel, needs to be updated for your hardware
     volumes:
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
Added an example in the Docker snippet for PCIe devices after running into the same confusion in #1577 