### PR TITLE
Fix "expired: #" log spam

### DIFF
--- a/frigate/objects.py
+++ b/frigate/objects.py
@@ -109,7 +109,6 @@ class ObjectTracker:
             obj["motionless_count"] - self.detect_config.stationary.threshold
             > max_frames
         ):
-            print(f"expired: {obj['motionless_count']}")
             return True
 
     def update(self, id, new_obj):


### PR DESCRIPTION
if an object has exceeded the max_frames value the message "expired: ###" would be printed in the log regardless of logging level.  

I assume this is a remnant of development? If it was your intention to make use of logging methods feel free to update this PR. 

Below is a screenshot of the original behavior
![image](https://user-images.githubusercontent.com/23481284/156306629-4a56269e-2387-4b35-b1f7-816b6749e995.png)
