### PR TITLE
Catch crash on no internet for github stats

### DIFF
--- a/frigate/stats.py
+++ b/frigate/stats.py
@@ -20,9 +20,13 @@ logger = logging.getLogger(__name__)
 
 
 def get_latest_version() -> str:
-    request = requests.get(
-        "https://api.github.com/repos/blakeblackshear/frigate/releases/latest"
-    )
+    try:
+        request = requests.get(
+            "https://api.github.com/repos/blakeblackshear/frigate/releases/latest"
+        )
+    except:
+        return "unknown"
+
     response = request.json()
 
     if request.ok and response and "tag_name" in response:


### PR DESCRIPTION
Per https://github.com/blakeblackshear/frigate/discussions/3221#discussioncomment-2801597 if a user has no internet connection to frigate and GitHub can't connect for version check it would crash, needs to be caught.