### PR TITLE
Retention by available disk space

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -72,6 +72,7 @@ class RetainModeEnum(str, Enum):
 
 class RetainConfig(FrigateBaseModel):
     default: float = Field(default=10, title="Default retention period.")
+    storage_percent: float = Field(default=95, title="Max storage to utilize.")
     mode: RetainModeEnum = Field(default=RetainModeEnum.motion, title="Retain mode.")
     objects: Dict[str, float] = Field(
         default_factory=dict, title="Object retention period."
@@ -96,6 +97,7 @@ class EventsConfig(FrigateBaseModel):
 
 class RecordRetainConfig(FrigateBaseModel):
     days: float = Field(default=0, title="Default retention period.")
+    storage_percent: float = Field(default=95, title="Max storage to utilize.")
     mode: RetainModeEnum = Field(default=RetainModeEnum.all, title="Retain mode.")
 
 


### PR DESCRIPTION
WIP PR to add the ability to configure `storage_percent` to delete recordings and events in case storage is used but is not expired yet. I have not fully worked out some of the implementation details so if anyone has any answers to the questions or has ideas please feel free to make comments / suggestions. 

#### Open Questions

1. Delete recordings processes one camera at a time, what is the best way to consider storage use?
2. Is there a good way to delete and check the storage use after a certain # of deletions or just delete a certain number per camera?
3. The cameras are processed one at a time, so the first camera will have a bias to be deleted before the lower ones.
4. If it this is allowed to be a per-camera configuration, is there any special handling needed for different values (ex: one camera is set to 95% and another is set to 70%
5. Since clips and snapshots are currently handled separately, should this also handle separately or delete both at the same time?

- [x] Add `storage_percent` to record and event retain config
- [ ] Remove recordings if storage is overutilized
- [ ] Remove events if storage is overutilized
- [ ] Potentially balance per camera to not bias first camera in list

Will retarget `0.11.0` once available.