### PR TITLE
Update go2rtc version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /rootfs
 FROM wget AS go2rtc
 ARG TARGETARCH
 WORKDIR /rootfs/usr/local/go2rtc/bin
-RUN wget -qO go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/v0.1-rc.3/go2rtc_linux_${TARGETARCH}" \
+RUN wget -qO go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/v0.1-rc.5/go2rtc_linux_${TARGETARCH}" \
     && chmod +x go2rtc
 
 # Download and Convert OpenVino model


### PR DESCRIPTION
Improvements include:
- Support for RTSP auth (added via go2rtc yaml config)
- new tracks can be added after initial stream is started (camera that doesn't have audio for first x seconds can have audio added without restarting stream)
- Fix MSE Empty SPS issue with h.265
- Improve webRTC delay on startup
- Fix race conditions for processing
- Fix issue when no audio but multiple audio codecs are specified
- Remove log warning when websocket is disconnected normally