### PR TITLE
Fix VOD issues with longer keyframe intervals

### DIFF
--- a/frigate/util.py
+++ b/frigate/util.py
@@ -697,8 +697,6 @@ def get_adjusted_offset(source: str, target_offset: int) -> int:
 
     This is used to pass information to the VOD module and is useful for codec variants
     with long or variable keyframe intervals."""
-    if target_offset == 0:
-        return 0
     ffprobe_cmd = [
         "ffprobe",
         "-skip_frame",

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -690,3 +690,37 @@ class SharedMemoryFrameManager(FrameManager):
             self.shm_store[name].close()
             self.shm_store[name].unlink()
             del self.shm_store[name]
+
+
+def get_keyframe_timestamps_and_adjusted_offset(
+    source: str, target_offset: int
+) -> tuple[list[int], int]:
+    """Get timestamp metadata from the source.
+
+    This is used to pass information to the VOD module and is useful for codec variants
+    with long or variable keyframe intervals.
+    Returns a tuple of: 1) the keyframe timestamp locations for this source
+                    and 2) the timestamp of the nearest keyframe before target_offset."""
+    ffprobe_cmd = [
+        "ffprobe",
+        "-skip_frame",
+        "nokey",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "frame=pts_time",
+        "-v",
+        "quiet",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        source,
+    ]
+    p = sp.run(ffprobe_cmd, capture_output=True)
+    keyframe_timestamps = [int(1000 * float(pts)) for pts in p.stdout.split()]
+    if target_offset == 0:
+        return keyframe_timestamps, 0
+    for ts in reversed(keyframe_timestamps):
+        if ts <= target_offset:
+            return keyframe_timestamps, ts
+    logger.warning("Couldn't find starting keyframe for VOD clip")
+    return keyframe_timestamps, 0

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -690,31 +690,3 @@ class SharedMemoryFrameManager(FrameManager):
             self.shm_store[name].close()
             self.shm_store[name].unlink()
             del self.shm_store[name]
-
-
-def get_adjusted_offset(source: str, target_offset: int) -> int:
-    """Get the timestamp of the nearest keyframe before target_offset.
-
-    This is used to pass information to the VOD module and is useful for codec variants
-    with long or variable keyframe intervals."""
-    ffprobe_cmd = [
-        "ffprobe",
-        "-skip_frame",
-        "nokey",
-        "-select_streams",
-        "v:0",
-        "-show_entries",
-        "frame=pts_time",
-        "-v",
-        "quiet",
-        "-of",
-        "default=noprint_wrappers=1:nokey=1",
-        source,
-    ]
-    p = sp.run(ffprobe_cmd, capture_output=True)
-    keyframe_timestamps = [int(1000 * float(pts)) for pts in p.stdout.split()]
-    for ts in reversed(keyframe_timestamps):
-        if ts <= target_offset:
-            return ts
-    logger.warning("Couldn't find starting keyframe for VOD clip")
-    return 0


### PR DESCRIPTION
When using keyframe intervals of a few seconds or longer, and especially when using the H264+/H265+ codec variants with very long keyframe intervals, the VOD segmentation breaks. There are 2 main issues:
1) The start of the event generally does not line up with a keyframe. The Kaltura VOD module starts from the _next_ keyframe, effectively shortening the clip, and making the duration calculation incorrect. This can be seen when comparing the VOD clip length (from `vod_ts()`) with the downloaded clip length (from `recording_clip()`)
2) When combining multiple clips, setting `vod_manifest_segment_durations_mode` to `accurate` does not work. This results in the manifest not matching the media. Also, the segmenting can often result in segments with no keyframes. These two problems will generally cause playback to fail.

This PR uses ffprobe to get the keyframe durations, fixing 1) by adjusting the offset to the previous keyframe and 2) by using the `keyFrameDurations` field to give the VOD module enough information to create working manifests/segments.