### PR TITLE
Recording: Bring playlist in front of video.js modals

### DIFF
--- a/web/src/components/RecordingPlaylist.jsx
+++ b/web/src/components/RecordingPlaylist.jsx
@@ -41,7 +41,7 @@ export default function RecordingPlaylist({ camera, recordings, selectedDate }) 
   const openClass = active ? '-left-6' : 'right-0';
 
   return (
-    <div className="flex absolute inset-y-0 right-0 w-9/12 md:w-1/2 lg:w-3/5 max-w-md text-base text-white font-sans">
+    <div className="flex absolute z-10 inset-y-0 right-0 w-9/12 md:w-1/2 lg:w-3/5 max-w-md text-base text-white font-sans">
       <div
         onClick={toggle}
         className={`absolute ${openClass} cursor-pointer items-center self-center rounded-tl-lg rounded-bl-lg border border-r-0 w-6 h-20 py-7 bg-gray-800 bg-opacity-70`}


### PR DESCRIPTION
Ensure that the recording playlist pane doesn't get covered by video.js error messages, preventing interaction. This currently happens whenever a video is unplayable, such as when trying to view h.265 content in a browser without support. The playlist is still useful to scroll through the recording history even if the videos don't play, and in cases where a single video file is corrupted, being able to interact with the playlist to select another file is essential.

A z-index of 2 seems to be sufficient to stack the playlist above the video.js modals, but the "z-10" utility class seemed like the easiest way to do it.

## Before
![recording-before](https://user-images.githubusercontent.com/27739622/188291543-5ebfee06-d0ab-4a99-9a49-35b6f2f78464.png)

## After
![recording-after](https://user-images.githubusercontent.com/27739622/188291542-da23beb1-22fc-46de-a44f-3ae979896529.png)
