### PR TITLE
Always show recording link even if recordings are currently disabled

### DIFF
--- a/web/src/routes/Cameras.jsx
+++ b/web/src/routes/Cameras.jsx
@@ -29,12 +29,8 @@ function Camera({ name, conf }) {
   const { payload: snapshotValue, send: sendSnapshots } = useSnapshotsState(name);
   const href = `/cameras/${name}`;
   const buttons = useMemo(() => {
-    const result = [{ name: 'Events', href: `/events?camera=${name}` }];
-    if (conf.record.enabled) {
-      result.push({ name: 'Recordings', href: `/recording/${name}` });
-    }
-    return result;
-  }, [name, conf.record.enabled]);
+    return [{ name: 'Events', href: `/events?camera=${name}` }, { name: 'Recordings', href: `/recording/${name}` }];
+  }, [name]);
   const icons = useMemo(
     () => [
       {

--- a/web/src/routes/__tests__/Cameras.test.jsx
+++ b/web/src/routes/__tests__/Cameras.test.jsx
@@ -46,7 +46,7 @@ describe('Cameras Route', () => {
 
     expect(screen.queryByLabelText('Loading…')).not.toBeInTheDocument();
 
-    expect(screen.queryAllByText('Recordings')).toHaveLength(1);
+    expect(screen.queryAllByText('Recordings')).toHaveLength(2);
   });
 
   test('buttons toggle detect, clips, and snapshots', async () => {


### PR DESCRIPTION
Fix for #2610 

I keep recordings on for both of my cameras, but I have one that I only record when my dog is left at home. It is helpful to always be able to view those recordings even if they are currently disabled. I'm thinking perhaps it may be possible to check if that camera currently has any recording clips but that might also be an expensive call. 