### PR TITLE
Allow for ".yaml"

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -67,6 +67,12 @@ class FrigateApp:
 
     def init_config(self):
         config_file = os.environ.get("CONFIG_FILE", "/config/config.yml")
+
+        # Check if we can use .yaml instead of .yml
+        config_file_yaml = config_file.replace(".yml", ".yaml")
+        if os.path.isfile(config_file_yaml):
+            config_file = config_file_yaml
+
         user_config = FrigateConfig.parse_file(config_file)
         self.config = user_config.runtime_config
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -12,7 +12,7 @@ import yaml
 from pydantic import BaseModel, Extra, Field, validator
 from pydantic.fields import PrivateAttr
 
-from frigate.const import BASE_DIR, CACHE_DIR, RECORD_DIR, YAML_EXT
+from frigate.const import BASE_DIR, CACHE_DIR, YAML_EXT
 from frigate.edgetpu import load_labels
 from frigate.util import create_mask, deep_merge
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -12,7 +12,7 @@ import yaml
 from pydantic import BaseModel, Extra, Field, validator
 from pydantic.fields import PrivateAttr
 
-from frigate.const import BASE_DIR, CACHE_DIR, RECORD_DIR
+from frigate.const import BASE_DIR, CACHE_DIR, RECORD_DIR, YAML_EXT
 from frigate.edgetpu import load_labels
 from frigate.util import create_mask, deep_merge
 
@@ -823,7 +823,7 @@ class FrigateConfig(FrigateBaseModel):
         with open(config_file) as f:
             raw_config = f.read()
 
-        if config_file.endswith(".yml"):
+        if config_file.endswith(YAML_EXT):
             config = yaml.safe_load(raw_config)
         elif config_file.endswith(".json"):
             config = json.loads(raw_config)

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -2,3 +2,4 @@ BASE_DIR = "/media/frigate"
 CLIPS_DIR = f"{BASE_DIR}/clips"
 RECORD_DIR = f"{BASE_DIR}/recordings"
 CACHE_DIR = "/tmp/cache"
+YAML_EXT = (".yaml", ".yml")


### PR DESCRIPTION
Nit-picky, but would like to be able to use `.yaml` vs. `.yml`.

[Follows file extension preferences put forward by YAML.org](https://yaml.org/faq.html), but without breaking every existing user's config.

Addresses parenthetical from #1312.