### PR TITLE
Add OpenVino Detector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,17 +29,47 @@ RUN wget -qO go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/v0.1-rc
 # Download and Convert OpenVino model
 FROM base_amd64 AS ov-converter
 ARG DEBIAN_FRONTEND
-RUN apt-get -qq update \
-    && apt-get -qq install -y wget python3 python3-distutils
-RUN wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py \
-    && python3 get-pip.py "pip"
 
+# Install OpenVino Runtime and Dev library
 COPY requirements-ov.txt /requirements-ov.txt
-RUN pip install -r /requirements-ov.txt
+RUN apt-get -qq update \
+    && apt-get -qq install -y wget python3 python3-distutils \
+    && wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py \
+    && python3 get-pip.py "pip" \
+    && pip install -r /requirements-ov.txt
 
-RUN mkdir /models
-RUN cd /models && omz_downloader --name ssdlite_mobilenet_v2
-RUN cd /models && omz_converter --name ssdlite_mobilenet_v2 --precision FP16
+# Get OpenVino Model
+RUN mkdir /models \
+    && cd /models && omz_downloader --name ssdlite_mobilenet_v2 \
+    && cd /models && omz_converter --name ssdlite_mobilenet_v2 --precision FP16
+
+
+# libUSB - No Udev
+FROM wget as libusb-build
+ARG TARGETARCH
+ARG DEBIAN_FRONTEND
+
+# Build libUSB without udev.  Needed for Openvino NCS2 support
+WORKDIR /opt
+RUN apt-get update && apt-get install -y unzip build-essential automake libtool
+RUN wget -q https://github.com/libusb/libusb/archive/v1.0.25.zip -O v1.0.25.zip && \
+    unzip v1.0.25.zip && cd libusb-1.0.25 && \
+    ./bootstrap.sh && \
+    ./configure --disable-udev --enable-shared && \
+    make -j $(nproc --all)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libusb-1.0-0-dev && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/libusb-1.0.25/libusb
+RUN /bin/mkdir -p '/usr/local/lib' && \
+    /bin/bash ../libtool  --mode=install /usr/bin/install -c libusb-1.0.la '/usr/local/lib' && \
+    /bin/mkdir -p '/usr/local/include/libusb-1.0' && \
+    /usr/bin/install -c -m 644 libusb.h '/usr/local/include/libusb-1.0' && \
+    /bin/mkdir -p '/usr/local/lib/pkgconfig' && \
+    cd  /opt/libusb-1.0.25/ && \
+    /usr/bin/install -c -m 644 libusb-1.0.pc '/usr/local/lib/pkgconfig' && \
+    ldconfig
+
 
 
 FROM wget AS models
@@ -106,6 +136,7 @@ RUN pip3 wheel --wheel-dir=/wheels -r requirements-wheels.txt
 FROM scratch AS deps-rootfs
 COPY --from=nginx /usr/local/nginx/ /usr/local/nginx/
 COPY --from=go2rtc /rootfs/ /
+COPY --from=libusb-build /usr/local/lib /usr/local/lib
 COPY --from=s6-overlay /rootfs/ /
 COPY --from=models /rootfs/ /
 COPY docker/rootfs/ /
