### PR TITLE
Fix 'got unconvertible type' error for docker compose.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     user: vscode
     # add groups from host for render, plugdev, video
     group_add:
-      - 109 # render
-      - 44  # video
-      - 46  # plugdev
+      - "109" # render
+      - "44"  # video
+      - "46"  # plugdev
     shm_size: "256mb"
     build:
       context: .


### PR DESCRIPTION
After pulling down latest release and opening up visual studio code I am getting this issue:

<img width="687" alt="Screen Shot 2022-03-11 at 6 59 02 AM" src="https://user-images.githubusercontent.com/14866235/157881808-16dac1d7-3c9f-468f-baee-e18bc0209c4d.png">

This PR fixes that, hopefully it won't conflict with places where it was working?