### PR TITLE
Fix stationary threshold event

### DIFF
--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -158,10 +158,10 @@ class TrackedObject:
             if self.obj_data["position_changes"] != obj_data["position_changes"]:
                 significant_change = True
 
-            # if the motionless_count crosses the stationary threshold
+            # if the motionless_count reaches the stationary threshold
             if (
                 self.obj_data["motionless_count"]
-                > self.camera_config.detect.stationary_threshold
+                == self.camera_config.detect.stationary_threshold
             ):
                 significant_change = True
 


### PR DESCRIPTION
The changes in https://github.com/blakeblackshear/frigate/commit/64f80a4732973d5b968202a2d6a2de12222ee6ec actually send an update event once per frame when `stationary_threshold` is exceeded. We should only send one event at the time it is exceeded then rely on the periodic updates thereafter.