### PR TITLE
Log all services to memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -192,8 +192,9 @@ CMD []
 # Frigate deps with Node.js and NPM for devcontainer
 FROM deps AS devcontainer
 
-# Do not start frigate on devcontainer
-RUN rm -rf /etc/services.d/frigate
+# Do not start the actual Frigate service on devcontainer as it will be started by VSCode
+# But start a fake service for simulating the logs
+COPY docker/fake_frigate_run /etc/services.d/frigate/run
 
 # Install Node 16
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,6 +177,8 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 ENV S6_CMD_WAIT_FOR_SERVICES=1
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
 # Give services (including Frigate) 30 seconds to stop before killing them
+# But this is not working currently because of:
+# https://github.com/just-containers/s6-overlay/issues/503
 ENV S6_SERVICES_GRACETIME=30000
 # Configure logging to prepend timestamps, log to stdout, keep 1 archive and rotate on 10MB
 ENV S6_LOGGING_SCRIPT="T 1 n1 s10000000 T"

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,8 +160,8 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 # Wait indefinitely for cont-init.d to finish before starting services
 ENV S6_CMD_WAIT_FOR_SERVICES=1
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
-# Configure logging to log to stdout and prepend timestamps
-ENV S6_LOGGING_SCRIPT="T 1 n20 s1000000 T"
+# Configure logging to prepend timestamps, log to stdout, keep 1 archive and rotate on 10MB
+ENV S6_LOGGING_SCRIPT="T 1 n1 s10000000 T"
 # TODO: remove after a new version of s6-overlay is released. See:
 # https://github.com/just-containers/s6-overlay/issues/460#issuecomment-1327127006
 ENV S6_SERVICES_READYTIME=50

--- a/Dockerfile
+++ b/Dockerfile
@@ -155,17 +155,6 @@ ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 ENV PATH="/usr/lib/btbn-ffmpeg/bin:/usr/local/go2rtc/bin:/usr/local/nginx/sbin:${PATH}"
 
-# Fails if cont-init.d fails
-ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
-# Wait indefinitely for cont-init.d to finish before starting services
-ENV S6_CMD_WAIT_FOR_SERVICES=1
-ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
-# Configure logging to prepend timestamps, log to stdout, keep 1 archive and rotate on 10MB
-ENV S6_LOGGING_SCRIPT="T 1 n1 s10000000 T"
-# TODO: remove after a new version of s6-overlay is released. See:
-# https://github.com/just-containers/s6-overlay/issues/460#issuecomment-1327127006
-ENV S6_SERVICES_READYTIME=50
-
 # Install dependencies
 RUN --mount=type=bind,source=docker/install_deps.sh,target=/deps/install_deps.sh \
     /deps/install_deps.sh
@@ -181,6 +170,19 @@ EXPOSE 5000
 EXPOSE 1935
 EXPOSE 8554
 EXPOSE 8555
+
+# Fails if cont-init.d fails
+ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
+# Wait indefinitely for cont-init.d to finish before starting services
+ENV S6_CMD_WAIT_FOR_SERVICES=1
+ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
+# Give services (including Frigate) 30 seconds to stop before killing them
+ENV S6_SERVICES_GRACETIME=30000
+# Configure logging to prepend timestamps, log to stdout, keep 1 archive and rotate on 10MB
+ENV S6_LOGGING_SCRIPT="T 1 n1 s10000000 T"
+# TODO: remove after a new version of s6-overlay is released. See:
+# https://github.com/just-containers/s6-overlay/issues/460#issuecomment-1327127006
+ENV S6_SERVICES_READYTIME=50
 
 ENTRYPOINT ["/init"]
 CMD []

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ push: build
 	docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag $(IMAGE_REPO):${GITHUB_REF_NAME}-$(COMMIT_HASH) .
 
 run: local
-	docker run --rm --volume=${PWD}/config/config.yml:/config/config.yml frigate:latest
+	docker run --rm --publish=5000:5000 --volume=${PWD}/config/config.yml:/config/config.yml frigate:latest
 
 run_tests: local
-	docker run --rm --entrypoint=python3 frigate:latest -u -m unittest
-	docker run --rm --entrypoint=python3 frigate:latest -u -m mypy --config-file frigate/mypy.ini frigate
+	docker run --rm --workdir=/opt/frigate --entrypoint= frigate:latest python3 -u -m unittest
+	docker run --rm --workdir=/opt/frigate --entrypoint= frigate:latest python3 -u -m mypy --config-file frigate/mypy.ini frigate
 
 .PHONY: run_tests

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ build: version amd64 arm64 armv7
 push: build
 	docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag $(IMAGE_REPO):${GITHUB_REF_NAME}-$(COMMIT_HASH) .
 
+run: local
+	docker run --rm --volume=${PWD}/config/config.yml:/config/config.yml frigate:latest
+
 run_tests: local
 	docker run --rm --entrypoint=python3 frigate:latest -u -m unittest
 	docker run --rm --entrypoint=python3 frigate:latest -u -m mypy --config-file frigate/mypy.ini frigate

