### PR TITLE
Stop tracked thumbnail from being cached

### DIFF
--- a/web/src/routes/Camera.jsx
+++ b/web/src/routes/Camera.jsx
@@ -134,7 +134,7 @@ export default function Camera({ camera }) {
               key={objectType}
               header={objectType}
               href={`/events?camera=${camera}&label=${objectType}`}
-              media={<img src={`${apiHost}/api/${camera}/${objectType}/thumbnail.jpg`} />}
+              media={<img src={`${apiHost}/api/${camera}/${objectType}/thumbnail.jpg?=${Date.now()}`} />}
             />
           ))}
         </div>

--- a/web/src/routes/Camera.jsx
+++ b/web/src/routes/Camera.jsx
@@ -134,7 +134,7 @@ export default function Camera({ camera }) {
               key={objectType}
               header={objectType}
               href={`/events?camera=${camera}&label=${objectType}`}
-              media={<img src={`${apiHost}/api/${camera}/${objectType}/thumbnail.jpg?=${Date.now()}`} />}
+              media={<img src={`${apiHost}/api/${camera}/${objectType}/thumbnail.jpg?t=${Date.now()}`} />}
             />
           ))}
         </div>


### PR DESCRIPTION
I noticed after merging #2944 that the thumbnails under camera were being cached and not updating (even after deleting the related event).