### PR TITLE
Ability to set point of bounding box that triggers a zone

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -438,8 +438,10 @@ cameras:
       #       camera.
       front_steps:
         # Required: List of x,y coordinates to define the polygon of the zone.
-        # NOTE: Presence in a zone is evaluated only based on the bottom center of the objects bounding box.
+        # NOTE: Presence in a zone is evaluated only based on a specific point of the objects bounding box.
         coordinates: 545,1077,747,939,788,805
+        # Optional: Point of the bounding box that needs to be within the zone to be considered active. (default: shown below)
+        bounding_box_trigger: bottom_center
         # Optional: List of objects that can trigger this zone (default: all tracked objects)
         objects:
           - person

--- a/docs/docs/configuration/zones.md
+++ b/docs/docs/configuration/zones.md
@@ -3,7 +3,7 @@ id: zones
 title: Zones
 ---
 
-Zones allow you to define a specific area of the frame and apply additional filters for object types so you can determine whether or not an object is within a particular area. Presence in a zone is evaluated based on the bottom center of the bounding box for the object. It does not matter how much of the bounding box overlaps with the zone.
+Zones allow you to define a specific area of the frame and apply additional filters for object types so you can determine whether or not an object is within a particular area. Presence in a zone is evaluated based on a specified point of the bounding box for the object (bottom center by default). It does not matter how much of the bounding box overlaps with the zone.
 
 Zones cannot have the same name as a camera. If desired, a single zone can include multiple cameras if you have multiple cameras covering the same area by configuring zones with the same name for each camera.
 
