### PR TITLE
Show on debug bounding box if obj is currently stationary

### DIFF
--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -399,7 +399,7 @@ class CameraState:
                     box[2],
                     box[3],
                     obj["label"],
-                    f"{obj['score']:.0%} {int(obj['area'])}",
+                    f"{'(Stat)' if obj['stationary'] else '(Actv)'} {obj['score']:.0%} {int(obj['area'])}",
                     thickness=thickness,
                     color=color,
                 )

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -399,7 +399,7 @@ class CameraState:
                     box[2],
                     box[3],
                     obj["label"],
-                    f"{'(Stat)' if obj['stationary'] else '(Actv)'} {obj['score']:.0%} {int(obj['area'])}",
+                    f"{'(Stat)' if obj['stationary'] else ''} {obj['score']:.0%} {int(obj['area'])}",
                     thickness=thickness,
                     color=color,
                 )


### PR DESCRIPTION
I think it is helpful for debugging to show if an object is currently considered stationary. This implementation will have it show nothing when active and `(Stat)` when stationary. Definitely open to suggestions on that as I'm thinking there may be a better way to designate that.

I think having a different color box is less of a good option since it could be more confusing and is less obvious what it means.

Screenshot for reference:

![Screen Shot 2022-06-23 at 12 49 16 PM](https://user-images.githubusercontent.com/14866235/175375793-0d72648f-3dd5-4984-b43e-5f039d07b2c3.png)