### PR TITLE
Add more issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/camera_support_request.yml
+++ b/.github/ISSUE_TEMPLATE/camera_support_request.yml
@@ -1,7 +1,7 @@
 name: Camera Support Request
 description: Support for setting up cameras in Frigate
 title: "[Camera Support]: "
-labels: ["support", "triage", "camera"]
+labels: ["support", "triage"]
 assignees: []
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/camera_support_request.yml
+++ b/.github/ISSUE_TEMPLATE/camera_support_request.yml
@@ -1,0 +1,107 @@
+name: Camera Support Request
+description: Support for setting up cameras in Frigate
+title: "[Camera Support]: "
+labels: ["support", "triage", "camera"]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem you are having
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Visible on the Debug page in the Web UI
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Frigate config file
+      description: This will be automatically formatted into code, so no need for backticks.
+      render: yaml
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: ffprobe
+    attributes:
+      label: FFprobe output from your camera
+      description: Run `ffprobe <camera_url>` and provide output below
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: stats
+    attributes:
+      label: Frigate stats
+      description: Output from frigate's /api/stats endpoint
+      render: json
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - HassOS
+        - Debian
+        - Other Linux
+        - Proxmox
+        - UNRAID
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - HassOS Addon
+        - Docker Compose
+        - Docker CLI
+    validations:
+      required: true
+  - type: dropdown
+    id: coral
+    attributes:
+      label: Coral version
+      options:
+        - USB
+        - PCIe
+        - M.2
+        - Dev Board
+        - Other
+        - CPU (no coral)
+    validations:
+      required: true
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network connection
+      options:
+        - Wired
+        - Wireless
+        - Mixed
+    validations:
+      required: true
+  - type: input
+    id: camera
+    attributes:
+      label: Camera make and model
+      description: Dahua, hikvision, amcrest, reolink, etc and model number
+    validations:
+      required: true
+  - type: textarea
+    id: other
+    attributes:
+      label: Any other information that may be helpful

--- a/.github/ISSUE_TEMPLATE/config_support_request.yml
+++ b/.github/ISSUE_TEMPLATE/config_support_request.yml
@@ -1,0 +1,82 @@
+name: Config Support Request
+description: Support for Frigate configuration
+title: "[Config Support]: "
+labels: ["support", "triage"]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem you are having
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Visible on the Debug page in the Web UI
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Frigate config file
+      description: This will be automatically formatted into code, so no need for backticks.
+      render: yaml
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: stats
+    attributes:
+      label: Frigate stats
+      description: Output from frigate's /api/stats endpoint
+      render: json
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - HassOS
+        - Debian
+        - Other Linux
+        - Proxmox
+        - UNRAID
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - HassOS Addon
+        - Docker Compose
+        - Docker CLI
+    validations:
+      required: true
+  - type: dropdown
+    id: coral
+    attributes:
+      label: Coral version
+      options:
+        - USB
+        - PCIe
+        - M.2
+        - Dev Board
+        - Other
+        - CPU (no coral)
+    validations:
+      required: true
+  - type: textarea
+    id: other
+    attributes:
+      label: Any other information that may be helpful

--- a/.github/ISSUE_TEMPLATE/general_support_request.yml
+++ b/.github/ISSUE_TEMPLATE/general_support_request.yml
@@ -1,5 +1,5 @@
-name: Support Request
-description: Support for Frigate setup or configuration
+name: General Support Request
+description: General support request for Frigate
 title: "[Support]: "
 labels: ["support", "triage"]
 assignees: []


### PR DESCRIPTION
I've noticed occasionally users skipping some "irrelavant" fields and they end up skipping fields that are important to solve their issue. I'm thinking some specific support templates for different types of support should help with that and keep things more tidy in general as well. Curious on others thoughts.

Summary:

- Renamed the existing support to general_support_request
- Added camera_support_request which is similar
- Added config_support_request which removes camera specific fields. 

I know there may be some overlap here but I think it should be straightforward which types of issues go where.