### PR TITLE
Adding clip duration to Events View

### DIFF
--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -455,11 +455,12 @@ export default function Events({ path, ...props }) {
                       <div className="flex flex-col grow">
                         <div className="capitalize text-lg font-bold">
                           {event.sub_label ? `${event.label}: ${event.sub_label}` : event.label} (
-                          {(event.top_score * 100).toFixed(0)}%)
+                          {(event.top_score * 100).toFixed(0)}%) <span className="text-red-300">{(event.end_time - event.start_time).toFixed(0)}s</span>
                         </div>
                         <div className="text-sm">
                           {new Date(event.start_time * 1000).toLocaleDateString()}{' '}
-                          {new Date(event.start_time * 1000).toLocaleTimeString()}
+                          {new Date(event.start_time * 1000).toLocaleTimeString()}{' - '}
+                          {new Date(event.end_time * 1000).toLocaleTimeString()}
                         </div>
                         <div className="capitalize text-sm flex align-center mt-1">
                           <Camera className="h-5 w-5 mr-2 inline" />

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -22,6 +22,11 @@ import CalendarIcon from '../icons/Calendar';
 import Calendar from '../components/Calendar';
 import Button from '../components/Button';
 import Dialog from '../components/Dialog';
+import {
+  fromUnixTime,
+  intervalToDuration,
+  formatDuration,
+} from 'date-fns';
 
 const API_LIMIT = 25;
 
@@ -37,19 +42,14 @@ const monthsAgo = (num) => {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime() / 1000;
 };
 
-const clipLength = (num) => {
-  let totalSeconds = num;
-  let hours = Math.floor(totalSeconds / 3600);
-  totalSeconds %= 3600;
-  let minutes = Math.floor(totalSeconds / 60);
-  let seconds = (totalSeconds % 60).toFixed(0);
-  let length=`${hours} Hours ${minutes} Minutes ${seconds} Seconds`
-  if (hours == 0 && minutes == 0) {
-    length=`${seconds} Seconds`
-  } else {
-    length=`${minutes} Minutes ${seconds} Seconds`
+const clipLength = (start_time, end_time) => {
+  const start = fromUnixTime(start_time);
+  const end = fromUnixTime(end_time);
+  let duration = 'In Progress';
+  if (end_time) {
+    duration = formatDuration(intervalToDuration({ start, end }));
   }
-  return length;
+  return duration;
 }
 
 export default function Events({ path, ...props }) {
@@ -474,7 +474,7 @@ export default function Events({ path, ...props }) {
                         </div>
                         <div className="text-sm">
                           {new Date(event.start_time * 1000).toLocaleDateString()}{' '}
-                          {new Date(event.start_time * 1000).toLocaleTimeString()} <span className="text-red-300">({clipLength(event.end_time - event.start_time)})</span>
+                          {new Date(event.start_time * 1000).toLocaleTimeString()} ({clipLength(event.end_time, event.start_time)})
                         </div>
                         <div className="capitalize text-sm flex align-center mt-1">
                           <Camera className="h-5 w-5 mr-2 inline" />

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -22,11 +22,7 @@ import CalendarIcon from '../icons/Calendar';
 import Calendar from '../components/Calendar';
 import Button from '../components/Button';
 import Dialog from '../components/Dialog';
-import {
-  fromUnixTime,
-  intervalToDuration,
-  formatDuration,
-} from 'date-fns';
+import { fromUnixTime, intervalToDuration, formatDuration } from 'date-fns';
 
 const API_LIMIT = 25;
 
@@ -42,7 +38,7 @@ const monthsAgo = (num) => {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime() / 1000;
 };
 
-const clipLength = (start_time, end_time) => {
+const clipDuration = (start_time, end_time) => {
   const start = fromUnixTime(start_time);
   const end = fromUnixTime(end_time);
   let duration = 'In Progress';
@@ -474,7 +470,7 @@ export default function Events({ path, ...props }) {
                         </div>
                         <div className="text-sm">
                           {new Date(event.start_time * 1000).toLocaleDateString()}{' '}
-                          {new Date(event.start_time * 1000).toLocaleTimeString()} ({clipLength(event.end_time, event.start_time)})
+                          {new Date(event.start_time * 1000).toLocaleTimeString()} ({clipDuration(event.start_time, event.end_time)})
                         </div>
                         <div className="capitalize text-sm flex align-center mt-1">
                           <Camera className="h-5 w-5 mr-2 inline" />
@@ -537,9 +533,9 @@ export default function Events({ path, ...props }) {
                                 ],
                               }}
                               seekOptions={{ forward: 10, back: 5 }}
-                              onReady={() => {}}
+                              onReady={() => { }}
                             />
-                          ) : null }
+                          ) : null}
 
                           {((eventDetailType == 'image') || !event.has_clip) ? (
                             <div className="flex justify-center">
@@ -553,7 +549,7 @@ export default function Events({ path, ...props }) {
                                 alt={`${event.label} at ${(event.top_score * 100).toFixed(0)}% confidence`}
                               />
                             </div>
-                          ) : null }
+                          ) : null}
                         </div>
                       </div>
                     </div>

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -37,6 +37,21 @@ const monthsAgo = (num) => {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime() / 1000;
 };
 
+const clipLength = (num) => {
+  let totalSeconds = num;
+  let hours = Math.floor(totalSeconds / 3600);
+  totalSeconds %= 3600;
+  let minutes = Math.floor(totalSeconds / 60);
+  let seconds = (totalSeconds % 60).toFixed(0);
+  let length=`${hours} Hours ${minutes} Minutes ${seconds} Seconds`
+  if (hours == 0 && minutes == 0) {
+    length=`${seconds} Seconds`
+  } else {
+    length=`${minutes} Minutes ${seconds} Seconds`
+  }
+  return length;
+}
+
 export default function Events({ path, ...props }) {
   const apiHost = useApiHost();
   const [searchParams, setSearchParams] = useState({
@@ -455,12 +470,11 @@ export default function Events({ path, ...props }) {
                       <div className="flex flex-col grow">
                         <div className="capitalize text-lg font-bold">
                           {event.sub_label ? `${event.label}: ${event.sub_label}` : event.label} (
-                          {(event.top_score * 100).toFixed(0)}%) <span className="text-red-300">{(event.end_time - event.start_time).toFixed(0)}s</span>
+                          {(event.top_score * 100).toFixed(0)}%)
                         </div>
                         <div className="text-sm">
                           {new Date(event.start_time * 1000).toLocaleDateString()}{' '}
-                          {new Date(event.start_time * 1000).toLocaleTimeString()}{' - '}
-                          {new Date(event.end_time * 1000).toLocaleTimeString()}
+                          {new Date(event.start_time * 1000).toLocaleTimeString()} <span className="text-red-300">({clipLength(event.end_time - event.start_time)})</span>
                         </div>
                         <div className="capitalize text-sm flex align-center mt-1">
                           <Camera className="h-5 w-5 mr-2 inline" />


### PR DESCRIPTION
Issue #3813 
(I'm not sure if this is the correct workflow, but I try...:
In the GitHub Docs it should be possible to manually link an issue to this pull request via the Development in the sidebar. Is not possible here).

Simply added the difference between end and start time as a span-Block.
And in the next div after the Start-Time the End-Time.
![frigate Events with Length](https://user-images.githubusercontent.com/59219161/196948039-aae63cce-2c55-4fbf-8b3a-1972ae46b6e9.jpg)
