### PR TITLE
FEAT: Ability to set sub labels for specific events

### DIFF
--- a/docs/docs/integrations/api.md
+++ b/docs/docs/integrations/api.md
@@ -189,6 +189,7 @@ Sets retain to false for the event id (event may be deleted quickly after removi
 ### `POST /api/events/<id>/sub_label`
 
 Set a sub label for an event. For example to update `person` -> `person's name` if they were recognized with facial recognition.
+Sub labels must be 20 characters or shorter.
 
 ```json
 {
@@ -196,17 +197,13 @@ Set a sub label for an event. For example to update `person` -> `person's name` 
 }
 ```
 
-### `DELETE /api/events/<id>/sub_label`
-
-Clear the already set sub label to be blank.
-
 ### `GET /api/events/<id>/thumbnail.jpg`
 
 Returns a thumbnail for the event id optimized for notifications. Works while the event is in progress and after completion. Passing `?format=android` will convert the thumbnail to 2:1 aspect ratio.
 
 ### `GET /api/<camera_name>/<label>/thumbnail.jpg`
 
-Returns the thumbnail from the latest event for the given camera and label combo. Using `any` as the label will return the latest thumbnail regardless of type. 
+Returns the thumbnail from the latest event for the given camera and label combo. Using `any` as the label will return the latest thumbnail regardless of type.
 
 ### `GET /api/events/<id>/clip.mp4`
 

--- a/docs/docs/integrations/api.md
+++ b/docs/docs/integrations/api.md
@@ -186,6 +186,22 @@ Sets retain to true for the event id.
 
 Sets retain to false for the event id (event may be deleted quickly after removing).
 
+### `POST /api/events/<id>/sub_label`
+
+Set a sub label for a person event. For example to update `person` -> `person's name` if they were recognized with facial recognition. 
+
+```
+Headers:
+Content-Type: application/json
+
+Body:
+subLabel
+```
+
+### `DELETE /api/events/<id>/sub_label`
+
+Clear the already set sub label to be blank.
+
 ### `GET /api/events/<id>/thumbnail.jpg`
 
 Returns a thumbnail for the event id optimized for notifications. Works while the event is in progress and after completion. Passing `?format=android` will convert the thumbnail to 2:1 aspect ratio.

