### PR TITLE
Mqtt set motion switch on init

### DIFF
--- a/frigate/mqtt.py
+++ b/frigate/mqtt.py
@@ -241,6 +241,11 @@ def create_mqtt_client(config: FrigateConfig, camera_metrics):
             retain=True,
         )
         client.publish(
+            f"{mqtt_config.topic_prefix}/{name}/motion/state",
+            "ON",
+            retain=True,
+        )
+        client.publish(
             f"{mqtt_config.topic_prefix}/{name}/improve_contrast/state",
             "ON" if config.cameras[name].motion.improve_contrast else "OFF",
             retain=True,


### PR DESCRIPTION
I realized I didn't set the initial motion switch, but it needs to be set to "ON" in on connection so after frigate integration restarts it still has a value to read.