@@ -38,3 +38,15 @@ camera:
 ```
 
 Only car objects can trigger the `front_yard_street` zone and only person can trigger the `entire_yard`. You will get events for person objects that enter anywhere in the yard, and events for cars only if they enter the street.
+
+### Setting trigger point for zone
+
+```yaml
+camera:
+  zones:
+    couch:
+      coordinates: ... (everywhere you want a person)
+      objects:
+        - person
+      bounding_box_trigger: top_center
+```

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -289,6 +289,10 @@ class ZoneConfig(BaseModel):
         default_factory=list,
         title="List of objects that can trigger the zone.",
     )
+    bounding_box_trigger: str = Field(
+        default="bottom-center",
+        title="Point of an objects bounding box that triggers this zone.",
+    )
     _color: Optional[Tuple[int, int, int]] = PrivateAttr()
     _contour: np.ndarray = PrivateAttr()
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
-import yaml
 from pydantic import BaseModel, Extra, Field, validator, parse_obj_as
 from pydantic.fields import PrivateAttr
 
@@ -19,12 +18,12 @@ from frigate.const import (
     YAML_EXT,
 )
 from frigate.util import (
+    BoundingBoxTriggerEnum,
     create_mask,
     deep_merge,
     get_ffmpeg_arg_list,
     escape_special_characters,
     load_config_with_no_duplicates,
-    load_labels,
 )
 from frigate.ffmpeg_presets import (
     parse_preset_hardware_acceleration,
@@ -33,13 +32,10 @@ from frigate.ffmpeg_presets import (
     parse_preset_output_rtmp,
 )
 from frigate.detectors import (
-    PixelFormatEnum,
-    InputTensorEnum,
     ModelConfig,
     DetectorConfig,
 )
 from frigate.version import VERSION
-
 
 logger = logging.getLogger(__name__)
 
@@ -275,13 +271,6 @@ class RuntimeFilterConfig(FilterConfig):
     class Config:
         arbitrary_types_allowed = True
         extra = Extra.ignore
-
-
-class BoundingBoxTriggerEnum(str, Enum):
-    bottom_center = "bottom-center"
-    left_center = "left-center"
-    top_center = "top-center"
-    right_center = "right-center"
 
 
 # this uses the base model because the color is an extra attribute

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -277,6 +277,13 @@ class RuntimeFilterConfig(FilterConfig):
         extra = Extra.ignore
 
 
+class BoundingBoxTriggerEnum(str, Enum):
+    bottom_center = "bottom-center"
+    left_center = "left-center"
+    top_center = "top-center"
+    right_center = "right-center"
+
+
 # this uses the base model because the color is an extra attribute
 class ZoneConfig(BaseModel):
     filters: Dict[str, FilterConfig] = Field(
@@ -289,8 +296,8 @@ class ZoneConfig(BaseModel):
         default_factory=list,
         title="List of objects that can trigger the zone.",
     )
-    bounding_box_trigger: str = Field(
-        default="bottom-center",
+    bounding_box_trigger: BoundingBoxTriggerEnum = Field(
+        default=BoundingBoxTriggerEnum.bottom_center,
         title="Point of an objects bounding box that triggers this zone.",
     )
     _color: Optional[Tuple[int, int, int]] = PrivateAttr()

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -136,15 +136,19 @@ class TrackedObject:
 
         # check zones
         current_zones = []
-        bottom_center = (obj_data["centroid"][0], obj_data["box"][3])
+
         # check each zone
         for name, zone in self.camera_config.zones.items():
             # if the zone is not for this object type, skip
             if len(zone.objects) > 0 and not obj_data["label"] in zone.objects:
                 continue
-            contour = zone.contour
+
             # check if the object is in the zone
-            if cv2.pointPolygonTest(contour, bottom_center, False) >= 0:
+            if zone.bounding_box_trigger.is_in_zone(
+                obj_data["centroid"],
+                obj_data["box"],
+                zone.contour,
+            ):
                 # if the object passed the filters once, dont apply again
                 if name in self.current_zones or not zone_filtered(self, zone.filters):
                     current_zones.append(name)

--- a/frigate/test/test_util.py
+++ b/frigate/test/test_util.py
@@ -23,14 +23,14 @@ class TestConfig(unittest.TestCase):
                         "width": 1920,
                         "fps": 5,
                     },
-                    "zones": {"test": {"coordinates": "100,100,400,400"}},
+                    "zones": {"test": {"coordinates": "0,0,0,400,400,400,400,0"}},
                 }
             },
         }
 
     def test_bounding_box_trigger_points_in_zone(self):
         frigate_config = FrigateConfig(**self.config)
-        centroid = (200, 200)
+        centroid = (250, 250)
         box = (150, 150, 350, 350)
         zone = frigate_config.cameras["back"].zones["test"]
 
@@ -47,8 +47,8 @@ class TestConfig(unittest.TestCase):
 
     def test_bounding_box_trigger_points_outside_zone(self):
         frigate_config = FrigateConfig(**self.config)
-        centroid = (200, 200)
-        box = (0, 0, 500, 500)
+        centroid = (500, 500)
+        box = (400, 400, 600, 600)
         zone = frigate_config.cameras["back"].zones["test"]
 
         assert not BoundingBoxTriggerEnum.bottom_center.is_in_zone(

--- a/frigate/test/test_util.py
+++ b/frigate/test/test_util.py
@@ -1,0 +1,50 @@
+import unittest
+
+from frigate.config import FrigateConfig
+from frigate.util import BoundingBoxTriggerEnum
+
+class TestConfig(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            "mqtt": {"host": "mqtt"},
+            "record": {
+                "events": {"retain": {"default": 20, "objects": {"person": 30}}}
+            },
+            "cameras": {
+                "back": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}
+                        ]
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
+                    "zones": {"test": {"coordinates": "100,100,400,400"}},
+                }
+            },
+        }
+
+    def test_bounding_box_trigger_points_in_zone(self):
+        frigate_config = FrigateConfig(**self.config)
+        centroid = (200, 200)
+        box = (150, 150, 350, 350)
+        zone = frigate_config.cameras["back"].zones["test"]
+
+        assert BoundingBoxTriggerEnum.bottom_center.is_in_zone(centroid, box, zone.contour)
+        assert BoundingBoxTriggerEnum.left_center.is_in_zone(centroid, box, zone.contour)
+        assert BoundingBoxTriggerEnum.right_center.is_in_zone(centroid, box, zone.contour)
+        assert BoundingBoxTriggerEnum.top_center.is_in_zone(centroid, box, zone.contour)
+
+    def test_bounding_box_trigger_points_outside_zone(self):
+        frigate_config = FrigateConfig(**self.config)
+        centroid = (200, 200)
+        box = (0, 0, 500, 500)
+        zone = frigate_config.cameras["back"].zones["test"]
+
+        assert not BoundingBoxTriggerEnum.bottom_center.is_in_zone(centroid, box, zone.contour)
+        assert not BoundingBoxTriggerEnum.left_center.is_in_zone(centroid, box, zone.contour)
+        assert not BoundingBoxTriggerEnum.right_center.is_in_zone(centroid, box, zone.contour)
+        assert not BoundingBoxTriggerEnum.top_center.is_in_zone(centroid, box, zone.contour)

--- a/frigate/test/test_util.py
+++ b/frigate/test/test_util.py
@@ -79,6 +79,4 @@ class TestConfig(unittest.TestCase):
         assert not BoundingBoxTriggerEnum.right_center.is_in_zone(
             centroid, box, zone.contour
         )
-        assert BoundingBoxTriggerEnum.top_center.is_in_zone(
-            centroid, box, zone.contour
-        )
+        assert BoundingBoxTriggerEnum.top_center.is_in_zone(centroid, box, zone.contour)

--- a/frigate/test/test_util.py
+++ b/frigate/test/test_util.py
@@ -3,6 +3,7 @@ import unittest
 from frigate.config import FrigateConfig
 from frigate.util import BoundingBoxTriggerEnum
 
+
 class TestConfig(unittest.TestCase):
     def setUp(self):
         self.config = {
@@ -33,9 +34,15 @@ class TestConfig(unittest.TestCase):
         box = (150, 150, 350, 350)
         zone = frigate_config.cameras["back"].zones["test"]
 
-        assert BoundingBoxTriggerEnum.bottom_center.is_in_zone(centroid, box, zone.contour)
-        assert BoundingBoxTriggerEnum.left_center.is_in_zone(centroid, box, zone.contour)
-        assert BoundingBoxTriggerEnum.right_center.is_in_zone(centroid, box, zone.contour)
+        assert BoundingBoxTriggerEnum.bottom_center.is_in_zone(
+            centroid, box, zone.contour
+        )
+        assert BoundingBoxTriggerEnum.left_center.is_in_zone(
+            centroid, box, zone.contour
+        )
+        assert BoundingBoxTriggerEnum.right_center.is_in_zone(
+            centroid, box, zone.contour
+        )
         assert BoundingBoxTriggerEnum.top_center.is_in_zone(centroid, box, zone.contour)
 
     def test_bounding_box_trigger_points_outside_zone(self):
@@ -44,7 +51,15 @@ class TestConfig(unittest.TestCase):
         box = (0, 0, 500, 500)
         zone = frigate_config.cameras["back"].zones["test"]
 
-        assert not BoundingBoxTriggerEnum.bottom_center.is_in_zone(centroid, box, zone.contour)
-        assert not BoundingBoxTriggerEnum.left_center.is_in_zone(centroid, box, zone.contour)
-        assert not BoundingBoxTriggerEnum.right_center.is_in_zone(centroid, box, zone.contour)
-        assert not BoundingBoxTriggerEnum.top_center.is_in_zone(centroid, box, zone.contour)
+        assert not BoundingBoxTriggerEnum.bottom_center.is_in_zone(
+            centroid, box, zone.contour
+        )
+        assert not BoundingBoxTriggerEnum.left_center.is_in_zone(
+            centroid, box, zone.contour
+        )
+        assert not BoundingBoxTriggerEnum.right_center.is_in_zone(
+            centroid, box, zone.contour
+        )
+        assert not BoundingBoxTriggerEnum.top_center.is_in_zone(
+            centroid, box, zone.contour
+        )

--- a/frigate/test/test_util.py
+++ b/frigate/test/test_util.py
@@ -63,3 +63,22 @@ class TestConfig(unittest.TestCase):
         assert not BoundingBoxTriggerEnum.top_center.is_in_zone(
             centroid, box, zone.contour
         )
+
+    def test_bounding_box_trigger_points_half_in_zone(self):
+        frigate_config = FrigateConfig(**self.config)
+        centroid = (300, 300)
+        box = (200, 200, 500, 500)
+        zone = frigate_config.cameras["back"].zones["test"]
+
+        assert not BoundingBoxTriggerEnum.bottom_center.is_in_zone(
+            centroid, box, zone.contour
+        )
+        assert BoundingBoxTriggerEnum.left_center.is_in_zone(
+            centroid, box, zone.contour
+        )
+        assert not BoundingBoxTriggerEnum.right_center.is_in_zone(
+            centroid, box, zone.contour
+        )
+        assert BoundingBoxTriggerEnum.top_center.is_in_zone(
+            centroid, box, zone.contour
+        )

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -5,6 +5,7 @@ import shlex
 import subprocess as sp
 import json
 import re
+from enum import Enum
 import signal
 import traceback
 import urllib.parse
@@ -972,3 +973,24 @@ class SharedMemoryFrameManager(FrameManager):
             self.shm_store[name].close()
             self.shm_store[name].unlink()
             del self.shm_store[name]
+
+
+class BoundingBoxTriggerEnum(str, Enum):
+    bottom_center = "bottom-center"
+    left_center = "left-center"
+    right_center = "right-center"
+    top_center = "top-center"
+
+    def is_in_zone(self, centroid, box, contour) -> bool:
+        """Tests a zone based on the bounding box
+        trigger and the objects bounding box."""
+        if self.value is self.bottom_center:
+            point = (centroid[0], box[3])
+        elif self.value is self.left_center:
+            point = (box[0], centroid[1])
+        elif self.value is self.right_center:
+            point = (box[2], centroid[1])
+        elif self.value is self.top_center:
+            point = (centroid[0], box[1])
+
+        return cv2.pointPolygonTest(contour, point, False) >= 0

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -984,13 +984,13 @@ class BoundingBoxTriggerEnum(str, Enum):
     def is_in_zone(self, centroid, box, contour) -> bool:
         """Tests a zone based on the bounding box
         trigger and the objects bounding box."""
-        if self.value is self.bottom_center:
+        if self is self.bottom_center:
             point = (centroid[0], box[3])
-        elif self.value is self.left_center:
+        elif self is self.left_center:
             point = (box[0], centroid[1])
-        elif self.value is self.right_center:
+        elif self is self.right_center:
             point = (box[2], centroid[1])
-        elif self.value is self.top_center:
+        elif self is self.top_center:
             point = (centroid[0], box[1])
 
         return cv2.pointPolygonTest(contour, point, False) >= 0

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -976,10 +976,10 @@ class SharedMemoryFrameManager(FrameManager):
 
 
 class BoundingBoxTriggerEnum(str, Enum):
-    bottom_center = "bottom-center"
-    left_center = "left-center"
-    right_center = "right-center"
-    top_center = "top-center"
+    bottom_center = "bottom_center"
+    left_center = "left_center"
+    right_center = "right_center"
+    top_center = "top_center"
 
     def is_in_zone(self, centroid, box, contour) -> bool:
         """Tests a zone based on the bounding box


### PR DESCRIPTION
## Description

Probably fits into a future release after `0.11` but happy to discuss either way.

Per discussion https://github.com/blakeblackshear/frigate/discussions/3262 there are some cases where the bottom center is difficult to create a zone for, zones can be configured to be trigger by (bottom, left, right, top)-center of the bounding box. 

Default remains the bottom-center

## Open Questions

Potentially could add others but I personally thought these four should suffice, but curious if more should be added?