### PR TITLE
Add option enabled for each camera in config

### DIFF
--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -7,6 +7,8 @@ title: Cameras
 
 Several inputs can be configured for each camera and the role of each input can be mixed and matched based on your needs. This allows you to use a lower resolution stream for object detection, but create recordings from a higher resolution stream, or vice versa.
 
+A camera is enabled by default but can be temporarily disabled by using `enabled: False`.
+
 Each role can only be assigned to one input per camera. The options for roles are as follows:
 
 | Role     | Description                                                                                     |
@@ -20,6 +22,7 @@ mqtt:
   host: mqtt.server.com
 cameras:
   back:
+    enabled: True
     ffmpeg:
       inputs:
         - path: rtsp://viewer:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2

--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -7,7 +7,7 @@ title: Cameras
 
 Several inputs can be configured for each camera and the role of each input can be mixed and matched based on your needs. This allows you to use a lower resolution stream for object detection, but create recordings from a higher resolution stream, or vice versa.
 
-A camera is enabled by default but can be temporarily disabled by using `enabled: False`.
+A camera is enabled by default but can be temporarily disabled by using `enabled: False`. Existing events and recordings can still be accessed. Live streams, recording and detecting are not working. Camera specific configurations will be used.
 
 Each role can only be assigned to one input per camera. The options for roles are as follows:
 

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -380,7 +380,9 @@ timestamp_style:
 cameras:
   # Required: name of the camera
   back:
-    # Optional: Enable/Disable the camera (default: shown below)
+    # Optional: Enable/Disable the camera (default: shown below).
+    #           If disabled: config is used but no live stream and no capture etc.
+    #           Events/Recordings are still viewable.
     enabled: True
     # Required: ffmpeg settings for the camera
     ffmpeg:

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -381,8 +381,8 @@ cameras:
   # Required: name of the camera
   back:
     # Optional: Enable/Disable the camera (default: shown below).
-    #           If disabled: config is used but no live stream and no capture etc.
-    #           Events/Recordings are still viewable.
+    # If disabled: config is used but no live stream and no capture etc.
+    # Events/Recordings are still viewable.
     enabled: True
     # Required: ffmpeg settings for the camera
     ffmpeg:

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -380,7 +380,7 @@ timestamp_style:
 cameras:
   # Required: name of the camera
   back:
-    # Optional: Enable/Disable the camera (default: camera is enabled automatically)
+    # Optional: Enable/Disable the camera (default: shown below)
     enabled: True
     # Required: ffmpeg settings for the camera
     ffmpeg:

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -380,6 +380,8 @@ timestamp_style:
 cameras:
   # Required: name of the camera
   back:
+    # Optional: Enable/Disable the camera (default: camera is enabled automatically)
+    enabled: True
     # Required: ffmpeg settings for the camera
     ffmpeg:
       # Required: A list of input streams for the camera. See documentation for more information.

--- a/docs/docs/guides/getting_started.md
+++ b/docs/docs/guides/getting_started.md
@@ -62,6 +62,7 @@ detectors:
 
 cameras:
   camera_1: # <------ Name the camera
+    enabled: True # <----- Enable/disable camera
     ffmpeg:
       inputs:
         - path: rtsp://10.0.10.10:554/rtsp # <----- Update for your camera

--- a/docs/docs/guides/getting_started.md
+++ b/docs/docs/guides/getting_started.md
@@ -62,7 +62,6 @@ detectors:
 
 cameras:
   camera_1: # <------ Name the camera
-    enabled: True # <----- Enable/disable camera
     ffmpeg:
       inputs:
         - path: rtsp://10.0.10.10:554/rtsp # <----- Update for your camera

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -250,36 +250,42 @@ class FrigateApp:
     def start_camera_processors(self) -> None:
         model_shape = (self.config.model.height, self.config.model.width)
         for name, config in self.config.cameras.items():
-            camera_process = mp.Process(
-                target=track_camera,
-                name=f"camera_processor:{name}",
-                args=(
-                    name,
-                    config,
-                    model_shape,
-                    self.config.model.merged_labelmap,
-                    self.detection_queue,
-                    self.detection_out_events[name],
-                    self.detected_frames_queue,
-                    self.camera_metrics[name],
-                ),
-            )
-            camera_process.daemon = True
-            self.camera_metrics[name]["process"] = camera_process
-            camera_process.start()
-            logger.info(f"Camera processor started for {name}: {camera_process.pid}")
+            if self.config.cameras[name].enabled:
+                camera_process = mp.Process(
+                    target=track_camera,
+                    name=f"camera_processor:{name}",
+                    args=(
+                        name,
+                        config,
+                        model_shape,
+                        self.config.model.merged_labelmap,
+                        self.detection_queue,
+                        self.detection_out_events[name],
+                        self.detected_frames_queue,
+                        self.camera_metrics[name],
+                    ),
+                )
+                camera_process.daemon = True
+                self.camera_metrics[name]["process"] = camera_process
+                camera_process.start()
+                logger.info(f"Camera processor started for {name}: {camera_process.pid}")
+            else:
+                logger.info(f"Camera processor not started for disabled camera {name}")
 
     def start_camera_capture_processes(self) -> None:
         for name, config in self.config.cameras.items():
