### PR TITLE
Allow improve_contrast to be toggled via mqtt

### DIFF
--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -115,6 +115,7 @@ Topic to turn snapshots for a camera on and off. Expected values are `ON` and `O
 ### `frigate/<camera_name>/snapshots/state`
 
 Topic with current state of snapshots for a camera. Published values are `ON` and `OFF`.
+
 ### `frigate/<camera_name>/improve_contrast/set`
 
 Topic to turn improve_contrast for a camera on and off. Expected values are `ON` and `OFF`.

--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -115,3 +115,10 @@ Topic to turn snapshots for a camera on and off. Expected values are `ON` and `O
 ### `frigate/<camera_name>/snapshots/state`
 
 Topic with current state of snapshots for a camera. Published values are `ON` and `OFF`.
+### `frigate/<camera_name>/improve_contrast/set`
+
+Topic to turn improve_contrast for a camera on and off. Expected values are `ON` and `OFF`.
+
+### `frigate/<camera_name>/improve_contrast/state`
+
+Topic with current state of improve_contrast for a camera. Published values are `ON` and `OFF`.

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -86,6 +86,9 @@ class FrigateApp:
                 "detection_enabled": mp.Value(
                     "i", self.config.cameras[camera_name].detect.enabled
                 ),
+                "improve_contrast_enabled": mp.Value(
+                    "i", self.config.cameras[camera_name].motion.improve_contrast 
+                ),                
                 "detection_fps": mp.Value("d", 0.0),
                 "detection_frame": mp.Value("d", 0.0),
                 "read_start": mp.Value("d", 0.0),

--- a/frigate/motion.py
+++ b/frigate/motion.py
@@ -25,7 +25,7 @@ class MotionDetector:
         self.mask = np.where(resized_mask == [0])
         self.save_images = False
 
-    def detect(self, frame):
+    def detect(self, frame, improve_contrast):
         motion_boxes = []
 
         gray = frame[0 : self.frame_shape[0], 0 : self.frame_shape[1]]
@@ -38,14 +38,15 @@ class MotionDetector:
         )
 
         # Improve contrast
-        minval = np.percentile(resized_frame, 4)
-        maxval = np.percentile(resized_frame, 96)
-        # don't adjust if the image is a single color
-        if minval < maxval:
-            resized_frame = np.clip(resized_frame, minval, maxval)
-            resized_frame = (
-                ((resized_frame - minval) / (maxval - minval)) * 255
-            ).astype(np.uint8)
+        if improve_contrast:
+            minval = np.percentile(resized_frame, 4)
+            maxval = np.percentile(resized_frame, 96)
+            # don't adjust if the image is a single color
+            if minval < maxval:
+                resized_frame = np.clip(resized_frame, minval, maxval)
+                resized_frame = (
+                    ((resized_frame - minval) / (maxval - minval)) * 255
+                ).astype(np.uint8)
 
         # mask frame
         resized_frame[self.mask] = [255]

--- a/frigate/motion.py
+++ b/frigate/motion.py
@@ -24,7 +24,7 @@ class MotionDetector:
         )
         self.mask = np.where(resized_mask == [0])
         self.save_images = False
-        self.improve_contrast = improve_contrast_enabled.value
+        self.improve_contrast = improve_contrast_enabled
 
     def detect(self, frame):
         motion_boxes = []
@@ -39,7 +39,7 @@ class MotionDetector:
         )
 
         # Improve contrast
-        if self.improve_contrast:
+        if self.improve_contrast.value:
             minval = np.percentile(resized_frame, 4)
             maxval = np.percentile(resized_frame, 96)
             # don't adjust if the image is a single color

--- a/frigate/motion.py
+++ b/frigate/motion.py
@@ -5,7 +5,7 @@ from frigate.config import MotionConfig
 
 
 class MotionDetector:
-    def __init__(self, frame_shape, config: MotionConfig):
+    def __init__(self, frame_shape, config: MotionConfig, improve_contrast_enabled):
         self.config = config
         self.frame_shape = frame_shape
         self.resize_factor = frame_shape[0] / config.frame_height
@@ -24,7 +24,7 @@ class MotionDetector:
         )
         self.mask = np.where(resized_mask == [0])
         self.save_images = False
-        self.improve_contrast = self.config.improve_contrast
+        self.improve_contrast = improve_contrast_enabled.value
 
     def detect(self, frame):
         motion_boxes = []

--- a/frigate/motion.py
+++ b/frigate/motion.py
@@ -24,8 +24,9 @@ class MotionDetector:
         )
         self.mask = np.where(resized_mask == [0])
         self.save_images = False
