### PR TITLE
Update BtBn ffmpeg to august build to potentially fix memory issues

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,7 +82,7 @@ RUN apt-get -qq update \
     # btbn-ffmpeg -> amd64 / arm64
     && if [ "${TARGETARCH}" = "amd64" ] || [ "${TARGETARCH}" = "arm64" ]; then \
     mkdir -p /usr/lib/btbn-ffmpeg \
-    && wget -O btbn-ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linux$( [ "$TARGETARCH" = "amd64" ] && echo "64" || echo "arm64" )-gpl-5.1.tar.xz" \
+    && wget -O btbn-ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2022-08-31-12-39/ffmpeg-n5.1-27-g6f53f0d09e-linux$( [ "$TARGETARCH" = "amd64" ] && echo "64" || echo "arm64" )-gpl-5.1.tar.xz" \
     && tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/btbn-ffmpeg --strip-components 1 \
     && rm btbn-ffmpeg.tar.xz; \
     fi \


### PR DESCRIPTION
Not suggesting this should be updated monthly, and I am not 100% sure if this change is necessary, but I updated to the latest long-term build of BtBn (end of august) and after running for a couple days the memory usage is remaining lower than the current build. May help with #3751 