### PR TITLE
Adding configuration example for retain modes

### DIFF
--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -42,3 +42,16 @@ The same options are available with events. Let's consider a scenario where you 
 - With the `all` option all segments for the duration of the event would be saved for the event. This event would have 4 hours of footage.
 - With the `motion` option all segments for the duration of the event with motion would be saved. This means any segment where a car drove by in the street, person walked by, lighting changed, etc. would be saved. 
 - With the `active_objects` it would only keep segments where the object was active. In this case the only segments that would be saved would be the ones where the car was driving up, you going inside, you coming outside, and the car driving away. Essentially reducing the 4 hours to a minute or two of event footage. 
+
+A configration example of the above retain modes where `motion` is stored for 7 days and `active objects` are store for 14 would be as follows:
+```yaml
+record:
+  enabled: True
+  retain:
+    days: 7
+    mode: motion
+  events:
+    retain:
+      default: 14
+      mode: active_objects
+```

--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -43,7 +43,7 @@ The same options are available with events. Let's consider a scenario where you 
 - With the `motion` option all segments for the duration of the event with motion would be saved. This means any segment where a car drove by in the street, person walked by, lighting changed, etc. would be saved. 
 - With the `active_objects` it would only keep segments where the object was active. In this case the only segments that would be saved would be the ones where the car was driving up, you going inside, you coming outside, and the car driving away. Essentially reducing the 4 hours to a minute or two of event footage. 
 
-A configration example of the above retain modes where all `motion` segments are stored for 7 days and `active objects` are stored for 14 days would be as follows:
+A configuration example of the above retain modes where all `motion` segments are stored for 7 days and `active objects` are stored for 14 days would be as follows:
 ```yaml
 record:
   enabled: True

--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -57,7 +57,9 @@ record:
 ```
 The above configuration example can be added globally or on a per camera basis.
 
-You can also set specific retention length for each object type. The below configuration example builds on from above but also specifies that recordings of dogs only need to be kept for 2 days and recordings of cars should be kept for 7 days.
+### Object Specific Retention
+
+You can also set specific retention length for an object type. The below configuration example builds on from above but also specifies that recordings of dogs only need to be kept for 2 days and recordings of cars should be kept for 7 days.
 ```yaml
 record:
   enabled: True

--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -43,7 +43,7 @@ The same options are available with events. Let's consider a scenario where you 
 - With the `motion` option all segments for the duration of the event with motion would be saved. This means any segment where a car drove by in the street, person walked by, lighting changed, etc. would be saved. 
 - With the `active_objects` it would only keep segments where the object was active. In this case the only segments that would be saved would be the ones where the car was driving up, you going inside, you coming outside, and the car driving away. Essentially reducing the 4 hours to a minute or two of event footage. 
 
-A configration example of the above retain modes where `motion` is stored for 7 days and `active objects` are store for 14 would be as follows:
+A configration example of the above retain modes where all `motion` segments are stored for 7 days and `active objects` are stored for 14 days would be as follows:
 ```yaml
 record:
   enabled: True
@@ -54,4 +54,21 @@ record:
     retain:
       default: 14
       mode: active_objects
+```
+The above configuration example can be added globally or on a per camera basis.
+
+You can also set specific retention length for each object type. The below configuration example builds on from above but also specifies that recordings of dogs only need to be kept for 2 days and recordings of cars should be kept for 7 days.
+```yaml
+record:
+  enabled: True
+  retain:
+    days: 7
+    mode: motion
+  events:
+    retain:
+      default: 14
+      mode: active_objects
+      objects:
+        dog: 2
+        car: 7
 ```


### PR DESCRIPTION
Reading this page of the documentation on its own didn't help me understand how to configure my Frigate instance. But when I found https://github.com/blakeblackshear/frigate/discussions/2447, I was able to understand how to add it to my configuration. I've added the example given in that discussion to help future readers of the page.

I myself am still not 100% confident with the configuration setup - If possible it may be worth someone helping to also add the `all` option into the configuration example if that's possible? eg. `all` retained for 1 day, `motion` for 7 and `active_objects` for 14?
Would it worth adding object retention examples here too? eg.
```
record:
  events:
    retain:
      default: 14
      mode: all
      objects:
        person: 30
        car: 14
```
And my PR is for the global configuration, I can't seem to find an example of camera specific retention unfortunately so haven't added that.