### PR TITLE
Create PlusApi after config env_vars are set

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -48,17 +48,11 @@ class FrigateApp:
         self.detection_out_events: dict[str, Event] = {}
         self.detection_shms: list[mp.shared_memory.SharedMemory] = []
         self.log_queue: Queue = mp.Queue()
-        self.plus_api = PlusApi()
         self.camera_metrics: dict[str, CameraMetricsTypes] = {}
 
     def set_environment_vars(self) -> None:
         for key, value in self.config.environment_vars.items():
             os.environ[key] = value
-
-            # plus needs to be re-created if API KEY
-            # is included in config env vars
-            if key == PLUS_ENV_VAR:
-                self.plus_api = PlusApi()
 
     def ensure_dirs(self) -> None:
         for d in [RECORD_DIR, CLIPS_DIR, CACHE_DIR]:
@@ -175,6 +169,9 @@ class FrigateApp:
             self.mqtt_client, self.config.mqtt.topic_prefix
         )
         self.mqtt_relay.start()
+
+    def init_plus(self) -> None:
+        self.plus_api = PlusApi()
 
     def start_detectors(self) -> None:
         model_path = self.config.model.path
@@ -352,6 +349,7 @@ class FrigateApp:
             self.init_queues()
             self.init_database()
             self.init_mqtt()
+            self.init_plus()
         except Exception as e:
             print(e)
             self.log_process.terminate()

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -20,7 +20,7 @@ from playhouse.sqliteq import SqliteQueueDatabase
 from pydantic import ValidationError
 
 from frigate.config import DetectorTypeEnum, FrigateConfig
-from frigate.const import CACHE_DIR, CLIPS_DIR, RECORD_DIR
+from frigate.const import CACHE_DIR, CLIPS_DIR, PLUS_ENV_VAR, RECORD_DIR
 from frigate.edgetpu import EdgeTPUProcess
 from frigate.events import EventCleanup, EventProcessor
 from frigate.http import create_app
@@ -54,6 +54,11 @@ class FrigateApp:
     def set_environment_vars(self) -> None:
         for key, value in self.config.environment_vars.items():
             os.environ[key] = value
+
+            # plus needs to be re-created if API KEY
+            # is included in config env vars
+            if key == PLUS_ENV_VAR:
+                self.plus_api = PlusApi()
 
     def ensure_dirs(self) -> None:
         for d in [RECORD_DIR, CLIPS_DIR, CACHE_DIR]:


### PR DESCRIPTION
Fix https://github.com/blakeblackshear/frigate/issues/3346

PlusApi should be created during the configuration init logic so the configuration environment_vars are considered