--- a/docker/fake_frigate_run
+++ b/docker/fake_frigate_run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/command/with-contenv bash
 # shellcheck shell=bash
 # Start the fake Frigate service
 

--- a/docker/fake_frigate_run
+++ b/docker/fake_frigate_run
@@ -1,0 +1,8 @@
+#!/bin/bash
+# shellcheck shell=bash
+# Start the fake Frigate service
+
+while true; do
+  echo "The fake Frigate service is running..."
+  sleep 5s
+done

--- a/docker/rootfs/etc/cont-init.d/prepare-logs.sh
+++ b/docker/rootfs/etc/cont-init.d/prepare-logs.sh
@@ -1,7 +1,8 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
+# Prepare the logs folder for s6-log
 
-set -euo pipefail
+set -o errexit -o nounset -o pipefail
 
 mkdir -p /dev/shm/logs
 chown nobody:nogroup /dev/shm/logs

--- a/docker/rootfs/etc/cont-init.d/prepare-logs.sh
+++ b/docker/rootfs/etc/cont-init.d/prepare-logs.sh
@@ -1,0 +1,8 @@
+#!/command/with-contenv bash
+# shellcheck shell=bash
+
+set -euo pipefail
+
+mkdir -p /dev/shm/logs
+chown nobody:nogroup /dev/shm/logs
+chmod 02755 /dev/shm/logs

--- a/docker/rootfs/etc/cont-init.d/prepare-logs.sh
+++ b/docker/rootfs/etc/cont-init.d/prepare-logs.sh
@@ -4,7 +4,6 @@
 
 set -o errexit -o nounset -o pipefail
 
-
 dirs=(/dev/shm/logs/frigate /dev/shm/logs/go2rtc /dev/shm/logs/nginx)
 
 mkdir -p "${dirs[@]}"

--- a/docker/rootfs/etc/cont-init.d/prepare-logs.sh
+++ b/docker/rootfs/etc/cont-init.d/prepare-logs.sh
@@ -4,6 +4,9 @@
 
 set -o errexit -o nounset -o pipefail
 
-mkdir -p /dev/shm/logs
-chown nobody:nogroup /dev/shm/logs
-chmod 02755 /dev/shm/logs
+
+dirs=(/dev/shm/logs/frigate /dev/shm/logs/go2rtc /dev/shm/logs/nginx)
+
+mkdir -p "${dirs[@]}"
+chown nobody:nogroup "${dirs[@]}"
+chmod 02755 "${dirs[@]}"

--- a/docker/rootfs/etc/services.d/frigate/finish
+++ b/docker/rootfs/etc/services.d/frigate/finish
@@ -1,0 +1,7 @@
+#!/command/with-contenv bash
+# shellcheck shell=bash
+# Take down the S6 supervision tree when the process fails
+
+if [[ "${1}" -ne 0 && "${1}" -ne 256 ]]; then
+  exec /run/s6/basedir/bin/halt
+fi

--- a/docker/rootfs/etc/services.d/frigate/finish
+++ b/docker/rootfs/etc/services.d/frigate/finish
@@ -1,7 +1,16 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
-# Take down the S6 supervision tree when the process fails
+# Take down the S6 supervision tree when the service exits
 
-if [[ "${1}" -ne 0 && "${1}" -ne 256 ]]; then
-  exec /run/s6/basedir/bin/halt
+set -o errexit -o nounset -o pipefail
+
+# Prepare exit code
+if [[ "${1}" -eq 256 ]]; then
+  exit_code="$((128 + ${2}))"
+else
+  exit_code="${1}"
 fi
+
+# Make the container exit with the same exit code as the service
+echo "${exit_code}" > /run/s6-linux-init-container-results/exitcode
+exec /run/s6/basedir/bin/halt

--- a/docker/rootfs/etc/services.d/frigate/log/run
+++ b/docker/rootfs/etc/services.d/frigate/log/run
@@ -1,5 +1,4 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
 
-exec 2>&1
-exec nginx
+exec logutil-service /dev/shm/logs/frigate

--- a/docker/rootfs/etc/services.d/frigate/run
+++ b/docker/rootfs/etc/services.d/frigate/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/command/with-contenv bash
 # shellcheck shell=bash
 # Start the Frigate service
 

--- a/docker/rootfs/etc/services.d/frigate/run
+++ b/docker/rootfs/etc/services.d/frigate/run
@@ -1,9 +1,11 @@
-#!/command/with-contenv bash
+#!/bin/bash
 # shellcheck shell=bash
+# Start the Frigate service
 
-set -euo pipefail
+set -o errexit -o nounset -o pipefail -o xtrace
 
 cd /opt/frigate
 
+# Replace the bash process with the Frigate process, redirecting stderr to stdout
 exec 2>&1
 exec python3 -u -m frigate

