### PR TITLE
FEAT: Remove `best.jpg` endpoint in favor of `latest.jpg` enpoint which uses snapshot from most recent event

### DIFF
--- a/docs/docs/integrations/api.md
+++ b/docs/docs/integrations/api.md
@@ -24,9 +24,10 @@ Accepts the following query string parameters:
 
 You can access a higher resolution mjpeg stream by appending `h=height-in-pixels` to the endpoint. For example `http://localhost:5000/api/back?h=1080`. You can also increase the FPS by appending `fps=frame-rate` to the URL such as `http://localhost:5000/api/back?fps=10` or both with `?fps=10&h=1000`.
 
-### `GET /api/<camera_name>/<object_name>/best.jpg[?h=300&crop=1&quality=70]`
+### `GET /api/<camera_name>/<object_name>/latest.jpg[?h=300&crop=1&quality=70]`
 
-The best snapshot for any object type. It is a full resolution image by default.
+The snapshot from the latest event for a given object type. It is a full resolution image by default.
+`any` can be passed as the `object_name` to get snapshot from the latest event regardless of object type.
 
 Example parameters:
 

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -357,19 +357,20 @@ def stats():
 def latest(camera_name, label):
     png_bytes = None
     if camera_name in current_app.frigate_config.cameras:
-
-        if label == "any":
-            label = "*"
-
-        event = (
+        event_query = (
             Event.select()
             .where(Event.camera == camera_name)
-            .where(Event.label == label)
             .where(Event.has_snapshot == True)
             .where(Event.end_time != None)
-            .order_by(Event.start_time.desc())
-            .get()
         )
+
+        if label != "any":
+            event_query.where(Event.label == label)
+
+        event = event_query.order_by(Event.start_time.desc()).get()
+
+        if event is None:
+            return "No event for {} was found".format(label), 404
 
         # read snapshot from disk
         with open(

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -355,27 +355,30 @@ def stats():
 
 @bp.route("/<camera_name>/<label>/latest.jpg")
 def latest(camera_name, label):
-    jpg_bytes = None
+    png_bytes = None
     if camera_name in current_app.frigate_config.cameras:
+
+        if label == "any":
+            label = "*"
+
         event = (
             Event.select()
             .where(Event.camera == camera_name)
-            .where(Event.label == "*" if label is "any" else label)
+            .where(Event.label == label)
             .where(Event.has_snapshot == True)
             .where(Event.end_time != None)
             .order_by(Event.start_time.desc())
             .get()
         )
 
-        #event = events.first()
         # read snapshot from disk
         with open(
-            os.path.join(CLIPS_DIR, f"{event.camera}-{event.id}.jpg"), "rb"
+            os.path.join(CLIPS_DIR, f"{event.camera}-{event.id}-clean.png"), "rb"
         ) as image_file:
-            jpg_bytes = image_file.read()
+            png_bytes = image_file.read()
 
-        response = make_response(jpg_bytes)
-        response.headers["Content-Type"] = "image/jpeg"
+        response = make_response(png_bytes)
+        response.headers["Content-Type"] = "image/png"
         return response
     else:
         return "Camera named {} not found".format(camera_name), 404

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -383,7 +383,25 @@ def latest(camera_name, label):
             return "No event for {} was found".format(label), 404
 
         # read snapshot from disk
-        frame = cv2.imread(os.path.join(CLIPS_DIR, f"{event.camera}-{event.id}-clean.png"))
+        frame = cv2.imread(
+            os.path.join(CLIPS_DIR, f"{event.camera}-{event.id}-clean.png")
+        )
+
+        crop = bool(request.args.get("crop", 0, type=int))
+        if crop:
+            box_size = 300
+            box = event.box
+            region = calculate_region(
+                frame.shape,
+                box[0],
+                box[1],
+                box[2],
+                box[3],
+                box_size,
+                multiplier=1.1,
+            )
+            frame = frame[region[1] : region[3], region[0] : region[2]]
+
         height = int(request.args.get("h", str(frame.shape[0])))
         width = int(height * frame.shape[1] / frame.shape[0])
         frame = cv2.resize(frame, dsize=(width, height), interpolation=cv2.INTER_AREA)

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -1,5 +1,4 @@
 import base64
-from cgi import test
 from collections import OrderedDict
 from datetime import datetime, timedelta
 import copy

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -352,22 +352,25 @@ def stats():
     stats = stats_snapshot(current_app.stats_tracking)
     return jsonify(stats)
 
+
 @bp.route("/<camera_name>/<label>/latest.jpg")
 def latest(camera_name, label):
     jpg_bytes = None
     if camera_name in current_app.frigate_config.cameras:
-        events = (
+        event = (
             Event.select()
             .where(Event.camera == camera_name)
             .where(Event.label == "*" if label is "any" else label)
             .where(Event.has_snapshot == True)
             .where(Event.end_time != None)
             .order_by(Event.start_time.desc())
+            .get()
         )
 
+        #event = events.first()
         # read snapshot from disk
         with open(
-            os.path.join(CLIPS_DIR, f"{event.camera}-{id}.jpg"), "rb"
+            os.path.join(CLIPS_DIR, f"{event.camera}-{event.id}.jpg"), "rb"
         ) as image_file:
             jpg_bytes = image_file.read()
 
@@ -376,6 +379,7 @@ def latest(camera_name, label):
         return response
     else:
         return "Camera named {} not found".format(camera_name), 404
+
 
 @bp.route("/<camera_name>/<label>/best.jpg")
 def best(camera_name, label):

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -356,18 +356,10 @@ def stats():
 @bp.route("/<camera_name>/<label>/latest.jpg")
 def latest(camera_name, label):
     png_bytes = None
-    draw_options = {
-        "bounding_boxes": request.args.get("bbox", type=int),
-        "timestamp": request.args.get("timestamp", type=int),
-        "zones": request.args.get("zones", type=int),
-        "mask": request.args.get("mask", type=int),
-        "motion_boxes": request.args.get("motion", type=int),
-        "regions": request.args.get("regions", type=int),
-    }
     resize_quality = request.args.get("quality", default=70, type=int)
 
     if camera_name in current_app.frigate_config.cameras:
-        if label is "any":
+        if label == "any":
             event_query = (
                 Event.select()
                 .where(Event.camera == camera_name)

--- a/web/src/routes/Camera.jsx
+++ b/web/src/routes/Camera.jsx
@@ -127,7 +127,7 @@ export default function Camera({ camera }) {
               key={objectType}
               header={objectType}
               href={`/events?camera=${camera}&label=${objectType}`}
-              media={<img src={`${apiHost}/api/${camera}/${objectType}/best.jpg?crop=1&h=150`} />}
+              media={<img src={`${apiHost}/api/${camera}/${objectType}/latest.jpg?crop=1&h=150`} />}
             />
           ))}
         </div>


### PR DESCRIPTION
## Description

This PR is an implementation as described in #2799 to replace the `best.jpg` endpoint.

The new endpoint is `GET /api/<camera_name>/<object_name>/latest.jpg` This endpoint has feature parity with the old `best.jpg` endpoint and also includes the ability to pass `any` as the `object_name` and it will return the snapshot from the latest event of any type.

## Open Questions

- Currently the docs entry for `best.jpg` was removed but the API was left in place. Unsure if this should stay that way (perhaps redirect to the new API?) for a release and it can be considered deprecated? I am not sure if many users utilize this endpoint other than frigate itself.
- Maybe should reverse the order of the two `latest.jpg` endpoints in the docs?

Currently targeting `release-0.10.0` but will update to `release-0.11.0` once available.