@@ -132,6 +163,8 @@ RUN --mount=type=bind,from=wheels,source=/wheels,target=/deps/wheels \
     pip3 install -U /deps/wheels/*.whl
 
 COPY --from=deps-rootfs / /
+
+RUN ldconfig
 
 EXPOSE 5000
 EXPOSE 1935

--- a/docker/install_deps.sh
+++ b/docker/install_deps.sh
@@ -53,6 +53,7 @@ if [[ "${TARGETARCH}" == "amd64" ]]; then
     echo 'deb http://deb.debian.org/debian testing main non-free' >/etc/apt/sources.list.d/debian-testing.list
     apt-get -qq update
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
+        intel-opencl-icd \
         mesa-va-drivers libva-drm2 intel-media-va-driver-non-free i965-va-driver libmfx1 radeontop intel-gpu-tools
     rm -f /etc/apt/sources.list.d/debian-testing.list
 fi

--- a/docker/install_deps.sh
+++ b/docker/install_deps.sh
@@ -52,6 +52,7 @@ if [[ "${TARGETARCH}" == "amd64" ]]; then
     # Use debian testing repo only for hwaccel packages
     echo 'deb http://deb.debian.org/debian testing main non-free' >/etc/apt/sources.list.d/debian-testing.list
     apt-get -qq update
+    # intel-opencl-icd specifically for GPU support in OpenVino
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
         intel-opencl-icd \
         mesa-va-drivers libva-drm2 intel-media-va-driver-non-free i965-va-driver libmfx1 radeontop intel-gpu-tools

--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -122,7 +122,7 @@ device_cgroup_rules:
   - 'c 189:* rmw'
 volumes:
   - /dev/bus/usb:/dev/bus/usb
-``` 
+```
 
 ### OpenVINO Models
 
@@ -133,8 +133,8 @@ model:
   path: /openvino-model/ssdlite_mobilenet_v2.xml
   width: 300
   height: 300
-  input_tensor: [B, H, W, C]
-  input_pixel_format: "bgr"
+  input_tensor: nhwc
+  input_pixel_format: bgr
   labelmap_path: /openvino-model/coco_91cl_bkgr.txt
 
 ```

--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -77,3 +77,33 @@ detectors:
 ```
 
 When using CPU detectors, you can add a CPU detector per camera. Adding more detectors than the number of cameras should not improve performance.
+
+## OpenVino
+
+The OpenVino detector allows Frigate to run an OpenVino IR model on Intel CPU, GPU and VPU hardware.
+
+### OpenVino Devices
+
+The OpenVino detector supports the Intel-supplied device plugins and can specify one or more devices in the configuration.  See OpenVino's device naming conventions in the [Device Documentation](https://docs.openvino.ai/latest/openvino_docs_OV_UG_Working_with_devices.html) for more detail. Other supported devices could be `AUTO`, `CPU`, `GPU`, etc.
+
+```yaml
+detectors:
+  ov_detector:
+    type: openvino
+    device: GPU
+```
+
+### OpenVino Models
+
+The included model for an OpenVino detector comes from Intel's Open Model Zoo [SSDLite MobileNet V2](https://github.com/openvinotoolkit/open_model_zoo/tree/master/models/public/ssdlite_mobilenet_v2) and is converted to an FP16 precision IR model.  Use the model configuration shown below when using the OpenVino detector.
+
+```yaml
+model:
+  path: /openvino-model/ssdlite_mobilenet_v2.xml
+  width: 300
+  height: 300
+  input_tensor: [B, H, W, C]
+  input_pixel_format: "bgr"
+  labelmap_path: /openvino-model/coco_91cl_bkgr.txt
+
+```

--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -78,13 +78,13 @@ detectors:
 
 When using CPU detectors, you can add a CPU detector per camera. Adding more detectors than the number of cameras should not improve performance.
 
-## OpenVino
+## OpenVINO
 
-The OpenVino detector allows Frigate to run an OpenVino IR model on Intel CPU, GPU and VPU hardware.
+The OpenVINO detector allows Frigate to run an OpenVINO IR model on Intel CPU, GPU and VPU hardware.
 
-### OpenVino Devices
+### OpenVINO Devices
 
-The OpenVino detector supports the Intel-supplied device plugins and can specify one or more devices in the configuration.  See OpenVino's device naming conventions in the [Device Documentation](https://docs.openvino.ai/latest/openvino_docs_OV_UG_Working_with_devices.html) for more detail. Other supported devices could be `AUTO`, `CPU`, `GPU`, etc.
+The OpenVINO detector supports the Intel-supplied device plugins and can specify one or more devices in the configuration.  See OpenVINO's device naming conventions in the [Device Documentation](https://docs.openvino.ai/latest/openvino_docs_OV_UG_Working_with_devices.html) for more detail. Other supported devices could be `AUTO`, `CPU`, `GPU`, `MYRIAD`, etc.
 
 ```yaml
 detectors:
@@ -93,9 +93,40 @@ detectors:
     device: GPU
 ```
 
-### OpenVino Models
+OpenVINO is supported on 6th Gen Intel platforms (Skylake) and newer.  A supported Intel platform is required to use the GPU device with OpenVINO.  The `MYRIAD` device may be run on any platform, including Arm devices.  For detailed system requirements, see [OpenVINO System Requirements](https://www.intel.com/content/www/us/en/developer/tools/openvino-toolkit/system-requirements.html)
 
-The included model for an OpenVino detector comes from Intel's Open Model Zoo [SSDLite MobileNet V2](https://github.com/openvinotoolkit/open_model_zoo/tree/master/models/public/ssdlite_mobilenet_v2) and is converted to an FP16 precision IR model.  Use the model configuration shown below when using the OpenVino detector.
+#### Intel NCS2 VPU and Myriad X Setup
+
+Intel produces a neural net inference accelleration chip called Myriad X.  This chip was sold in their Neural Compute Stick 2 (NCS2) which has been discontinued.  If intending to use the MYRIAD device for accelleration, additional setup is required to pass through the USB device.  The host needs a udev rule installed to handle the NCS2 device.  
+
+```bash
+sudo usermod -a -G users "$(whoami)"
+cat <<EOF > 97-myriad-usbboot.rules
+SUBSYSTEM=="usb", ATTRS{idProduct}=="2485", ATTRS{idVendor}=="03e7", GROUP="users", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEM=="usb", ATTRS{idProduct}=="f63b", ATTRS{idVendor}=="03e7", GROUP="users", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"
+EOF
+sudo cp 97-myriad-usbboot.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+Additionally, the Frigate docker container needs to run with the following configuration:
+
+```bash
+--device-cgroup-rule='c 189:\* rmw' -v /dev/bus/usb:/dev/bus/usb
+```
+or in your compose file:
+
+```yml
+device_cgroup_rules:
+  - 'c 189:* rmw'
+volumes:
+  - /dev/bus/usb:/dev/bus/usb
+``` 
+
+### OpenVINO Models
+
+The included model for an OpenVINO detector comes from Intel's Open Model Zoo [SSDLite MobileNet V2](https://github.com/openvinotoolkit/open_model_zoo/tree/master/models/public/ssdlite_mobilenet_v2) and is converted to an FP16 precision IR model.  Use the model configuration shown below when using the OpenVINO detector.
 
 ```yaml
 model:

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -76,9 +76,9 @@ detectors:
   # Required: name of the detector
   coral:
     # Required: type of the detector
-    # Valid values are 'edgetpu' (requires device property below) and 'cpu'.
+    # Valid values are 'edgetpu' (requires device property below)  `openvino` (see Detectors documentation), and 'cpu'.
     type: edgetpu
-    # Optional: device name as defined here: https://coral.ai/docs/edgetpu/multiple-edgetpu/#using-the-tensorflow-lite-python-api
+    # Optional: Edgetpu or OpenVino device name
     device: usb
     # Optional: num_threads value passed to the tflite.Interpreter (default: shown below)
     # This value is only used for CPU types

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -104,7 +104,7 @@ model:
   input_pixel_format: rgb
   # Optional: Object detection model input tensor format
   # Valid values are nhwc or nchw (default: shown below)
-  input_tensor: "nhwc"
+  input_tensor: nhwc
   # Optional: Label name modifications. These are merged into the standard labelmap.
   labelmap:
     2: vehicle

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -54,6 +54,7 @@ class FrigateBaseModel(BaseModel):
 
 class DetectorTypeEnum(str, Enum):
     edgetpu = "edgetpu"
+    openvino = "openvino"
     cpu = "cpu"
 
 

--- a/frigate/detectors/openvino.py
+++ b/frigate/detectors/openvino.py
@@ -9,49 +9,38 @@ logger = logging.getLogger(__name__)
 
 
 class OvDetector(DetectionApi):
-    def __init__(self, det_device=None, model_path=None, num_threads=1):
+    def __init__(self, det_device=None, model_config=None, num_threads=1):
         self.ov_core = ov.Core()
-        self.ov_model = self.ov_core.read_model(model_path)
+        self.ov_model = self.ov_core.read_model(model_config.path)
+
         self.interpreter = self.ov_core.compile_model(
             model=self.ov_model, device_name=det_device
         )
-        logger.info(f"Model Input Shape: {self.interpreter.input().shape}")
-        logger.info(f"Model Output Shape: {self.interpreter.output().shape}")
+        logger.info(f"Model Input Shape: {self.interpreter.input(0).shape}")
+        logger.info(f"Model Output Shape: {self.interpreter.output(0).shape}")
 
     def detect_raw(self, tensor_input):
-        tensor_transpose = np.reshape(tensor_input, self.interpreter.input().shape)
 
         infer_request = self.interpreter.create_infer_request()
-        results = infer_request.infer([tensor_transpose])
+        infer_request.infer([tensor_input])
 
-        # class_ids = self.interpreter.tensor(self.tensor_output_details[1]["index"])()[0]
-        # scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[0]
-        # count = int(
-        #     self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
-        # # )
-
-        # class_ids = results[0, 0, :, 1]
-        # # class_ids = [0, 0, 1, 1]
-        # print(class_ids)
-
-        # scores = results
-        # print(scores)
+        results = infer_request.get_output_tensor()
 
         detections = np.zeros((20, 6), np.float32)
-        # i = 0
-        # for object_detected in results["detection_out"][0, 0, :]:
-        #     if object_detected[2] < 0.1 or i == 20:
-        #         break
-        #     detections.append(
-        #         [
-        #             object_detected[1],
-        #             float(object_detected[2]),
-        #             object_detected[3],
-        #             object_detected[4],
-        #             object_detected[5],
-        #             object_detected[6],
-        #         ]
-        #     )
-        #     i += 1
+        i = 0
+        for object_detected in results.data[0, 0, :]:
+            if object_detected[0] != -1:
+                logger.debug(object_detected)
+            if object_detected[2] < 0.1 or i == 20:
+                break
+            detections[i] = [
+                object_detected[1],  # Label ID
+                float(object_detected[2]),  # Confidence
+                object_detected[4],  # y_min
+                object_detected[3],  # x_min
+                object_detected[6],  # y_max
+                object_detected[5],  # x_max
+            ]
+            i += 1
 
         return detections

--- a/frigate/detectors/openvino.py
+++ b/frigate/detectors/openvino.py
@@ -10,79 +10,48 @@ logger = logging.getLogger(__name__)
 
 class OvDetector(DetectionApi):
     def __init__(self, det_device=None, model_path=None, num_threads=1):
-        self.ovCore = ov.Core()
-        self.ovModel = self.ovCore.read_model(model_path)
-        self.interpreter = self.ovCore.compile_model(
-            model=self.ovModel, device_name=det_device
+        self.ov_core = ov.Core()
+        self.ov_model = self.ov_core.read_model(model_path)
+        self.interpreter = self.ov_core.compile_model(
+            model=self.ov_model, device_name=det_device
         )
-
-        self.interpreter.allocate_tensors()
-
-        self.tensor_input_details = self.interpreter.get_input_details()
-        self.tensor_output_details = self.interpreter.get_output_details()
+        logger.info(f"Model Input Shape: {self.interpreter.input().shape}")
+        logger.info(f"Model Output Shape: {self.interpreter.output().shape}")
 
     def detect_raw(self, tensor_input):
-        self.interpreter.set_tensor(self.tensor_input_details[0]["index"], tensor_input)
-        self.interpreter.invoke()
+        tensor_transpose = np.reshape(tensor_input, self.interpreter.input().shape)
 
-        boxes = self.interpreter.tensor(self.tensor_output_details[0]["index"])()[0]
-        class_ids = self.interpreter.tensor(self.tensor_output_details[1]["index"])()[0]
-        scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[0]
-        count = int(
-            self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
-        )
+        infer_request = self.interpreter.create_infer_request()
+        results = infer_request.infer([tensor_transpose])
 
-        detections = np.zeros((20, 6), np.float32)
+        # class_ids = self.interpreter.tensor(self.tensor_output_details[1]["index"])()[0]
+        # scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[0]
+        # count = int(
+        #     self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
+        # # )
 
-        for i in range(count):
-            if scores[i] < 0.4 or i == 20:
-                break
-            detections[i] = [
-                class_ids[i],
-                float(scores[i]),
-                boxes[i][0],
-                boxes[i][1],
-                boxes[i][2],
-                boxes[i][3],
-            ]
+        # class_ids = results[0, 0, :, 1]
+        # # class_ids = [0, 0, 1, 1]
+        # print(class_ids)
 
-        return detections
-
-
-class GpuOpenVino(DetectionApi):
-    def __init__(self, det_device=None, model_path=None, num_threads=1):
-        self.interpreter = tflite.Interpreter(
-            model_path=model_path or "/cpu_model.tflite", num_threads=3
-        )
-
-        self.interpreter.allocate_tensors()
-
-        self.tensor_input_details = self.interpreter.get_input_details()
-        self.tensor_output_details = self.interpreter.get_output_details()
-
-    def detect_raw(self, tensor_input):
-        self.interpreter.set_tensor(self.tensor_input_details[0]["index"], tensor_input)
-        self.interpreter.invoke()
-
-        boxes = self.interpreter.tensor(self.tensor_output_details[0]["index"])()[0]
-        class_ids = self.interpreter.tensor(self.tensor_output_details[1]["index"])()[0]
-        scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[0]
-        count = int(
-            self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
-        )
+        # scores = results
+        # print(scores)
 
         detections = np.zeros((20, 6), np.float32)
-
-        for i in range(count):
-            if scores[i] < 0.4 or i == 20:
-                break
-            detections[i] = [
-                class_ids[i],
-                float(scores[i]),
-                boxes[i][0],
-                boxes[i][1],
-                boxes[i][2],
-                boxes[i][3],
-            ]
+        # i = 0
+        # for object_detected in results["detection_out"][0, 0, :]:
+        #     if object_detected[2] < 0.1 or i == 20:
+        #         break
+        #     detections.append(
+        #         [
+        #             object_detected[1],
+        #             float(object_detected[2]),
+        #             object_detected[3],
+        #             object_detected[4],
+        #             object_detected[5],
+        #             object_detected[6],
+        #         ]
+        #     )
+        #     i += 1
 
         return detections

--- a/frigate/detectors/openvino.py
+++ b/frigate/detectors/openvino.py
@@ -17,7 +17,15 @@ class OvDetector(DetectionApi):
             model=self.ov_model, device_name=det_device
         )
         logger.info(f"Model Input Shape: {self.interpreter.input(0).shape}")
-        logger.info(f"Model Output Shape: {self.interpreter.output(0).shape}")
+        self.output_indexes = 0
+        while True:
+            try:
+                tensor_shape = self.interpreter.output(self.output_indexes).shape
+                logger.info(f"Model Output-{self.output_indexes} Shape: {tensor_shape}")
+                self.output_indexes += 1
+            except:
+                logger.info(f"Model has {self.output_indexes} Output Tensors")
+                break
 
     def detect_raw(self, tensor_input):
 

--- a/frigate/detectors/openvino.py
+++ b/frigate/detectors/openvino.py
@@ -1,0 +1,88 @@
+import logging
+import numpy as np
+import openvino.runtime as ov
+
+from frigate.detectors.detection_api import DetectionApi
+
+
+logger = logging.getLogger(__name__)
+
+
+class OvDetector(DetectionApi):
+    def __init__(self, det_device=None, model_path=None, num_threads=1):
+        self.ovCore = ov.Core()
+        self.ovModel = self.ovCore.read_model(model_path)
+        self.interpreter = self.ovCore.compile_model(
+            model=self.ovModel, device_name=det_device
+        )
+
+        self.interpreter.allocate_tensors()
+
+        self.tensor_input_details = self.interpreter.get_input_details()
+        self.tensor_output_details = self.interpreter.get_output_details()
+
+    def detect_raw(self, tensor_input):
+        self.interpreter.set_tensor(self.tensor_input_details[0]["index"], tensor_input)
+        self.interpreter.invoke()
+
+        boxes = self.interpreter.tensor(self.tensor_output_details[0]["index"])()[0]
+        class_ids = self.interpreter.tensor(self.tensor_output_details[1]["index"])()[0]
+        scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[0]
+        count = int(
+            self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
+        )
+
+        detections = np.zeros((20, 6), np.float32)
+
+        for i in range(count):
+            if scores[i] < 0.4 or i == 20:
+                break
+            detections[i] = [
+                class_ids[i],
+                float(scores[i]),
+                boxes[i][0],
+                boxes[i][1],
+                boxes[i][2],
+                boxes[i][3],
+            ]
+
+        return detections
+
+
+class GpuOpenVino(DetectionApi):
+    def __init__(self, det_device=None, model_path=None, num_threads=1):
+        self.interpreter = tflite.Interpreter(
+            model_path=model_path or "/cpu_model.tflite", num_threads=3
+        )
+
+        self.interpreter.allocate_tensors()
+
+        self.tensor_input_details = self.interpreter.get_input_details()
+        self.tensor_output_details = self.interpreter.get_output_details()
+
+    def detect_raw(self, tensor_input):
+        self.interpreter.set_tensor(self.tensor_input_details[0]["index"], tensor_input)
+        self.interpreter.invoke()
+
+        boxes = self.interpreter.tensor(self.tensor_output_details[0]["index"])()[0]
+        class_ids = self.interpreter.tensor(self.tensor_output_details[1]["index"])()[0]
+        scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[0]
+        count = int(
+            self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
+        )
+
+        detections = np.zeros((20, 6), np.float32)
+
+        for i in range(count):
+            if scores[i] < 0.4 or i == 20:
+                break
+            detections[i] = [
+                class_ids[i],
+                float(scores[i]),
+                boxes[i][0],
+                boxes[i][1],
+                boxes[i][2],
+                boxes[i][3],
+            ]
+
+        return detections

--- a/frigate/object_detection.py
+++ b/frigate/object_detection.py
@@ -12,6 +12,7 @@ from setproctitle import setproctitle
 
 from frigate.config import DetectorTypeEnum, InputTensorEnum
 from frigate.detectors.edgetpu_tfl import EdgeTpuTfl
+from frigate.detectors.openvino import OvDetector
 from frigate.detectors.cpu_tfl import CpuTfl
 
 from frigate.util import EventsPerSecond, SharedMemoryFrameManager, listen, load_labels
@@ -55,6 +56,10 @@ class LocalObjectDetector(ObjectDetector):
 
         if det_type == DetectorTypeEnum.edgetpu:
             self.detect_api = EdgeTpuTfl(
+                det_device=det_device, model_config=model_config
+            )
+        elif det_type == DetectorTypeEnum.openvino:
+            self.detect_api = OvDetector(
                 det_device=det_device, model_config=model_config
             )
         else:

--- a/requirements-ov.txt
+++ b/requirements-ov.txt
@@ -1,0 +1,3 @@
+numpy == 1.19.*
+openvino == 2022.*
+openvino-dev[tensorflow2] == 2022.*

--- a/requirements-wheels.txt
+++ b/requirements-wheels.txt
@@ -3,7 +3,6 @@ Flask == 2.2.*
 imutils == 0.5.*
 matplotlib == 3.6.*
 mypy == 0.942
-# numpy == 1.22.*
 numpy == 1.19.*
 opencv-python-headless == 4.5.5.*
 paho-mqtt == 1.6.*

--- a/requirements-wheels.txt
+++ b/requirements-wheels.txt
@@ -3,7 +3,7 @@ Flask == 2.2.*
 imutils == 0.5.*
 matplotlib == 3.6.*
 mypy == 0.942
-numpy == 1.19.*
+numpy == 1.22.*
 opencv-python-headless == 4.5.5.*
 paho-mqtt == 1.6.*
 peewee == 3.15.*
@@ -18,4 +18,7 @@ scipy == 1.8.*
 setproctitle == 1.2.*
 ws4py == 0.5.*
 zeroconf == 0.39.4
-openvino == 2022.*
+# Openvino Library - Custom built with MYRIAD support
+openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.2.0/openvino-2022.2.0-000-cp39-cp39-manylinux_2_31_x86_64.whl; platform_machine == 'x86_64'
+openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.2.0/openvino-2022.2.0-000-cp39-cp39-linux_aarch64.whl; platform_machine == 'aarch64'
+openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.2.0/openvino-2022.2.0-000-cp39-cp39-linux_armv7l.whl; platform_machine == 'armv7l'

--- a/requirements-wheels.txt
+++ b/requirements-wheels.txt
@@ -3,7 +3,8 @@ Flask == 2.2.*
 imutils == 0.5.*
 matplotlib == 3.6.*
 mypy == 0.942
-numpy == 1.22.*
+# numpy == 1.22.*
+numpy == 1.19.*
 opencv-python-headless == 4.5.5.*
 paho-mqtt == 1.6.*
 peewee == 3.15.*
@@ -18,3 +19,4 @@ scipy == 1.8.*
 setproctitle == 1.2.*
 ws4py == 0.5.*
 zeroconf == 0.39.4
+openvino == 2022.*


### PR DESCRIPTION
This PR is dependent on the Object Detector Abstraction change #3656.

This adds the OpenVino framework and a default model to the build image and a detector implementation that uses the OpenVino framework.  I have developed and tested this on my i5 1135G7, using the Xe iGPU.

The necessary configuration to run the included model is explained in the Detectors page of the documentation.

TODO:

- [x] Build OpenVino Wheel for amd64
- [x] Build OpenVino Wheel for ARM (32 and 64)
- [x] Determine what is needed to run on VPU/MyriadX hardware
- [x] Rebase to dev branch
- [x] Update Documentation with supported hardware

~- Update default model~ Further Model support can be reviewed/developed later
