### PR TITLE
Update camera_specific.md

### DIFF
--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -58,18 +58,17 @@ ffmpeg:
 
 ### Reolink 410/520 (possibly others)
 
-According to [this discussion](https://github.com/blakeblackshear/frigate/issues/1713#issuecomment-932976305), the http video streams seem to be the most reliable for Reolink.
+According to [this discussion](https://github.com/blakeblackshear/frigate/issues/3235#issuecomment-1135876973), the http video streams seem to be the most reliable for Reolink.
 
 ```yaml
 cameras:
   reolink:
     ffmpeg:
-      hwaccel_args:
       input_args:
         - -avoid_negative_ts
         - make_zero
         - -fflags
-        - nobuffer+genpts+discardcorrupt
+        - +genpts+discardcorrupt
         - -flags
         - low_delay
         - -strict


### PR DESCRIPTION
Change fflag arg for Reolink to remove `nobuffer`, which causes stream errors in 0.11-beta2

Different HW accel arguments are required too, but I'm not sure if this is Reolink specific, or more general as part of changed FFmpeg? e.g. 

Intel QSV:
```yaml
ffmpeg:
  hwaccel_args: -hwaccel qsv -qsv_device /dev/dri/renderD128 -hwaccel_output_format nv12 -c:v h264_qsv
```

VAAPI: (from @minglarn)
```yaml
ffmpeg:
  hwaccel_args: -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -hwaccel_output_format yuv420p
```