### PR TITLE
DOCS: Add stationary tracking config section to elaborate more on stationary tracking

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -161,8 +161,9 @@ detect:
   max_disappeared: 25
   # Optional: Configuration for stationary object tracking
   stationary:
-    # Optional: Frequency for running detection on stationary objects (default: shown below)
-    # When set to 0, object detection will never be run on stationary objects. If set to 10, it will be run on every 10th frame.
+    # Optional: Frequency for confirming stationary objects (default: shown below)
+    # When set to 0, object detection will not confirm stationary objects until movement is detected.
+    # If set to 10, object detection will run to confirm the object still exists on every 10th frame.
     interval: 0
     # Optional: Number of frames without a position change for an object to be considered stationary (default: 10x the frame rate or 10s)
     threshold: 50

--- a/docs/docs/configuration/stationary_objects.md
+++ b/docs/docs/configuration/stationary_objects.md
@@ -4,7 +4,7 @@ An object is considered stationary when it is being tracked and has been in a ve
 
 ## Why does it matter if an object is stationary?
 
-Once an object becomes stationary, object detection will not be continually run on that object. This serves to reduce resource usage and redundant detections when there has been no motion near the tracked object. This also means that Frigate is contextually aware, and can for example [filter out recording segments](record.md) to only when the object is considered active.
+Once an object becomes stationary, object detection will not be continually run on that object. This serves to reduce resource usage and redundant detections when there has been no motion near the tracked object. This also means that Frigate is contextually aware, and can for example [filter out recording segments](record.md#what-do-the-different-retain-modes-mean) to only when the object is considered active.
 
 ## Tuning stationary behavior
 
@@ -22,3 +22,7 @@ detect:
 NOTE: There is no way to disable stationary object tracking with this value.
 
 `threshold` is the number of frames an object needs to remain relatively still before it is considered stationary.
+
+## Avoiding stationary objects
+
+In some cases, like a driveway, you may prefer to only have an event when a car is coming & going vs a constant event of it stationary in the driveway. [This docs sections](../guides/stationary_objects.md) explains how to approach that scenario.

--- a/docs/docs/configuration/stationary_objects.md
+++ b/docs/docs/configuration/stationary_objects.md
@@ -17,7 +17,7 @@ detect:
     threshold: 50
 ```
 
-`interval` is defined as the frequency for running detection on stationary objects. This means that by default, once an object is considered stationary detection will not be run on it until motion is detected. With `interval > 0`, every nth frames detection will be run to make sure the object is still there. 
+`interval` is defined as the frequency for running detection on stationary objects. This means that by default once an object is considered stationary, detection will not be run on it until motion is detected. With `interval > 0`, every nth frames detection will be run to make sure the object is still there.
 
 NOTE: There is no way to disable stationary object tracking with this value.
 

--- a/docs/docs/configuration/stationary_objects.md
+++ b/docs/docs/configuration/stationary_objects.md
@@ -1,10 +1,10 @@
 # Stationary Objects
 
-An object is considered stationary when it is being tracked and has been in a very similar position for a certain number of frames. This number is defined in the configuration under `detect -> stationary -> threshold`, and is 10x the frame rate (or 10 seconds) by default. Once an object is considered stationary, it will remain stationary until motion occurs near the object at which point it will be considered active.
+An object is considered stationary when it is being tracked and has been in a very similar position for a certain number of frames. This number is defined in the configuration under `detect -> stationary -> threshold`, and is 10x the frame rate (or 10 seconds) by default. Once an object is considered stationary, it will remain stationary until motion occurs near the object at which point object detection will start running again. If the object changes location, it will be considered active.
 
 ## Why does it matter if an object is stationary?
 
-Once an object becomes stationary, object detection will not be continually run on that object. This serves to reduce resource usage and redundant detections when there has been no motion near the tracked object. This also means that Frigate is contextually aware, and can for example [filter out recording segments](record.md#what-do-the-different-retain-modes-mean) to only when the object is considered active.
+Once an object becomes stationary, object detection will not be continually run on that object. This serves to reduce resource usage and redundant detections when there has been no motion near the tracked object. This also means that Frigate is contextually aware, and can for example [filter out recording segments](record.md#what-do-the-different-retain-modes-mean) to only when the object is considered active. Motion alone does not determine if an object is "active" for active_objects segment retention. Lighting changes for a parked car won't make an object active.
 
 ## Tuning stationary behavior
 

--- a/docs/docs/configuration/stationary_objects.md
+++ b/docs/docs/configuration/stationary_objects.md
@@ -1,0 +1,24 @@
+# Stationary Objects
+
+An object is considered stationary when it is being tracked and has been in a very similar position for a certain number of frames. This number is defined in the configuration under `detect -> stationary -> threshold`, and is 10x the frame rate (or 10 seconds) by default. Once an object is considered stationary, it will remain stationary until motion occurs near the object at which point it will be considered active.
+
+## Why does it matter if an object is stationary?
+
+Once an object becomes stationary, object detection will not be continually run on that object. This serves to reduce resource usage and redundant detections when there has been no motion near the tracked object. This also means that Frigate is contextually aware, and can for example [filter out recording segments](record.md) to only when the object is considered active.
+
+## Tuning stationary behavior
+
+The default config is:
+
+```yaml
+detect:
+  stationary:
+    interval: 0
+    threshold: 50
+```
+
+`interval` is defined as the frequency for running detection on stationary objects. This means that by default, once an object is considered stationary detection will not be run on it until motion is detected. With `interval > 0`, every nth frames detection will be run to make sure the object is still there. 
+
+NOTE: There is no way to disable stationary object tracking with this value.
+
+`threshold` is the number of frames an object needs to remain relatively still before it is considered stationary.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -22,6 +22,7 @@ module.exports = {
       'configuration/objects',
       'configuration/rtmp',
       'configuration/zones',
+      'configuration/stationary_objects',
       'configuration/advanced',
       'configuration/hardware_acceleration',
       'configuration/nvdec',


### PR DESCRIPTION
As discussed here: https://github.com/blakeblackshear/frigate/issues/3070

Some users have been confused by the `0` default value, thinking it disabled stationary tracking. I figured instead of elaborating more in the config comments, adding a dedicated section about stationary objects would be more helpful.  Curious on thoughts and happy to make edits / adjustments 👍 