### PR TITLE
Add log message when discarding recording segments in cache

### DIFF
--- a/frigate/record.py
+++ b/frigate/record.py
@@ -101,7 +101,9 @@ class RecordingMaintainer(threading.Thread):
         for camera in grouped_recordings.keys():
             segment_count = len(grouped_recordings[camera])
             if segment_count > keep_count:
-                logger.warning(f"Too many recording segments in cache for {camera}. Keeping the {keep_count} most recent segments out of {segment_count}, discarding the rest...")
+                logger.warning(
+                    f"Too many recording segments in cache for {camera}. Keeping the {keep_count} most recent segments out of {segment_count}, discarding the rest..."
+                )
                 to_remove = grouped_recordings[camera][:-keep_count]
                 for f in to_remove:
                     cache_path = f["cache_path"]

--- a/frigate/record.py
+++ b/frigate/record.py
@@ -102,6 +102,7 @@ class RecordingMaintainer(threading.Thread):
             if len(grouped_recordings[camera]) > keep_count:
                 to_remove = grouped_recordings[camera][:-keep_count]
                 for f in to_remove:
+                    logger.warning(f"Discarding a recording segment: {f}")
                     Path(f["cache_path"]).unlink(missing_ok=True)
                     self.end_time_cache.pop(f["cache_path"], None)
                 grouped_recordings[camera] = grouped_recordings[camera][-keep_count:]

--- a/frigate/record.py
+++ b/frigate/record.py
@@ -99,12 +99,15 @@ class RecordingMaintainer(threading.Thread):
         # delete all cached files past the most recent 5
         keep_count = 5
         for camera in grouped_recordings.keys():
-            if len(grouped_recordings[camera]) > keep_count:
+            segment_count = len(grouped_recordings[camera])
+            if segment_count > keep_count:
+                logger.warning(f"Too many recording segments in cache for {camera}. Keeping the {keep_count} most recent segments out of {segment_count}, discarding the rest...")
                 to_remove = grouped_recordings[camera][:-keep_count]
                 for f in to_remove:
-                    logger.warning(f"Discarding a recording segment: {f}")
-                    Path(f["cache_path"]).unlink(missing_ok=True)
-                    self.end_time_cache.pop(f["cache_path"], None)
+                    cache_path = f["cache_path"]
+                    logger.warning(f"Discarding a recording segment: {cache_path}")
+                    Path(cache_path).unlink(missing_ok=True)
+                    self.end_time_cache.pop(cache_path, None)
                 grouped_recordings[camera] = grouped_recordings[camera][-keep_count:]
 
         for camera, recordings in grouped_recordings.items():


### PR DESCRIPTION
Currently Frigate silently discards recording segments in cache if there's more than "keep_count" for a camera.
This was happening on my system because it had a high load and was being slow to process the segments (copy segment and commit to the database).

I noticed when watching recordings that there was missing segments of video at random times, but I had no idea why because the segments were being discarded silently (even when logging set to debug).

This PR adds a warning log entry when discarding segments (in the same way as discarding corrupted segments) to aid troubleshooting.