### PR TITLE
Remove ffplay from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN --mount=type=bind,from=wheels,source=/wheels,target=/wheels \
     mkdir -p /usr/lib/btbn-ffmpeg \
     && wget -O btbn-ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linux$( [ "$TARGETARCH" = "amd64" ] && echo "64" || echo "arm64" )-gpl-5.1.tar.xz" \
     && tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/btbn-ffmpeg --strip-components 1 \
-    && rm btbn-ffmpeg.tar.xz; \
+    && rm -rf btbn-ffmpeg.tar.xz /usr/lib/btbn-ffmpeg/doc /usr/lib/btbn-ffmpeg/bin/ffplay ; \
     fi \
     # ffmpeg -> arm32
     && if [ "${TARGETARCH}" = "arm" ]; then \


### PR DESCRIPTION
I don't think `ffplay` is being used, and this saves ~120MB from the final image.