### PR TITLE
Limit size of player in events view

### DIFF
--- a/web/src/components/VideoPlayer.jsx
+++ b/web/src/components/VideoPlayer.jsx
@@ -93,6 +93,7 @@ export default function VideoPlayer({ children, options, seekOptions = {}, onRea
 
   return (
     <div data-vjs-player>
+      {/* Setting an empty data-setup is required to override the default values and allow video to be resizable */}
       <video ref={playerRef} className="small-player video-js vjs-default-skin" data-setup="{}" controls playsinline />
       {children}
     </div>

--- a/web/src/components/VideoPlayer.jsx
+++ b/web/src/components/VideoPlayer.jsx
@@ -93,7 +93,7 @@ export default function VideoPlayer({ children, options, seekOptions = {}, onRea
 
   return (
     <div data-vjs-player>
-      <video ref={playerRef} className="small-player video-js vjs-default-skin" controls playsinline />
+      <video ref={playerRef} className="small-player video-js vjs-default-skin" data-setup="{}" controls playsinline />
       {children}
     </div>
   );

--- a/web/src/components/VideoPlayer.jsx
+++ b/web/src/components/VideoPlayer.jsx
@@ -93,7 +93,7 @@ export default function VideoPlayer({ children, options, seekOptions = {}, onRea
 
   return (
     <div data-vjs-player>
-      {/* Setting an empty data-setup is required to override the default values and allow video to be resizable */}
+      {/* Setting an empty data-setup is required to override the default values and allow video to be fit the size of its parent */}
       <video ref={playerRef} className="small-player video-js vjs-default-skin" data-setup="{}" controls playsinline />
       {children}
     </div>

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -494,7 +494,7 @@ export default function Events({ path, ...props }) {
                   </div>
                   {viewEvent !== event.id ? null : (
                     <div className="space-y-4">
-                      <div className="mx-auto">
+                      <div className="mx-auto max-w-7xl">
                         {event.has_clip ? (
                           <>
                             <Heading size="lg">Clip</Heading>


### PR DESCRIPTION
As reported in https://github.com/blakeblackshear/frigate/issues/3287 having 100% size for player leads to issue with larger displays / aspect ratios.