### PR TITLE
Describe Intel Quicksync Video hardware acceleration

### DIFF
--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -21,7 +21,15 @@ ffmpeg:
 ffmpeg:
   hwaccel_args: -hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -hwaccel_output_format yuv420p
 ```
-**NOTICE**: With some of the processors, like the J4125, the default driver `iHD` doesn't seem to work correctly for hardware acceleration. You may need to change the driver to `i965` by adding the following environment variable `LIBVA_DRIVER_NAME=i965` to your docker-compose file or [in the frigate.yml for HA OS users](advanced.md#environment_vars).   
+**NOTICE**: With some of the processors, like the J4125, the default driver `iHD` doesn't seem to work correctly for hardware acceleration. You may need to change the driver to `i965` by adding the following environment variable `LIBVA_DRIVER_NAME=i965` to your docker-compose file or [in the frigate.yml for HA OS users](advanced.md#environment_vars).
+
+### Intel-based CPUs (>=2nd Generation and <10th Generation) via Quicksync Video
+
+Using Intel Quick Sync Video (check Intel Ark page for your CPU to see if it supports it) might give much lower CPU utilization compared to `vaapi`.
+```yaml
+ffmpeg:
+  hwaccel_args: -hwaccel qsv -qsv_device /dev/dri/renderD128
+```
 
 ### Intel-based CPUs (>=10th Generation) via Quicksync
 


### PR DESCRIPTION
On my [Intel 7700t](https://ark.intel.com/content/www/us/en/ark/products/97122/intel-core-i77700t-processor-8m-cache-up-to-3-80-ghz.html) `qsv` gives about half the CPU utilization compared to `vaapi` decoding two 1080p h.264 streams (Unifi G3 bullet).

With `vaapi` it did around 60% cpu for each ffmpeg process and 35% for the detector.
With `qsv` it does around 15% cpu usage for each ffmpeg process and 35% for the detector

Running Frigate as Hassio addon on a Proxmox VM (with gpu passthrough and a usb Coral)