### PR TITLE
Update camera specific input_agrs for ESP32-cam using ESPHome

### DIFF
--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -8,7 +8,7 @@ title: Camera Specific Configurations
 The input and output parameters need to be adjusted for MJPEG cameras
 
 ```yaml
-input_args: -avoid_negative_ts make_zero -fflags nobuffer -flags low_delay -strict experimental -fflags +genpts+discardcorrupt -use_wallclock_as_timestamps 1
+input_args: -avoid_negative_ts make_zero -fflags nobuffer -flags low_delay -strict experimental -fflags +genpts+discardcorrupt -use_wallclock_as_timestamps 1 -c:v mjpeg
 ```
 
 Note that mjpeg cameras require encoding the video into h264 for recording, and rtmp roles. This will use significantly more CPU than if the cameras supported h264 feeds directly.


### PR DESCRIPTION
Added "-c:v mjpeg" to MJPEG Cameras input_agrs in order to make a video stream work that comes from an ESP32-cam using ESPHome standard software