### PR TITLE
CONFIG: Timestamp format for frontend

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -342,6 +342,15 @@ snapshots:
     objects:
       person: 15
 
+# Optional: Frontend UI Configuration
+ui:
+  # Optional: Enable experimental frontend ui features (default: shown below).
+  use_experimental: false
+  # Optional: Configuration for frontend timestamp
+  timestamp:
+    # Optional: Show hour as 12-hour format (default: shown below).
+    hour_12: true
+
 # Optional: RTMP configuration
 # NOTE: RTMP is deprecated in favor of restream
 # NOTE: Can be overridden at the camera level

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -61,12 +61,15 @@ class FrigateBaseModel(BaseModel):
 
 class UiTimestampConfig(FrigateBaseModel):
     """Configuration for the UI timestamps."""
+
     hour_12: bool = Field(default=True, title="Use 12 hour format in UI.")
 
 
 class UIConfig(FrigateBaseModel):
     use_experimental: bool = Field(default=False, title="Experimental UI")
-    timestamp: UiTimestampConfig = Field(default_factory=UiTimestampConfig, title="UI timestamp configuration.")
+    timestamp: UiTimestampConfig = Field(
+        default_factory=UiTimestampConfig, title="UI timestamp configuration."
+    )
 
 
 class MqttConfig(FrigateBaseModel):

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -60,8 +60,6 @@ class FrigateBaseModel(BaseModel):
 
 
 class UiTimestampConfig(FrigateBaseModel):
-    """Configuration for the UI timestamps."""
-
     hour_12: bool = Field(default=True, title="Use 12 hour format in UI.")
 
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -59,8 +59,14 @@ class FrigateBaseModel(BaseModel):
         extra = Extra.forbid
 
 
+class UiTimestampConfig(FrigateBaseModel):
+    """Configuration for the UI timestamps."""
+    hour_12: bool = Field(default=True, title="Use 12 hour format in UI.")
+
+
 class UIConfig(FrigateBaseModel):
     use_experimental: bool = Field(default=False, title="Experimental UI")
+    timestamp: UiTimestampConfig = Field(default_factory=UiTimestampConfig, title="UI timestamp configuration.")
 
 
 class MqttConfig(FrigateBaseModel):

--- a/web/__test__/handlers.js
+++ b/web/__test__/handlers.js
@@ -12,6 +12,9 @@ export const handlers = [
         service: {
           version: '0.8.3',
         },
+        ui: {
+          timestamp: { hour_12: true },
+        },
         cameras: {
           front: {
             name: 'front',

--- a/web/src/components/RecordingPlaylist.jsx
+++ b/web/src/components/RecordingPlaylist.jsx
@@ -144,7 +144,11 @@ export function EventCard({ camera, event }) {
   const apiHost = useApiHost();
   const start = fromUnixTime(event.start_time);
   const end = fromUnixTime(event.end_time);
+
+  const { data: config } = useSWR('config');
+
   let duration = 'In Progress';
+
   if (event.end_time) {
     duration = formatDuration(intervalToDuration({ start, end }));
   }
@@ -160,7 +164,7 @@ export function EventCard({ camera, event }) {
             <div className="flex flex-row items-center">
               <div className="flex-1">
                 <div className="text-2xl text-white leading-tight capitalize">{event.label}</div>
-                <div className="text-xs md:text-normal text-gray-300">Start: {format(start, 'HH:mm:ss')}</div>
+                <div className="text-xs md:text-normal text-gray-300">Start: {format(start, `${config.ui.timestamp.hour_12 ? 'hh' : 'HH'}:mm:ss ${config.ui.timestamp.hour_12 ? 'a' : ''}`)}</div>
                 <div className="text-xs md:text-normal text-gray-300">Duration: {duration}</div>
               </div>
               <div className="text-lg text-white text-right leading-tight">{(event.top_score * 100).toFixed(1)}%</div>

--- a/web/src/components/RecordingPlaylist.jsx
+++ b/web/src/components/RecordingPlaylist.jsx
@@ -148,7 +148,6 @@ export function EventCard({ camera, event }) {
   const { data: config } = useSWR('config');
 
   let duration = 'In Progress';
-
   if (event.end_time) {
     duration = formatDuration(intervalToDuration({ start, end }));
   }

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -502,7 +502,7 @@ export default function Events({ path, ...props }) {
                           ({(event.top_score * 100).toFixed(0)}%)
                         </div>
                         <div className="text-sm">
-                          {new Date(event.start_time * 1000).toLocaleDateString()}{' '}
+                          {new Date(event.start_time * 1000).toLocaleTimeString([], {hour12: config.ui.timestamp.hour_12})}{' '}
                           {new Date(event.start_time * 1000).toLocaleTimeString()} (
                           {clipDuration(event.start_time, event.end_time)})
                         </div>


### PR DESCRIPTION
Implementation of https://github.com/blakeblackshear/frigate/discussions/2629. Only option so far is 12 / 24 hour style but could be expanded later. 