### PR TITLE
docker: Add VAAPI to arm64

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,6 +89,10 @@ RUN apt-get -qq update \
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
     mesa-va-drivers intel-media-va-driver-non-free; \
     fi \
+    && if [ "${TARGETARCH}" = "arm64" ]; then \
+    apt-get -qq install --no-install-recommends --no-install-suggests -y \
+    libva-drm2 mesa-va-drivers; \
+    fi \
     # not sure why 32bit arm requires all these
     && if [ "${TARGETARCH}" = "arm" ]; then \
     apt-get -qq install --no-install-recommends --no-install-suggests -y \


### PR DESCRIPTION
This adds the needed bits for VAAPI to be available on arm64.

Worth noting that the current jellyfin build does not include vaapi support, so I'm currently running with an alternate build of it which is then mapped directly to /usr/lib/jellyfin-ffmpeg. This works fine for now until I can convince the jellyfin folks to build with --enable-vaapi too :)