### PR TITLE
add a ? to the events href in the sidebar

### DIFF
--- a/web/src/Sidebar.jsx
+++ b/web/src/Sidebar.jsx
@@ -51,7 +51,7 @@ export default function Sidebar() {
         }
       </Match>
       {birdseye?.enabled ? <Destination href="/birdseye" text="Birdseye" /> : null}
-      <Destination href="/events" text="Events" />
+      <Destination href="/events?" text="Events" />
       <Destination href="/debug" text="Debug" />
       <Separator />
       <div className="flex flex-grow" />


### PR DESCRIPTION
Clicking on "Events" in the Sidebar does not show the latest events requiring the user to refresh the page.  Adding a question mark to the HREF forces the browser to not cache on the events page.