### PR TITLE
docker: Enable IPv6 support in nginx

### DIFF
--- a/docker/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/rootfs/usr/local/nginx/conf/nginx.conf
@@ -45,7 +45,7 @@ http {
     }
 
     server {
-        listen 5000;
+        listen [::]:5000;
 
         # vod settings
         vod_base_url '';
@@ -207,7 +207,7 @@ http {
 
 rtmp {
     server {
-        listen 1935;
+        listen [::]:1935;
         chunk_size 4096;
         allow publish 127.0.0.1;
         deny publish all;


### PR DESCRIPTION
This adds IPv6 support to the nginx configuration as was required for things to work properly here in a dual-stack environment.