### PR TITLE
Support special characters in passwords, redacted logs & debug config

### DIFF
--- a/docs/docs/guides/getting_started.md
+++ b/docs/docs/guides/getting_started.md
@@ -45,12 +45,6 @@ More details on available detectors can be found [here](/configuration/detectors
 
 Now let's add the first camera:
 
-:::caution
-
-Note that passwords that contain special characters often cause issues with ffmpeg connecting to the camera. If receiving `end-of-file` or `unauthorized` errors with a verified correct password, try changing the password to something simple to rule out the possibility that the password is the issue.
-
-:::
-
 ```yaml
 mqtt:
   host: <ip of your mqtt server>

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 from enum import Enum
-import re
 from typing import Dict, List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
@@ -13,8 +12,13 @@ import yaml
 from pydantic import BaseModel, Extra, Field, validator
 from pydantic.fields import PrivateAttr
 
-from frigate.const import BASE_DIR, CACHE_DIR, REGEX_CAMERA_NAME, REGEX_CAMERA_USER_PASS, YAML_EXT
-from frigate.util import create_mask, deep_merge, load_labels
+from frigate.const import (
+    BASE_DIR,
+    CACHE_DIR,
+    REGEX_CAMERA_NAME,
+    YAML_EXT,
+)
+from frigate.util import clean_camera_user_pass, create_mask, deep_merge, load_labels
 
 logger = logging.getLogger(__name__)
 
@@ -690,7 +694,7 @@ class CameraConfig(FrigateBaseModel):
         input_args = (
             input_args if isinstance(input_args, list) else input_args.split(" ")
         )
-        cleaned_input = re.sub(REGEX_CAMERA_USER_PASS, "*:*@", ffmpeg_input.path)
+        cleaned_input = clean_camera_user_pass(ffmpeg_input.path)
 
         cmd = (
             ["ffmpeg"]

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 from enum import Enum
+import re
 from typing import Dict, List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
@@ -12,7 +13,7 @@ import yaml
 from pydantic import BaseModel, Extra, Field, validator
 from pydantic.fields import PrivateAttr
 
-from frigate.const import BASE_DIR, CACHE_DIR, REGEX_CAMERA_NAME, YAML_EXT
+from frigate.const import BASE_DIR, CACHE_DIR, REGEX_CAMERA_NAME, REGEX_CAMERA_USER_PASS, YAML_EXT
 from frigate.util import create_mask, deep_merge, load_labels
 
 logger = logging.getLogger(__name__)
@@ -689,13 +690,14 @@ class CameraConfig(FrigateBaseModel):
         input_args = (
             input_args if isinstance(input_args, list) else input_args.split(" ")
         )
+        cleaned_input = re.sub(REGEX_CAMERA_USER_PASS, "*:*@", ffmpeg_input.path)
 
         cmd = (
             ["ffmpeg"]
             + global_args
             + hwaccel_args
             + input_args
-            + ["-i", ffmpeg_input.path]
+            + ["-i", cleaned_input]
             + ffmpeg_output_args
         )
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -18,7 +18,12 @@ from frigate.const import (
     REGEX_CAMERA_NAME,
     YAML_EXT,
 )
-from frigate.util import clean_camera_user_pass, create_mask, deep_merge, load_labels
+from frigate.util import (
+    create_mask,
+    deep_merge,
+    escape_special_characters,
+    load_labels,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -694,14 +699,13 @@ class CameraConfig(FrigateBaseModel):
         input_args = (
             input_args if isinstance(input_args, list) else input_args.split(" ")
         )
-        cleaned_input = clean_camera_user_pass(ffmpeg_input.path)
 
         cmd = (
             ["ffmpeg"]
             + global_args
             + hwaccel_args
             + input_args
-            + ["-i", cleaned_input]
+            + ["-i", escape_special_characters(ffmpeg_input.path)]
             + ffmpeg_output_args
         )
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -12,7 +12,7 @@ import yaml
 from pydantic import BaseModel, Extra, Field, validator
 from pydantic.fields import PrivateAttr
 
-from frigate.const import BASE_DIR, CACHE_DIR, YAML_EXT
+from frigate.const import BASE_DIR, CACHE_DIR, REGEX_CAMERA_NAME, YAML_EXT
 from frigate.util import create_mask, deep_merge, load_labels
 
 logger = logging.getLogger(__name__)
@@ -540,7 +540,7 @@ class CameraUiConfig(FrigateBaseModel):
 
 
 class CameraConfig(FrigateBaseModel):
-    name: Optional[str] = Field(title="Camera name.", regex="^[a-zA-Z0-9_-]+$")
+    name: Optional[str] = Field(title="Camera name.", regex=REGEX_CAMERA_NAME)
     enabled: bool = Field(default=True, title="Enable camera.")
     ffmpeg: CameraFfmpegConfig = Field(title="FFmpeg configuration for the camera.")
     best_image_timeout: int = Field(

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -9,4 +9,4 @@ PLUS_API_HOST = "https://api.frigate.video"
 # Regex Consts
 
 REGEX_CAMERA_NAME = "^[a-zA-Z0-9_-]+$"
-REGEX_CAMERA_USER_PASS = "[a-zA-Z0-9_-]+:[a-zA-Z0-9!$_-]+@"
+REGEX_CAMERA_USER_PASS = "[a-zA-Z0-9_-]+:[a-zA-Z0-9!*'();:@&=+$,?%#_-]+@"

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -9,4 +9,4 @@ PLUS_API_HOST = "https://api.frigate.video"
 # Regex Consts
 
 REGEX_CAMERA_NAME = "^[a-zA-Z0-9_-]+$"
-REGEX_CAMERA_USER_PASS = ""
+REGEX_CAMERA_USER_PASS = "[a-zA-Z0-9_-]+:[a-zA-Z0-9!$_-]+@"

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -5,3 +5,8 @@ CACHE_DIR = "/tmp/cache"
 YAML_EXT = (".yaml", ".yml")
 PLUS_ENV_VAR = "PLUS_API_KEY"
 PLUS_API_HOST = "https://api.frigate.video"
+
+# Regex Consts
+
+REGEX_CAMERA_NAME = "^[a-zA-Z0-9_-]+$"
+REGEX_CAMERA_USER_PASS = ""

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -30,6 +30,7 @@ from frigate.const import CLIPS_DIR
 from frigate.models import Event, Recordings
 from frigate.object_processing import TrackedObject, TrackedObjectProcessor
 from frigate.stats import stats_snapshot
+from frigate.util import clean_camera_user_pass
 from frigate.version import VERSION
 
 logger = logging.getLogger(__name__)
@@ -581,7 +582,7 @@ def config():
         camera_dict = config["cameras"][camera_name]
         camera_dict["ffmpeg_cmds"] = copy.deepcopy(camera.ffmpeg_cmds)
         for cmd in camera_dict["ffmpeg_cmds"]:
-            cmd["cmd"] = " ".join(cmd["cmd"])
+            cmd["cmd"] = clean_camera_user_pass(" ".join(cmd["cmd"]))
 
     config["plus"] = {"enabled": current_app.plus_api.is_active()}
 

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -12,6 +12,7 @@ from typing import Deque
 from collections import deque
 
 from frigate.const import REGEX_CAMERA_USER_PASS
+from frigate.util import clean_camera_user_pass
 
 
 def listener_configurer() -> None:
@@ -60,7 +61,7 @@ class LogPipe(threading.Thread):
 
     def cleanup_log(self, log: str) -> str:
         """Cleanup the log line to remove sensitive info and string tokens."""
-        log = re.sub(REGEX_CAMERA_USER_PASS, "*:*@", log).strip("\n")
+        log = clean_camera_user_pass(log).strip("\n")
         return log
 
     def fileno(self) -> int:

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -1,9 +1,7 @@
 # adapted from https://medium.com/@jonathonbao/python3-logging-with-multiprocessing-f51f460b8778
 import logging
-import re
 import threading
 import os
-import signal
 import queue
 from multiprocessing.queues import Queue
 from logging import handlers
@@ -11,7 +9,6 @@ from setproctitle import setproctitle
 from typing import Deque
 from collections import deque
 
-from frigate.const import REGEX_CAMERA_USER_PASS
 from frigate.util import clean_camera_user_pass
 
 

--- a/frigate/test/test_camera_pw.py
+++ b/frigate/test/test_camera_pw.py
@@ -2,12 +2,13 @@
 
 import unittest
 
-from frigate.util import clean_camera_user_pass
+from frigate.util import clean_camera_user_pass, escape_special_characters
 
 
 class TestUserPassCleanup(unittest.TestCase):
     def setUp(self) -> None:
         self.rtsp_with_pass = "rtsp://user:password@192.168.0.2:554/live"
+        self.rtsp_with_special_pass = "rtsp://user:password#$@@192.168.0.2:554/live"
         self.rtsp_no_pass = "rtsp://192.168.0.3:554/live"
 
     def test_cleanup(self):
@@ -20,3 +21,13 @@ class TestUserPassCleanup(unittest.TestCase):
         """Test that nothing changes when no user / pass are defined."""
         clean = clean_camera_user_pass(self.rtsp_no_pass)
         assert clean == self.rtsp_no_pass
+
+    def test_special_char_password(self):
+        """Test that special characters in pw are escaped, but not others."""
+        escaped = escape_special_characters(self.rtsp_with_special_pass)
+        assert escaped == "rtsp://user:password%23%24%40@192.168.0.2:554/live"
+
+    def test_no_special_char_password(self):
+        """Test that no change is made to path with no special characters."""
+        escaped = escape_special_characters(self.rtsp_with_pass)
+        assert escaped == self.rtsp_with_pass

--- a/frigate/test/test_camera_pw_clean.py
+++ b/frigate/test/test_camera_pw_clean.py
@@ -8,7 +8,7 @@ from frigate.util import clean_camera_user_pass
 class TestUserPassCleanup(unittest.TestCase):
     def setUp(self) -> None:
         self.rtsp_with_pass = "rtsp://user:password@192.168.0.2:554/live"
-        self.rtsp_no_pass = "rtsp://192.168.0.3/live"
+        self.rtsp_no_pass = "rtsp://192.168.0.3:554/live"
 
     def test_cleanup(self):
         """Test that user / pass are cleaned up."""

--- a/frigate/test/test_camera_pw_clean.py
+++ b/frigate/test/test_camera_pw_clean.py
@@ -1,0 +1,24 @@
+"""Test camera user and password cleanup."""
+
+import unittest
+
+from frigate.util import clean_camera_user_pass
+
+
+class TestUserPassCleanup(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.rtsp_with_pass = "rtsp://user:password@192.168.0.2:554/live"
+        self.rtsp_no_pass = "rtsp://192.168.0.3/live"
+
+
+    def test_cleanup(self):
+        """Test that user / pass are cleaned up."""
+        clean = clean_camera_user_pass(self.rtsp_with_pass)
+        assert clean != self.rtsp_with_pass
+        assert "user:password" not in self.rtsp_with_pass
+
+    def test_no_cleanup(self):
+        """Test that nothing changes when no user / pass are defined."""
+        clean = clean_camera_user_pass(self.rtsp_no_pass)
+        assert clean == self.rtsp_no_pass

--- a/frigate/test/test_camera_pw_clean.py
+++ b/frigate/test/test_camera_pw_clean.py
@@ -14,7 +14,7 @@ class TestUserPassCleanup(unittest.TestCase):
         """Test that user / pass are cleaned up."""
         clean = clean_camera_user_pass(self.rtsp_with_pass)
         assert clean != self.rtsp_with_pass
-        assert "user:password" not in self.rtsp_with_pass
+        assert "user:password" not in clean
 
     def test_no_cleanup(self):
         """Test that nothing changes when no user / pass are defined."""

--- a/frigate/test/test_camera_pw_clean.py
+++ b/frigate/test/test_camera_pw_clean.py
@@ -6,11 +6,9 @@ from frigate.util import clean_camera_user_pass
 
 
 class TestUserPassCleanup(unittest.TestCase):
-
     def setUp(self) -> None:
         self.rtsp_with_pass = "rtsp://user:password@192.168.0.2:554/live"
         self.rtsp_no_pass = "rtsp://192.168.0.3/live"
-
 
     def test_cleanup(self):
         """Test that user / pass are cleaned up."""

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -627,6 +627,7 @@ def load_labels(path, encoding="utf-8"):
         else:
             return {index: line.strip() for index, line in enumerate(lines)}
 
+
 def clean_camera_user_pass(line: str) -> str:
     """Removes user and password from line."""
     return re.sub(REGEX_CAMERA_USER_PASS, "*:*@", line)

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -1,22 +1,16 @@
 import copy
 import datetime
-import hashlib
-import json
 import logging
-import math
 import re
 import signal
-import subprocess as sp
-import threading
-import time
 import traceback
+import urllib.parse
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from multiprocessing import shared_memory
 from typing import AnyStr
 
 import cv2
-import matplotlib.pyplot as plt
 import numpy as np
 import os
 import psutil
@@ -630,7 +624,20 @@ def load_labels(path, encoding="utf-8"):
 
 def clean_camera_user_pass(line: str) -> str:
     """Removes user and password from line."""
+    # todo also remove http password like reolink
     return re.sub(REGEX_CAMERA_USER_PASS, "*:*@", line)
+
+
+def escape_special_characters(path: str) -> str:
+    """Cleans reserved characters to encodings for ffmpeg."""
+    try:
+        found = re.search(REGEX_CAMERA_USER_PASS, path).group(0)[:-1]
+        pw = found[(found.index(":") + 1) :]
+        logger.error(f"Found {found} and pw {pw}")
+        return path.replace(pw, urllib.parse.quote_plus(pw))
+    except AttributeError:
+        # path does not have user:pass
+        return path
 
 
 class FrameManager(ABC):

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import math
+import re
 import signal
 import subprocess as sp
 import threading
@@ -19,6 +20,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import os
 import psutil
+
+from frigate.const import REGEX_CAMERA_USER_PASS
 
 logger = logging.getLogger(__name__)
 
@@ -623,6 +626,10 @@ def load_labels(path, encoding="utf-8"):
             return {int(index): label.strip() for index, label in pairs}
         else:
             return {index: line.strip() for index, line in enumerate(lines)}
+
+def clean_camera_user_pass(line: str) -> str:
+    """Removes user and password from line."""
+    return re.sub(REGEX_CAMERA_USER_PASS, "*:*@", line)
 
 
 class FrameManager(ABC):

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -633,7 +633,6 @@ def escape_special_characters(path: str) -> str:
     try:
         found = re.search(REGEX_CAMERA_USER_PASS, path).group(0)[:-1]
         pw = found[(found.index(":") + 1) :]
-        logger.error(f"Found {found} and pw {pw}")
         return path.replace(pw, urllib.parse.quote_plus(pw))
     except AttributeError:
         # path does not have user:pass


### PR DESCRIPTION
Redact user:pass from cameras in logs and ffmpeg commands in debug

### Example:

```
[2022-10-09 12:06:45] watchdog.no_cam                ERROR   : The following ffmpeg logs include the last 100 lines prior to exit.
[2022-10-09 12:06:45] ffmpeg.no_cam.detect           ERROR   : [tcp @ 0xaaaace295ba0] Connection to tcp://192.168.50.106:554?timeout=5000000 failed: Connection refused
[2022-10-09 12:06:45] ffmpeg.no_cam.detect           ERROR   : rtsp://*:*@192.168.50.106/live0: Connection refused
[2022-10-09 12:06:45] frigate.video                  ERROR   : no_cam: Unable to read frames from ffmpeg process.
[2022-10-09 12:06:45] frigate.video                  ERROR   : no_cam: ffmpeg process is not running. exiting capture thread...
```