### PR TITLE
Set vod_ignore_edit_list option

### DIFF
--- a/docker/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/rootfs/usr/local/nginx/conf/nginx.conf
@@ -55,6 +55,7 @@ http {
         vod_upstream_location /api;
         vod_align_segments_to_key_frames on;
         vod_manifest_segment_durations_mode accurate;
+        vod_ignore_edit_list on;
 
         # vod caches
         vod_metadata_cache metadata_cache 512m;


### PR DESCRIPTION
Some vod clips may exhibit temporary freezing at segment boundaries. This seems to be due to edit lists altering the keyframe timestamps, resulting in some keyframes getting skipped.
Setting the vod_ignore_edit_list option corrects this behavior.