### PR TITLE
Fix hwaccel docs for nvidia docker-compose

### DIFF
--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -69,7 +69,9 @@ services:
     resources:
       reservations:
         devices:
-        - capabilities: [gpu]
+          - driver: nvidia
+            count: 1
+            capabilities: [gpu]
 ```
 
 The decoder you need to pass in the `hwaccel_args` will depend on the input video.


### PR DESCRIPTION
According to https://github.com/blakeblackshear/frigate/issues/3232 and https://github.com/blakeblackshear/frigate/issues/2078 nvidia hardware acceleration is not working with just `- capabilities: [gpu]` in the docker compose, it seems to require to specify the driver.

This is also shown in https://docs.docker.com/compose/gpu-support/