### PR TITLE
FEAT: Replace best jpg endpoint

### DIFF
--- a/docs/docs/integrations/api.md
+++ b/docs/docs/integrations/api.md
@@ -190,6 +190,10 @@ Sets retain to false for the event id (event may be deleted quickly after removi
 
 Returns a thumbnail for the event id optimized for notifications. Works while the event is in progress and after completion. Passing `?format=android` will convert the thumbnail to 2:1 aspect ratio.
 
+### `GET /api/<camera_name>/<label>/thumbnail.jpg`
+
+Returns the thumbnail from the latest event for the given camera and label combo. Using `any` as the label will return the latest thumbnail regardless of type. 
+
 ### `GET /api/events/<id>/clip.mp4`
 
 Returns the clip for the event id. Works after the event has ended.
@@ -207,6 +211,10 @@ Accepts the following query string parameters, but they are only applied when an
 | `timestamp` | int  | Print the timestamp in the upper left (0 or 1)    |
 | `crop`      | int  | Crop the snapshot to the (0 or 1)                 |
 | `quality`   | int  | Jpeg encoding quality (0-100). Defaults to 70.    |
+
+### `GET /api/<camera_name>/<label>/snapshot.jpg`
+
+Returns the snapshot image from the latest event for the given camera and label combo. Using `any` as the label will return the latest thumbnail regardless of type.
 
 ### `GET /clips/<camera>-<id>.jpg`
 

--- a/docs/docs/integrations/api.md
+++ b/docs/docs/integrations/api.md
@@ -24,16 +24,6 @@ Accepts the following query string parameters:
 
 You can access a higher resolution mjpeg stream by appending `h=height-in-pixels` to the endpoint. For example `http://localhost:5000/api/back?h=1080`. You can also increase the FPS by appending `fps=frame-rate` to the URL such as `http://localhost:5000/api/back?fps=10` or both with `?fps=10&h=1000`.
 
-### `GET /api/<camera_name>/<object_name>/best.jpg[?h=300&crop=1&quality=70]`
-
-The best snapshot for any object type. It is a full resolution image by default.
-
-Example parameters:
-
-- `h=300`: resizes the image to 300 pixes tall
-- `crop=1`: crops the image to the region of the detection rather than returning the entire image
-- `quality=70`: sets the jpeg encoding quality (0-100)
-
 ### `GET /api/<camera_name>/latest.jpg[?h=300]`
 
 The most recent frame that frigate has finished processing. It is a full resolution image by default.

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -221,6 +221,39 @@ def event_thumbnail(id):
     response.headers["Content-Type"] = "image/jpeg"
     return response
 
+@bp.route("/<camera_name>/<label>/best.jpg")
+@bp.route("/<camera_name>/<label>/thumbnail.jpg")
+def label_thumbnail(camera_name, label):
+    if label == "any":
+        event_query = (
+            Event.select()
+            .where(Event.camera == camera_name)
+            .where(Event.has_snapshot == True)
+            .order_by(Event.start_time.desc())
+        )
+    else:
+        event_query = (
+            Event.select()
+            .where(Event.camera == camera_name)
+            .where(Event.label == label)
+            .where(Event.has_snapshot == True)
+            .order_by(Event.start_time.desc())
+        )
+
+    try:
+        event = event_query.get()
+
+        return event_thumbnail(event.id)
+    except DoesNotExist:
+        frame = np.zeros((175, 175, 3), np.uint8)
+        ret, jpg = cv2.imencode(
+            ".jpg", frame, [int(cv2.IMWRITE_JPEG_QUALITY), 70]
+        )
+
+        response = make_response(jpg.tobytes())
+        response.headers["Content-Type"] = "image/jpeg"
+        return response
+
 
 @bp.route("/events/<id>/snapshot.jpg")
 def event_snapshot(id):
@@ -384,48 +417,6 @@ def version():
 def stats():
     stats = stats_snapshot(current_app.stats_tracking)
     return jsonify(stats)
-
-
-@bp.route("/<camera_name>/<label>/best.jpg")
-def best(camera_name, label):
-    if camera_name in current_app.frigate_config.cameras:
-        best_object = current_app.detected_frames_processor.get_best(camera_name, label)
-        best_frame = best_object.get("frame")
-        if best_frame is None:
-            best_frame = np.zeros((720, 1280, 3), np.uint8)
-        else:
-            best_frame = cv2.cvtColor(best_frame, cv2.COLOR_YUV2BGR_I420)
-
-        crop = bool(request.args.get("crop", 0, type=int))
-        if crop:
-            box_size = 300
-            box = best_object.get("box", (0, 0, box_size, box_size))
-            region = calculate_region(
-                best_frame.shape,
-                box[0],
-                box[1],
-                box[2],
-                box[3],
-                box_size,
-                multiplier=1.1,
-            )
-            best_frame = best_frame[region[1] : region[3], region[0] : region[2]]
-
-        height = int(request.args.get("h", str(best_frame.shape[0])))
-        width = int(height * best_frame.shape[1] / best_frame.shape[0])
-        resize_quality = request.args.get("quality", default=70, type=int)
-
-        best_frame = cv2.resize(
-            best_frame, dsize=(width, height), interpolation=cv2.INTER_AREA
-        )
-        ret, jpg = cv2.imencode(
-            ".jpg", best_frame, [int(cv2.IMWRITE_JPEG_QUALITY), resize_quality]
-        )
-        response = make_response(jpg.tobytes())
-        response.headers["Content-Type"] = "image/jpeg"
-        return response
-    else:
-        return "Camera named {} not found".format(camera_name), 404
 
 
 @bp.route("/<camera_name>")

--- a/web/src/routes/Camera.jsx
+++ b/web/src/routes/Camera.jsx
@@ -127,7 +127,7 @@ export default function Camera({ camera }) {
               key={objectType}
               header={objectType}
               href={`/events?camera=${camera}&label=${objectType}`}
-              media={<img src={`${apiHost}/api/${camera}/${objectType}/best.jpg?crop=1&h=150`} />}
+              media={<img src={`${apiHost}/api/${camera}/${objectType}/thumbnail.jpg`} />}
             />
           ))}
         </div>


### PR DESCRIPTION
Following the advice on #2833 I created this PR to remove the `best.jpg` endpoint with `snapshot.jpg` and `thumbnail.jpg`  endpoints that leverage the existing functions to reduce work. 

This is also a fix for #2799 

I left the `best.jpg` endpoint in as another route to the thumbnail function so it can be considered deprecated in case any users were leveraging it. Let me know if I should outright delete it (it has already been deleted from the docs).