+        self.improve_contrast = self.config.improve_contrast
 
-    def detect(self, frame, improve_contrast):
+    def detect(self, frame):
         motion_boxes = []
 
         gray = frame[0 : self.frame_shape[0], 0 : self.frame_shape[1]]
@@ -38,7 +39,7 @@ class MotionDetector:
         )
 
         # Improve contrast
-        if improve_contrast:
+        if self.improve_contrast:
             minval = np.percentile(resized_frame, 4)
             maxval = np.percentile(resized_frame, 96)
             # don't adjust if the image is a single color

--- a/frigate/mqtt.py
+++ b/frigate/mqtt.py
@@ -98,12 +98,14 @@ def create_mqtt_client(config: FrigateConfig, camera_metrics):
         motion_settings = config.cameras[camera_name].motion
 
         if payload == "ON":
-            if not motion_settings.improve_contrast:
+            if not camera_metrics[camera_name]["improve_contrast_enabled"].value:
                 logger.info(f"Turning on improve contrast for {camera_name} via mqtt")
+                camera_metrics[camera_name]["improve_contrast_enabled"].value = True
                 motion_settings.improve_contrast = True
         elif payload == "OFF":
-            if motion_settings.improve_contrast:
+            if camera_metrics[camera_name]["improve_contrast_enabled"].value:
                 logger.info(f"Turning off improve contrast for {camera_name} via mqtt")
+                camera_metrics[camera_name]["improve_contrast_enabled"].value = False
                 motion_settings.improve_contrast = False
         else:
             logger.warning(f"Received unsupported value at {message.topic}: {payload}")

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -378,7 +378,6 @@ def track_camera(
         objects_to_track,
         object_filters,
         detection_enabled,
-        improve_contrast_enabled,
         stop_event,
     )
 

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -354,7 +354,7 @@ def track_camera(
     objects_to_track = config.objects.track
     object_filters = config.objects.filters
 
-    motion_detector = MotionDetector(frame_shape, config.motion)
+    motion_detector = MotionDetector(frame_shape, config.motion, improve_contrast_enabled)
     object_detector = RemoteObjectDetector(
         name, labelmap, detection_queue, result_connection, model_shape
     )
@@ -493,8 +493,6 @@ def process_frames(
         if frame is None:
             logger.info(f"{camera_name}: frame {frame_time} is not in memory store.")
             continue
-
-        motion_detector.improve_contrast = improve_contrast_enabled.value
 
         # look for motion
         motion_boxes = motion_detector.detect(frame)

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -494,8 +494,10 @@ def process_frames(
             logger.info(f"{camera_name}: frame {frame_time} is not in memory store.")
             continue
 
+        motion_detector.improve_contrast = improve_contrast_enabled.value
+
         # look for motion
-        motion_boxes = motion_detector.detect(frame, improve_contrast_enabled.value)
+        motion_boxes = motion_detector.detect(frame)
 
         regions = []
 

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -348,6 +348,7 @@ def track_camera(
 
     frame_queue = process_info["frame_queue"]
     detection_enabled = process_info["detection_enabled"]
+    improve_contrast_enabled = process_info["improve_contrast_enabled"]
 
     frame_shape = config.frame_shape
     objects_to_track = config.objects.track
@@ -377,6 +378,7 @@ def track_camera(
         objects_to_track,
         object_filters,
         detection_enabled,
+        improve_contrast_enabled,
         stop_event,
     )
 
@@ -458,6 +460,7 @@ def process_frames(
     objects_to_track: List[str],
     object_filters,
     detection_enabled: mp.Value,
+    improve_contrast_enabled: mp.Value,
     stop_event,
     exit_on_empty: bool = False,
 ):
@@ -492,7 +495,7 @@ def process_frames(
             continue
 
         # look for motion
-        motion_boxes = motion_detector.detect(frame)
+        motion_boxes = motion_detector.detect(frame, improve_contrast_enabled.value)
 
         regions = []
 

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -460,7 +460,6 @@ def process_frames(
     objects_to_track: List[str],
     object_filters,
     detection_enabled: mp.Value,
-    improve_contrast_enabled: mp.Value,
     stop_event,
     exit_on_empty: bool = False,
 ):


### PR DESCRIPTION
I love the ``improve_contrast`` setting on some of my cameras at night, but didn't want to enable the setting during the day. This PR enables toggling it via mqtt in the same way that detection is toggled: ``frigate/<camera name>/improve_contrast/set`` 