-            capture_process = mp.Process(
-                target=capture_camera,
-                name=f"camera_capture:{name}",
-                args=(name, config, self.camera_metrics[name]),
-            )
-            capture_process.daemon = True
-            self.camera_metrics[name]["capture_process"] = capture_process
-            capture_process.start()
-            logger.info(f"Capture process started for {name}: {capture_process.pid}")
+            if self.config.cameras[name].enabled:
+                capture_process = mp.Process(
+                    target=capture_camera,
+                    name=f"camera_capture:{name}",
+                    args=(name, config, self.camera_metrics[name]),
+                )
+                capture_process.daemon = True
+                self.camera_metrics[name]["capture_process"] = capture_process
+                capture_process.start()
+                logger.info(f"Capture process started for {name}: {capture_process.pid}")
+            else:
+                logger.info(f"Capture process not started for disabled camera {name}")
 
     def start_event_processor(self) -> None:
         self.event_processor = EventProcessor(

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -530,7 +530,7 @@ class CameraUiConfig(FrigateBaseModel):
 
 class CameraConfig(FrigateBaseModel):
     name: Optional[str] = Field(title="Camera name.", regex="^[a-zA-Z0-9_-]+$")
-    enabled: Optional[bool] = Field(default=True, title="Enable camera.")
+    enabled: bool = Field(default=True, title="Enable camera.")
     ffmpeg: CameraFfmpegConfig = Field(title="FFmpeg configuration for the camera.")
     best_image_timeout: int = Field(
         default=60,
@@ -823,107 +823,106 @@ class FrigateConfig(FrigateBaseModel):
                 {"name": name, **merged_config}
             )
 
-            if camera_config.enabled:
-                # Default max_disappeared configuration
-                max_disappeared = camera_config.detect.fps * 5
-                if camera_config.detect.max_disappeared is None:
-                    camera_config.detect.max_disappeared = max_disappeared
-
-                # Default stationary_threshold configuration
-                stationary_threshold = camera_config.detect.fps * 10
-                if camera_config.detect.stationary.threshold is None:
-                    camera_config.detect.stationary.threshold = stationary_threshold
-
-                # FFMPEG input substitution
-                for input in camera_config.ffmpeg.inputs:
-                    input.path = input.path.format(**FRIGATE_ENV_VARS)
-
-                # Add default filters
-                object_keys = camera_config.objects.track
-                if camera_config.objects.filters is None:
-                    camera_config.objects.filters = {}
-                object_keys = object_keys - camera_config.objects.filters.keys()
-                for key in object_keys:
-                    camera_config.objects.filters[key] = FilterConfig()
-
-                # Apply global object masks and convert masks to numpy array
-                for object, filter in camera_config.objects.filters.items():
-                    if camera_config.objects.mask:
-                        filter_mask = []
-                        if filter.mask is not None:
-                            filter_mask = (
-                                filter.mask
-                                if isinstance(filter.mask, list)
-                                else [filter.mask]
-                            )
-                        object_mask = (
-                            camera_config.objects.mask
-                            if isinstance(camera_config.objects.mask, list)
-                            else [camera_config.objects.mask]
-                        )
-                        filter.mask = filter_mask + object_mask
-
-                    # Set runtime filter to create masks
-                    camera_config.objects.filters[object] = RuntimeFilterConfig(
-                        frame_shape=camera_config.frame_shape,
-                        **filter.dict(exclude_unset=True),
-                    )
-
-                # Convert motion configuration
-                if camera_config.motion is None:
-                    camera_config.motion = RuntimeMotionConfig(
-                        frame_shape=camera_config.frame_shape
-                    )
-                else:
-                    camera_config.motion = RuntimeMotionConfig(
-                        frame_shape=camera_config.frame_shape,
-                        raw_mask=camera_config.motion.mask,
-                        **camera_config.motion.dict(exclude_unset=True),
-                    )
-
-                # check runtime config
-                assigned_roles = list(
-                    set([r for i in camera_config.ffmpeg.inputs for r in i.roles])
-                )
-                if camera_config.record.enabled and not "record" in assigned_roles:
-                    raise ValueError(
-                        f"Camera {name} has record enabled, but record is not assigned to an input."
-                    )
-
-                if camera_config.rtmp.enabled and not "rtmp" in assigned_roles:
-                    raise ValueError(
-                        f"Camera {name} has rtmp enabled, but rtmp is not assigned to an input."
-                    )
-
-                # backwards compatibility for retain_days
-                if not camera_config.record.retain_days is None:
-                    logger.warning(
-                        "The 'retain_days' config option has been DEPRECATED and will be removed in a future version. Please use the 'days' setting under 'retain'"
-                    )
-                    if camera_config.record.retain.days == 0:
-                        camera_config.record.retain.days = (
-                            camera_config.record.retain_days
-                        )
-
-                # warning if the higher level record mode is potentially more restrictive than the events
-                rank_map = {
-                    RetainModeEnum.all: 0,
-                    RetainModeEnum.motion: 1,
-                    RetainModeEnum.active_objects: 2,
-                }
-                if (
-                    camera_config.record.retain.days != 0
-                    and rank_map[camera_config.record.retain.mode]
-                    > rank_map[camera_config.record.events.retain.mode]
-                ):
-                    logger.warning(
-                        f"{name}: Recording retention is configured for {camera_config.record.retain.mode} and event retention is configured for {camera_config.record.events.retain.mode}. The more restrictive retention policy will be applied."
-                    )
-                # generate the ffmpeg commands
-                camera_config.create_ffmpeg_cmds()
-                config.cameras[name] = camera_config
-            else:
+            if not camera_config.enabled:
                 config.cameras.pop(name)
+                continue
+
+            # Default max_disappeared configuration
+            max_disappeared = camera_config.detect.fps * 5
+            if camera_config.detect.max_disappeared is None:
+                camera_config.detect.max_disappeared = max_disappeared
+
+            # Default stationary_threshold configuration
+            stationary_threshold = camera_config.detect.fps * 10
+            if camera_config.detect.stationary.threshold is None:
+                camera_config.detect.stationary.threshold = stationary_threshold
+
+            # FFMPEG input substitution
+            for input in camera_config.ffmpeg.inputs:
+                input.path = input.path.format(**FRIGATE_ENV_VARS)
+
+            # Add default filters
+            object_keys = camera_config.objects.track
+            if camera_config.objects.filters is None:
+                camera_config.objects.filters = {}
+            object_keys = object_keys - camera_config.objects.filters.keys()
+            for key in object_keys:
+                camera_config.objects.filters[key] = FilterConfig()
+
+            # Apply global object masks and convert masks to numpy array
+            for object, filter in camera_config.objects.filters.items():
+                if camera_config.objects.mask:
+                    filter_mask = []
+                    if filter.mask is not None:
+                        filter_mask = (
+                            filter.mask
+                            if isinstance(filter.mask, list)
+                            else [filter.mask]
+                        )
+                    object_mask = (
+                        camera_config.objects.mask
+                        if isinstance(camera_config.objects.mask, list)
+                        else [camera_config.objects.mask]
+                    )
+                    filter.mask = filter_mask + object_mask
+
+                # Set runtime filter to create masks
+                camera_config.objects.filters[object] = RuntimeFilterConfig(
+                    frame_shape=camera_config.frame_shape,
+                    **filter.dict(exclude_unset=True),
+                )
+
+            # Convert motion configuration
+            if camera_config.motion is None:
+                camera_config.motion = RuntimeMotionConfig(
+                    frame_shape=camera_config.frame_shape
+                )
+            else:
+                camera_config.motion = RuntimeMotionConfig(
+                    frame_shape=camera_config.frame_shape,
+                    raw_mask=camera_config.motion.mask,
+                    **camera_config.motion.dict(exclude_unset=True),
+                )
+
+            # check runtime config
+            assigned_roles = list(
+                set([r for i in camera_config.ffmpeg.inputs for r in i.roles])
+            )
+            if camera_config.record.enabled and not "record" in assigned_roles:
+                raise ValueError(
+                    f"Camera {name} has record enabled, but record is not assigned to an input."
+                )
+
+            if camera_config.rtmp.enabled and not "rtmp" in assigned_roles:
+                raise ValueError(
+                    f"Camera {name} has rtmp enabled, but rtmp is not assigned to an input."
+                )
+
+            # backwards compatibility for retain_days
+            if not camera_config.record.retain_days is None:
+                logger.warning(
+                    "The 'retain_days' config option has been DEPRECATED and will be removed in a future version. Please use the 'days' setting under 'retain'"
+                )
+                if camera_config.record.retain.days == 0:
+                    camera_config.record.retain.days = camera_config.record.retain_days
+
+            # warning if the higher level record mode is potentially more restrictive than the events
+            rank_map = {
+                RetainModeEnum.all: 0,
+                RetainModeEnum.motion: 1,
+                RetainModeEnum.active_objects: 2,
+            }
+            if (
+                camera_config.record.retain.days != 0
+                and rank_map[camera_config.record.retain.mode]
+                > rank_map[camera_config.record.events.retain.mode]
+            ):
+                logger.warning(
+                    f"{name}: Recording retention is configured for {camera_config.record.retain.mode} and event retention is configured for {camera_config.record.events.retain.mode}. The more restrictive retention policy will be applied."
+                )
+            # generate the ffmpeg commands
+            camera_config.create_ffmpeg_cmds()
+            config.cameras[name] = camera_config
         return config
 
     @validator("cameras")

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -823,10 +823,6 @@ class FrigateConfig(FrigateBaseModel):
                 {"name": name, **merged_config}
             )
 
