### PR TITLE
Handle spaces in labels

### DIFF
--- a/docker/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/rootfs/usr/local/nginx/conf/nginx.conf
@@ -172,10 +172,11 @@ http {
             proxy_set_header Host $host;
         }
 
-        location ~* /api/(.*\.(jpg|jpeg|png)$) {
+        location ~* /api/.*\.(jpg|jpeg|png)$ {
             add_header 'Access-Control-Allow-Origin' '*';
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
-            proxy_pass http://frigate_api/$1$is_args$args;
+            rewrite ^/api/(.*)$ $1 break;
+            proxy_pass http://frigate_api;
             proxy_pass_request_headers on;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -18,7 +18,6 @@ from flask import (
     Flask,
     Response,
     current_app,
-    g,
     jsonify,
     make_response,
     request,
@@ -35,11 +34,6 @@ from frigate.version import VERSION
 logger = logging.getLogger(__name__)
 
 bp = Blueprint("frigate", __name__)
-
-
-@bp.url_value_preprocessor
-def unquote_label(endpoint, values):
-    g.label = unquote(values.pop("label", ""))
 
 
 def create_app(
@@ -347,8 +341,9 @@ def event_thumbnail(id, max_cache_age=2592000):
 
 @bp.route("/<camera_name>/<label>/best.jpg")
 @bp.route("/<camera_name>/<label>/thumbnail.jpg")
-def label_thumbnail(camera_name):
-    if g.label == "any":
+def label_thumbnail(camera_name, label):
+    label = unquote(label)
+    if label == "any":
         event_query = (
             Event.select()
             .where(Event.camera == camera_name)
@@ -359,7 +354,7 @@ def label_thumbnail(camera_name):
         event_query = (
             Event.select()
             .where(Event.camera == camera_name)
-            .where(Event.label == g.label)
+            .where(Event.label == label)
             .where(Event.has_snapshot == True)
             .order_by(Event.start_time.desc())
         )
@@ -430,8 +425,9 @@ def event_snapshot(id):
 
 
 @bp.route("/<camera_name>/<label>/snapshot.jpg")
-def label_snapshot(camera_name):
-    if g.label == "any":
+def label_snapshot(camera_name, label):
+    label = unquote(label)
+    if label == "any":
         event_query = (
             Event.select()
             .where(Event.camera == camera_name)
@@ -442,7 +438,7 @@ def label_snapshot(camera_name):
         event_query = (
             Event.select()
             .where(Event.camera == camera_name)
-            .where(Event.label == g.label)
+            .where(Event.label == label)
             .where(Event.has_snapshot == True)
             .order_by(Event.start_time.desc())
         )

--- a/web/src/routes/Camera.jsx
+++ b/web/src/routes/Camera.jsx
@@ -133,8 +133,8 @@ export default function Camera({ camera }) {
               className="mb-4 mr-4"
               key={objectType}
               header={objectType}
-              href={`/events?camera=${camera}&label=${objectType}`}
-              media={<img src={`${apiHost}/api/${camera}/${objectType}/thumbnail.jpg`} />}
+              href={`/events?camera=${camera}&label=${encodeURIComponent(objectType)}`}
+              media={<img src={`${apiHost}/api/${camera}/${encodeURIComponent(objectType)}/thumbnail.jpg`} />}
             />
           ))}
         </div>


### PR DESCRIPTION
Also use `camera_name` instead of `camera` in all routes for consistency.

Something like this should work for #3678, but I haven't tested this yet.