### PR TITLE
Fix intel gpu stats

### DIFF
--- a/frigate/test/test_gpu_stats.py
+++ b/frigate/test/test_gpu_stats.py
@@ -35,11 +35,11 @@ class TestGpuStats(unittest.TestCase):
     @patch("subprocess.run")
     def test_intel_gpu_stats(self, sp):
         process = MagicMock()
-        process.returncode = 0
+        process.returncode = 124
         process.stdout = self.intel_results
         sp.return_value = process
         intel_stats = get_intel_gpu_stats()
         assert intel_stats == {
-            "gpu": "10.73 %",
+            "gpu": "1.34 %",
             "mem": "- %",
         }

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -844,7 +844,7 @@ def get_intel_gpu_stats() -> dict[str, str]:
         else:
             video_avg = 1
 
-        results["gpu"] = round((video_avg + render_avg) / 2, 2)
+        results["gpu"] = f"{round((video_avg + render_avg) / 2, 2)} %"
         results["mem"] = "- %"
         return results
 

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -812,7 +812,8 @@ def get_intel_gpu_stats() -> dict[str, str]:
         capture_output=True,
     )
 
-    if p.returncode != 0:
+    # timeout has a non-zero returncode when timeout is reached
+    if p.returncode != 124:
         logger.error(p.stderr)
         return None
     else:

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -797,7 +797,7 @@ def get_intel_gpu_stats() -> dict[str, str]:
     """Get stats using intel_gpu_top."""
     intel_gpu_top_command = [
         "timeout",
-        "0.1s",
+        "0.5s",
         "intel_gpu_top",
         "-J",
         "-o",
@@ -817,23 +817,34 @@ def get_intel_gpu_stats() -> dict[str, str]:
         logger.error(p.stderr)
         return None
     else:
-        readings = json.loads(f"[{p.stdout}]")
+        reading = "".join(p.stdout.split())
         results: dict[str, str] = {}
 
-        for reading in readings:
-            if reading.get("engines", {}).get("Video/0", {}).get(
-                "busy", 0
-            ) or reading.get("engines", {}).get("Video/1", {}).get("busy", 0):
-                gpu_usage = round(
-                    float(reading.get("engines", {}).get("Video/0", {}).get("busy", 0))
-                    + float(
-                        reading.get("engines", {}).get("Video/1", {}).get("busy", 0)
-                    ),
-                    2,
-                )
-                results["gpu"] = f"{gpu_usage} %"
-                break
+        # render is used for qsv
+        render = []
+        for result in re.findall('"Render/3D/0":{[a-z":\d.,%]+}', reading):
+            packet = json.loads(result[14:])
+            single = packet.get("busy", 0.0)
+            render.append(float(single))
 
+        if render:
+            render_avg = sum(render) / len(render)
+        else:
+            render_avg = 1
+
+        # video is used for vaapi
+        video = []
+        for result in re.findall('"Video/\d":{[a-z":\d.,%]+}', reading):
+            packet = json.loads(result[10:])
+            single = packet.get("busy", 0.0)
+            video.append(float(single))
+
+        if video:
+            video_avg = sum(video) / len(video)
+        else:
+            video_avg = 1
+
+        results["gpu"] = round((video_avg + render_avg) / 2, 2)
         results["mem"] = "- %"
         return results
 


### PR DESCRIPTION
Rewrote the intel gpu stats since using the `timeout` can lead to broken json. Regex should make the logic more precise as well.

![Screenshot from 2022-12-03 07-33-42](https://user-images.githubusercontent.com/14866235/205446179-bfec5c51-88b7-49d9-907d-fa44728586ca.png)
