### PR TITLE
Update hardware_acceleration.md

### DIFF
--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -43,6 +43,8 @@ ffmpeg:
 
 ### Intel-based CPUs (>=10th Generation) via Quicksync
 
+**Note:** You might also need to set `LIBVA_DRIVER_NAME=iHD` as an environment variable on the container. Check with `vainfo` inside the container to see if it works.
+
 ```yaml
 ffmpeg:
   hwaccel_args:


### PR DESCRIPTION
I had to set the environment variable `LIBVA_DRIVER_NAME: iHD` in my docker-compose.yml for hwaccel to work.
Perhaps this depends on host configuration/drivers, if it'll use i965 (default) or iHD?
My CPU is Intel i3-10320.