### PR TITLE
Support more special chars in camera passwords

### DIFF
--- a/frigate/const.py
+++ b/frigate/const.py
@@ -9,4 +9,4 @@ PLUS_API_HOST = "https://api.frigate.video"
 # Regex Consts
 
 REGEX_CAMERA_NAME = "^[a-zA-Z0-9_-]+$"
-REGEX_CAMERA_USER_PASS = "[a-zA-Z0-9_-]+:[a-zA-Z0-9!*'();:@&=+$,?%#_-]+@"
+REGEX_CAMERA_USER_PASS = ":\/\/[a-zA-Z0-9_-]+:[\S]+@"

--- a/frigate/restream.py
+++ b/frigate/restream.py
@@ -3,6 +3,7 @@
 
 import logging
 import requests
+from frigate.util import escape_special_characters
 
 from frigate.config import FrigateConfig
 
@@ -34,10 +35,10 @@ class RestreamApi:
                         input.path.startswith("rtsp")
                         and not camera.restream.force_audio
                     ):
-                        self.relays[cam_name] = input.path
+                        self.relays[cam_name] = escape_special_characters(input.path)
                     else:
                         # go2rtc only supports rtsp for direct relay, otherwise ffmpeg is used
-                        self.relays[cam_name] = get_manual_go2rtc_stream(input.path)
+                        self.relays[cam_name] = get_manual_go2rtc_stream(escape_special_characters(input.path))
 
         for name, path in self.relays.items():
             params = {"src": path, "name": name}

--- a/frigate/restream.py
+++ b/frigate/restream.py
@@ -38,7 +38,9 @@ class RestreamApi:
                         self.relays[cam_name] = escape_special_characters(input.path)
                     else:
                         # go2rtc only supports rtsp for direct relay, otherwise ffmpeg is used
-                        self.relays[cam_name] = get_manual_go2rtc_stream(escape_special_characters(input.path))
+                        self.relays[cam_name] = get_manual_go2rtc_stream(
+                            escape_special_characters(input.path)
+                        )
 
         for name, path in self.relays.items():
             params = {"src": path, "name": name}

--- a/frigate/test/test_camera_pw.py
+++ b/frigate/test/test_camera_pw.py
@@ -8,7 +8,7 @@ from frigate.util import clean_camera_user_pass, escape_special_characters
 class TestUserPassCleanup(unittest.TestCase):
     def setUp(self) -> None:
         self.rtsp_with_pass = "rtsp://user:password@192.168.0.2:554/live"
-        self.rtsp_with_special_pass = "rtsp://user:password`~!@#$%^&*()-_;',.<>:\"\{\}\[\]@192.168.0.2:554/live"
+        self.rtsp_with_special_pass = "rtsp://user:password`~!@#$%^&*()-_;',.<>:\"\{\}\[\]@@192.168.0.2:554/live"
         self.rtsp_no_pass = "rtsp://192.168.0.3:554/live"
 
     def test_cleanup(self):
@@ -25,7 +25,7 @@ class TestUserPassCleanup(unittest.TestCase):
     def test_special_char_password(self):
         """Test that special characters in pw are escaped, but not others."""
         escaped = escape_special_characters(self.rtsp_with_special_pass)
-        assert escaped == "rtsp://user:password%60~%21%40%23%24%25%5E%26%2A%28%29-_%3B%27%2C.%3C%3E%3A%22%5C%7B%5C%7D%5C%5B%5C%5D@192.168.0.2:554/live"
+        assert escaped == "rtsp://user:password%60~%21%40%23%24%25%5E%26%2A%28%29-_%3B%27%2C.%3C%3E%3A%22%5C%7B%5C%7D%5C%5B%5C%5D%40@192.168.0.2:554/live"
 
     def test_no_special_char_password(self):
         """Test that no change is made to path with no special characters."""

--- a/frigate/test/test_camera_pw.py
+++ b/frigate/test/test_camera_pw.py
@@ -8,7 +8,9 @@ from frigate.util import clean_camera_user_pass, escape_special_characters
 class TestUserPassCleanup(unittest.TestCase):
     def setUp(self) -> None:
         self.rtsp_with_pass = "rtsp://user:password@192.168.0.2:554/live"
