### PR TITLE
Fix ffprobe with special characters

### DIFF
--- a/frigate/http.py
+++ b/frigate/http.py
@@ -1091,7 +1091,19 @@ def ffprobe():
             {"success": False, "message": f"Path needs to be provided."}, "404"
         )
 
-    if "," in clean_camera_user_pass(path_param):
+    if path_param.startswith("camera"):
+        camera = path_param[7:]
+
+        if camera not in current_app.frigate_config.cameras.keys():
+            return jsonify(
+                {"success": False, "message": f"{camera} is not a valid camera."}, "404"
+            )
+
+        paths = map(
+            lambda input: input.path,
+            current_app.frigate_config.cameras[camera].ffmpeg.inputs,
+        )
+    elif "," in clean_camera_user_pass(path_param):
         paths = path_param.split(",")
     else:
         paths = [path_param]
@@ -1100,7 +1112,7 @@ def ffprobe():
     output = []
 
     for path in paths:
-        ffprobe = ffprobe_stream(path)
+        ffprobe = ffprobe_stream(path.strip())
         output.append(
             {
                 "return_code": ffprobe.returncode,

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -880,6 +880,7 @@ def get_nvidia_gpu_stats() -> dict[str, str]:
 
 def ffprobe_stream(path: str) -> sp.CompletedProcess:
     """Run ffprobe on stream."""
+    clean_path = escape_special_characters(path)
     ffprobe_cmd = [
         "ffprobe",
         "-print_format",
@@ -888,7 +889,7 @@ def ffprobe_stream(path: str) -> sp.CompletedProcess:
         "stream=codec_long_name,width,height,bit_rate,duration,display_aspect_ratio,avg_frame_rate",
         "-loglevel",
         "quiet",
-        path,
+        clean_path,
     ]
     return sp.run(ffprobe_cmd, capture_output=True)
 

--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -40,18 +40,9 @@ export default function System() {
     }
 
     setState({ ...state, showFfprobe: true });
-    let paths = '';
-    config.cameras[camera].ffmpeg.inputs.forEach((input) => {
-      if (paths) {
-        paths += ',';
-        paths += input.path;
-      } else {
-        paths = input.path;
-      }
-    });
     const response = await axios.get('ffprobe', {
       params: {
-        paths,
+        paths: `camera:${camera}`,
       },
     });
 
@@ -117,7 +108,11 @@ export default function System() {
         <Dialog>
           <div className="p-4">
             <Heading size="lg">Vainfo Output</Heading>
-            {state.vainfo != '' ? <p className="mb-2 max-h-96 overflow-scroll">{state.vainfo}</p> : <ActivityIndicator />}
+            {state.vainfo != '' ? (
+              <p className="mb-2 max-h-96 overflow-scroll">{state.vainfo}</p>
+            ) : (
+              <ActivityIndicator />
+            )}
           </div>
           <div className="p-2 flex justify-start flex-row-reverse space-x-2">
             <Button className="ml-2" onClick={() => onCopyVainfo()} type="text">


### PR DESCRIPTION
The json config with camera paths has the obfuscated paths so they won't work with cameras that have user/pass. This way the system will work by using the internal config but users can still use the ffprobe path for whatever camera they want.