### PR TITLE
Show snapshots on events page

### DIFF
--- a/web/src/components/Tabs.jsx
+++ b/web/src/components/Tabs.jsx
@@ -27,12 +27,14 @@ export function Tabs({ children, selectedIndex: selectedIndexProp, onChange, cla
   );
 }
 
-export function TextTab({ selected, text, onClick }) {
-  const selectedStyle = selected
-    ? 'text-white bg-blue-500 dark:text-black dark:bg-white'
-    : 'text-black dark:text-white bg-transparent';
+export function TextTab({ selected, text, onClick, disabled }) {
+  const selectedStyle = disabled
+    ? 'text-gray-400 dark:text-gray-600 bg-transparent'
+    : selected
+      ? 'text-white bg-blue-500 dark:text-black dark:bg-white'
+      : 'text-black dark:text-white bg-transparent';
   return (
-    <button onClick={onClick} className={`rounded-full px-4 py-2 ${selectedStyle}`}>
+    <button onClick={onClick} disabled={disabled} className={`rounded-full px-4 py-2 ${selectedStyle}`}>
       <span>{text}</span>
     </button>
   );

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -2,6 +2,7 @@ import { h, Fragment } from 'preact';
 import { route } from 'preact-router';
 import ActivityIndicator from '../components/ActivityIndicator';
 import Heading from '../components/Heading';
+import { Tabs, TextTab } from '../components/Tabs';
 import { useApiHost } from '../api';
 import useSWR from 'swr';
 import useSWRInfinite from 'swr/infinite';
@@ -54,6 +55,7 @@ export default function Events({ path, ...props }) {
   });
   const [uploading, setUploading] = useState([]);
   const [viewEvent, setViewEvent] = useState();
+  const [eventDetailType, setEventDetailType] = useState('clip');
   const [downloadEvent, setDownloadEvent] = useState({
     id: null,
     has_clip: false,
@@ -233,6 +235,10 @@ export default function Events({ path, ...props }) {
     if (state.showDownloadMenu && downloadEvent.id === id) {
       setState({ ...state, showDownloadMenu: false });
     }
+  };
+
+  const handleEventDetailTabChange = (index) => {
+    setEventDetailType(index == 0 ? 'clip' : 'image');
   };
 
   if (!config) {
@@ -495,9 +501,15 @@ export default function Events({ path, ...props }) {
                   {viewEvent !== event.id ? null : (
                     <div className="space-y-4">
                       <div className="mx-auto max-w-7xl">
-                        {event.has_clip ? (
-                          <>
-                            <Heading size="lg">Clip</Heading>
+                        <div className='flex justify-center w-full py-2'>
+                          <Tabs selectedIndex={event.has_clip && eventDetailType == 'clip' ? 0 : 1} onChange={handleEventDetailTabChange} className='justify'>
+                            <TextTab text='Clip' disabled={!event.has_clip} />
+                            <TextTab text={event.has_snapshot ? 'Snapshot' : 'Thumbnail'} />
+                          </Tabs>
+                        </div>
+
+                        <div>
+                          {((eventDetailType == 'clip') && event.has_clip) ? (
                             <VideoPlayer
                               options={{
                                 preload: 'auto',
@@ -512,23 +524,22 @@ export default function Events({ path, ...props }) {
                               seekOptions={{ forward: 10, back: 5 }}
                               onReady={() => {}}
                             />
-                          </>
-                        ) : (
-                          <div className="flex justify-center">
-                            <div>
-                              <Heading size="sm">{event.has_snapshot ? 'Best Image' : 'Thumbnail'}</Heading>
+                          ) : null }
+
+                          {((eventDetailType == 'image') || !event.has_clip) ? (
+                            <div className="flex justify-center">
                               <img
                                 className="flex-grow-0"
                                 src={
                                   event.has_snapshot
                                     ? `${apiHost}/api/events/${event.id}/snapshot.jpg`
-                                    : `data:image/jpeg;base64,${event.thumbnail}`
+                                    : `${apiHost}/api/events/${event.id}/thumbnail.jpg`
                                 }
                                 alt={`${event.label} at ${(event.top_score * 100).toFixed(0)}% confidence`}
                               />
                             </div>
-                          </div>
-                        )}
+                          ) : null }
+                        </div>
                       </div>
                     </div>
                   )}


### PR DESCRIPTION
Add tabs to show snapshot or thumbnail as part of event details, even if event has a clip available. The previous version of the events page (0.10 and previous) showed the snapshot as the poster image for the video element. The new events page autoplays the video when details are shown, removing the opportunity to use the video poster image for the snapshot.

This PR introduces a set of buttons/tabs using the same elements as the experimental Camera UI to select whether to show the clip or snapshot, instead of assuming that clip is preferred over snapshot. The default is still clip if available.

If a snapshot is not available, the thumbnail is shown in its place, in accordance with the previous fallback logic. I opted to keep the UI text "Best Image" from the previous fallback logic, even though this is inconsistent with the "Download Snapshot" action on the right hand side of the card and the name "snapshot" across the rest of Frigate (config, directories and filenames on disk, etc). Please let me know if a different label is preferred.

Finally, the URI for the thumbnail in the snapshot fallback logic was updated to match the URI used in the main part of the event card, as the base64 encoded variant didn't actually seem to work.

## Clip and snapshot available, snapshot selected
![events-clip-and-snapshot](https://user-images.githubusercontent.com/27739622/188292349-cfa9f9dc-ecad-4a4e-9ebf-5f73476e32a1.png)

## Only clip available, snapshot falls back to thumbnail
![events-clip-only](https://user-images.githubusercontent.com/27739622/188292351-ba85762f-f412-45d1-ab15-f2efb172c97a.png)

## Only snapshot available, clip button is disabled
![events-snapshot-only](https://user-images.githubusercontent.com/27739622/188292352-ac0fd8e3-ece2-47a7-97e1-800013f29139.png)