--- a/docs/docs/integrations/api.md
+++ b/docs/docs/integrations/api.md
@@ -188,14 +188,12 @@ Sets retain to false for the event id (event may be deleted quickly after removi
 
 ### `POST /api/events/<id>/sub_label`
 
-Set a sub label for a person event. For example to update `person` -> `person's name` if they were recognized with facial recognition. 
+Set a sub label for an event. For example to update `person` -> `person's name` if they were recognized with facial recognition.
 
-```
-Headers:
-Content-Type: application/json
-
-Body:
-subLabel
+```json
+{
+  "subLabel": "some_string"
+}
 ```
 
 ### `DELETE /api/events/<id>/sub_label`

--- a/frigate/events.py
+++ b/frigate/events.py
@@ -79,6 +79,7 @@ class EventProcessor(threading.Thread):
                         area=event_data["area"],
                         has_clip=event_data["has_clip"],
                         has_snapshot=event_data["has_snapshot"],
+                        sub_label=None,
                     ).execute()
 
             elif event_type == "end":

--- a/frigate/events.py
+++ b/frigate/events.py
@@ -79,8 +79,6 @@ class EventProcessor(threading.Thread):
                         area=event_data["area"],
                         has_clip=event_data["has_clip"],
                         has_snapshot=event_data["has_snapshot"],
-                        sub_label="",
-                        retain_indefinitely=False,
                     ).execute()
 
             elif event_type == "end":
@@ -100,8 +98,6 @@ class EventProcessor(threading.Thread):
                         area=event_data["area"],
                         has_clip=event_data["has_clip"],
                         has_snapshot=event_data["has_snapshot"],
-                        sub_label="",
-                        retain_indefinitely=False,
                     ).execute()
 
                 del self.events_in_process[event_data["id"]]

--- a/frigate/events.py
+++ b/frigate/events.py
@@ -14,6 +14,11 @@ from frigate.models import Event
 
 logger = logging.getLogger(__name__)
 
+def should_insert_db(prev_event, current_event):
+    return (
+        (not prev_event["has_clip"] and not prev_event["has_snapshot"])
+        and (current_event["has_clip"] or current_event["has_snapshot"])
+    )
 
 def should_update_db(prev_event, current_event):
     return (
@@ -58,7 +63,7 @@ class EventProcessor(threading.Thread):
             if event_type == "start":
                 self.events_in_process[event_data["id"]] = event_data
 
-            elif event_type == "update" and should_update_db(
+            elif event_type == "update" and should_insert_db(
                 self.events_in_process[event_data["id"]], event_data
             ):
                 self.events_in_process[event_data["id"]] = event_data
@@ -81,10 +86,31 @@ class EventProcessor(threading.Thread):
                         has_snapshot=event_data["has_snapshot"],
                     ).execute()
 
+            elif event_type == "update" and should_update_db(
+                self.events_in_process[event_data["id"]], event_data
+            ):
+                self.events_in_process[event_data["id"]] = event_data
+                # TODO: this will generate a lot of db activity possibly
+                if event_data["has_clip"] or event_data["has_snapshot"]:
+                    Event.update(
+                        label=event_data["label"],
+                        camera=camera,
+                        start_time=event_data["start_time"] - event_config.pre_capture,
+                        end_time=None,
+                        top_score=event_data["top_score"],
+                        false_positive=event_data["false_positive"],
+                        zones=list(event_data["entered_zones"]),
+                        thumbnail=event_data["thumbnail"],
+                        region=event_data["region"],
+                        box=event_data["box"],
+                        area=event_data["area"],
+                        has_clip=event_data["has_clip"],
+                        has_snapshot=event_data["has_snapshot"],
+                    ).where(Event.id == event_data["id"]).execute()
+
             elif event_type == "end":
                 if event_data["has_clip"] or event_data["has_snapshot"]:
-                    Event.replace(
-                        id=event_data["id"],
+                    Event.update(
                         label=event_data["label"],
                         camera=camera,
                         start_time=event_data["start_time"] - event_config.pre_capture,
@@ -98,7 +124,7 @@ class EventProcessor(threading.Thread):
                         area=event_data["area"],
                         has_clip=event_data["has_clip"],
                         has_snapshot=event_data["has_snapshot"],
-                    ).execute()
+                    ).where(Event.id == event_data["id"]).execute()
 
                 del self.events_in_process[event_data["id"]]
                 self.event_processed_queue.put((event_data["id"], camera))

--- a/frigate/events.py
+++ b/frigate/events.py
@@ -15,18 +15,21 @@ from frigate.models import Event
 logger = logging.getLogger(__name__)
 
 def should_insert_db(prev_event, current_event):
+    """If current event has new clip or snapshot."""
     return (
         (not prev_event["has_clip"] and not prev_event["has_snapshot"])
         and (current_event["has_clip"] or current_event["has_snapshot"])
     )
 
 def should_update_db(prev_event, current_event):
+    """If current_event has updated fields and (clip or snapshot)."""
     return (
-        prev_event["top_score"] != current_event["top_score"]
-        or prev_event["entered_zones"] != current_event["entered_zones"]
-        or prev_event["thumbnail"] != current_event["thumbnail"]
-        or prev_event["has_clip"] != current_event["has_clip"]
-        or prev_event["has_snapshot"] != current_event["has_snapshot"]
+        (current_event["has_clip"] or current_event["has_snapshot"])
+        and (prev_event["top_score"] != current_event["top_score"]
+            or prev_event["entered_zones"] != current_event["entered_zones"]
+            or prev_event["thumbnail"] != current_event["thumbnail"]
+            or prev_event["has_clip"] != current_event["has_clip"]
+            or prev_event["has_snapshot"] != current_event["has_snapshot"])
     )
 
 
@@ -68,45 +71,43 @@ class EventProcessor(threading.Thread):
             ):
                 self.events_in_process[event_data["id"]] = event_data
                 # TODO: this will generate a lot of db activity possibly
-                if event_data["has_clip"] or event_data["has_snapshot"]:
-                    Event.insert(
-                        id=event_data["id"],
-                        label=event_data["label"],
-                        camera=camera,
-                        start_time=event_data["start_time"] - event_config.pre_capture,
-                        end_time=None,
-                        top_score=event_data["top_score"],
-                        false_positive=event_data["false_positive"],
-                        zones=list(event_data["entered_zones"]),
-                        thumbnail=event_data["thumbnail"],
-                        region=event_data["region"],
-                        box=event_data["box"],
-                        area=event_data["area"],
-                        has_clip=event_data["has_clip"],
-                        has_snapshot=event_data["has_snapshot"],
-                    ).execute()
+                Event.insert(
+                    id=event_data["id"],
+                    label=event_data["label"],
+                    camera=camera,
+                    start_time=event_data["start_time"] - event_config.pre_capture,
+                    end_time=None,
+                    top_score=event_data["top_score"],
+                    false_positive=event_data["false_positive"],
+                    zones=list(event_data["entered_zones"]),
+                    thumbnail=event_data["thumbnail"],
+                    region=event_data["region"],
+                    box=event_data["box"],
+                    area=event_data["area"],
+                    has_clip=event_data["has_clip"],
+                    has_snapshot=event_data["has_snapshot"],
+                ).execute()
 
             elif event_type == "update" and should_update_db(
                 self.events_in_process[event_data["id"]], event_data
             ):
                 self.events_in_process[event_data["id"]] = event_data
                 # TODO: this will generate a lot of db activity possibly
-                if event_data["has_clip"] or event_data["has_snapshot"]:
-                    Event.update(
-                        label=event_data["label"],
-                        camera=camera,
-                        start_time=event_data["start_time"] - event_config.pre_capture,
-                        end_time=None,
-                        top_score=event_data["top_score"],
-                        false_positive=event_data["false_positive"],
-                        zones=list(event_data["entered_zones"]),
-                        thumbnail=event_data["thumbnail"],
-                        region=event_data["region"],
-                        box=event_data["box"],
-                        area=event_data["area"],
-                        has_clip=event_data["has_clip"],
-                        has_snapshot=event_data["has_snapshot"],
-                    ).where(Event.id == event_data["id"]).execute()
+                Event.update(
+                    label=event_data["label"],
+                    camera=camera,
+                    start_time=event_data["start_time"] - event_config.pre_capture,
+                    end_time=None,
+                    top_score=event_data["top_score"],
+                    false_positive=event_data["false_positive"],
+                    zones=list(event_data["entered_zones"]),
+                    thumbnail=event_data["thumbnail"],
+                    region=event_data["region"],
+                    box=event_data["box"],
+                    area=event_data["area"],
+                    has_clip=event_data["has_clip"],
+                    has_snapshot=event_data["has_snapshot"],
+                ).where(Event.id == event_data["id"]).execute()
 
             elif event_type == "end":
                 if event_data["has_clip"] or event_data["has_snapshot"]:

--- a/frigate/events.py
+++ b/frigate/events.py
@@ -79,6 +79,8 @@ class EventProcessor(threading.Thread):
                         area=event_data["area"],
                         has_clip=event_data["has_clip"],
                         has_snapshot=event_data["has_snapshot"],
+                        sub_label="",
+                        retain_indefinitely=False,
                     ).execute()
 
             elif event_type == "end":
@@ -98,6 +100,8 @@ class EventProcessor(threading.Thread):
                         area=event_data["area"],
                         has_clip=event_data["has_clip"],
                         has_snapshot=event_data["has_snapshot"],
+                        sub_label="",
+                        retain_indefinitely=False,
                     ).execute()
 
                 del self.events_in_process[event_data["id"]]

--- a/frigate/events.py
+++ b/frigate/events.py
@@ -69,7 +69,7 @@ class EventProcessor(threading.Thread):
                 self.events_in_process[event_data["id"]] = event_data
                 # TODO: this will generate a lot of db activity possibly
                 if event_data["has_clip"] or event_data["has_snapshot"]:
-                    Event.replace(
+                    Event.insert(
                         id=event_data["id"],
                         label=event_data["label"],
                         camera=camera,

--- a/frigate/events.py
+++ b/frigate/events.py
@@ -67,6 +67,7 @@ class EventProcessor(threading.Thread):
                     Event.replace(
                         id=event_data["id"],
                         label=event_data["label"],
+                        sub_label=event_data.get("sub_label", ""),
                         camera=camera,
                         start_time=event_data["start_time"] - event_config.pre_capture,
                         end_time=None,
@@ -86,6 +87,7 @@ class EventProcessor(threading.Thread):
                     Event.replace(
                         id=event_data["id"],
                         label=event_data["label"],
+                        sub_label=event_data.get("sub_label", ""),
                         camera=camera,
                         start_time=event_data["start_time"] - event_config.pre_capture,
                         end_time=event_data["end_time"] + event_config.post_capture,

--- a/frigate/events.py
+++ b/frigate/events.py
@@ -79,7 +79,6 @@ class EventProcessor(threading.Thread):
                         area=event_data["area"],
                         has_clip=event_data["has_clip"],
                         has_snapshot=event_data["has_snapshot"],
-                        sub_label=None,
                     ).execute()
 
             elif event_type == "end":

--- a/frigate/events.py
+++ b/frigate/events.py
@@ -67,7 +67,6 @@ class EventProcessor(threading.Thread):
                     Event.replace(
                         id=event_data["id"],
                         label=event_data["label"],
-                        sub_label=event_data.get("sub_label", ""),
                         camera=camera,
                         start_time=event_data["start_time"] - event_config.pre_capture,
                         end_time=None,
@@ -87,7 +86,6 @@ class EventProcessor(threading.Thread):
                     Event.replace(
                         id=event_data["id"],
                         label=event_data["label"],
-                        sub_label=event_data.get("sub_label", ""),
                         camera=camera,
                         start_time=event_data["start_time"] - event_config.pre_capture,
                         end_time=event_data["end_time"] + event_config.post_capture,

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -168,30 +168,10 @@ def set_sub_label(id):
         new_sub_label = None
 
 
-    if new_sub_label:
-        event.sub_label = new_sub_label
-        event.save()
-        return make_response(
-            jsonify({"success": True, "message": "Event " + id + " sub label set to " + new_sub_label}), 200
-        )
-
-    return make_response(
-        jsonify({"success": False, "message": "Sublabel " + new_sub_label + " not provided."}), 400
-    )
-
-@bp.route("/events/<id>/sub_label", methods=("DELETE",))
-def delete_sub_label(id):
-    try:
-        event = Event.get(Event.id == id)
-    except DoesNotExist:
-        return make_response(
-            jsonify({"success": False, "message": "Event " + id + " not found"}), 404
-        )
-
-    event.sub_label = None
+    event.sub_label = new_sub_label
     event.save()
     return make_response(
-        jsonify({"success": True, "message": "Event " + id + " sub label removed"}), 200
+        jsonify({"success": True, "message": "Event " + id + " sub label set to " + new_sub_label}), 200
     )
 
 @bp.route("/events/<id>", methods=("DELETE",))

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -157,7 +157,7 @@ def delete_retain(id):
 def set_sub_label(id):
     try:
         event = Event.get(Event.id == id)
-    except DoesNotExit:
+    except DoesNotExist:
         return make_response(
             jsonify({"success": False, "message": "Event " + id + " not found"}), 404
         )
@@ -167,7 +167,10 @@ def set_sub_label(id):
             jsonify({"success": False, "message": "Event " + id + " is not a person event"}), 400
         )
 
-    new_sub_label = request.json.get("subLabel", "")
+    if request.json:
+        new_sub_label = request.json.get("subLabel", "")
+    else:
+        new_sub_label = ""
 
     if new_sub_label:
         event.sub_label = new_sub_label
@@ -184,7 +187,7 @@ def set_sub_label(id):
 def delete_sub_label(id):
     try:
         event = Event.get(Event.id == id)
-    except DoesNotExit:
+    except DoesNotExist:
         return make_response(
             jsonify({"success": False, "message": "Event " + id + " not found"}), 404
         )

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -187,7 +187,7 @@ def delete_sub_label(id):
             jsonify({"success": False, "message": "Event " + id + " not found"}), 404
         )
 
-    event.sub_label = ""
+    event.sub_label = None
     event.save()
     return make_response(
         jsonify({"success": True, "message": "Event " + id + " sub label removed"}), 200

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -168,7 +168,6 @@ def set_sub_label(id):
         )
 
     new_sub_label = request.json.get("subLabel", "")
-    print(f'Found value as {request.json} with {request.json.get("subLabel", "")}')
 
     if new_sub_label:
         event.sub_label = new_sub_label
@@ -202,7 +201,7 @@ def delete_event(id):
         event = Event.get(Event.id == id)
     except DoesNotExist:
         return make_response(
-            jsonify({"success": False, "message": "Event" + id + " not found"}), 404
+            jsonify({"success": False, "message": "Event " + id + " not found"}), 404
         )
 
     media_name = f"{event.camera}-{event.id}"
@@ -217,7 +216,7 @@ def delete_event(id):
 
     event.delete_instance()
     return make_response(
-        jsonify({"success": True, "message": "Event" + id + " deleted"}), 200
+        jsonify({"success": True, "message": "Event " + id + " deleted"}), 200
     )
 
 

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -167,12 +167,10 @@ def set_sub_label(id):
     else:
         new_sub_label = ""
 
-    print(f'Check before {event.sub_label}')
 
     if new_sub_label:
         event.sub_label = new_sub_label
-        something = event.save()
-        print(f'Set sub_label to {new_sub_label} verify {event.sub_label} and {something}')
+        event.save()
         return make_response(
             jsonify({"success": True, "message": "Event " + id + " sub label set to " + new_sub_label}), 200
         )

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -162,11 +162,6 @@ def set_sub_label(id):
             jsonify({"success": False, "message": "Event " + id + " not found"}), 404
         )
 
-    if event.label != "person":
-        return make_response(
-            jsonify({"success": False, "message": "Event " + id + " is not a person event"}), 400
-        )
-
     if request.json:
         new_sub_label = request.json.get("subLabel", "")
     else:

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -153,6 +153,45 @@ def delete_retain(id):
         jsonify({"success": True, "message": "Event" + id + " un-retained"}), 200
     )
 
+@bp.route("/events/<id>/sub_label", methods=("POST",))
+def set_sub_label(id):
+    try:
+        event = Event.get(Event.id == id)
+    except DoesNotExit:
+        return make_response(
+            jsonify({"success": False, "message": "Event" + id + " not found"}), 404
+        )
+
+    if event.label != "person":
+        return make_response(
+            jsonify({"success": False, "message": "Event" + id + " is not a person event"}), 400
+        )
+
+    new_sub_label = request.form.get("subLabel", "")
+
+    if new_sub_label:
+        event.sub_label = new_sub_label
+        event.save()
+        jsonify({"success": True, "message": "Event" + id + " sub label set to " + new_sub_label}), 200
+
+    return make_response(
+        jsonify({"success": False, "message": "Sublabel not provided."}), 400
+    )
+
+@bp.route("/events/<id>/sub_label", methods=("DELETE",))
+def delete_sub_label(id):
+    try:
+        event = Event.get(Event.id == id)
+    except DoesNotExit:
+        return make_response(
+            jsonify({"success": False, "message": "Event" + id + " not found"}), 404
+        )
+
+    event.sub_label = ""
+    event.save()
+    return make_response(
+        jsonify({"success": True, "message": "Event" + id + " sub label removed"}), 200
+    )
 
 @bp.route("/events/<id>", methods=("DELETE",))
 def delete_event(id):

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -168,6 +168,12 @@ def set_sub_label(id):
         new_sub_label = None
 
 
+    if new_sub_label and len(new_sub_label) > 20:
+        return make_response(
+            jsonify({"success": False, "message": new_sub_label + " exceeds the 20 character limit for sub_label"}), 400
+        )
+
+
     event.sub_label = new_sub_label
     event.save()
     return make_response(

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -167,9 +167,12 @@ def set_sub_label(id):
     else:
         new_sub_label = ""
 
+    print(f'Check before {event.sub_label}')
+
     if new_sub_label:
         event.sub_label = new_sub_label
-        event.save()
+        something = event.save()
+        print(f'Set sub_label to {new_sub_label} verify {event.sub_label} and {something}')
         return make_response(
             jsonify({"success": True, "message": "Event " + id + " sub label set to " + new_sub_label}), 200
         )
@@ -187,7 +190,7 @@ def delete_sub_label(id):
             jsonify({"success": False, "message": "Event " + id + " not found"}), 404
         )
 
-    event.sub_label = None
+    event.sub_label = ""
     event.save()
     return make_response(
         jsonify({"success": True, "message": "Event " + id + " sub label removed"}), 200

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -163,9 +163,9 @@ def set_sub_label(id):
         )
 
     if request.json:
-        new_sub_label = request.json.get("subLabel", "")
+        new_sub_label = request.json.get("subLabel")
     else:
-        new_sub_label = ""
+        new_sub_label = None
 
 
     if new_sub_label:
@@ -188,7 +188,7 @@ def delete_sub_label(id):
             jsonify({"success": False, "message": "Event " + id + " not found"}), 404
         )
 
-    event.sub_label = ""
+    event.sub_label = None
     event.save()
     return make_response(
         jsonify({"success": True, "message": "Event " + id + " sub label removed"}), 200

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -126,14 +126,14 @@ def set_retain(id):
         event = Event.get(Event.id == id)
     except DoesNotExist:
         return make_response(
-            jsonify({"success": False, "message": "Event" + id + " not found"}), 404
+            jsonify({"success": False, "message": "Event " + id + " not found"}), 404
         )
 
     event.retain_indefinitely = True
     event.save()
 
     return make_response(
-        jsonify({"success": True, "message": "Event" + id + " retained"}), 200
+        jsonify({"success": True, "message": "Event " + id + " retained"}), 200
     )
 
 
@@ -143,14 +143,14 @@ def delete_retain(id):
         event = Event.get(Event.id == id)
     except DoesNotExist:
         return make_response(
-            jsonify({"success": False, "message": "Event" + id + " not found"}), 404
+            jsonify({"success": False, "message": "Event " + id + " not found"}), 404
         )
 
     event.retain_indefinitely = False
     event.save()
 
     return make_response(
-        jsonify({"success": True, "message": "Event" + id + " un-retained"}), 200
+        jsonify({"success": True, "message": "Event " + id + " un-retained"}), 200
     )
 
 @bp.route("/events/<id>/sub_label", methods=("POST",))
@@ -159,23 +159,26 @@ def set_sub_label(id):
         event = Event.get(Event.id == id)
     except DoesNotExit:
         return make_response(
-            jsonify({"success": False, "message": "Event" + id + " not found"}), 404
+            jsonify({"success": False, "message": "Event " + id + " not found"}), 404
         )
 
     if event.label != "person":
         return make_response(
-            jsonify({"success": False, "message": "Event" + id + " is not a person event"}), 400
+            jsonify({"success": False, "message": "Event " + id + " is not a person event"}), 400
         )
 
-    new_sub_label = request.form.get("subLabel", "")
+    new_sub_label = request.json.get("subLabel", "")
+    print(f'Found value as {request.json} with {request.json.get("subLabel", "")}')
 
     if new_sub_label:
         event.sub_label = new_sub_label
         event.save()
-        jsonify({"success": True, "message": "Event" + id + " sub label set to " + new_sub_label}), 200
+        return make_response(
+            jsonify({"success": True, "message": "Event " + id + " sub label set to " + new_sub_label}), 200
+        )
 
     return make_response(
-        jsonify({"success": False, "message": "Sublabel not provided."}), 400
+        jsonify({"success": False, "message": "Sublabel " + new_sub_label + " not provided."}), 400
     )
 
 @bp.route("/events/<id>/sub_label", methods=("DELETE",))
@@ -184,13 +187,13 @@ def delete_sub_label(id):
         event = Event.get(Event.id == id)
     except DoesNotExit:
         return make_response(
-            jsonify({"success": False, "message": "Event" + id + " not found"}), 404
+            jsonify({"success": False, "message": "Event " + id + " not found"}), 404
         )
 
     event.sub_label = ""
     event.save()
     return make_response(
-        jsonify({"success": True, "message": "Event" + id + " sub label removed"}), 200
+        jsonify({"success": True, "message": "Event " + id + " sub label removed"}), 200
     )
 
 @bp.route("/events/<id>", methods=("DELETE",))

--- a/frigate/models.py
+++ b/frigate/models.py
@@ -6,7 +6,7 @@ from playhouse.sqlite_ext import *
 class Event(Model):
     id = CharField(null=False, primary_key=True, max_length=30)
     label = CharField(index=True, max_length=20)
-    sub_label = CharField(index=True, max_length=12, default=None, null=True),
+    sub_label = CharField(max_length=20, default="")
     camera = CharField(index=True, max_length=20)
     start_time = DateTimeField()
     end_time = DateTimeField()

--- a/frigate/models.py
+++ b/frigate/models.py
@@ -6,6 +6,7 @@ from playhouse.sqlite_ext import *
 class Event(Model):
     id = CharField(null=False, primary_key=True, max_length=30)
     label = CharField(index=True, max_length=20)
+    sub_label = CharField(index=True, max_length=12)
     camera = CharField(index=True, max_length=20)
     start_time = DateTimeField()
     end_time = DateTimeField()

--- a/frigate/models.py
+++ b/frigate/models.py
@@ -6,7 +6,7 @@ from playhouse.sqlite_ext import *
 class Event(Model):
     id = CharField(null=False, primary_key=True, max_length=30)
     label = CharField(index=True, max_length=20)
-    sub_label = CharField(index=True, max_length=12, default="")
+    sub_label = CharField(index=True, max_length=12, default=None),
     camera = CharField(index=True, max_length=20)
     start_time = DateTimeField()
     end_time = DateTimeField()

--- a/frigate/models.py
+++ b/frigate/models.py
@@ -6,7 +6,7 @@ from playhouse.sqlite_ext import *
 class Event(Model):
     id = CharField(null=False, primary_key=True, max_length=30)
     label = CharField(index=True, max_length=20)
-    sub_label = CharField(index=True, max_length=12, default=None),
+    sub_label = CharField(index=True, max_length=12, default=None, null=True),
     camera = CharField(index=True, max_length=20)
     start_time = DateTimeField()
     end_time = DateTimeField()

--- a/frigate/models.py
+++ b/frigate/models.py
@@ -6,7 +6,7 @@ from playhouse.sqlite_ext import *
 class Event(Model):
     id = CharField(null=False, primary_key=True, max_length=30)
     label = CharField(index=True, max_length=20)
-    sub_label = CharField(max_length=20, default="")
+    sub_label = CharField(max_length=20, null=True)
     camera = CharField(index=True, max_length=20)
     start_time = DateTimeField()
     end_time = DateTimeField()

--- a/frigate/models.py
+++ b/frigate/models.py
@@ -6,7 +6,7 @@ from playhouse.sqlite_ext import *
 class Event(Model):
     id = CharField(null=False, primary_key=True, max_length=30)
     label = CharField(index=True, max_length=20)
-    sub_label = CharField(index=True, max_length=12)
+    sub_label = CharField(index=True, max_length=12, default="")
     camera = CharField(index=True, max_length=20)
     start_time = DateTimeField()
     end_time = DateTimeField()

--- a/migrations/008_add_sub_label.py
+++ b/migrations/008_add_sub_label.py
@@ -38,7 +38,7 @@ SQL = pw.SQL
 def migrate(migrator, database, fake=False, **kwargs):
     migrator.add_fields(
         Event,
-        sub_label=pw.CharField(default=None, null=True),
+        sub_label=pw.CharField(max_length=20, default=""),
     )
 
 

--- a/migrations/008_add_sub_label.py
+++ b/migrations/008_add_sub_label.py
@@ -38,7 +38,7 @@ SQL = pw.SQL
 def migrate(migrator, database, fake=False, **kwargs):
     migrator.add_fields(
         Event,
-        sub_label=pw.CharField(max_length=20, default=""),
+        sub_label=pw.CharField(max_length=20, null=True),
     )
 
 

--- a/migrations/008_add_sub_label.py
+++ b/migrations/008_add_sub_label.py
@@ -38,7 +38,7 @@ SQL = pw.SQL
 def migrate(migrator, database, fake=False, **kwargs):
     migrator.add_fields(
         Event,
-        sub_label=pw.CharField(default=""),
+        sub_label=pw.CharField(default=None),
     )
 
 

--- a/migrations/008_add_sub_label.py
+++ b/migrations/008_add_sub_label.py
@@ -38,7 +38,7 @@ SQL = pw.SQL
 def migrate(migrator, database, fake=False, **kwargs):
     migrator.add_fields(
         Event,
-        sub_label=pw.CharField(default=None),
+        sub_label=pw.CharField(default=None, null=True),
     )
 
 

--- a/migrations/008_add_sub_label.py
+++ b/migrations/008_add_sub_label.py
@@ -1,0 +1,46 @@
+"""Peewee migrations -- 008_add_sub_label.py.
+
+Some examples (model - class or model name)::
+
+    > Model = migrator.orm['model_name']            # Return model in current state by name
+
+    > migrator.sql(sql)                             # Run custom SQL
+    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.create_model(Model)                  # Create a model (could be used as decorator)
+    > migrator.remove_model(model, cascade=True)    # Remove a model
+    > migrator.add_fields(model, **fields)          # Add fields to a model
+    > migrator.change_fields(model, **fields)       # Change fields
+    > migrator.remove_fields(model, *field_names, cascade=True)
+    > migrator.rename_field(model, old_field_name, new_field_name)
+    > migrator.rename_table(model, new_table_name)
+    > migrator.add_index(model, *col_names, unique=False)
+    > migrator.drop_index(model, *col_names)
+    > migrator.add_not_null(model, *field_names)
+    > migrator.drop_not_null(model, *field_names)
+    > migrator.add_default(model, field_name, default)
+
+"""
+
+import datetime as dt
+import peewee as pw
+from playhouse.sqlite_ext import *
+from decimal import ROUND_HALF_EVEN
+from frigate.models import Event
+
+try:
+    import playhouse.postgres_ext as pw_pext
+except ImportError:
+    pass
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.add_fields(
+        Event,
+        sub_label=pw.CharField(default=""),
+    )
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.remove_fields(Event, ["sub_label"])

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -315,7 +315,7 @@ export default function Events({ path, ...props }) {
                     <div className="m-2 flex grow">
                       <div className="flex flex-col grow">
                         <div className="capitalize text-lg font-bold">
-                          {event.sub_label != "" ? `${event.label}: ${event.sub_label}` : event.label} ({(event.top_score * 100).toFixed(0)}%)
+                          {event.sub_label ? `${event.label}: ${event.sub_label}` : event.label} ({(event.top_score * 100).toFixed(0)}%)
                         </div>
                         <div className="text-sm">
                           {new Date(event.start_time * 1000).toLocaleDateString()}{' '}

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -315,7 +315,7 @@ export default function Events({ path, ...props }) {
                     <div className="m-2 flex grow">
                       <div className="flex flex-col grow">
                         <div className="capitalize text-lg font-bold">
-                          {event.sub_label != "" ? event.sub_label : event.label} ({(event.top_score * 100).toFixed(0)}%)
+                          {event.sub_label != "" ? `${event.label}: ${event.sub_label}` : event.label} ({(event.top_score * 100).toFixed(0)}%)
                         </div>
                         <div className="text-sm">
                           {new Date(event.start_time * 1000).toLocaleDateString()}{' '}

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -315,7 +315,7 @@ export default function Events({ path, ...props }) {
                     <div className="m-2 flex grow">
                       <div className="flex flex-col grow">
                         <div className="capitalize text-lg font-bold">
-                          {event.label} ({(event.top_score * 100).toFixed(0)}%)
+                          {event.sub_label != "" ? event.sub_label : event.label} ({(event.top_score * 100).toFixed(0)}%)
                         </div>
                         <div className="text-sm">
                           {new Date(event.start_time * 1000).toLocaleDateString()}{' '}


### PR DESCRIPTION
Implementation for #2900 

This adds an API to update a specific event with the name or type. For example, I am using Double-Take and can use this to add a sub label so it shows in the UI going from `Person` -> `Person: Nick`.