### PR TITLE
docker-compose: Changes group type from int to str

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     user: vscode
     # add groups from host for render, plugdev, video
     group_add:
-      - 109 # render
-      - 44  # video
-      - 46  # plugdev
+      - "109" # render
+      - "44"  # video
+      - "46"  # plugdev
     shm_size: "256mb"
     build:
       context: .


### PR DESCRIPTION
With the docker-compose file I got the following error:

$ docker-compose up
3 error(s) decoding:

* 'group_add[0]' expected type 'string', got unconvertible type 'int', value: '109'
* 'group_add[1]' expected type 'string', got unconvertible type 'int', value: '44'
* 'group_add[2]' expected type 'string', got unconvertible type 'int', value: '46'


This commit changes the type to string to fix this issue.

$ docker-compose --version
Docker Compose version 2.3.3