### PR TITLE
Add UI option to hide configuration options

### DIFF
--- a/docs/docs/configuration/user_interface.md
+++ b/docs/docs/configuration/user_interface.md
@@ -13,3 +13,12 @@ ui:
 ```
 
 Note that experimental changes may contain bugs or may be removed at any time in future releases of the software. Use of these features are presented as-is and with no functional guarantee.
+
+### Configuration options
+
+Set to true if you'd like to hide configuration options within the frontend. Not recommended while setting up Frigate.
+
+```yaml
+ui:
+  hide_configuration_options: false
+```

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -46,6 +46,9 @@ class DetectorConfig(FrigateBaseModel):
 
 class UIConfig(FrigateBaseModel):
     use_experimental: bool = Field(default=False, title="Experimental UI")
+    hide_configuration_options: bool = Field(
+        default=False, title="Hide UI components used for configuring Frigate"
+    )
 
 
 class MqttConfig(FrigateBaseModel):

--- a/web/src/Sidebar.jsx
+++ b/web/src/Sidebar.jsx
@@ -23,7 +23,8 @@ export default function Sidebar() {
   if (!config) {
     return null;
   }
-  const { birdseye } = config;
+  const { birdseye, ui } = config;
+  const hideConfigurationOptions = ui?.hide_configuration_options;
 
   return (
     <NavigationDrawer header={<Header />}>
@@ -44,7 +45,7 @@ export default function Sidebar() {
       </Match>
       {birdseye?.enabled ? <Destination href="/birdseye" text="Birdseye" /> : null}
       <Destination href="/events" text="Events" />
-      <Destination href="/debug" text="Debug" />
+      { hideConfigurationOptions ? null : <Destination href="/debug" text="Debug" /> }
       <Separator />
       <div className="flex flex-grow" />
       {ENV !== 'production' ? (

--- a/web/src/components/Tabs.jsx
+++ b/web/src/components/Tabs.jsx
@@ -14,6 +14,9 @@ export function Tabs({ children, selectedIndex: selectedIndexProp, onChange, cla
 
   const RenderChildren = useCallback(() => {
     return children.map((child, i) => {
+      if (!child) {
+        return null
+      }
       child.props.selected = i === selectedIndex;
       child.props.onClick = handleSelected(i);
       return child;

--- a/web/src/routes/Camera_V2.jsx
+++ b/web/src/routes/Camera_V2.jsx
@@ -14,6 +14,7 @@ export default function Camera({ camera }) {
   const [playerType, setPlayerType] = useState('live');
 
   const cameraConfig = config?.cameras[camera];
+  const hideConfigurationOptions = config?.ui?.hide_configuration_options;
 
   const handleTabChange = (index) => {
     if (index === 0) {
@@ -49,7 +50,7 @@ export default function Camera({ camera }) {
           <Tabs selectedIndex={1} onChange={handleTabChange} className='justify'>
             <TextTab text='History' />
             <TextTab text='Live' />
-            <TextTab text='Debug' />
+            {hideConfigurationOptions ? null : <TextTab text="Debug"/>}
           </Tabs>
         </div>
       </div>


### PR DESCRIPTION
Not sure if this is desired. But it follows my [previous pr](https://github.com/blakeblackshear/frigate/pull/3131) to simplify the interface for end users who are less technically savvy.


Perhaps it makes sense to have a toggle (similar to the dark/light mode toggle) which turns hides/shows all setup/configuration options on the front-end. It could be stored on the client in index-db alongside the dark-mode toggle.  