### PR TITLE
Add security workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: "CodeQL"
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: '24 19 * * 3'
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript', 'python' ]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
   schedule:
     - cron: '24 19 * * 3'
 jobs:

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,0 +1,33 @@
+name: "KICS"
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+  schedule:
+    - cron: '24 19 * * 3'
+jobs:
+  kics-scan:
+    name: KICS Scan
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run KICS
+        continue-on-error: true
+        run: |
+          docker pull checkmarx/kics:latest
+          docker run -v ${{ github.workspace }}:/path checkmarx/kics scan -p "/path" -o "/path/" --report-formats "sarif" --no-progress
+      - name: actions/upload-artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: kics-analysis
+          path: results.sarif
+      - name: Upload KICS scan results to GitHub Security tab
+        if: ${{ env.CODEQL_ENABLED }}
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,41 @@
+name: "Container Scan"
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+  schedule:
+    - cron: '24 19 * * 3'
+jobs:
+  trivy:
+    name: Trivy
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Check out code
+      uses: actions/checkout@v2
+    - uses: actions/setup-node@master
+      with:
+        node-version: 16.x
+    - run: npm install
+      working-directory: ./web
+    - name: Build web
+      run: npm run build
+      working-directory: ./web
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Build
+      run: make
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: 'frigate:latest'
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v2
+      if: always()
+      with:
+        sarif_file: 'trivy-results.sarif'

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ web/node_modules
 web/coverage
 core
 !/web/**/*.ts
+.dccache


### PR DESCRIPTION
This adds several GitHub workflows that run security checks on PR and on a cron.

Workflows added
---
- CodeQL (Scans the python and javascript code)
- KICS (Scans docker-compose, dockerfiles and other IAC files)
- Trivy (Scans the built container and looks at SCA of the manifests and packages installed in the container)

Why
---
I run automatic scans of containers in my home kubernetes cluster and would like to add the above workflows to increase awareness of potential issues that can be easily remediated.

Todo
---
- [ ] `make` fails, so the image is not available for scanning, this also fails in the existing PR checks, need to investigate why and confirm image scan works as expected
- [ ] Confirm KICs scan is configured correctly


Questions
---
Is this something this project wants? If it is let me know what else needs to be done to get this PR accepted   cc: @blakeblackshear 
