### PR TITLE
minor modifications to allow running directly on osx

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -270,7 +270,7 @@ class FrigateApp:
                 ),
             )
             camera_process.daemon = True
-            self.camera_metrics[name]["process"] = camera_process
+            self.camera_metrics[name]["process_pid"] = camera_process.pid
             camera_process.start()
             logger.info(f"Camera processor started for {name}: {camera_process.pid}")
 
@@ -282,7 +282,7 @@ class FrigateApp:
                 args=(name, config, self.camera_metrics[name]),
             )
             capture_process.daemon = True
-            self.camera_metrics[name]["capture_process"] = capture_process
+            self.camera_metrics[name]["capture_process_pid"] = capture_process.pid
             capture_process.start()
             logger.info(f"Capture process started for {name}: {capture_process.pid}")
 

--- a/frigate/edgetpu.py
+++ b/frigate/edgetpu.py
@@ -4,13 +4,17 @@ import multiprocessing as mp
 import os
 import queue
 import signal
+import sys
 import threading
 from abc import ABC, abstractmethod
 
 import numpy as np
-import tflite_runtime.interpreter as tflite
+if (sys.platform == "darwin"):
+    import tensorflow.lite as tflite
+else:
+    import tflite_runtime.interpreter as tflite
+    from tflite_runtime.interpreter import load_delegate
 from setproctitle import setproctitle
-from tflite_runtime.interpreter import load_delegate
 
 from frigate.util import EventsPerSecond, SharedMemoryFrameManager, listen, load_labels
 

--- a/frigate/stats.py
+++ b/frigate/stats.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 import threading
 import time
 import psutil
@@ -87,12 +88,9 @@ def stats_snapshot(stats_tracking: StatsTrackingTypes) -> dict[str, Any]:
 
     for name, camera_stats in camera_metrics.items():
         total_detection_fps += camera_stats["detection_fps"].value
-        pid = camera_stats["process"].pid if camera_stats["process"] else None
-        cpid = (
-            camera_stats["capture_process"].pid
-            if camera_stats["capture_process"]
-            else None
-        )
+        pid = camera_stats["process_pid"]
+        cpid = camera_stats["capture_process_pid"]
+
         stats[name] = {
             "camera_fps": round(camera_stats["camera_fps"].value, 2),
             "process_fps": round(camera_stats["process_fps"].value, 2),
@@ -121,6 +119,9 @@ def stats_snapshot(stats_tracking: StatsTrackingTypes) -> dict[str, Any]:
     }
 
     for path in [RECORD_DIR, CLIPS_DIR, CACHE_DIR, "/dev/shm"]:
+        if sys.platform == "darwin" and path == "/dev/shm": #osx doesn't have /dev/shm
+            continue
+
         storage_stats = shutil.disk_usage(path)
         stats["service"]["storage"][path] = {
             "total": round(storage_stats.total / 1000000, 1),

--- a/frigate/types.py
+++ b/frigate/types.py
@@ -8,7 +8,7 @@ from frigate.edgetpu import EdgeTPUProcess
 
 class CameraMetricsTypes(TypedDict):
     camera_fps: Synchronized
-    capture_process: Optional[Process]
+    capture_process_pid: Optional[int]
     detection_enabled: Synchronized
     detection_fps: Synchronized
     detection_frame: Synchronized
@@ -18,7 +18,7 @@ class CameraMetricsTypes(TypedDict):
     improve_contrast_enabled: Synchronized
     motion_threshold: Synchronized
     motion_contour_area: Synchronized
-    process: Optional[Process]
+    process_pid: Optional[int]
     process_fps: Synchronized
     read_start: Synchronized
     skipped_fps: Synchronized

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -11,7 +11,8 @@ import time
 from collections import defaultdict
 
 import numpy as np
-from cv2 import cv2, reduce
+import cv2
+from cv2 import reduce
 from setproctitle import setproctitle
 
 from frigate.config import CameraConfig, DetectConfig
@@ -165,7 +166,7 @@ def capture_frames(
         frame_name = f"{camera_name}{current_frame.value}"
         frame_buffer = frame_manager.create(frame_name, frame_size)
         try:
-            frame_buffer[:] = ffmpeg_process.stdout.read(frame_size)
+            frame_buffer[:frame_size] = ffmpeg_process.stdout.read(frame_size) #on osx frame_buffer isn't always the right size (ftruncate can make it larger)
         except Exception as e:
             logger.error(f"{camera_name}: Unable to read frames from ffmpeg process.")
 


### PR DESCRIPTION
Seeing some pretty great performance running the core directly on the mac so figured I would share my changes.  Can get 16 cpu detectors running at 30-40ms on my M1 pro, and allows ffmpeg to use hardware decoding.

I changed the camera metrics to only store the pid for the processes as that was all that was used. This is to work with spawn rather than fork (spawn is default on osx, and opencv was losing it's mind with fork for me)

ftruncate on osx doesn't always truncate as you would expect so I made a small change to ffmpeg buffer buffer

I added a check to ignore /dev/shm in stats on darwin