### PR TITLE
Document JPEG streams

### DIFF
--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -31,6 +31,18 @@ input_args:
 - -1
 - -f
 - image2
+- -avoid_negative_ts
+- make_zero
+- -fflags
+- nobuffer
+- -flags
+- low_delay
+- -strict
+- experimental
+- -fflags
+- +genpts+discardcorrupt
+- -use_wallclock_as_timestamps
+- 1
 ```
 
 Outputting the stream will have the same args and caveats as per [MJPEG Cameras](#mjpeg-cameras)

--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -19,6 +19,22 @@ output_args:
   rtmp: -c:v libx264 -an -f flv
 ```
 
+### JPEG Stream Cameras
+
+Cameras using a live changing jpeg image will need input parameters as below
+
+```yaml
+input_args:
+- -r
+- 5 # << enter FPS here
+- -stream_loop
+- -1
+- -f
+- image2
+```
+
+Outputting the stream will have the same args and caveats as per [MJPEG Cameras](#mjpeg-cameras)
+
 ### RTMP Cameras
 
 The input parameters need to be adjusted for RTMP cameras


### PR DESCRIPTION
Provide input arguments for a changing jpg image stream. Specifically, [this](https://smile.amazon.com/dp/B07KSWNDXV/) camera uses this format for its mjpeg stream.