### PR TITLE
Show area size on event screen

### DIFF
--- a/web/src/routes/Event.jsx
+++ b/web/src/routes/Event.jsx
@@ -162,6 +162,10 @@ export default function Event({ eventId, close, scrollRef }) {
                 <Td>Score</Td>
                 <Td>{(data.top_score * 100).toFixed(2)}%</Td>
               </Tr>
+              <Tr>
+               <Td>Area</Td>
+               <Td>{(data.area)}%</Td>
+             </Tr>
               <Tr index={1}>
                 <Td>Zones</Td>
                 <Td>{data.zones.join(', ')}</Td>


### PR DESCRIPTION
It is useful to know area to fine tune object size. Some event screenshots displayed cropped without area size