-            if not camera_config.enabled:
-                config.cameras.pop(name)
-                continue
-
             # Default max_disappeared configuration
             max_disappeared = camera_config.detect.fps * 5
             if camera_config.detect.max_disappeared is None:

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -817,7 +817,7 @@ class FrigateConfig(FrigateBaseModel):
             exclude_unset=True,
         )
 
-        for name, camera in config.cameras.copy().items():
+        for name, camera in config.cameras.items():
             merged_config = deep_merge(camera.dict(exclude_unset=True), global_config)
             camera_config: CameraConfig = CameraConfig.parse_obj(
                 {"name": name, **merged_config}

--- a/web/src/components/CameraImage.jsx
+++ b/web/src/components/CameraImage.jsx
@@ -49,7 +49,7 @@ export default function CameraImage({ camera, onload, searchParams = '', stretch
       {
         (enabled) ?
           <canvas data-testid="cameraimage-canvas" height={scaledHeight} ref={canvasRef} width={scaledWidth} />
-          : <div class="text-center text-green-500">Camera is disabled in config, no stream or snapshot available!</div>
+          : <div class="text-center pt-6">Camera is disabled in config, no stream or snapshot available!</div>
       }
       {
         (!hasLoaded && enabled) ? (

--- a/web/src/components/CameraImage.jsx
+++ b/web/src/components/CameraImage.jsx
@@ -14,6 +14,7 @@ export default function CameraImage({ camera, onload, searchParams = '', stretch
   const [{ width: availableWidth }] = useResizeObserver(containerRef);
 
   const { name } = config ? config.cameras[camera] : '';
+  const enabled = config ? config.cameras[camera].enabled : 'True';
   const { width, height } = config ? config.cameras[camera].detect : { width: 1, height: 1 };
   const aspectRatio = width / height;
 
@@ -45,12 +46,18 @@ export default function CameraImage({ camera, onload, searchParams = '', stretch
 
   return (
     <div className="relative w-full" ref={containerRef}>
-      <canvas data-testid="cameraimage-canvas" height={scaledHeight} ref={canvasRef} width={scaledWidth} />
-      {!hasLoaded ? (
-        <div className="absolute inset-0 flex justify-center" style={`height: ${scaledHeight}px`}>
-          <ActivityIndicator />
-        </div>
-      ) : null}
-    </div>
+      {
+        (enabled) ?
+          <canvas data-testid="cameraimage-canvas" height={scaledHeight} ref={canvasRef} width={scaledWidth} />
+          : <div class="text-center text-green-500">Camera is disabled in config, no stream or snapshot available!</div>
+      }
+      {
+        (!hasLoaded && enabled) ? (
+          <div className="absolute inset-0 flex justify-center" style={`height: ${scaledHeight}px`}>
+            <ActivityIndicator />
+          </div>
+        ) : null
+      }
+    </div >
   );
 }


### PR DESCRIPTION
Based on requirement and discussion in #4109:
- for each camera an option "enabled: True/False" can be used
- if option isn't used in config file the camera is enable as default (so no changes in the old config are necessary

Corrected 2 typos in config.py (propagate, generate)

Adding the if block resulted in 91 deletions and 96 additions after changing the indentation. The only real changes were:
- in config.py in class CameraConfig
`enabled: Optional[bool] = Field(default=True, title="Enable camera.")`

- in config.py in class FrigateConfig in runtime_config:
replace 
`for name, camera in config.cameras.items():`
with 
`for name, camera in config.cameras.copy().items():`
... generate camera_config ...
`if camera_config.enabled:`
... configurations ...
`else: config.cameras.pop(name)`
befor line
`return config`