### PR TITLE
Update docs with instructions for adding the JSON config schema

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -25,6 +25,10 @@ cameras:
       height: 720
 ```
 
+### VSCode Configuration Schema
+
+VSCode (and VSCode addon) supports the JSON schemas which will automatically validate the config. This can be added by adding `# yaml-language-server: $schema=http://frigate_host:5000/api/config/schema` to the top of the config file. `frigate_host` being the IP address of frigate or `ccab4aaf-frigate` if running in the addon.
+
 ### Full configuration reference:
 
 :::caution


### PR DESCRIPTION
As discussed in #2421 

Not sure if vscode supports this or if it is supported by most editors, could make it more generalized if other editors support it as well.