--- a/docker/rootfs/etc/services.d/frigate/run
+++ b/docker/rootfs/etc/services.d/frigate/run
@@ -1,5 +1,9 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
 
+set -euo pipefail
+
+cd /opt/frigate
+
 exec 2>&1
-exec nginx
+exec python3 -u -m frigate

--- a/docker/rootfs/etc/services.d/frigate/run
+++ b/docker/rootfs/etc/services.d/frigate/run
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 # Start the Frigate service
 
-set -o errexit -o nounset -o pipefail -o xtrace
+set -o errexit -o nounset -o pipefail
 
 cd /opt/frigate
 

--- a/docker/rootfs/etc/services.d/go2rtc/finish
+++ b/docker/rootfs/etc/services.d/go2rtc/finish
@@ -1,6 +1,7 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
-# Take down the S6 supervision tree when the process fails
+# Take down the S6 supervision tree when the service fails, or restart it
+# otherwise
 
 if [[ "${1}" -ne 0 && "${1}" -ne 256 ]]; then
   exec /run/s6/basedir/bin/halt

--- a/docker/rootfs/etc/services.d/go2rtc/log/run
+++ b/docker/rootfs/etc/services.d/go2rtc/log/run
@@ -1,5 +1,4 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
 
-exec 2>&1
-exec nginx
+exec logutil-service /dev/shm/logs/go2rtc

--- a/docker/rootfs/etc/services.d/go2rtc/run
+++ b/docker/rootfs/etc/services.d/go2rtc/run
@@ -10,4 +10,5 @@ else
     config_path="/usr/local/go2rtc/go2rtc.yaml"
 fi
 
+exec 2>&1
 exec go2rtc -config="${config_path}"

--- a/docker/rootfs/etc/services.d/go2rtc/run
+++ b/docker/rootfs/etc/services.d/go2rtc/run
@@ -1,8 +1,8 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
+# Start the go2rtc service
 
-# https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425?permalink_comment_id=3945021
-set -euo pipefail
+set -o errexit -o nounset -o pipefail
 
 if [[ -f "/config/frigate-go2rtc.yaml" ]]; then
     config_path="/config/frigate-go2rtc.yaml"
@@ -10,5 +10,6 @@ else
     config_path="/usr/local/go2rtc/go2rtc.yaml"
 fi
 
+# Replace the bash process with the go2rtc process, redirecting stderr to stdout
 exec 2>&1
 exec go2rtc -config="${config_path}"

--- a/docker/rootfs/etc/services.d/nginx/finish
+++ b/docker/rootfs/etc/services.d/nginx/finish
@@ -1,6 +1,7 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
-# Take down the S6 supervision tree when the process fails
+# Take down the S6 supervision tree when the service fails, or restart it
+# otherwise
 
 if [[ "${1}" -ne 0 && "${1}" -ne 256 ]]; then
   exec /run/s6/basedir/bin/halt

--- a/docker/rootfs/etc/services.d/nginx/log/run
+++ b/docker/rootfs/etc/services.d/nginx/log/run
@@ -1,5 +1,4 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
 
-exec 2>&1
-exec nginx
+exec logutil-service /dev/shm/logs/nginx

--- a/docker/rootfs/etc/services.d/nginx/run
+++ b/docker/rootfs/etc/services.d/nginx/run
@@ -1,5 +1,7 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
+# Start the NGINX service
 
+# Replace the bash process with the NGINX process, redirecting stderr to stdout
 exec 2>&1
 exec nginx

--- a/docker/rootfs/usr/local/bin/frigate
+++ b/docker/rootfs/usr/local/bin/frigate
@@ -2,4 +2,4 @@
 # shellcheck shell=bash
 
 exec 2>&1
-exec nginx
+exec python3 -u -m frigate "${@}"

--- a/docker/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/rootfs/usr/local/nginx/conf/nginx.conf
@@ -2,7 +2,7 @@ daemon off;
 user root;
 worker_processes  1;
 
-error_log  /usr/local/nginx/logs/error.log warn;
+error_log  /dev/stdout warn;
 pid        /var/run/nginx.pid;
 
 events {
@@ -17,7 +17,7 @@ http {
                         '$status $body_bytes_sent "$http_referer" '
                         '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /usr/local/nginx/logs/access.log  main;
+    access_log  /dev/stdout  main;
 
     sendfile        on;
 


### PR DESCRIPTION
- All logs can be accessed from `/dev/shm/logs/<service>`, e.g. `/dev/shm/logs/go2rtc/current`.
- NGINX now logs to stdout as well (like in https://github.com/blakeblackshear/frigate/pull/4562)
- Frigate service isn't set in `CMD` anymore as this allows us to log it as well.
    - S6-Overlay does not seem to support customizing logging for CMD
- Refs https://github.com/blakeblackshear/frigate/pull/4562#issuecomment-1332606737
- Is depended on by https://github.com/blakeblackshear/frigate/pull/4562