### PR TITLE
Object Detector Abstraction

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -3,6 +3,7 @@ from statistics import mean
 import multiprocessing as mp
 import numpy as np
 import datetime
+from frigate.config import DetectorTypeEnum
 from frigate.object_detection import (
     LocalObjectDetector,
     ObjectDetectProcess,
@@ -81,8 +82,12 @@ events = {}
 for x in range(0, 10):
     events[str(x)] = mp.Event()
 detection_queue = mp.Queue()
-edgetpu_process_1 = ObjectDetectProcess(detection_queue, events, "usb:0")
-edgetpu_process_2 = ObjectDetectProcess(detection_queue, events, "usb:1")
+edgetpu_process_1 = ObjectDetectProcess(
+    detection_queue, events, DetectorTypeEnum.edgetpu, "usb:0"
+)
+edgetpu_process_2 = ObjectDetectProcess(
+    detection_queue, events, DetectorTypeEnum.edgetpu, "usb:1"
+)
 
 for x in range(0, 10):
     camera_process = mp.Process(

--- a/benchmark.py
+++ b/benchmark.py
@@ -3,10 +3,15 @@ from statistics import mean
 import multiprocessing as mp
 import numpy as np
 import datetime
-from frigate.edgetpu import LocalObjectDetector, EdgeTPUProcess, RemoteObjectDetector, load_labels
+from frigate.object_detection import (
+    LocalObjectDetector,
+    ObjectDetectProcess,
+    RemoteObjectDetector,
+    load_labels,
+)
 
-my_frame = np.expand_dims(np.full((300,300,3), 1, np.uint8), axis=0)
-labels = load_labels('/labelmap.txt')
+my_frame = np.expand_dims(np.full((300, 300, 3), 1, np.uint8), axis=0)
+labels = load_labels("/labelmap.txt")
 
 ######
 # Minimal same process runner
@@ -39,20 +44,23 @@ labels = load_labels('/labelmap.txt')
 
 
 def start(id, num_detections, detection_queue, event):
-  object_detector = RemoteObjectDetector(str(id), '/labelmap.txt', detection_queue, event)
-  start = datetime.datetime.now().timestamp()
+    object_detector = RemoteObjectDetector(
+        str(id), "/labelmap.txt", detection_queue, event
+    )
+    start = datetime.datetime.now().timestamp()
 
-  frame_times = []
-  for x in range(0, num_detections):
-    start_frame = datetime.datetime.now().timestamp()
-    detections = object_detector.detect(my_frame)
-    frame_times.append(datetime.datetime.now().timestamp()-start_frame)
+    frame_times = []
+    for x in range(0, num_detections):
+        start_frame = datetime.datetime.now().timestamp()
+        detections = object_detector.detect(my_frame)
+        frame_times.append(datetime.datetime.now().timestamp() - start_frame)
 
-  duration = datetime.datetime.now().timestamp()-start
-  object_detector.cleanup()
-  print(f"{id} - Processed for {duration:.2f} seconds.")
-  print(f"{id} - FPS: {object_detector.fps.eps():.2f}")
-  print(f"{id} - Average frame processing time: {mean(frame_times)*1000:.2f}ms")
+    duration = datetime.datetime.now().timestamp() - start
+    object_detector.cleanup()
+    print(f"{id} - Processed for {duration:.2f} seconds.")
+    print(f"{id} - FPS: {object_detector.fps.eps():.2f}")
+    print(f"{id} - Average frame processing time: {mean(frame_times)*1000:.2f}ms")
+
 
 ######
 # Separate process runner
@@ -71,23 +79,25 @@ camera_processes = []
 
 events = {}
 for x in range(0, 10):
-  events[str(x)] = mp.Event()
+    events[str(x)] = mp.Event()
 detection_queue = mp.Queue()
-edgetpu_process_1 = EdgeTPUProcess(detection_queue, events, 'usb:0')
-edgetpu_process_2 = EdgeTPUProcess(detection_queue, events, 'usb:1')
+edgetpu_process_1 = ObjectDetectProcess(detection_queue, events, "usb:0")
+edgetpu_process_2 = ObjectDetectProcess(detection_queue, events, "usb:1")
 
 for x in range(0, 10):
-  camera_process = mp.Process(target=start, args=(x, 300, detection_queue, events[str(x)]))
-  camera_process.daemon = True
-  camera_processes.append(camera_process)
+    camera_process = mp.Process(
+        target=start, args=(x, 300, detection_queue, events[str(x)])
+    )
+    camera_process.daemon = True
+    camera_processes.append(camera_process)
 
 start_time = datetime.datetime.now().timestamp()
 
 for p in camera_processes:
-  p.start()
+    p.start()
 
 for p in camera_processes:
-  p.join()
+    p.join()
 
-duration = datetime.datetime.now().timestamp()-start_time
+duration = datetime.datetime.now().timestamp() - start_time
 print(f"Total - Processed for {duration:.2f} seconds.")

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -23,7 +23,7 @@ Examples of available modules are:
 
 - `frigate.app`
 - `frigate.mqtt`
-- `frigate.edgetpu`
+- `frigate.object_detection`
 - `frigate.zeroconf`
 - `detector.<detector_name>`
 - `watchdog.<camera_name>`

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -61,7 +61,7 @@ Custom models may also require different input tensor formats. The colorspace co
 
 ```yaml
 model:
-  input_tensor: ["B", "H", "W", "C"]
+  input_tensor: "nhwc"
 ```
 
 The labelmap can be customized to your needs. A common reason to do this is to combine multiple object types that are easily confused when you don't need to be as granular such as car/truck. By default, truck is renamed to car because they are often confused. You cannot add new object types, but you can change the names of existing objects in the model.
@@ -85,6 +85,7 @@ Note that if you rename objects in the labelmap, you will also need to update yo
 Included with Frigate is a build of ffmpeg that works for the vast majority of users. However, there exists some hardware setups which have incompatibilities with the included build. In this case, a docker volume mapping can be used to overwrite the included ffmpeg build with an ffmpeg build that works for your specific hardware setup.
 
 To do this:
+
 1. Download your ffmpeg build and uncompress to a folder on the host (let's use `/home/appdata/frigate/custom-ffmpeg` for this example).
 2. Update your docker-compose or docker CLI to include `'/home/appdata/frigate/custom-ffmpeg':'/usr/lib/btbn-ffmpeg':'ro'` in the volume mappings.
 3. Restart frigate and the custom version will be used if the mapping was done correctly.

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -50,18 +50,28 @@ database:
 
 If using a custom model, the width and height will need to be specified.
 
-Custom models may also require different input tensor formats. The colorspace conversion supports RGB, BGR, or YUV frames to be sent to the object detector. The input tensor shape parameter is a list of axis to let the detector reorder (transpose) the standard layout [BHWC] to match what specified by the model.
+Custom models may also require different input tensor formats. The colorspace conversion supports RGB, BGR, or YUV frames to be sent to the object detector. The input tensor shape parameter is an enumeration to match what specified by the model.
 
 | Tensor Dimension | Description    |
 | :--------------: | -------------- |
-|        B         | Batch Size     |
+|        N         | Batch Size     |
 |        H         | Model Height   |
 |        W         | Model Width    |
 |        C         | Color Channels |
 
+| Available Input Tensor Shapes |
+| :---------------------------: |
+|            "nhwc"             |
+|            "nchw"             |
+
 ```yaml
+# Optional: model config
 model:
+  path: /path/to/model
+  width: 320
+  height: 320
   input_tensor: "nhwc"
+  input_pixel_format: "bgr"
 ```
 
 The labelmap can be customized to your needs. A common reason to do this is to combine multiple object types that are easily confused when you don't need to be as granular such as car/truck. By default, truck is renamed to car because they are often confused. You cannot add new object types, but you can change the names of existing objects in the model.

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -50,6 +50,20 @@ database:
 
 If using a custom model, the width and height will need to be specified.
 
+Custom models may also require different input tensor formats. The colorspace conversion supports RGB, BGR, or YUV frames to be sent to the object detector. The input tensor shape parameter is a list of axis to let the detector reorder (transpose) the standard layout [BHWC] to match what specified by the model.
+
+| Tensor Dimension | Description    |
+| :--------------: | -------------- |
+|        B         | Batch Size     |
+|        H         | Model Height   |
+|        W         | Model Width    |
+|        C         | Color Channels |
+
+```yaml
+model:
+  input_tensor: ["B", "H", "W", "C"]
+```
+
 The labelmap can be customized to your needs. A common reason to do this is to combine multiple object types that are easily confused when you don't need to be as granular such as car/truck. By default, truck is renamed to car because they are often confused. You cannot add new object types, but you can change the names of existing objects in the model.
 
 ```yaml

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -97,6 +97,11 @@ model:
   width: 320
   # Required: Object detection model input height (default: shown below)
   height: 320
+  # Optional: Object detection model input colorspace
+  # Valid values are rgb, bgr, or yuv. (default: shown below)
+  input_pixel_format: rgb
+  # Optional: Object detection model input tensor format (default: shown below)
+  input_tensor: ["B", "H", "W", "C"]
   # Optional: Label name modifications. These are merged into the standard labelmap.
   labelmap:
     2: vehicle

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -101,7 +101,7 @@ model:
   # Valid values are rgb, bgr, or yuv. (default: shown below)
   input_pixel_format: rgb
   # Optional: Object detection model input tensor format (default: shown below)
-  input_tensor: ["B", "H", "W", "C"]
+  input_tensor: "nhwc"
   # Optional: Label name modifications. These are merged into the standard labelmap.
   labelmap:
     2: vehicle

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -100,7 +100,8 @@ model:
   # Optional: Object detection model input colorspace
   # Valid values are rgb, bgr, or yuv. (default: shown below)
   input_pixel_format: rgb
-  # Optional: Object detection model input tensor format (default: shown below)
+  # Optional: Object detection model input tensor format
+  # Valid values are nhwc or nchw (default: shown below)
   input_tensor: "nhwc"
   # Optional: Label name modifications. These are merged into the standard labelmap.
   labelmap:

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -205,6 +205,7 @@ class FrigateApp:
                     self.detection_out_events,
                     model_path,
                     model_shape,
+                    detector.type,
                     "cpu",
                     detector.num_threads,
                 )
@@ -215,6 +216,7 @@ class FrigateApp:
                     self.detection_out_events,
                     model_path,
                     model_shape,
+                    detector.type,
                     detector.device,
                     detector.num_threads,
                 )

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -198,28 +198,16 @@ class FrigateApp:
             self.detection_shms.append(shm_out)
 
         for name, detector in self.config.detectors.items():
-            if detector.type == DetectorTypeEnum.cpu:
-                self.detectors[name] = ObjectDetectProcess(
-                    name,
-                    self.detection_queue,
-                    self.detection_out_events,
-                    model_path,
-                    model_shape,
-                    detector.type,
-                    "cpu",
-                    detector.num_threads,
-                )
-            if detector.type == DetectorTypeEnum.edgetpu:
-                self.detectors[name] = ObjectDetectProcess(
-                    name,
-                    self.detection_queue,
-                    self.detection_out_events,
-                    model_path,
-                    model_shape,
-                    detector.type,
-                    detector.device,
-                    detector.num_threads,
-                )
+            self.detectors[name] = ObjectDetectProcess(
+                name,
+                self.detection_queue,
+                self.detection_out_events,
+                model_path,
+                model_shape,
+                detector.type,
+                detector.device,
+                detector.num_threads,
+            )
 
     def start_detected_frames_processor(self) -> None:
         self.detected_frames_processor = TrackedObjectProcessor(

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -173,8 +173,6 @@ class FrigateApp:
         self.mqtt_relay.start()
 
     def start_detectors(self) -> None:
-        model_path = self.config.model.path
-        model_shape = (self.config.model.height, self.config.model.width)
         for name in self.config.cameras.keys():
             self.detection_out_events[name] = mp.Event()
 
@@ -202,8 +200,7 @@ class FrigateApp:
                 name,
                 self.detection_queue,
                 self.detection_out_events,
-                model_path,
-                model_shape,
+                self.config.model,
                 detector.type,
                 detector.device,
                 detector.num_threads,
@@ -238,7 +235,6 @@ class FrigateApp:
         logger.info(f"Output process started: {output_processor.pid}")
 
     def start_camera_processors(self) -> None:
-        model_shape = (self.config.model.height, self.config.model.width)
         for name, config in self.config.cameras.items():
             camera_process = mp.Process(
                 target=track_camera,
@@ -246,7 +242,7 @@ class FrigateApp:
                 args=(
                     name,
                     config,
-                    model_shape,
+                    self.config.model,
                     self.config.model.merged_labelmap,
                     self.detection_queue,
                     self.detection_out_events[name],

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -687,6 +687,12 @@ class DatabaseConfig(FrigateBaseModel):
     )
 
 
+class PixelFormatEnum(str, Enum):
+    rgb = "rgb"
+    bgr = "bgr"
+    yuv = "yuv"
+
+
 class ModelConfig(FrigateBaseModel):
     path: Optional[str] = Field(title="Custom Object detection model path.")
     labelmap_path: Optional[str] = Field(title="Label map for custom object detector.")
@@ -694,6 +700,12 @@ class ModelConfig(FrigateBaseModel):
     height: int = Field(default=320, title="Object detection model input height.")
     labelmap: Dict[int, str] = Field(
         default_factory=dict, title="Labelmap customization."
+    )
+    input_tensor: List[str] = Field(
+        default=["B", "H", "W", "C"], title="Model Input Tensor Shape"
+    )
+    input_pixel_format: PixelFormatEnum = Field(
+        default=PixelFormatEnum.rgb, title="Model Input Pixel Color Format"
     )
     _merged_labelmap: Optional[Dict[int, str]] = PrivateAttr()
     _colormap: Dict[int, Tuple[int, int, int]] = PrivateAttr()

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -693,6 +693,11 @@ class PixelFormatEnum(str, Enum):
     yuv = "yuv"
 
 
+class InputTensorEnum(str, Enum):
+    nchw = "nchw"
+    nhwc = "nhwc"
+
+
 class ModelConfig(FrigateBaseModel):
     path: Optional[str] = Field(title="Custom Object detection model path.")
     labelmap_path: Optional[str] = Field(title="Label map for custom object detector.")
@@ -701,8 +706,8 @@ class ModelConfig(FrigateBaseModel):
     labelmap: Dict[int, str] = Field(
         default_factory=dict, title="Labelmap customization."
     )
-    input_tensor: List[str] = Field(
-        default=["B", "H", "W", "C"], title="Model Input Tensor Shape"
+    input_tensor: InputTensorEnum = Field(
+        default=InputTensorEnum.nhwc, title="Model Input Tensor Shape"
     )
     input_pixel_format: PixelFormatEnum = Field(
         default=PixelFormatEnum.rgb, title="Model Input Pixel Color Format"

--- a/frigate/detectors/cpu_tfl.py
+++ b/frigate/detectors/cpu_tfl.py
@@ -8,9 +8,9 @@ logger = logging.getLogger(__name__)
 
 
 class CpuTfl(DetectionApi):
-    def __init__(self, det_device=None, model_path=None, num_threads=3):
+    def __init__(self, det_device=None, model_config=None, num_threads=3):
         self.interpreter = tflite.Interpreter(
-            model_path=model_path or "/cpu_model.tflite", num_threads=num_threads
+            model_path=model_config.path or "/cpu_model.tflite", num_threads=num_threads
         )
 
         self.interpreter.allocate_tensors()

--- a/frigate/detectors/cpu_tfl.py
+++ b/frigate/detectors/cpu_tfl.py
@@ -1,0 +1,46 @@
+import logging
+import numpy as np
+
+from frigate.detectors.detection_api import DetectionApi
+import tflite_runtime.interpreter as tflite
+
+logger = logging.getLogger(__name__)
+
+
+class CpuTfl(DetectionApi):
+    def __init__(self, tf_device=None, model_path=None, num_threads=3):
+        self.interpreter = tflite.Interpreter(
+            model_path=model_path or "/cpu_model.tflite", num_threads=3
+        )
+
+        self.interpreter.allocate_tensors()
+
+        self.tensor_input_details = self.interpreter.get_input_details()
+        self.tensor_output_details = self.interpreter.get_output_details()
+
+    def detect_raw(self, tensor_input):
+        self.interpreter.set_tensor(self.tensor_input_details[0]["index"], tensor_input)
+        self.interpreter.invoke()
+
+        boxes = self.interpreter.tensor(self.tensor_output_details[0]["index"])()[0]
+        class_ids = self.interpreter.tensor(self.tensor_output_details[1]["index"])()[0]
+        scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[0]
+        count = int(
+            self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
+        )
+
+        detections = np.zeros((20, 6), np.float32)
+
+        for i in range(count):
+            if scores[i] < 0.4 or i == 20:
+                break
+            detections[i] = [
+                class_ids[i],
+                float(scores[i]),
+                boxes[i][0],
+                boxes[i][1],
+                boxes[i][2],
+                boxes[i][3],
+            ]
+
+        return detections

--- a/frigate/detectors/cpu_tfl.py
+++ b/frigate/detectors/cpu_tfl.py
@@ -8,9 +8,9 @@ logger = logging.getLogger(__name__)
 
 
 class CpuTfl(DetectionApi):
-    def __init__(self, tf_device=None, model_path=None, num_threads=3):
+    def __init__(self, det_device=None, model_path=None, num_threads=3):
         self.interpreter = tflite.Interpreter(
-            model_path=model_path or "/cpu_model.tflite", num_threads=3
+            model_path=model_path or "/cpu_model.tflite", num_threads=num_threads
         )
 
         self.interpreter.allocate_tensors()

--- a/frigate/detectors/detection_api.py
+++ b/frigate/detectors/detection_api.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class DetectionApi(ABC):
     @abstractmethod
-    def __init__(self, tf_device=None, model_path=None):
+    def __init__(self, det_device=None, model_path=None):
         pass
 
     @abstractmethod

--- a/frigate/detectors/detection_api.py
+++ b/frigate/detectors/detection_api.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class DetectionApi(ABC):
     @abstractmethod
-    def __init__(self, det_device=None, model_path=None):
+    def __init__(self, det_device=None, model_config=None):
         pass
 
     @abstractmethod

--- a/frigate/detectors/detection_api.py
+++ b/frigate/detectors/detection_api.py
@@ -1,0 +1,17 @@
+import logging
+
+from abc import ABC, abstractmethod
+from typing import Dict
+
+
+logger = logging.getLogger(__name__)
+
+
+class DetectionApi(ABC):
+    @abstractmethod
+    def __init__(self, tf_device=None, model_path=None):
+        pass
+
+    @abstractmethod
+    def detect_raw(self, tensor_input):
+        pass

--- a/frigate/detectors/edgetpu_tfl.py
+++ b/frigate/detectors/edgetpu_tfl.py
@@ -9,10 +9,10 @@ logger = logging.getLogger(__name__)
 
 
 class EdgeTpuTfl(DetectionApi):
-    def __init__(self, tf_device=None, model_path=None):
+    def __init__(self, det_device=None, model_path=None):
         device_config = {"device": "usb"}
-        if not tf_device is None:
-            device_config = {"device": tf_device}
+        if not det_device is None:
+            device_config = {"device": det_device}
 
         edge_tpu_delegate = None
 

--- a/frigate/detectors/edgetpu_tfl.py
+++ b/frigate/detectors/edgetpu_tfl.py
@@ -1,0 +1,63 @@
+import logging
+import numpy as np
+
+from frigate.detectors.detection_api import DetectionApi
+import tflite_runtime.interpreter as tflite
+from tflite_runtime.interpreter import load_delegate
+
+logger = logging.getLogger(__name__)
+
+
+class EdgeTpuTfl(DetectionApi):
+    def __init__(self, tf_device=None, model_path=None):
+        device_config = {"device": "usb"}
+        if not tf_device is None:
+            device_config = {"device": tf_device}
+
+        edge_tpu_delegate = None
+
+        try:
+            logger.info(f"Attempting to load TPU as {device_config['device']}")
+            edge_tpu_delegate = load_delegate("libedgetpu.so.1.0", device_config)
+            logger.info("TPU found")
+            self.interpreter = tflite.Interpreter(
+                model_path=model_path or "/edgetpu_model.tflite",
+                experimental_delegates=[edge_tpu_delegate],
+            )
+        except ValueError:
+            logger.error(
+                "No EdgeTPU was detected. If you do not have a Coral device yet, you must configure CPU detectors."
+            )
+            raise
+
+        self.interpreter.allocate_tensors()
+
+        self.tensor_input_details = self.interpreter.get_input_details()
+        self.tensor_output_details = self.interpreter.get_output_details()
+
+    def detect_raw(self, tensor_input):
+        self.interpreter.set_tensor(self.tensor_input_details[0]["index"], tensor_input)
+        self.interpreter.invoke()
+
+        boxes = self.interpreter.tensor(self.tensor_output_details[0]["index"])()[0]
+        class_ids = self.interpreter.tensor(self.tensor_output_details[1]["index"])()[0]
+        scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[0]
+        count = int(
+            self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
+        )
+
+        detections = np.zeros((20, 6), np.float32)
+
+        for i in range(count):
+            if scores[i] < 0.4 or i == 20:
+                break
+            detections[i] = [
+                class_ids[i],
+                float(scores[i]),
+                boxes[i][0],
+                boxes[i][1],
+                boxes[i][2],
+                boxes[i][3],
+            ]
+
+        return detections

--- a/frigate/detectors/edgetpu_tfl.py
+++ b/frigate/detectors/edgetpu_tfl.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class EdgeTpuTfl(DetectionApi):
-    def __init__(self, det_device=None, model_path=None):
+    def __init__(self, det_device=None, model_config=None):
         device_config = {"device": "usb"}
         if not det_device is None:
             device_config = {"device": det_device}
@@ -21,7 +21,7 @@ class EdgeTpuTfl(DetectionApi):
             edge_tpu_delegate = load_delegate("libedgetpu.so.1.0", device_config)
             logger.info("TPU found")
             self.interpreter = tflite.Interpreter(
-                model_path=model_path or "/edgetpu_model.tflite",
+                model_path=model_config.path or "/edgetpu_model.tflite",
                 experimental_delegates=[edge_tpu_delegate],
             )
         except ValueError:

--- a/frigate/object_detection.py
+++ b/frigate/object_detection.py
@@ -41,12 +41,12 @@ class LocalObjectDetector(ObjectDetector):
             self.labels = load_labels(labels)
 
         if det_type == DetectorTypeEnum.edgetpu:
-            self.detectApi = EdgeTpuTfl(det_device=det_device, model_path=model_path)
+            self.detect_api = EdgeTpuTfl(det_device=det_device, model_path=model_path)
         else:
             logger.warning(
                 "CPU detectors are not recommended and should only be used for testing or for trial purposes."
             )
-            self.detectApi = CpuTfl(model_path=model_path, num_threads=num_threads)
+            self.detect_api = CpuTfl(model_path=model_path, num_threads=num_threads)
 
     def detect(self, tensor_input, threshold=0.4):
         detections = []
@@ -63,7 +63,7 @@ class LocalObjectDetector(ObjectDetector):
         return detections
 
     def detect_raw(self, tensor_input):
-        return self.detectApi.detect_raw(tensor_input=tensor_input)
+        return self.detect_api.detect_raw(tensor_input=tensor_input)
 
 
 def run_detector(

--- a/frigate/object_detection.py
+++ b/frigate/object_detection.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 from setproctitle import setproctitle
 
-from frigate.config import DetectorTypeEnum
+from frigate.config import DetectorTypeEnum, InputTensorEnum
 from frigate.detectors.edgetpu_tfl import EdgeTpuTfl
 from frigate.detectors.cpu_tfl import CpuTfl
 
@@ -27,14 +27,10 @@ class ObjectDetector(ABC):
 
 def tensor_transform(desired_shape):
     # Currently this function only supports BHWC permutations
-    if desired_shape == ["B", "H", "W", "C"]:
+    if desired_shape == InputTensorEnum.nhwc:
         return None
-    else:
-        transform = [0] * 4
-        transform[desired_shape.index("H")] = 1
-        transform[desired_shape.index("W")] = 2
-        transform[desired_shape.index("C")] = 3
-        return tuple(transform)
+    elif desired_shape == InputTensorEnum.nchw:
+        return (0, 3, 1, 2)
 
 
 class LocalObjectDetector(ObjectDetector):

--- a/frigate/object_detection.py
+++ b/frigate/object_detection.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 from setproctitle import setproctitle
+
 from frigate.config import DetectorTypeEnum
 from frigate.detectors.edgetpu_tfl import EdgeTpuTfl
 from frigate.detectors.cpu_tfl import CpuTfl

--- a/frigate/stats.py
+++ b/frigate/stats.py
@@ -14,7 +14,7 @@ from frigate.config import FrigateConfig
 from frigate.const import RECORD_DIR, CLIPS_DIR, CACHE_DIR
 from frigate.types import StatsTrackingTypes, CameraMetricsTypes
 from frigate.version import VERSION
-from frigate.edgetpu import EdgeTPUProcess
+from frigate.object_detection import ObjectDetectProcess
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,8 @@ def get_latest_version() -> str:
 
 
 def stats_init(
-    camera_metrics: dict[str, CameraMetricsTypes], detectors: dict[str, EdgeTPUProcess]
+    camera_metrics: dict[str, CameraMetricsTypes],
+    detectors: dict[str, ObjectDetectProcess],
 ) -> StatsTrackingTypes:
     stats_tracking: StatsTrackingTypes = {
         "camera_metrics": camera_metrics,

--- a/frigate/test/test_object_detector.py
+++ b/frigate/test/test_object_detector.py
@@ -1,0 +1,94 @@
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+from frigate.config import DetectorTypeEnum
+import frigate.object_detection
+
+
+class TestLocalObjectDetector(unittest.TestCase):
+    @patch("frigate.object_detection.EdgeTpuTfl")
+    @patch("frigate.object_detection.CpuTfl")
+    def test_localdetectorprocess_given_type_cpu_should_call_cputfl_init(
+        self, mock_cputfl, mock_edgetputfl
+    ):
+        test_obj = frigate.object_detection.LocalObjectDetector(
+            det_type=DetectorTypeEnum.cpu, model_path="/test/modelpath", num_threads=6
+        )
+
+        assert test_obj is not None
+        mock_edgetputfl.assert_not_called()
+        mock_cputfl.assert_called_once_with(model_path="/test/modelpath", num_threads=6)
+
+    @patch("frigate.object_detection.EdgeTpuTfl")
+    @patch("frigate.object_detection.CpuTfl")
+    def test_localdetectorprocess_given_type_edgtpu_should_call_edgtpu_init(
+        self, mock_cputfl, mock_edgetputfl
+    ):
+        test_obj = frigate.object_detection.LocalObjectDetector(
+            det_type=DetectorTypeEnum.edgetpu,
+            det_device="usb",
+            model_path="/test/modelpath",
+        )
+
+        assert test_obj is not None
+        mock_cputfl.assert_not_called()
+        mock_edgetputfl.assert_called_once_with(
+            det_device="usb", model_path="/test/modelpath"
+        )
+
+    @patch("frigate.object_detection.CpuTfl")
+    def test_detect_raw_given_tensor_input_should_return_api_detect_raw_result(
+        self, mock_cputfl
+    ):
+        TEST_DATA = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        TEST_DETECT_RESULT = np.ndarray([1, 2, 4, 8, 16, 32])
+        test_obj_detect = frigate.object_detection.LocalObjectDetector(
+            det_device=DetectorTypeEnum.cpu
+        )
+
+        mock_det_api = mock_cputfl.return_value
+        mock_det_api.detect_raw.return_value = TEST_DETECT_RESULT
+
+        test_result = test_obj_detect.detect_raw(TEST_DATA)
+
+        mock_det_api.detect_raw.assert_called_once_with(tensor_input=TEST_DATA)
+        assert test_result is mock_det_api.detect_raw.return_value
+
+    @patch("frigate.object_detection.CpuTfl")
+    @patch("frigate.object_detection.load_labels")
+    def test_detect_given_tensor_input_should_return_lfiltered_detections(
+        self, mock_load_labels, mock_cputfl
+    ):
+        TEST_DATA = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        TEST_DETECT_RAW = [
+            [2, 0.9, 5, 4, 3, 2],
+            [1, 0.5, 8, 7, 6, 5],
+            [0, 0.4, 2, 4, 8, 16],
+        ]
+        TEST_DETECT_RESULT = [
+            ("label-3", 0.9, (5, 4, 3, 2)),
+            ("label-2", 0.5, (8, 7, 6, 5)),
+        ]
+        TEST_LABEL_FILE = "/test_labels.txt"
+        mock_load_labels.return_value = [
+            "label-1",
+            "label-2",
+            "label-3",
+            "label-4",
+            "label-5",
+        ]
+
+        test_obj_detect = frigate.object_detection.LocalObjectDetector(
+            det_device=DetectorTypeEnum.cpu, labels=TEST_LABEL_FILE
+        )
+
+        mock_load_labels.assert_called_once_with(TEST_LABEL_FILE)
+
+        mock_det_api = mock_cputfl.return_value
+        mock_det_api.detect_raw.return_value = TEST_DETECT_RAW
+
+        test_result = test_obj_detect.detect(tensor_input=TEST_DATA, threshold=0.5)
+
+        mock_det_api.detect_raw.assert_called_once_with(tensor_input=TEST_DATA)
+        assert test_result == TEST_DETECT_RESULT

--- a/frigate/test/test_object_detector.py
+++ b/frigate/test/test_object_detector.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 
 import numpy as np
-from frigate.config import DetectorTypeEnum
+from frigate.config import DetectorTypeEnum, ModelConfig
 import frigate.object_detection
 
 
@@ -12,30 +12,33 @@ class TestLocalObjectDetector(unittest.TestCase):
     def test_localdetectorprocess_given_type_cpu_should_call_cputfl_init(
         self, mock_cputfl, mock_edgetputfl
     ):
+        test_cfg = ModelConfig()
+        test_cfg.path = "/test/modelpath"
         test_obj = frigate.object_detection.LocalObjectDetector(
-            det_type=DetectorTypeEnum.cpu, model_path="/test/modelpath", num_threads=6
+            det_type=DetectorTypeEnum.cpu, model_config=test_cfg, num_threads=6
         )
 
         assert test_obj is not None
         mock_edgetputfl.assert_not_called()
-        mock_cputfl.assert_called_once_with(model_path="/test/modelpath", num_threads=6)
+        mock_cputfl.assert_called_once_with(model_config=test_cfg, num_threads=6)
 
     @patch("frigate.object_detection.EdgeTpuTfl")
     @patch("frigate.object_detection.CpuTfl")
     def test_localdetectorprocess_given_type_edgtpu_should_call_edgtpu_init(
         self, mock_cputfl, mock_edgetputfl
     ):
+        test_cfg = ModelConfig()
+        test_cfg.path = "/test/modelpath"
+
         test_obj = frigate.object_detection.LocalObjectDetector(
             det_type=DetectorTypeEnum.edgetpu,
             det_device="usb",
-            model_path="/test/modelpath",
+            model_config=test_cfg,
         )
 
         assert test_obj is not None
         mock_cputfl.assert_not_called()
-        mock_edgetputfl.assert_called_once_with(
-            det_device="usb", model_path="/test/modelpath"
-        )
+        mock_edgetputfl.assert_called_once_with(det_device="usb", model_config=test_cfg)
 
     @patch("frigate.object_detection.CpuTfl")
     def test_detect_raw_given_tensor_input_should_return_api_detect_raw_result(

--- a/frigate/test/test_object_detector.py
+++ b/frigate/test/test_object_detector.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 
 import numpy as np
-from frigate.config import DetectorTypeEnum, ModelConfig
+from frigate.config import DetectorTypeEnum, InputTensorEnum, ModelConfig
 import frigate.object_detection
 
 
@@ -66,7 +66,7 @@ class TestLocalObjectDetector(unittest.TestCase):
         TEST_DETECT_RESULT = np.ndarray([1, 2, 4, 8, 16, 32])
 
         test_cfg = ModelConfig()
-        test_cfg.input_tensor = ["B", "C", "H", "W"]
+        test_cfg.input_tensor = InputTensorEnum.nchw
 
         test_obj_detect = frigate.object_detection.LocalObjectDetector(
             det_device=DetectorTypeEnum.cpu, model_config=test_cfg

--- a/frigate/types.py
+++ b/frigate/types.py
@@ -3,7 +3,7 @@ from multiprocessing.queues import Queue
 from multiprocessing.sharedctypes import Synchronized
 from multiprocessing.context import Process
 
-from frigate.edgetpu import EdgeTPUProcess
+from frigate.object_detection import ObjectDetectProcess
 
 
 class CameraMetricsTypes(TypedDict):
@@ -26,6 +26,6 @@ class CameraMetricsTypes(TypedDict):
 
 class StatsTrackingTypes(TypedDict):
     camera_metrics: dict[str, CameraMetricsTypes]
-    detectors: dict[str, EdgeTPUProcess]
+    detectors: dict[str, ObjectDetectProcess]
     started: int
     latest_frigate_version: str

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -479,6 +479,16 @@ def yuv_region_2_rgb(frame, region):
         raise
 
 
+def yuv_region_2_bgr(frame, region):
+    try:
+        yuv_cropped_frame = yuv_crop_and_resize(frame, region)
+        return cv2.cvtColor(yuv_cropped_frame, cv2.COLOR_YUV2BGR_I420)
+    except:
+        print(f"frame.shape: {frame.shape}")
+        print(f"region: {region}")
+        raise
+
+
 def intersection(box_a, box_b):
     return (
         max(box_a[0], box_b[0]),

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -11,11 +11,13 @@ import time
 from collections import defaultdict
 
 import numpy as np
-from cv2 import cv2, reduce
+import cv2
+
+# from cv2 import cv2, reduce
 from setproctitle import setproctitle
 
 from frigate.config import CameraConfig, DetectConfig
-from frigate.edgetpu import RemoteObjectDetector
+from frigate.object_detection import RemoteObjectDetector
 from frigate.log import LogPipe
 from frigate.motion import MotionDetector
 from frigate.objects import ObjectTracker

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -12,8 +12,6 @@ from collections import defaultdict
 
 import numpy as np
 import cv2
-
-# from cv2 import cv2, reduce
 from setproctitle import setproctitle
 
 from frigate.config import CameraConfig, DetectConfig

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -14,7 +14,7 @@ import numpy as np
 import cv2
 from setproctitle import setproctitle
 
-from frigate.config import CameraConfig, DetectConfig
+from frigate.config import CameraConfig, DetectConfig, PixelFormatEnum
 from frigate.object_detection import RemoteObjectDetector
 from frigate.log import LogPipe
 from frigate.motion import MotionDetector
@@ -29,7 +29,9 @@ from frigate.util import (
     intersection,
     intersection_over_union,
     listen,
+    yuv_crop_and_resize,
     yuv_region_2_rgb,
+    yuv_region_2_bgr,
 )
 
 logger = logging.getLogger(__name__)
@@ -89,13 +91,20 @@ def filtered(obj, objects_to_track, object_filters):
     return False
 
 
-def create_tensor_input(frame, model_shape, region):
-    cropped_frame = yuv_region_2_rgb(frame, region)
+def create_tensor_input(frame, model_config, region):
+    if model_config.input_pixel_format == PixelFormatEnum.rgb:
+        cropped_frame = yuv_region_2_rgb(frame, region)
+    elif model_config.input_pixel_format == PixelFormatEnum.bgr:
+        cropped_frame = yuv_region_2_bgr(frame, region)
+    else:
+        cropped_frame = yuv_crop_and_resize(frame, region)
 
-    # Resize to 300x300 if needed
-    if cropped_frame.shape != (model_shape[0], model_shape[1], 3):
+    # Resize if needed
+    if cropped_frame.shape != (model_config.height, model_config.width, 3):
         cropped_frame = cv2.resize(
-            cropped_frame, dsize=model_shape, interpolation=cv2.INTER_LINEAR
+            cropped_frame,
+            dsize=(model_config.height, model_config.width),
+            interpolation=cv2.INTER_LINEAR,
         )
 
     # Expand dimensions since the model expects images to have shape: [1, height, width, 3]
@@ -340,7 +349,7 @@ def capture_camera(name, config: CameraConfig, process_info):
 def track_camera(
     name,
     config: CameraConfig,
-    model_shape,
+    model_config,
     labelmap,
     detection_queue,
     result_connection,
@@ -378,7 +387,7 @@ def track_camera(
         motion_contour_area,
     )
     object_detector = RemoteObjectDetector(
-        name, labelmap, detection_queue, result_connection, model_shape
+        name, labelmap, detection_queue, result_connection, model_config
     )
 
     object_tracker = ObjectTracker(config.detect)
@@ -389,7 +398,7 @@ def track_camera(
         name,
         frame_queue,
         frame_shape,
-        model_shape,
+        model_config,
         config.detect,
         frame_manager,
         motion_detector,
@@ -443,12 +452,12 @@ def detect(
     detect_config: DetectConfig,
     object_detector,
     frame,
-    model_shape,
+    model_config,
     region,
     objects_to_track,
     object_filters,
 ):
-    tensor_input = create_tensor_input(frame, model_shape, region)
+    tensor_input = create_tensor_input(frame, model_config, region)
 
     detections = []
     region_detections = object_detector.detect(tensor_input)
@@ -487,7 +496,7 @@ def process_frames(
     camera_name: str,
     frame_queue: mp.Queue,
     frame_shape,
-    model_shape,
+    model_config,
     detect_config: DetectConfig,
     frame_manager: FrameManager,
     motion_detector: MotionDetector,
@@ -571,7 +580,7 @@ def process_frames(
             # combine motion boxes with known locations of existing objects
             combined_boxes = reduce_boxes(motion_boxes + tracked_object_boxes)
 
-            region_min_size = max(model_shape[0], model_shape[1])
+            region_min_size = max(model_config.height, model_config.width)
             # compute regions
             regions = [
                 calculate_region(
@@ -634,7 +643,7 @@ def process_frames(
                         detect_config,
                         object_detector,
                         frame,
-                        model_shape,
+                        model_config,
                         region,
                         objects_to_track,
                         object_filters,
@@ -694,7 +703,7 @@ def process_frames(
                                     detect_config,
                                     object_detector,
                                     frame,
-                                    model_shape,
+                                    model_config,
                                     region,
                                     objects_to_track,
                                     object_filters,

--- a/frigate/watchdog.py
+++ b/frigate/watchdog.py
@@ -5,7 +5,7 @@ import time
 import os
 import signal
 
-from frigate.edgetpu import EdgeTPUProcess
+from frigate.object_detection import ObjectDetectProcess
 from frigate.util import restart_frigate
 from multiprocessing.synchronize import Event
 
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class FrigateWatchdog(threading.Thread):
-    def __init__(self, detectors: dict[str, EdgeTPUProcess], stop_event: Event):
+    def __init__(self, detectors: dict[str, ObjectDetectProcess], stop_event: Event):
         threading.Thread.__init__(self)
         self.name = "frigate_watchdog"
         self.detectors = detectors

--- a/process_clip.py
+++ b/process_clip.py
@@ -16,7 +16,7 @@ import cv2
 import numpy as np
 
 from frigate.config import FrigateConfig
-from frigate.edgetpu import LocalObjectDetector
+from frigate.object_detection import LocalObjectDetector
 from frigate.motion import MotionDetector
 from frigate.object_processing import CameraState
 from frigate.objects import ObjectTracker

--- a/process_clip.py
+++ b/process_clip.py
@@ -117,13 +117,12 @@ class ProcessClip:
         detection_enabled = mp.Value("d", 1)
         motion_enabled = mp.Value("d", True)
         stop_event = mp.Event()
-        model_shape = (self.config.model.height, self.config.model.width)
 
         process_frames(
             self.camera_name,
             self.frame_queue,
             self.frame_shape,
-            model_shape,
+            self.config.model,
             self.camera_config.detect,
             self.frame_manager,
             motion_detector,


### PR DESCRIPTION
This is an initial change to abstract the edgtpu module to a more generic Object Detector.  The idea is to be able to add different inference runtimes into the Detectors folder, add a new DetectorTypeEnum, and an else-if in the LocalObjectDetector init function to setup the new detector type.

The object_detection module keeps the multi-process logic to run the detector asynchronously and apply the detection thresholds.  All the detector modules are required to do is setup the runtime, load the model, and process a tensor (detect_raw).

Future work to build on this:
- Add an OpenVino detector module
- Add a RKNPU/RKNN detector module
- Possibly add a config for a "plugin" folder that will be scanned at runtime for user-supplied detector implementations?
