### PR TITLE
Use presets by default

### DIFF
--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -3,6 +3,12 @@ id: camera_specific
 title: Camera Specific Configurations
 ---
 
+:::note
+
+This page makes use of presets of FFmpeg args. For more information on presets, see the [FFmpeg Presets](/configuration/ffmpeg_presets) page.
+
+:::
+
 ## MJPEG Cameras
 
 The input and output parameters need to be adjusted for MJPEG cameras
@@ -50,6 +56,7 @@ ffmpeg:
 ## Model/vendor specific setup
 
 ### Annke C800
+
 This camera is H.265 only. To be able to play clips on some devices (like MacOs or iPhone) the H.265 stream has to be repackaged and the audio stream has to be converted to aac. Unfortunately direct playback of in the browser is not working (yet), but the downloaded clip can be played locally.
 
 ```yaml
@@ -69,10 +76,8 @@ cameras:
     rtmp:
       enabled: False # <-- RTMP should be disabled if your stream is not H264
     detect:
-      width:  # <---- update for your camera's resolution
-      height:  # <---- update for your camera's resolution
-
-
+      width: # <---- update for your camera's resolution
+      height: # <---- update for your camera's resolution
 ```
 
 ### Blue Iris RTSP Cameras

--- a/docs/docs/configuration/ffmpeg_presets.md
+++ b/docs/docs/configuration/ffmpeg_presets.md
@@ -1,0 +1,10 @@
+---
+id: ffmpeg_presets
+title: FFmpeg presets
+---
+
+Some presets of FFmpeg args are provided by default to make the configuration easier. All presets can be seen in [this file](https://github.com/blakeblackshear/frigate/blob/master/frigate/ffmpeg_presets.py).
+
+<!--
+TODO: Use [markdown-magic](https://github.com/DavidWells/markdown-magic) to generate this list from the source code.
+-->

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -140,6 +140,7 @@ birdseye:
   mode: objects
 
 # Optional: ffmpeg configuration
+# More information about presets at https://docs.frigate.video/configuration/ffmpeg_presets
 ffmpeg:
   # Optional: global ffmpeg args (default: shown below)
   global_args: -hide_banner -loglevel warning
@@ -147,15 +148,15 @@ ffmpeg:
   # NOTE: See hardware acceleration docs for your specific device
   hwaccel_args: []
   # Optional: global input args (default: shown below)
-  input_args: -avoid_negative_ts make_zero -fflags +genpts+discardcorrupt -rtsp_transport tcp -timeout 5000000 -use_wallclock_as_timestamps 1
+  input_args: preset-rtsp-generic
   # Optional: global output args
   output_args:
     # Optional: output args for detect streams (default: shown below)
     detect: -f rawvideo -pix_fmt yuv420p
     # Optional: output args for record streams (default: shown below)
-    record: -f segment -segment_time 10 -segment_format mp4 -reset_timestamps 1 -strftime 1 -c copy -an
+    record: preset-record-generic
     # Optional: output args for rtmp streams (default: shown below)
-    rtmp: -c copy -f flv
+    rtmp: preset-rtmp-generic
 
 # Optional: Detect configuration
 # NOTE: Can be overridden at the camera level

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -25,6 +25,7 @@ module.exports = {
       "configuration/advanced",
       "configuration/hardware_acceleration",
       "configuration/camera_specific",
+      "configuration/ffmpeg_presets",
     ],
     Integrations: [
       "integrations/home-assistant",

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -360,35 +360,10 @@ class BirdseyeCameraConfig(BaseModel):
 
 
 FFMPEG_GLOBAL_ARGS_DEFAULT = ["-hide_banner", "-loglevel", "warning"]
-FFMPEG_INPUT_ARGS_DEFAULT = [
-    "-avoid_negative_ts",
-    "make_zero",
-    "-fflags",
-    "+genpts+discardcorrupt",
-    "-rtsp_transport",
-    "tcp",
-    "-timeout",
-    "5000000",
-    "-use_wallclock_as_timestamps",
-    "1",
-]
+FFMPEG_INPUT_ARGS_DEFAULT = "preset-rtsp-generic"
 DETECT_FFMPEG_OUTPUT_ARGS_DEFAULT = ["-f", "rawvideo", "-pix_fmt", "yuv420p"]
-RTMP_FFMPEG_OUTPUT_ARGS_DEFAULT = ["-c", "copy", "-f", "flv"]
-RECORD_FFMPEG_OUTPUT_ARGS_DEFAULT = [
-    "-f",
-    "segment",
-    "-segment_time",
-    "10",
-    "-segment_format",
-    "mp4",
-    "-reset_timestamps",
-    "1",
-    "-strftime",
-    "1",
-    "-c",
-    "copy",
-    "-an",
-]
+RTMP_FFMPEG_OUTPUT_ARGS_DEFAULT = "preset-rtmp-generic"
+RECORD_FFMPEG_OUTPUT_ARGS_DEFAULT = "preset-record-generic"
 
 
 class FfmpegOutputArgsConfig(FrigateBaseModel):

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -77,8 +77,8 @@ class TestFfmpegPresets(unittest.TestCase):
         frigate_preset_config.cameras["back"].create_ffmpeg_cmds()
         assert (
             # Ignore global and user_agent args in comparison
-            frigate_preset_config.cameras["back"].ffmpeg_cmds[0]["cmd"][6::]
-            == frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"][4::]
+            frigate_preset_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
+            == frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
         )
 
     def test_ffmpeg_input_preset(self):
@@ -95,8 +95,10 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_input_args_as_string(self):
-        argsString = " ".join(FFMPEG_INPUT_ARGS_DEFAULT) + ' -some "arg with space"'
-        argsList = FFMPEG_INPUT_ARGS_DEFAULT + ["-some", "arg with space"]
+        # Strip user_agent args here to avoid handling quoting issues
+        defaultArgsList = parse_preset_input(FFMPEG_INPUT_ARGS_DEFAULT, 5)[2::]
+        argsString = " ".join(defaultArgsList) + ' -some "arg with space"'
+        argsList = defaultArgsList + ["-some", "arg with space"]
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["input_args"] = argsString
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         frigate_config.cameras["back"].create_ffmpeg_cmds()


### PR DESCRIPTION
- Started from https://github.com/blakeblackshear/frigate/pull/3840#issuecomment-1329973550.

- This PR is especially needed since after https://github.com/blakeblackshear/frigate/pull/4596 the `-user_agent` would only get applied when using a preset, which was not the case for the default configuration.

- We can use markdown-magic to generate the list in a better readable manner, but I suggest we leave it for a future PR.