### PR TITLE
docker: Enable VAAPI on aarch64

### DIFF
--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -5,6 +5,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install packages for apt repo
 RUN apt-get -qq update \
     && apt-get -qq install --no-install-recommends -y \
+    # VAAPI drivers for Intel hardware accel
+    libva-drm2 libva2 vainfo mesa-vdpau-drivers mesa-va-drivers mesa-vdpau-drivers libdrm-radeon1 \
     # ffmpeg runtime dependencies
     libgomp1 \
     # runtime dependencies

--- a/docker/Dockerfile.ffmpeg.aarch64
+++ b/docker/Dockerfile.ffmpeg.aarch64
@@ -79,6 +79,7 @@ RUN     buildDeps="autoconf \
         python \
         libssl-dev \
         yasm \
+        libva-dev \
         linux-headers-raspi2 \
         libomxil-bellagio-dev \
         zlib1g-dev" && \
@@ -444,6 +445,7 @@ RUN \
         --enable-libkvazaar \
         --enable-libaom \
         --extra-libs=-lpthread \
+        --enable-vaapi \
         --enable-rkmpp \
         --enable-libdrm \
         # --enable-omx \
@@ -482,5 +484,10 @@ CMD         ["--help"]
 ENTRYPOINT  ["ffmpeg"]
 
 COPY --from=build /usr/local /usr/local/
+
+RUN \
+        apt-get update -y && \
+        apt-get install -y --no-install-recommends libva-drm2 libva2 mesa-va-drivers && \
+        rm -rf /var/lib/apt/lists/*
 
 # Run ffmpeg with -c:v h264_v4l2m2m to enable HW accell for decoding on raspberry pi4 64-bit

--- a/docker/Dockerfile.ffmpeg.aarch64
+++ b/docker/Dockerfile.ffmpeg.aarch64
@@ -394,15 +394,6 @@ RUN \
         rm -rf ${DIR}
 
 
-RUN \
-        DIR=/tmp/rkmpp && \
-        mkdir -p ${DIR} && \
-        cd ${DIR} && \
-        git clone https://github.com/rockchip-linux/libdrm-rockchip && git clone https://github.com/rockchip-linux/mpp && \
-        cd libdrm-rockchip && bash autogen.sh && ./configure && make && make install && \
-        cd ../mpp && cmake -DRKPLATFORM=ON -DHAVE_DRM=ON && make -j6 && make install && \
-        rm -rf ${DIR}
-
 ## ffmpeg https://ffmpeg.org/
 RUN  \
         DIR=/tmp/ffmpeg && mkdir -p ${DIR} && cd ${DIR} && \
@@ -446,8 +437,6 @@ RUN \
         --enable-libaom \
         --extra-libs=-lpthread \
         --enable-vaapi \
-        --enable-rkmpp \
-        --enable-libdrm \
         # --enable-omx \
         # --enable-omx-rpi \
         # --enable-mmal \


### PR DESCRIPTION
I'm using Arm servers with PCIe slots and so have an AMD card (Firepro) available.

This gives me proper VAAPI (as confirmed by vainfo) but it's not available in Frigate because the aarch64 Docker container is lacking VAAPI support.

While adding this I also noticed that the Docker containers don't currently build due to libdrm-rockchip not being a thing anymore? (Github repo is completely gone). So I had to fix that up too.