-        self.rtsp_with_special_pass = "rtsp://user:password`~!@#$%^&*()-_;',.<>:\"\{\}\[\]@@192.168.0.2:554/live"
+        self.rtsp_with_special_pass = (
+            "rtsp://user:password`~!@#$%^&*()-_;',.<>:\"\{\}\[\]@@192.168.0.2:554/live"
+        )
         self.rtsp_no_pass = "rtsp://192.168.0.3:554/live"
 
     def test_cleanup(self):
@@ -25,7 +27,10 @@ class TestUserPassCleanup(unittest.TestCase):
     def test_special_char_password(self):
         """Test that special characters in pw are escaped, but not others."""
         escaped = escape_special_characters(self.rtsp_with_special_pass)
-        assert escaped == "rtsp://user:password%60~%21%40%23%24%25%5E%26%2A%28%29-_%3B%27%2C.%3C%3E%3A%22%5C%7B%5C%7D%5C%5B%5C%5D%40@192.168.0.2:554/live"
+        assert (
+            escaped
+            == "rtsp://user:password%60~%21%40%23%24%25%5E%26%2A%28%29-_%3B%27%2C.%3C%3E%3A%22%5C%7B%5C%7D%5C%5B%5C%5D%40@192.168.0.2:554/live"
+        )
 
     def test_no_special_char_password(self):
         """Test that no change is made to path with no special characters."""

--- a/frigate/test/test_camera_pw.py
+++ b/frigate/test/test_camera_pw.py
@@ -8,7 +8,7 @@ from frigate.util import clean_camera_user_pass, escape_special_characters
 class TestUserPassCleanup(unittest.TestCase):
     def setUp(self) -> None:
         self.rtsp_with_pass = "rtsp://user:password@192.168.0.2:554/live"
-        self.rtsp_with_special_pass = "rtsp://user:password#$@@192.168.0.2:554/live"
+        self.rtsp_with_special_pass = "rtsp://user:password`~!@#$%^&*()-_;',.<>:\"\{\}\[\]@192.168.0.2:554/live"
         self.rtsp_no_pass = "rtsp://192.168.0.3:554/live"
 
     def test_cleanup(self):
@@ -25,7 +25,7 @@ class TestUserPassCleanup(unittest.TestCase):
     def test_special_char_password(self):
         """Test that special characters in pw are escaped, but not others."""
         escaped = escape_special_characters(self.rtsp_with_special_pass)
-        assert escaped == "rtsp://user:password%23%24%40@192.168.0.2:554/live"
+        assert escaped == "rtsp://user:password%60~%21%40%23%24%25%5E%26%2A%28%29-_%3B%27%2C.%3C%3E%3A%22%5C%7B%5C%7D%5C%5B%5C%5D@192.168.0.2:554/live"
 
     def test_no_special_char_password(self):
         """Test that no change is made to path with no special characters."""

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -635,13 +635,13 @@ def load_labels(path, encoding="utf-8"):
 def clean_camera_user_pass(line: str) -> str:
     """Removes user and password from line."""
     # todo also remove http password like reolink
-    return re.sub(REGEX_CAMERA_USER_PASS, "*:*@", line)
+    return re.sub(REGEX_CAMERA_USER_PASS, "://*:*@", line)
 
 
 def escape_special_characters(path: str) -> str:
     """Cleans reserved characters to encodings for ffmpeg."""
     try:
-        found = re.search(REGEX_CAMERA_USER_PASS, path).group(0)[:-1]
+        found = re.search(REGEX_CAMERA_USER_PASS, path).group(0)[3:-1]
         pw = found[(found.index(":") + 1) :]
         return path.replace(pw, urllib.parse.quote_plus(pw))
     except AttributeError:


### PR DESCRIPTION
For issue #4257. Match all non-whitespace characters in password field.  Need to explicitly match `://` at the beginning so it isn't considered the user delimiter.