### PR TITLE
Add warning dialog to toggle buttons on camera cards

### DIFF
--- a/docs/docs/configuration/user_interface.md
+++ b/docs/docs/configuration/user_interface.md
@@ -13,3 +13,12 @@ ui:
 ```
 
 Note that experimental changes may contain bugs or may be removed at any time in future releases of the software. Use of these features are presented as-is and with no functional guarantee.
+
+### Show confirmation prompts
+
+Used to hide non-critical confirmation prompts.
+
+```yaml
+ui:
+  show_confirmation_prompts: true
+```

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -47,7 +47,7 @@ class DetectorConfig(FrigateBaseModel):
 class UIConfig(FrigateBaseModel):
     use_experimental: bool = Field(default=False, title="Experimental UI")
     show_confirmation_prompts: bool = Field(
-        default=False, title="Show confirmation prompts"
+        default=True, title="Show confirmation prompts"
     )
 
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -46,6 +46,9 @@ class DetectorConfig(FrigateBaseModel):
 
 class UIConfig(FrigateBaseModel):
     use_experimental: bool = Field(default=False, title="Experimental UI")
+    show_confirmation_prompts: bool = Field(
+        default=False, title="Show confirmation prompts"
+    )
 
 
 class MqttConfig(FrigateBaseModel):

--- a/web/src/routes/Cameras.jsx
+++ b/web/src/routes/Cameras.jsx
@@ -5,7 +5,7 @@ import CameraImage from '../components/CameraImage';
 import ClipIcon from '../icons/Clip';
 import MotionIcon from '../icons/Motion';
 import SnapshotIcon from '../icons/Snapshot';
-import Dialog from '../components/Dialog';
+import Prompt from '../components/Prompt';
 import { useDetectState, useRecordingsState, useSnapshotsState } from '../api/mqtt';
 import { useMemo, useState } from 'preact/hooks';
 import useSWR from 'swr';
@@ -40,6 +40,8 @@ function SortedCameras({ unsortedCameras }) {
 }
 
 function Camera({ name }) {
+  const {data: config} = useSWR('config');
+  const showConfirmationPrompts = config && config.ui.show_confirmation_prompts;
   const { payload: detectValue, send: sendDetect } = useDetectState(name);
   const [showToggleDetectDialog, setShowToggleDetectDialog] = useState(false);
   const { payload: recordValue, send: sendRecordings } = useRecordingsState(name);
@@ -60,7 +62,11 @@ function Camera({ name }) {
         icon: MotionIcon,
         color: detectValue === 'ON' ? 'blue' : 'gray',
         onClick: () => {
-          setShowToggleDetectDialog(true);
+          if (showConfirmationPrompts) {
+            setShowToggleDetectDialog(true);
+          } else {
+            sendDetect(recordValue === 'ON' ? 'OFF' : 'ON');
+          }
         },
       },
       {
@@ -68,7 +74,11 @@ function Camera({ name }) {
         icon: ClipIcon,
         color: recordValue === 'ON' ? 'blue' : 'gray',
         onClick: () => {
-          setShowToggleRecordingDialog(true);
+          if (showConfirmationPrompts) {
+            setShowToggleRecordingDialog(true);
+          } else {
+            sendRecordings(recordValue === 'ON' ? 'OFF' : 'ON');
+          }
         },
       },
       {
@@ -76,7 +86,11 @@ function Camera({ name }) {
         icon: SnapshotIcon,
         color: snapshotValue === 'ON' ? 'blue' : 'gray',
         onClick: () => {
-          setShowToggleSnapshotDialog(true);
+          if (showConfirmationPrompts) {
+            setShowToggleSnapshotDialog(true);
+          } else {
+            sendSnapshots(recordValue === 'ON' ? 'OFF' : 'ON');
+          }
         },
       },
     ],
@@ -120,7 +134,7 @@ function Camera({ name }) {
     <Fragment>
       <Card buttons={buttons} href={href} header={name} icons={icons} media={<CameraImage camera={name} stretch />} />
       {dialogs.map(({showDialog, dismiss, title, callback}) =>
-        showDialog ? <Dialog
+        showDialog ? <Prompt
           title={title}
           text="Are you sure?"
           onDismiss={dismiss}


### PR DESCRIPTION
:wave:, I noticed that as soon as I gave my family access to the UI of Frigate, they immediately started clicking the toggle buttons, unaware that they were disabling recording, detection, & snapshots.

I figure that making a change like disabling/enabling recording (and others) should be behind a dialog to prevent accidental changes.

P.S. I haven't touched a front-end/JS/JSX in years! I tried my best to look around but it's fairly foreign to me!