### PR TITLE
Update go2rtc to rc1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -118,7 +118,7 @@ RUN apt-get -qq update \
 ENV PATH=$PATH:/usr/lib/btbn-ffmpeg/bin
 
 # install go2rtc
-RUN wget -O go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/v0.1-beta.10/go2rtc_linux_${TARGETARCH}" \
+RUN wget -O go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/v0.1-rc.1/go2rtc_linux_${TARGETARCH}" \
     && chmod +x go2rtc \
     && mkdir -p /usr/local/go2rtc/sbin/ \
     && mv go2rtc /usr/local/go2rtc/sbin/go2rtc


### PR DESCRIPTION
Full change log at https://github.com/AlexxIT/go2rtc/releases/tag/v0.1-rc.1 but the highlights are:
• Fully supports reconnecting to camera if stream fails
• Fixes some issues that caused go2rtc to crash
• Streams can now reference other streams (not useful now but can be useful in the future for supporting multiple audio codecs)