### PR TITLE
Update docs to include warnings about needing record enabled in the config

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -245,6 +245,9 @@ motion:
 # NOTE: Can be overridden at the camera level
 record:
   # Optional: Enable recording (default: shown below)
+  # WARNING: If automations will be used to control enabling/disabling record,
+  #          record must still be enabled in the config for the automation to
+  #          be successful.
   # WARNING: Frigate does not currently support limiting recordings based
   #          on available disk space automatically. If using recordings,
   #          you must specify retention settings for a number of days that

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -245,9 +245,8 @@ motion:
 # NOTE: Can be overridden at the camera level
 record:
   # Optional: Enable recording (default: shown below)
-  # WARNING: If automations will be used to control enabling/disabling record,
-  #          record must still be enabled in the config for the automation to
-  #          be successful.
+  # WARNING: If recording is disabled in the config, turning it on via 
+  #          the UI or MQTT later will have no effect.
   # WARNING: Frigate does not currently support limiting recordings based
   #          on available disk space automatically. If using recordings,
   #          you must specify retention settings for a number of days that

--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -23,6 +23,12 @@ This configuration will retain recording segments that overlap with events and h
 
 When `retain -> days` is set to `0`, segments will be deleted from the cache if no events are in progress.
 
+## Can I have "24/7" recordings, but only at certain times?
+
+Using Frigate UI, HomeAssistant, or MQTT, cameras can be automated to only record in certain situations or at certain times. 
+
+**WARNING**: Recordings still must be enabled in the config. If a camera has recordings disabled in the config, enabling via the methods listed above will have no effect.
+
 ## What do the different retain modes mean?
 
 Frigate saves from the stream with the `record` role in 10 second segments. These options determine which recording segments are kept for 24/7 recording (but can also affect events). 


### PR DESCRIPTION
As discussed in #3041 I updated the docs to help users who try to automate recordings but leave record disabled in the config.