### PR TITLE
Support Controlling PTZ Cameras Via WebUI

### DIFF
--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -48,3 +48,21 @@ cameras:
 ```
 
 For camera model specific settings check the [camera specific](camera_specific.md) infos.
+
+## Setting up camera PTZ controls
+
+Add onvif config to camera
+
+```yaml
+cameras:
+  back:
+    ffmpeg:
+      ...
+    onvif:
+      host: 10.0.10.10
+      port: 8000
+      user: admin
+      password: "{FRIGATE_RTSP_PASSWORD}"
+```
+
+then PTZ controls will be available in the cameras WebUI.

--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -62,7 +62,7 @@ cameras:
       host: 10.0.10.10
       port: 8000
       user: admin
-      password: "{FRIGATE_RTSP_PASSWORD}"
+      password: password
 ```
 
 then PTZ controls will be available in the cameras WebUI.

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -409,6 +409,19 @@ timestamp_style:
   #           "shadow" (shadow for font)
   effect: None
 
+# Optional: connect to ONVIF camera
+# to enable PTZ controls.
+onvif:
+  # Required: host of the camera being connected to.
+  host: 0.0.0.0
+  # Optional: ONVIF port for device (default: shown below).
+  port: 8000
+  # Optional: username for login.
+  # NOTE: Some devices require admin to access ONVIF.
+  user: admin
+  # Optional: password for login.
+  password: admin
+
 # Required
 cameras:
   # Required: name of the camera

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -56,6 +56,14 @@ mqtt:
 ```
 
 ```yaml
+onvif:
+  host: 10.0.10.10
+  port: 8000
+  user: "{FRIGATE_RTSP_USER}"
+  password: "{FRIGATE_RTSP_PASSWORD}"
+```
+
+```yaml
 mqtt:
   # Optional: Enable mqtt server (default: shown below)
   enabled: True

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -409,19 +409,6 @@ timestamp_style:
   #           "shadow" (shadow for font)
   effect: None
 
-# Optional: connect to ONVIF camera
-# to enable PTZ controls.
-onvif:
-  # Required: host of the camera being connected to.
-  host: 0.0.0.0
-  # Optional: ONVIF port for device (default: shown below).
-  port: 8000
-  # Optional: username for login.
-  # NOTE: Some devices require admin to access ONVIF.
-  user: admin
-  # Optional: password for login.
-  password: admin
-
 # Required
 cameras:
   # Required: name of the camera
@@ -509,6 +496,19 @@ cameras:
       order: 0
       # Optional: Whether or not to show the camera in the Frigate UI (default: shown below)
       dashboard: True
+
+    # Optional: connect to ONVIF camera
+    # to enable PTZ controls.
+    onvif:
+      # Required: host of the camera being connected to.
+      host: 0.0.0.0
+      # Optional: ONVIF port for device (default: shown below).
+      port: 8000
+      # Optional: username for login.
+      # NOTE: Some devices require admin to access ONVIF.
+      user: admin
+      # Optional: password for login.
+      password: admin
 
 # Optional
 ui:

--- a/docs/docs/integrations/api.md
+++ b/docs/docs/integrations/api.md
@@ -291,3 +291,7 @@ Get ffprobe output for camera feed paths.
 | param   | Type   | Description                        |
 | ------- | ------ | ---------------------------------- |
 | `paths` | string | `,` separated list of camera paths |
+
+### `GET /api/<camera_name>/ptz/info`
+
+Get PTZ info for the camera.

--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -158,3 +158,14 @@ Topic to adjust motion contour area for a camera. Expected value is an integer.
 ### `frigate/<camera_name>/motion_contour_area/state`
 
 Topic with current motion contour area for a camera. Published value is an integer.
+
+### `frigate/<camera_name>/ptz`
+
+Topic to send PTZ commands to camera.
+
+| Command              | Description                                                                             |
+| -------------------- | --------------------------------------------------------------------------------------- |
+| preset-<preset_name> | send command to move to preset with name <preset_name>                                  |
+| MOVE_<dir>           | send command to continuously move in <dir>, possible values are [UP, DOWN, LEFT, RIGHT] |
+| ZOOM_<dir>           | send command to continuously zoom <dir>, possible values are [IN, OUT]                  |
+| STOP                 | send command to stop moving                                                             |

--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -165,7 +165,7 @@ Topic to send PTZ commands to camera.
 
 | Command                | Description                                                                             |
 | ---------------------- | --------------------------------------------------------------------------------------- |
-| `preset-<preset_name>` | send command to move to preset with name <preset_name>                                  |
-| `MOVE_<dir>`           | send command to continuously move in <dir>, possible values are [UP, DOWN, LEFT, RIGHT] |
-| `ZOOM_<dir>`           | send command to continuously zoom <dir>, possible values are [IN, OUT]                  |
+| `preset-<preset_name>` | send command to move to preset with name `<preset_name>`                                  |
+| `MOVE_<dir>`           | send command to continuously move in `<dir>`, possible values are [UP, DOWN, LEFT, RIGHT] |
+| `ZOOM_<dir>`           | send command to continuously zoom `<dir>`, possible values are [IN, OUT]                  |
 | `STOP`                 | send command to stop moving                                                             |

--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -163,9 +163,9 @@ Topic with current motion contour area for a camera. Published value is an integ
 
 Topic to send PTZ commands to camera.
 
-| Command              | Description                                                                             |
-| -------------------- | --------------------------------------------------------------------------------------- |
-| preset-<preset_name> | send command to move to preset with name <preset_name>                                  |
-| MOVE_<dir>           | send command to continuously move in <dir>, possible values are [UP, DOWN, LEFT, RIGHT] |
-| ZOOM_<dir>           | send command to continuously zoom <dir>, possible values are [IN, OUT]                  |
-| STOP                 | send command to stop moving                                                             |
+| Command                | Description                                                                             |
+| ---------------------- | --------------------------------------------------------------------------------------- |
+| `preset-<preset_name>` | send command to move to preset with name <preset_name>                                  |
+| `MOVE_<dir>`           | send command to continuously move in <dir>, possible values are [UP, DOWN, LEFT, RIGHT] |
+| `ZOOM_<dir>`           | send command to continuously zoom <dir>, possible values are [IN, OUT]                  |
+| `STOP`                 | send command to stop moving                                                             |

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -27,6 +27,7 @@ from frigate.models import Event, Recordings, Timeline
 from frigate.object_processing import TrackedObjectProcessor
 from frigate.output import output_frames
 from frigate.plus import PlusApi
+from frigate.ptz import OnvifController
 from frigate.record import RecordingCleanup, RecordingMaintainer
 from frigate.stats import StatsEmitter, stats_init
 from frigate.storage import StorageMaintainer
@@ -176,6 +177,9 @@ class FrigateApp:
             self.plus_api,
         )
 
+    def init_onvif(self) -> None:
+        self.onvif_controller = OnvifController(self.config)
+
     def init_dispatcher(self) -> None:
         comms: list[Communicator] = []
 
@@ -183,7 +187,9 @@ class FrigateApp:
             comms.append(MqttClient(self.config))
 
         comms.append(WebSocketClient(self.config))
-        self.dispatcher = Dispatcher(self.config, self.camera_metrics, comms)
+        self.dispatcher = Dispatcher(
+            self.config, self.onvif_controller, self.camera_metrics, comms
+        )
 
     def start_detectors(self) -> None:
         for name in self.config.cameras.keys():
@@ -382,6 +388,7 @@ class FrigateApp:
             self.set_log_levels()
             self.init_queues()
             self.init_database()
+            self.init_onvif()
             self.init_dispatcher()
         except Exception as e:
             print(e)

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -174,6 +174,7 @@ class FrigateApp:
             self.stats_tracking,
             self.detected_frames_processor,
             self.storage_maintainer,
+            self.onvif_controller,
             self.plus_api,
         )
 

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -229,6 +229,6 @@ class Dispatcher:
 
             logger.info(f"Setting ptz command to {command} for {camera_name}")
         except KeyError as k:
-            logger.error(f"Invalid PTZ command {payload}: {k.with_traceback()}")
+            logger.error(f"Invalid PTZ command {payload}: {k}")
         #except Exception as e:
         #    logger.error(f"Error sending {payload} to {camera_name}: {e}")

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -221,14 +221,13 @@ class Dispatcher:
         """Callback for ptz topic."""
         try:
             if "preset" in payload.lower():
+                command = OnvifCommandEnum.preset
                 param = payload.lower().split("-")[1]
-                self.onvif.handle_command(camera_name, OnvifCommandEnum.preset, param)
             else:
                 command = OnvifCommandEnum[payload.lower()]
-                self.onvif.handle_command(camera_name, command)
+                param = ""
 
+            self.onvif.handle_command(camera_name, command, param)
             logger.info(f"Setting ptz command to {command} for {camera_name}")
         except KeyError as k:
             logger.error(f"Invalid PTZ command {payload}: {k}")
-        # except Exception as e:
-        #    logger.error(f"Error sending {payload} to {camera_name}: {e}")

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 from abc import ABC, abstractmethod
 
 from frigate.config import FrigateConfig
+from frigate.ptz import OnvifController, OnvifCommandEnum
 from frigate.types import CameraMetricsTypes
 from frigate.util import restart_frigate
 
@@ -39,10 +40,12 @@ class Dispatcher:
     def __init__(
         self,
         config: FrigateConfig,
+        onvif: OnvifController,
         camera_metrics: dict[str, CameraMetricsTypes],
         communicators: list[Communicator],
     ) -> None:
         self.config = config
+        self.onvif = onvif
         self.camera_metrics = camera_metrics
         self.comms = communicators
 
@@ -63,11 +66,20 @@ class Dispatcher:
         """Handle receiving of payload from communicators."""
         if topic.endswith("set"):
             try:
+                # example /cam_name/detect/set payload=ON|OFF
                 camera_name = topic.split("/")[-3]
                 command = topic.split("/")[-2]
                 self._camera_settings_handlers[command](camera_name, payload)
             except Exception as e:
                 logger.error(f"Received invalid set command: {topic}")
+                return
+        elif topic.endswith("ptz"):
+            try:
+                # example /cam_name/ptz payload=MOVE_UP|MOVE_DOWN|STOP...
+                camera_name = topic.split("/")[-2]
+                self._on_ptz_command(camera_name, payload)
+            except Exception as e:
+                logger.error(f"Received invalid ptz command: {topic}")
                 return
         elif topic == "restart":
             restart_frigate()
@@ -204,3 +216,11 @@ class Dispatcher:
                 snapshots_settings.enabled = False
 
         self.publish(f"{camera_name}/snapshots/state", payload, retain=True)
+
+    def _on_ptz_command(self, camera_name: str, payload: str) -> None:
+        """Callback for ptz topic."""
+        try:
+            command = OnvifCommandEnum[payload.lower()]
+            self.onvif.handle_command(camera_name, command)
+        except Exception as e:
+            return

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -70,7 +70,7 @@ class Dispatcher:
                 camera_name = topic.split("/")[-3]
                 command = topic.split("/")[-2]
                 self._camera_settings_handlers[command](camera_name, payload)
-            except Exception as e:
+            except IndexError as e:
                 logger.error(f"Received invalid set command: {topic}")
                 return
         elif topic.endswith("ptz"):
@@ -78,7 +78,7 @@ class Dispatcher:
                 # example /cam_name/ptz payload=MOVE_UP|MOVE_DOWN|STOP...
                 camera_name = topic.split("/")[-2]
                 self._on_ptz_command(camera_name, payload)
-            except Exception as e:
+            except IndexError as e:
                 logger.error(f"Received invalid ptz command: {topic}")
                 return
         elif topic == "restart":
@@ -222,5 +222,8 @@ class Dispatcher:
         try:
             command = OnvifCommandEnum[payload.lower()]
             self.onvif.handle_command(camera_name, command)
-        except Exception as e:
-            return
+            logger.info(f"Setting ptz command to {command} for {camera_name}")
+        except KeyError as k:
+            logger.error(f"Invalid PTZ command {payload}: {k.with_traceback()}")
+        #except Exception as e:
+        #    logger.error(f"Error sending {payload} to {camera_name}: {e}")

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -220,8 +220,13 @@ class Dispatcher:
     def _on_ptz_command(self, camera_name: str, payload: str) -> None:
         """Callback for ptz topic."""
         try:
-            command = OnvifCommandEnum[payload.lower()]
-            self.onvif.handle_command(camera_name, command)
+            if "preset" in payload.lower():
+                param = payload.lower().split("-")[1]
+                self.onvif.handle_command(camera_name, OnvifCommandEnum.preset, param)
+            else:
+                command = OnvifCommandEnum[payload.lower()]
+                self.onvif.handle_command(camera_name, command)
+
             logger.info(f"Setting ptz command to {command} for {camera_name}")
         except KeyError as k:
             logger.error(f"Invalid PTZ command {payload}: {k.with_traceback()}")

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -230,5 +230,5 @@ class Dispatcher:
             logger.info(f"Setting ptz command to {command} for {camera_name}")
         except KeyError as k:
             logger.error(f"Invalid PTZ command {payload}: {k}")
-        #except Exception as e:
+        # except Exception as e:
         #    logger.error(f"Error sending {payload} to {camera_name}: {e}")

--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -169,7 +169,8 @@ class MqttClient(Communicator):  # type: ignore[misc]
 
             if self.config.cameras[name].onvif.host:
                 self.client.message_callback_add(
-                    f"{self.mqtt_config.topic_prefix}/{name}/ptz/#"
+                    f"{self.mqtt_config.topic_prefix}/{name}/ptz/#",
+                    self.on_mqtt_command,
                 )
 
         self.client.message_callback_add(

--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -167,6 +167,11 @@ class MqttClient(Communicator):  # type: ignore[misc]
                     self.on_mqtt_command,
                 )
 
+            if self.config.cameras[name].onvif.host:
+                self.client.message_callback_add(
+                    f"{self.mqtt_config.topic_prefix}/{name}/ptz/#"
+                )
+
         self.client.message_callback_add(
             f"{self.mqtt_config.topic_prefix}/restart", self.on_mqtt_command
         )

--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -169,7 +169,7 @@ class MqttClient(Communicator):  # type: ignore[misc]
 
             if self.config.cameras[name].onvif.host:
                 self.client.message_callback_add(
-                    f"{self.mqtt_config.topic_prefix}/{name}/ptz/#",
+                    f"{self.mqtt_config.topic_prefix}/{name}/ptz",
                     self.on_mqtt_command,
                 )
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -951,8 +951,12 @@ class FrigateConfig(FrigateBaseModel):
 
             # ONVIF substitution
             if camera_config.onvif.user or camera_config.onvif.password:
-                camera_config.onvif.user = camera_config.onvif.user.format(**FRIGATE_ENV_VARS)
-                camera_config.onvif.password = camera_config.onvif.password.format(**FRIGATE_ENV_VARS)
+                camera_config.onvif.user = camera_config.onvif.user.format(
+                    **FRIGATE_ENV_VARS
+                )
+                camera_config.onvif.password = camera_config.onvif.password.format(
+                    **FRIGATE_ENV_VARS
+                )
 
             # Add default filters
             object_keys = camera_config.objects.track

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -950,7 +950,8 @@ class FrigateConfig(FrigateBaseModel):
                 input.path = input.path.format(**FRIGATE_ENV_VARS)
 
             # ONVIF substitution
-            if camera_config.onvif.password:
+            if camera_config.onvif.user or camera_config.onvif.password:
+                camera_config.onvif.user = camera_config.onvif.user.format(**FRIGATE_ENV_VARS)
                 camera_config.onvif.password = camera_config.onvif.password.format(**FRIGATE_ENV_VARS)
 
             # Add default filters

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -125,6 +125,13 @@ class MqttConfig(FrigateBaseModel):
         return v
 
 
+class OnvifConfig(FrigateBaseModel):
+    host: str = Field(default="", title="Onvif Host")
+    port: int = Field(default=8000, title="Onvif Port")
+    user: Optional[str] = Field(title="Onvif Username")
+    password: Optional[str] = Field(title="Onvif Password")
+
+
 class RetainModeEnum(str, Enum):
     all = "all"
     motion = "motion"
@@ -606,6 +613,9 @@ class CameraConfig(FrigateBaseModel):
     motion: Optional[MotionConfig] = Field(title="Motion detection configuration.")
     detect: DetectConfig = Field(
         default_factory=DetectConfig, title="Object detection configuration."
+    )
+    onvif: OnvifConfig = Field(
+        default_factory=OnvifConfig, title="Camera Onvif Configuration."
     )
     ui: CameraUiConfig = Field(
         default_factory=CameraUiConfig, title="Camera UI Modifications."

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -949,6 +949,10 @@ class FrigateConfig(FrigateBaseModel):
             for input in camera_config.ffmpeg.inputs:
                 input.path = input.path.format(**FRIGATE_ENV_VARS)
 
+            # ONVIF substitution
+            if camera_config.onvif.password:
+                camera_config.onvif.password = camera_config.onvif.password.format(**FRIGATE_ENV_VARS)
+
             # Add default filters
             object_keys = camera_config.objects.track
             if camera_config.objects.filters is None:

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -36,6 +36,7 @@ from frigate.const import CLIPS_DIR, MAX_SEGMENT_DURATION, RECORD_DIR
 from frigate.models import Event, Recordings, Timeline
 from frigate.object_processing import TrackedObject
 from frigate.plus import PlusApi
+from frigate.ptz import OnvifController
 from frigate.stats import stats_snapshot
 from frigate.util import (
     clean_camera_user_pass,
@@ -59,6 +60,7 @@ def create_app(
     stats_tracking,
     detected_frames_processor,
     storage_maintainer: StorageMaintainer,
+    onvif: OnvifController,
     plus_api: PlusApi,
 ):
     app = Flask(__name__)
@@ -77,6 +79,7 @@ def create_app(
     app.stats_tracking = stats_tracking
     app.detected_frames_processor = detected_frames_processor
     app.storage_maintainer = storage_maintainer
+    app.onvif = onvif
     app.plus_api = plus_api
     app.camera_error_image = None
     app.hwaccel_errors = []
@@ -990,6 +993,14 @@ def mjpeg_feed(camera_name):
             ),
             mimetype="multipart/x-mixed-replace; boundary=frame",
         )
+    else:
+        return "Camera named {} not found".format(camera_name), 404
+
+
+@bp.route("/<camera_name>/ptz/info")
+def camera_ptz_info(camera_name):
+    if camera_name in current_app.frigate_config.cameras:
+        return jsonify(current_app.onvif.get_camera_info(camera_name))
     else:
         return "Camera named {} not found".format(camera_name), 404
 

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -19,6 +19,10 @@ from frigate.util import clean_camera_user_pass
 
 def listener_configurer() -> None:
     root = logging.getLogger()
+
+    if root.hasHandlers():
+        root.handlers.clear()
+
     console_handler = logging.StreamHandler()
     formatter = logging.Formatter(
         "[%(asctime)s] %(name)-30s %(levelname)-8s: %(message)s", "%Y-%m-%d %H:%M:%S"
@@ -31,6 +35,10 @@ def listener_configurer() -> None:
 def root_configurer(queue: Queue) -> None:
     h = handlers.QueueHandler(queue)
     root = logging.getLogger()
+
+    if root.hasHandlers():
+        root.handlers.clear()
+
     root.addHandler(h)
     root.setLevel(logging.INFO)
 

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -35,21 +35,24 @@ class OnvifController:
                 continue
 
             if cam.onvif.host:
-                self.cams[cam_name] = {
-                    "onvif": ONVIFCamera(
-                        cam.onvif.host,
-                        cam.onvif.port,
-                        cam.onvif.user,
-                        cam.onvif.password,
-                        wsdl_dir=site.getsitepackages()[0].replace(
-                            "dist-packages", "site-packages"
-                        )
-                        + "/wsdl",
-                    ),
-                    "init": False,
-                    "active": False,
-                    "presets": {},
-                }
+                try:
+                    self.cams[cam_name] = {
+                        "onvif": ONVIFCamera(
+                            cam.onvif.host,
+                            cam.onvif.port,
+                            cam.onvif.user,
+                            cam.onvif.password,
+                            wsdl_dir=site.getsitepackages()[0].replace(
+                                "dist-packages", "site-packages"
+                            )
+                            + "/wsdl",
+                        ),
+                        "init": False,
+                        "active": False,
+                        "presets": {},
+                    }
+                except ONVIFError as e:
+                    logger.error(f"Onvif connection to {cam.name} failed: {e}")
 
     def _init_onvif(self, camera_name: str) -> bool:
         onvif: ONVIFCamera = self.cams[camera_name]["onvif"]

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -41,7 +41,7 @@ class OnvifController:
                         cam.onvif.port,
                         cam.onvif.user,
                         cam.onvif.password,
-                        #wsdl_dir=site.getsitepackages()[0].replace('dist-packages', 'site-packages') + '/wsdl'
+                        wsdl_dir=site.getsitepackages()[0].replace('dist-packages', 'site-packages') + '/wsdl'
                     ),
                     "init": False,
                     "active": False,

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -61,7 +61,7 @@ class OnvifController:
         # setup existing presets
         presets: list[dict] = ptz.GetPresets({"ProfileToken": profile.token})
         for preset in presets:
-            self.cams[camera_name]["presets"][preset["Name"]] = preset["token"]
+            self.cams[camera_name]["presets"][preset["Name"].lower()] = preset["token"]
 
         # get list of supported features
         ptz_config = ptz.GetConfigurationOptions(request)

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -41,7 +41,10 @@ class OnvifController:
                         cam.onvif.port,
                         cam.onvif.user,
                         cam.onvif.password,
-                        wsdl_dir="/home/vscode/.local/lib/python3.4/site-packages/wsdl/",
+                        wsdl_dir=site.getsitepackages()[0].replace(
+                            "dist-packages", "site-packages"
+                        )
+                        + "/wsdl",
                     ),
                     "init": False,
                     "active": False,

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -52,7 +52,6 @@ class OnvifController:
         ptz = onvif.create_ptz_service()
         request = ptz.create_type("GetConfigurationOptions")
         request.ConfigurationToken = profile.PTZConfiguration.token
-        ptz_config = ptz.GetConfigurationOptions(request)
 
         # setup moving request
         move_request = ptz.create_type("ContinuousMove")
@@ -63,6 +62,10 @@ class OnvifController:
         presets: list[dict] = ptz.GetPresets({"ProfileToken": profile.token})
         for preset in presets:
             self.cams[camera_name]["presets"][preset["Name"]] = preset["token"]
+
+        # get list of supported features
+        ptz_config = ptz.GetConfigurationOptions(request)
+        logger.error(f"ptz config is {ptz_config}")
 
         self.cams[camera_name]["init"] = True
 
@@ -146,7 +149,7 @@ class OnvifController:
         onvif.get_service("ptz").ContinuousMove(move_request)
 
     def handle_command(
-        self, camera_name: str, command: OnvifCommandEnum, param: str
+        self, camera_name: str, command: OnvifCommandEnum, param: str = ""
     ) -> None:
         if camera_name not in self.cams.keys():
             logger.error(f"Onvif is not setup for {camera_name}")

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -38,6 +38,7 @@ class OnvifController:
                 }
 
     def _init_onvif(self, camera_name: str) -> None:
+        logger.error(f"Init onvif...")
         onvif: ONVIFCamera = self.cams[camera_name]["onvif"]
         media = onvif.create_media_service()
         profile = media.GetProfiles()[0]
@@ -56,6 +57,7 @@ class OnvifController:
         self.cams[camera_name]["move_request"] = move_request
 
     def _stop(self, camera_name: str) -> None:
+        logger.error(f"Stop onvif")
         onvif: ONVIFCamera = self.cams[camera_name]["onvif"]
         move_request = self.cams[camera_name]["move_request"]
         onvif.get_service("ptz").Stop(
@@ -68,6 +70,7 @@ class OnvifController:
         self.cams[camera_name]["active"] = False
 
     def _move(self, camera_name: str, command: OnvifCommandEnum) -> None:
+        logger.error(f"Move onvif {command}")
         if self.cams[camera_name]["active"]:
             logger.warning(
                 f"{camera_name} is already performing an action, stopping..."
@@ -78,13 +81,13 @@ class OnvifController:
         onvif: ONVIFCamera = self.cams[camera_name]["onvif"]
         move_request = self.cams[camera_name]["move_request"]
 
-        if command == OnvifCommandEnum.left:
+        if command == OnvifCommandEnum.move_left:
             move_request.Velocity.PanTilt.x = -0.5
             move_request.Velocity.PanTilt.y = 0
-        elif command == OnvifCommandEnum.right:
+        elif command == OnvifCommandEnum.move_right:
             move_request.Velocity.PanTilt.x = 0.5
             move_request.Velocity.PanTilt.y = 0
-        elif command == OnvifCommandEnum.up:
+        elif command == OnvifCommandEnum.move_up:
             move_request.Velocity.PanTilt.x = 0
             move_request.Velocity.PanTilt.y = 1
         else:

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -1,6 +1,7 @@
 """Configure and control camera via onvif."""
 
 import logging
+import site
 
 from enum import Enum
 from onvif import ONVIFCamera
@@ -37,6 +38,7 @@ class OnvifController:
                         cam.onvif.port,
                         cam.onvif.user,
                         cam.onvif.password,
+                        wsdl_dir=site.getsitepackages()[0].replace('dist-packages', 'site-packages') + '/wsdl'
                     ),
                     "init": False,
                     "active": False,

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -67,10 +67,10 @@ class OnvifController:
         ptz_config = ptz.GetConfigurationOptions(request)
         supported_features = []
 
-        if ptz_config.get("Spaces", {}).get("ContinuousPanTiltVelocitySpace"):
+        if ptz_config.Spaces and ptz_config.Spaces.ContinuousPanTiltVelocitySpace:
             supported_features.append("pt")
 
-        if ptz_config.get("Spaces", {}).get("ContinuousZoomVelocitySpace"):
+        if ptz_config.Spaces and ptz_config.Spaces.ContinuousZoomVelocitySpace:
             supported_features.append("zoom")
 
         self.cams[camera_name]["features"] = supported_features
@@ -190,6 +190,6 @@ class OnvifController:
 
         return {
             "name": camera_name,
-            "features": self.cams[camera_name]["feautres"],
-            "presets": self.cams[camera_name]["presets"].keys(),
+            "features": self.cams[camera_name]["features"],
+            "presets": list(self.cams[camera_name]["presets"].keys()),
         }

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -152,7 +152,7 @@ class OnvifController:
         if command == OnvifCommandEnum.zoom_in:
             move_request.Velocity = {"Zoom": {"x": 0.5}}
         elif command == OnvifCommandEnum.zoom_out:
-            move_request.Velocity = {"PanTilt": {"x": -0.5}}
+            move_request.Velocity = {"Zoom": {"x": -0.5}}
 
         onvif.get_service("ptz").ContinuousMove(move_request)
 

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -76,7 +76,12 @@ class OnvifController:
         self.cams[camera_name]["move_request"] = move_request
 
         # setup existing presets
-        presets: list[dict] = ptz.GetPresets({"ProfileToken": profile.token})
+        try:
+            presets: list[dict] = ptz.GetPresets({"ProfileToken": profile.token})
+        except ONVIFError as e:
+            logger.error(f"Unable to get presets from camera: {camera_name}: {e}")
+            return False
+
         for preset in presets:
             self.cams[camera_name]["presets"][preset["Name"].lower()] = preset["token"]
 

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -1,0 +1,107 @@
+"""Configure and control camera via onvif."""
+
+import logging
+
+from enum import Enum
+from onvif import ONVIFCamera
+
+from frigate.config import FrigateConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+class OnvifCommandEnum(str, Enum):
+    """Holds all possible move commands"""
+    move_down = "move_down"
+    move_left = "move_left"
+    move_right = "move_right"
+    move_up = "move_up"
+    stop = "stop"
+
+
+class OnvifController:
+    def __init__(self, config: FrigateConfig) -> None:
+        self.cams: dict[str, ONVIFCamera] = {}
+
+        for cam_name, cam in config.cameras.items():
+            if cam.onvif.host:
+                self.cams[cam_name] = {
+                    "onvif": ONVIFCamera(
+                        cam.onvif.host,
+                        cam.onvif.port,
+                        cam.onvif.user,
+                        cam.onvif.password,
+                    ),
+                    "init": False,
+                    "active": False,
+                }
+
+    def _init_onvif(self, camera_name: str) -> None:
+        onvif: ONVIFCamera = self.cams[camera_name]["onvif"]
+        media = onvif.create_media_service()
+        profile = media.GetProfiles()[0]
+        ptz = onvif.create_ptz_service()
+        request = ptz.create_type("GetConfigurationOptions")
+        request.ConfigurationToken = profile.PTZConfiguration.token
+        ptz_config = ptz.GetConfigurationOptions(request)
+        move_request = ptz.create_type("ContinuousMove")
+        move_request.ProfileToken = profile.token
+
+        if move_request.Velocity is None:
+            move_request.Velocity = ptz.GetStatus(
+                {"ProfileToken": profile.token}
+            ).Position
+
+        self.cams[camera_name]["move_request"] = move_request
+
+    def _stop(self, camera_name: str) -> None:
+        onvif: ONVIFCamera = self.cams[camera_name]["onvif"]
+        move_request = self.cams[camera_name]["move_request"]
+        onvif.get_service("ptz").Stop(
+            {
+                "ProfileToken": move_request.ProfileToken,
+                "PanTilt": True,
+                "Zoom": True,
+            }
+        )
+        self.cams[camera_name]["active"] = False
+
+    def _move(self, camera_name: str, command: OnvifCommandEnum) -> None:
+        if self.cams[camera_name]["active"]:
+            logger.warning(
+                f"{camera_name} is already performing an action, stopping..."
+            )
+            self._stop(camera_name)
+
+        self.cams[camera_name]["active"] = True
+        onvif: ONVIFCamera = self.cams[camera_name]["onvif"]
+        move_request = self.cams[camera_name]["move_request"]
+
+        if command == OnvifCommandEnum.left:
+            move_request.Velocity.PanTilt.x = -0.5
+            move_request.Velocity.PanTilt.y = 0
+        elif command == OnvifCommandEnum.right:
+            move_request.Velocity.PanTilt.x = 0.5
+            move_request.Velocity.PanTilt.y = 0
+        elif command == OnvifCommandEnum.up:
+            move_request.Velocity.PanTilt.x = 0
+            move_request.Velocity.PanTilt.y = 1
+        else:
+            move_request.Velocity.PanTilt.x = 0
+            move_request.Velocity.PanTilt.y = -1
+
+        onvif.get_service("ptz").ContinuousMove(move_request)
+
+    def handle_command(self, camera_name, command: OnvifCommandEnum) -> None:
+        if camera_name not in self.cams.keys():
+            logger.error(f"Onvif is not setup for {camera_name}")
+            return
+
+        if not self.cams[camera_name]["init"]:
+            self._init_onvif(camera_name)
+
+        if command == OnvifCommandEnum.stop:
+            self._stop(camera_name)
+        else:
+            self._move(camera_name, command)

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -31,6 +31,9 @@ class OnvifController:
         self.cams: dict[str, ONVIFCamera] = {}
 
         for cam_name, cam in config.cameras.items():
+            if not cam.enabled:
+                continue
+
             if cam.onvif.host:
                 self.cams[cam_name] = {
                     "onvif": ONVIFCamera(
@@ -55,7 +58,7 @@ class OnvifController:
             profile = media.GetProfiles()[0]
         except ONVIFError as e:
             logger.error(f"Unable to connect to camera: {camera_name}: {e}")
-            
+
         ptz = onvif.create_ptz_service()
         request = ptz.create_type("GetConfigurationOptions")
         request.ConfigurationToken = profile.PTZConfiguration.token

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -4,7 +4,7 @@ import logging
 import site
 
 from enum import Enum
-from onvif import ONVIFCamera
+from onvif import ONVIFCamera, ONVIFError
 
 from frigate.config import FrigateConfig
 
@@ -38,7 +38,7 @@ class OnvifController:
                         cam.onvif.port,
                         cam.onvif.user,
                         cam.onvif.password,
-                        wsdl_dir=site.getsitepackages()[0].replace('dist-packages', 'site-packages') + '/wsdl'
+                        #wsdl_dir=site.getsitepackages()[0].replace('dist-packages', 'site-packages') + '/wsdl'
                     ),
                     "init": False,
                     "active": False,
@@ -50,7 +50,12 @@ class OnvifController:
 
         # create init services
         media = onvif.create_media_service()
-        profile = media.GetProfiles()[0]
+
+        try:
+            profile = media.GetProfiles()[0]
+        except ONVIFError as e:
+            logger.error(f"Unable to connect to camera: {camera_name}: {e}")
+            
         ptz = onvif.create_ptz_service()
         request = ptz.create_type("GetConfigurationOptions")
         request.ConfigurationToken = profile.PTZConfiguration.token

--- a/frigate/ptz.py
+++ b/frigate/ptz.py
@@ -41,7 +41,10 @@ class OnvifController:
                         cam.onvif.port,
                         cam.onvif.user,
                         cam.onvif.password,
-                        wsdl_dir=site.getsitepackages()[0].replace('dist-packages', 'site-packages') + '/wsdl'
+                        wsdl_dir=site.getsitepackages()[0].replace(
+                            "dist-packages", "site-packages"
+                        )
+                        + "/wsdl",
                     ),
                     "init": False,
                     "active": False,

--- a/frigate/test/test_http.py
+++ b/frigate/test/test_http.py
@@ -209,7 +209,13 @@ class TestHttp(unittest.TestCase):
 
     def test_event_retention(self):
         app = create_app(
-            FrigateConfig(**self.minimal_config), self.db, None, None, None, PlusApi()
+            FrigateConfig(**self.minimal_config),
+            self.db,
+            None,
+            None,
+            None,
+            None,
+            PlusApi(),
         )
         id = "123456.random"
 

--- a/frigate/test/test_http.py
+++ b/frigate/test/test_http.py
@@ -114,7 +114,13 @@ class TestHttp(unittest.TestCase):
 
     def test_get_event_list(self):
         app = create_app(
-            FrigateConfig(**self.minimal_config), self.db, None, None, None, PlusApi()
+            FrigateConfig(**self.minimal_config),
+            self.db,
+            None,
+            None,
+            None,
+            None,
+            PlusApi(),
         )
         id = "123456.random"
         id2 = "7890.random"
@@ -143,7 +149,13 @@ class TestHttp(unittest.TestCase):
 
     def test_get_good_event(self):
         app = create_app(
-            FrigateConfig(**self.minimal_config), self.db, None, None, None, PlusApi()
+            FrigateConfig(**self.minimal_config),
+            self.db,
+            None,
+            None,
+            None,
+            None,
+            PlusApi(),
         )
         id = "123456.random"
 
@@ -157,7 +169,13 @@ class TestHttp(unittest.TestCase):
 
     def test_get_bad_event(self):
         app = create_app(
-            FrigateConfig(**self.minimal_config), self.db, None, None, None, PlusApi()
+            FrigateConfig(**self.minimal_config),
+            self.db,
+            None,
+            None,
+            None,
+            None,
+            PlusApi(),
         )
         id = "123456.random"
         bad_id = "654321.other"
@@ -170,7 +188,13 @@ class TestHttp(unittest.TestCase):
 
     def test_delete_event(self):
         app = create_app(
-            FrigateConfig(**self.minimal_config), self.db, None, None, None, PlusApi()
+            FrigateConfig(**self.minimal_config),
+            self.db,
+            None,
+            None,
+            None,
+            None,
+            PlusApi(),
         )
         id = "123456.random"
 
@@ -204,7 +228,13 @@ class TestHttp(unittest.TestCase):
 
     def test_set_delete_sub_label(self):
         app = create_app(
-            FrigateConfig(**self.minimal_config), self.db, None, None, None, PlusApi()
+            FrigateConfig(**self.minimal_config),
+            self.db,
+            None,
+            None,
+            None,
+            None,
+            PlusApi(),
         )
         id = "123456.random"
         sub_label = "sub"
@@ -232,7 +262,13 @@ class TestHttp(unittest.TestCase):
 
     def test_sub_label_list(self):
         app = create_app(
-            FrigateConfig(**self.minimal_config), self.db, None, None, None, PlusApi()
+            FrigateConfig(**self.minimal_config),
+            self.db,
+            None,
+            None,
+            None,
+            None,
+            PlusApi(),
         )
         id = "123456.random"
         sub_label = "sub"
@@ -255,6 +291,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
+            None,
             PlusApi(),
         )
 
@@ -267,6 +304,7 @@ class TestHttp(unittest.TestCase):
         app = create_app(
             FrigateConfig(**self.minimal_config).runtime_config,
             self.db,
+            None,
             None,
             None,
             None,
@@ -285,6 +323,7 @@ class TestHttp(unittest.TestCase):
         app = create_app(
             FrigateConfig(**self.minimal_config).runtime_config,
             self.db,
+            None,
             None,
             None,
             None,

--- a/requirements-wheels.txt
+++ b/requirements-wheels.txt
@@ -4,6 +4,7 @@ imutils == 0.5.*
 matplotlib == 3.6.*
 mypy == 0.942
 numpy == 1.23.*
+onvif_zeep == 0.2.12
 opencv-python-headless == 4.5.5.*
 paho-mqtt == 1.6.*
 peewee == 3.15.*

--- a/web/src/api/ws.jsx
+++ b/web/src/api/ws.jsx
@@ -120,6 +120,15 @@ export function useSnapshotsState(camera) {
   return { payload, send, connected };
 }
 
+export function usePtzCommand(camera) {
+  const {
+    value: { payload },
+    send,
+    connected,
+  } = useWs(`${camera}/ptz`, `${camera}/ptz`);
+  return { payload, send, connected };
+}
+
 export function useRestart() {
   const {
     value: { payload },

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -115,20 +115,64 @@ export default function CameraControlPanel({ camera = '' }) {
             Pan / Tilt
           </Heading>
           <div className="w-full flex justify-center">
-            <button onMouseDown={(e) => onSetMove(e, 'UP')} onMouseUp={(e) => onSetStop(e)}>
+            <button
+              onMouseDown={(e) => onSetMove(e, 'UP')}
+              onMouseUp={(e) => onSetStop(e)}
+              onTouchStart={(e) => {
+                onSetMove(e, 'UP');
+                e.preventDefault();
+              }}
+              onTouchEnd={(e) => {
+                onSetStop(e);
+                e.preventDefault();
+              }}
+            >
               <ArrowUpDouble className="h-12 p-2 bg-slate-500" />
             </button>
           </div>
           <div className="w-full flex justify-between">
-            <button onMouseDown={(e) => onSetMove(e, 'LEFT')} onMouseUp={(e) => onSetStop(e)}>
+            <button
+              onMouseDown={(e) => onSetMove(e, 'LEFT')}
+              onMouseUp={(e) => onSetStop(e)}
+              onTouchStart={(e) => {
+                onSetMove(e, 'LEFT');
+                e.preventDefault();
+              }}
+              onTouchEnd={(e) => {
+                onSetStop(e);
+                e.preventDefault();
+              }}
+            >
               <ArrowLeftDouble className="btn h-12 p-2 bg-slate-500" />
             </button>
-            <button onMouseDown={(e) => onSetMove(e, 'RIGHT')} onMouseUp={(e) => onSetStop(e)}>
+            <button
+              onMouseDown={(e) => onSetMove(e, 'RIGHT')}
+              onMouseUp={(e) => onSetStop(e)}
+              onTouchStart={(e) => {
+                onSetMove(e, 'RIGHT');
+                e.preventDefault();
+              }}
+              onTouchEnd={(e) => {
+                onSetStop(e);
+                e.preventDefault();
+              }}
+            >
               <ArrowRightDouble className="h-12 p-2 bg-slate-500" />
             </button>
           </div>
           <div className="flex justify-center">
-            <button onMouseDown={(e) => onSetMove(e, 'DOWN')} onMouseUp={(e) => onSetStop(e)}>
+            <button
+              onMouseDown={(e) => onSetMove(e, 'DOWN')}
+              onMouseUp={(e) => onSetStop(e)}
+              onTouchStart={(e) => {
+                onSetMove(e, 'DOWN');
+                e.preventDefault();
+              }}
+              onTouchEnd={(e) => {
+                onSetStop(e);
+                e.preventDefault();
+              }}
+            >
               <ArrowDownDouble className="h-12 p-2 bg-slate-500" />
             </button>
           </div>
@@ -141,13 +185,35 @@ export default function CameraControlPanel({ camera = '' }) {
             Zoom
           </Heading>
           <div className="w-full flex justify-center">
-            <button onMouseDown={(e) => onSetZoom(e, 'IN')} onMouseUp={(e) => onSetStop(e)}>
+            <button
+              onMouseDown={(e) => onSetZoom(e, 'IN')}
+              onMouseUp={(e) => onSetStop(e)}
+              onTouchStart={(e) => {
+                onSetZoom(e, 'IN');
+                e.preventDefault();
+              }}
+              onTouchEnd={(e) => {
+                onSetStop(e);
+                e.preventDefault();
+              }}
+            >
               <div className="h-12 w-12 p-2 text-2xl bg-slate-500 select-none">+</div>
             </button>
           </div>
           <div className="h-12" />
           <div className="flex justify-center">
-            <button onMouseDown={(e) => onSetZoom(e, 'OUT')} onMouseUp={(e) => onSetStop(e)}>
+            <button
+              onMouseDown={(e) => onSetZoom(e, 'OUT')}
+              onMouseUp={(e) => onSetStop(e)}
+              onTouchStart={(e) => {
+                onSetZoom(e, 'OUT');
+                e.preventDefault();
+              }}
+              onTouchEnd={(e) => {
+                onSetStop(e);
+                e.preventDefault();
+              }}
+            >
               <div className="h-12 w-12 p-2 text-2xl bg-slate-500 select-none">-</div>
             </button>
           </div>

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -1,0 +1,56 @@
+import { h } from 'preact';
+import { useState } from 'preact/hooks';
+import useSWR from 'swr';
+import { usePtzCommand } from '../api/ws';
+import ActivityIndicator from './ActivityIndicator';
+import Button from './Button';
+
+export default function CameraControlPanel({ camera = '' }) {
+  const { data: ptz } = useSWR(`${camera}/ptz/info`);
+  const [currentPreset, setCurrentPreset] = useState('');
+
+  const { payload: _, send: sendPtz } = usePtzCommand(camera);
+
+  const onSetPreview = async (e) => {
+    e.stopPropagation();
+
+    if (currentPreset == 'none') {
+      return;
+    }
+
+    sendPtz(`preset-${currentPreset}`);
+    setCurrentPreset('');
+  };
+
+  if (!ptz) {
+    return <ActivityIndicator />;
+  }
+
+  return (
+    <div data-testid="cameras" className="grid grid-cols-1 3xl:grid-cols-4 md:grid-cols-3 gap-4">
+      ptz is enabled with features {ptz.features[0]}
+      {ptz.presets && (
+        <div>
+          <div className="p-4">
+            <select
+              className="cursor-pointer rounded dark:bg-slate-800"
+              value={currentPreset}
+              onChange={(e) => {
+                setCurrentPreset(e.target.value);
+              }}
+            >
+              <option value="">Select Preset</option>
+              {ptz.presets.map((item) => (
+                <option key={item} value={item}>
+                  {item}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <Button onClick={(e) => onSetPreview(e)}>Move Camera To Preset</Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -142,13 +142,13 @@ export default function CameraControlPanel({ camera = '' }) {
           </Heading>
           <div className="w-full flex justify-center">
             <button onMouseDown={(e) => onSetZoom(e, 'IN')} onMouseUp={(e) => onSetStop(e)}>
-              <div className="h-12 w-12 p-2 text-2xl bg-slate-500">+</div>
+              <div className="h-12 w-12 p-2 text-2xl bg-slate-500 select-none">+</div>
             </button>
           </div>
           <div className="h-12" />
           <div className="flex justify-center">
             <button onMouseDown={(e) => onSetZoom(e, 'OUT')} onMouseUp={(e) => onSetStop(e)}>
-              <div className="h-12 w-12 p-2 text-2xl bg-slate-500">-</div>
+              <div className="h-12 w-12 p-2 text-2xl bg-slate-500 select-none">-</div>
             </button>
           </div>
         </div>

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -42,7 +42,7 @@ export default function CameraControlPanel({ camera = '' }) {
               <option value="">Select Preset</option>
               {ptz.presets.map((item) => (
                 <option key={item} value={item}>
-                  {item}
+                  {item.charAt(0).toUpperCase() + item.slice(1)}
                 </option>
               ))}
             </select>

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -105,7 +105,7 @@ export default function CameraControlPanel({ camera = '' }) {
 
   return (
     <div data-testid="control-panel" className="p-4 sm:flex justify-start">
-      {ptz.features.includes('zoom') && (
+      {ptz.features.includes('pt') && (
         <div className="flex justify-center">
           <div className="w-44 px-4">
             <Heading size="xs" className="my-4">

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -26,6 +26,17 @@ export default function CameraControlPanel({ camera = '' }) {
     setCurrentPreset('');
   };
 
+  const onSetMove = async (e, dir) => {
+    e.stopPropagation();
+    sendPtz(`MOVE_${dir}`);
+    setCurrentPreset('');
+  };
+
+  const onSetStop = async (e) => {
+    e.stopPropagation();
+    sendPtz('STOP');
+  };
+
   if (!ptz) {
     return <ActivityIndicator />;
   }
@@ -35,14 +46,22 @@ export default function CameraControlPanel({ camera = '' }) {
       {ptz.features.includes('pt') && (
         <div className="w-44 p-4">
           <div className="w-full flex justify-center">
-            <ArrowUpDouble className="h-12 p-2 bg-slate-500" />
+            <button onMouseDown={(e) => onSetMove(e, 'UP')} onMouseUp={(e) => onSetStop(e)}>
+              <ArrowUpDouble className="h-12 p-2 bg-slate-500" />
+            </button>
           </div>
           <div className="w-full flex justify-between">
-            <ArrowLeftDouble className="h-12 p-2 bg-slate-500" />
-            <ArrowRightDouble className="h-12 p-2 bg-slate-500" />
+            <button onMouseDown={(e) => onSetMove(e, 'LEFT')} onMouseUp={(e) => onSetStop(e)}>
+              <ArrowLeftDouble className="btn h-12 p-2 bg-slate-500" />
+            </button>
+            <button onMouseDown={(e) => onSetMove(e, 'RIGHT')} onMouseUp={(e) => onSetStop(e)}>
+              <ArrowRightDouble className="h-12 p-2 bg-slate-500" />
+            </button>
           </div>
           <div className="flex justify-center">
-            <ArrowDownDouble className="h-12 p-2 bg-slate-500" />
+            <button onMouseDown={(e) => onSetMove(e, 'DOWN')} onMouseUp={(e) => onSetStop(e)}>
+              <ArrowDownDouble className="h-12 p-2 bg-slate-500" />
+            </button>
           </div>
         </div>
       )}

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -104,7 +104,7 @@ export default function CameraControlPanel({ camera = '' }) {
   });
 
   return (
-    <div data-testid="control-panel" className="p-4 sm:flex justify-start">
+    <div data-testid="control-panel" className="p-4 text-center sm:flex justify-start">
       {ptz.features.includes('pt') && (
         <div className="flex justify-center">
           <div className="w-44 px-4">

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -48,6 +48,65 @@ export default function CameraControlPanel({ camera = '' }) {
     return <ActivityIndicator />;
   }
 
+  document.addEventListener('keydown', (e) => {
+    if (!e) {
+      return;
+    }
+
+    if (e.repeat) {
+      e.preventDefault();
+      return;
+    }
+
+    console.log('Handling key down ' + e.key);
+
+    if (ptz.features.includes('pt')) {
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        onSetMove(e, 'LEFT');
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        onSetMove(e, 'RIGHT');
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        onSetMove(e, 'UP');
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        onSetMove(e, 'DOWN');
+      }
+
+      if (ptz.features.includes('zoom')) {
+        if (e.key == '+') {
+          e.preventDefault();
+          onSetZoom(e, 'IN');
+        } else if (e.key == '-') {
+          e.preventDefault();
+          onSetZoom(e, 'OUT');
+        }
+      }
+    }
+  });
+
+  document.addEventListener('keyup', (e) => {
+    if (!e || e.repeat) {
+      return;
+    }
+
+    console.log('Handling key up ' + e.key);
+
+    if (
+      e.key === 'ArrowLeft' ||
+      e.key === 'ArrowRight' ||
+      e.key === 'ArrowUp' ||
+      e.key === 'ArrowDown' ||
+      e.key === '+' ||
+      e.key === '-'
+    ) {
+      e.preventDefault();
+      onSetStop(e);
+    }
+  });
+
   return (
     <div data-testid="control-panel" className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
       {ptz.features.includes('pt') && (

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -3,6 +3,10 @@ import { useState } from 'preact/hooks';
 import useSWR from 'swr';
 import { usePtzCommand } from '../api/ws';
 import ActivityIndicator from './ActivityIndicator';
+import ArrowRightDouble from '../icons/ArrowRightDouble';
+import ArrowUpDouble from '../icons/ArrowUpDouble';
+import ArrowDownDouble from '../icons/ArrowDownDouble';
+import ArrowLeftDouble from '../icons/ArrowLeftDouble';
 import Button from './Button';
 
 export default function CameraControlPanel({ camera = '' }) {
@@ -27,8 +31,24 @@ export default function CameraControlPanel({ camera = '' }) {
   }
 
   return (
-    <div data-testid="control-panel" className="grid grid-cols-1 3xl:grid-cols-4 md:grid-cols-3 gap-4">
-      ptz is enabled with features {ptz.features[0]}
+    <div data-testid="control-panel" className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+      {ptz.features.includes('pt') && (
+        <div className="w-44 p-4">
+          <div className="w-full flex justify-center">
+            <ArrowUpDouble className="h-12 p-2 bg-slate-500" />
+          </div>
+          <div className="w-full flex justify-between">
+            <ArrowLeftDouble className="h-12 p-2 bg-slate-500" />
+            <ArrowRightDouble className="h-12 p-2 bg-slate-500" />
+          </div>
+          <div className="flex justify-center">
+            <ArrowDownDouble className="h-12 p-2 bg-slate-500" />
+          </div>
+        </div>
+      )}
+
+      {ptz.features.includes('zoom') && <div>zoom</div>}
+
       {ptz.presets && (
         <div>
           <div className="p-4">

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -104,79 +104,81 @@ export default function CameraControlPanel({ camera = '' }) {
   });
 
   return (
-    <div data-testid="control-panel" className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-      {ptz.features.includes('pt') && (
-        <div className="w-44 px-4">
-          <Heading size="xs" className="my-4">
-            Pan / Tilt
-          </Heading>
-          <div className="w-full flex justify-center">
-            <button
-              onMouseDown={(e) => onSetMove(e, 'UP')}
-              onMouseUp={(e) => onSetStop(e)}
-              onTouchStart={(e) => {
-                onSetMove(e, 'UP');
-                e.preventDefault();
-              }}
-              onTouchEnd={(e) => {
-                onSetStop(e);
-                e.preventDefault();
-              }}
-            >
-              <ArrowUpDouble className="h-12 p-2 bg-slate-500" />
-            </button>
-          </div>
-          <div className="w-full flex justify-between">
-            <button
-              onMouseDown={(e) => onSetMove(e, 'LEFT')}
-              onMouseUp={(e) => onSetStop(e)}
-              onTouchStart={(e) => {
-                onSetMove(e, 'LEFT');
-                e.preventDefault();
-              }}
-              onTouchEnd={(e) => {
-                onSetStop(e);
-                e.preventDefault();
-              }}
-            >
-              <ArrowLeftDouble className="btn h-12 p-2 bg-slate-500" />
-            </button>
-            <button
-              onMouseDown={(e) => onSetMove(e, 'RIGHT')}
-              onMouseUp={(e) => onSetStop(e)}
-              onTouchStart={(e) => {
-                onSetMove(e, 'RIGHT');
-                e.preventDefault();
-              }}
-              onTouchEnd={(e) => {
-                onSetStop(e);
-                e.preventDefault();
-              }}
-            >
-              <ArrowRightDouble className="h-12 p-2 bg-slate-500" />
-            </button>
-          </div>
-          <div className="flex justify-center">
-            <button
-              onMouseDown={(e) => onSetMove(e, 'DOWN')}
-              onMouseUp={(e) => onSetStop(e)}
-              onTouchStart={(e) => {
-                onSetMove(e, 'DOWN');
-                e.preventDefault();
-              }}
-              onTouchEnd={(e) => {
-                onSetStop(e);
-                e.preventDefault();
-              }}
-            >
-              <ArrowDownDouble className="h-12 p-2 bg-slate-500" />
-            </button>
+    <div data-testid="control-panel" className="p-4 sm:flex justify-start">
+      {ptz.features.includes('zoom') && (
+        <div className="flex justify-center">
+          <div className="w-44 px-4">
+            <Heading size="xs" className="my-4">
+              Pan / Tilt
+            </Heading>
+            <div className="w-full flex justify-center">
+              <button
+                onMouseDown={(e) => onSetMove(e, 'UP')}
+                onMouseUp={(e) => onSetStop(e)}
+                onTouchStart={(e) => {
+                  onSetMove(e, 'UP');
+                  e.preventDefault();
+                }}
+                onTouchEnd={(e) => {
+                  onSetStop(e);
+                  e.preventDefault();
+                }}
+              >
+                <ArrowUpDouble className="h-12 p-2 bg-slate-500" />
+              </button>
+            </div>
+            <div className="w-full flex justify-between">
+              <button
+                onMouseDown={(e) => onSetMove(e, 'LEFT')}
+                onMouseUp={(e) => onSetStop(e)}
+                onTouchStart={(e) => {
+                  onSetMove(e, 'LEFT');
+                  e.preventDefault();
+                }}
+                onTouchEnd={(e) => {
+                  onSetStop(e);
+                  e.preventDefault();
+                }}
+              >
+                <ArrowLeftDouble className="btn h-12 p-2 bg-slate-500" />
+              </button>
+              <button
+                onMouseDown={(e) => onSetMove(e, 'RIGHT')}
+                onMouseUp={(e) => onSetStop(e)}
+                onTouchStart={(e) => {
+                  onSetMove(e, 'RIGHT');
+                  e.preventDefault();
+                }}
+                onTouchEnd={(e) => {
+                  onSetStop(e);
+                  e.preventDefault();
+                }}
+              >
+                <ArrowRightDouble className="h-12 p-2 bg-slate-500" />
+              </button>
+            </div>
+            <div className="flex justify-center">
+              <button
+                onMouseDown={(e) => onSetMove(e, 'DOWN')}
+                onMouseUp={(e) => onSetStop(e)}
+                onTouchStart={(e) => {
+                  onSetMove(e, 'DOWN');
+                  e.preventDefault();
+                }}
+                onTouchEnd={(e) => {
+                  onSetStop(e);
+                  e.preventDefault();
+                }}
+              >
+                <ArrowDownDouble className="h-12 p-2 bg-slate-500" />
+              </button>
+            </div>
           </div>
         </div>
       )}
 
       {ptz.features.includes('zoom') && (
-        <div className="w-44 px-4">
+        <div className="px-4 sm:w-44">
           <Heading size="xs" className="my-4">
             Zoom
           </Heading>

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -218,7 +218,7 @@ export default function CameraControlPanel({ camera = '' }) {
         </div>
       )}
 
-      {ptz.presets && (
+      {(ptz.presets || []).length > 0 && (
         <div className="px-4">
           <Heading size="xs" className="my-4">
             Presets

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -27,7 +27,7 @@ export default function CameraControlPanel({ camera = '' }) {
   }
 
   return (
-    <div data-testid="cameras" className="grid grid-cols-1 3xl:grid-cols-4 md:grid-cols-3 gap-4">
+    <div data-testid="control-panel" className="grid grid-cols-1 3xl:grid-cols-4 md:grid-cols-3 gap-4">
       ptz is enabled with features {ptz.features[0]}
       {ptz.presets && (
         <div>

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -58,8 +58,6 @@ export default function CameraControlPanel({ camera = '' }) {
       return;
     }
 
-    console.log('Handling key down ' + e.key);
-
     if (ptz.features.includes('pt')) {
       if (e.key === 'ArrowLeft') {
         e.preventDefault();
@@ -91,8 +89,6 @@ export default function CameraControlPanel({ camera = '' }) {
     if (!e || e.repeat) {
       return;
     }
-
-    console.log('Handling key up ' + e.key);
 
     if (
       e.key === 'ArrowLeft' ||

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -8,6 +8,7 @@ import ArrowUpDouble from '../icons/ArrowUpDouble';
 import ArrowDownDouble from '../icons/ArrowDownDouble';
 import ArrowLeftDouble from '../icons/ArrowLeftDouble';
 import Button from './Button';
+import Heading from './Heading';
 
 export default function CameraControlPanel({ camera = '' }) {
   const { data: ptz } = useSWR(`${camera}/ptz/info`);
@@ -32,6 +33,12 @@ export default function CameraControlPanel({ camera = '' }) {
     setCurrentPreset('');
   };
 
+  const onSetZoom = async (e, dir) => {
+    e.stopPropagation();
+    sendPtz(`ZOOM_${dir}`);
+    setCurrentPreset('');
+  };
+
   const onSetStop = async (e) => {
     e.stopPropagation();
     sendPtz('STOP');
@@ -44,7 +51,10 @@ export default function CameraControlPanel({ camera = '' }) {
   return (
     <div data-testid="control-panel" className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
       {ptz.features.includes('pt') && (
-        <div className="w-44 p-4">
+        <div className="w-44 px-4">
+          <Heading size="xs" className="my-4">
+            Pan / Tilt
+          </Heading>
           <div className="w-full flex justify-center">
             <button onMouseDown={(e) => onSetMove(e, 'UP')} onMouseUp={(e) => onSetStop(e)}>
               <ArrowUpDouble className="h-12 p-2 bg-slate-500" />
@@ -66,11 +76,31 @@ export default function CameraControlPanel({ camera = '' }) {
         </div>
       )}
 
-      {ptz.features.includes('zoom') && <div>zoom</div>}
+      {ptz.features.includes('zoom') && (
+        <div className="w-44 px-4">
+          <Heading size="xs" className="my-4">
+            Zoom
+          </Heading>
+          <div className="w-full flex justify-center">
+            <button onMouseDown={(e) => onSetZoom(e, 'IN')} onMouseUp={(e) => onSetStop(e)}>
+              <div className="h-12 w-12 p-2 text-2xl bg-slate-500">+</div>
+            </button>
+          </div>
+          <div className="h-12" />
+          <div className="flex justify-center">
+            <button onMouseDown={(e) => onSetZoom(e, 'OUT')} onMouseUp={(e) => onSetStop(e)}>
+              <div className="h-12 w-12 p-2 text-2xl bg-slate-500">-</div>
+            </button>
+          </div>
+        </div>
+      )}
 
       {ptz.presets && (
-        <div>
-          <div className="p-4">
+        <div className="px-4">
+          <Heading size="xs" className="my-4">
+            Presets
+          </Heading>
+          <div className="py-4">
             <select
               className="cursor-pointer rounded dark:bg-slate-800"
               value={currentPreset}

--- a/web/src/icons/ArrowDownDouble.jsx
+++ b/web/src/icons/ArrowDownDouble.jsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { memo } from 'preact/compat';
 
-export function ArrowRightDouble({ className = '' }) {
+export function ArrowDownDouble({ className = '' }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -11,9 +11,9 @@ export function ArrowRightDouble({ className = '' }) {
       stroke="currentColor"
       className={`${className}`}
     >
-      <path d="M11.25 4.5l7.5 7.5-7.5 7.5m-6-15l7.5 7.5-7.5 7.5" />
+      <path d="M19.5 5.25l-7.5 7.5-7.5-7.5m15 6l-7.5 7.5-7.5-7.5" />
     </svg>
   );
 }
 
-export default memo(ArrowRightDouble);
+export default memo(ArrowDownDouble);

--- a/web/src/icons/ArrowLeftDouble.jsx
+++ b/web/src/icons/ArrowLeftDouble.jsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { memo } from 'preact/compat';
 
-export function ArrowRightDouble({ className = '' }) {
+export function ArrowLeftDouble({ className = '' }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -11,9 +11,9 @@ export function ArrowRightDouble({ className = '' }) {
       stroke="currentColor"
       className={`${className}`}
     >
-      <path d="M11.25 4.5l7.5 7.5-7.5 7.5m-6-15l7.5 7.5-7.5 7.5" />
+      <path d="M18.75 19.5l-7.5-7.5 7.5-7.5m-6 15L5.25 12l7.5-7.5" />
     </svg>
   );
 }
 
-export default memo(ArrowRightDouble);
+export default memo(ArrowLeftDouble);

--- a/web/src/icons/ArrowUpDouble.jsx
+++ b/web/src/icons/ArrowUpDouble.jsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { memo } from 'preact/compat';
 
-export function ArrowRightDouble({ className = '' }) {
+export function ArrowUpDouble({ className = '' }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -11,9 +11,9 @@ export function ArrowRightDouble({ className = '' }) {
       stroke="currentColor"
       className={`${className}`}
     >
-      <path d="M11.25 4.5l7.5 7.5-7.5 7.5m-6-15l7.5 7.5-7.5 7.5" />
+      <path d="M4.5 12.75l7.5-7.5 7.5 7.5m-15 6l7.5-7.5 7.5 7.5" />
     </svg>
   );
 }
 
-export default memo(ArrowRightDouble);
+export default memo(ArrowUpDouble);

--- a/web/src/routes/Birdseye.jsx
+++ b/web/src/routes/Birdseye.jsx
@@ -97,7 +97,7 @@ export default function Birdseye() {
         <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4 w-fit">
           <Heading size="sm">Control Panel</Heading>
           {ptzCameras.map((camera) => (
-            <div key={camera}>
+            <div className="p-4" key={camera}>
               <Heading size="lg">{camera.replaceAll('_', ' ')}</Heading>
               <CameraControlPanel camera={camera} />
             </div>

--- a/web/src/routes/Birdseye.jsx
+++ b/web/src/routes/Birdseye.jsx
@@ -91,19 +91,21 @@ export default function Birdseye() {
         )}
       </div>
 
-      {player}
+      <div className="xl:flex justify-between">
+        {player}
 
-      {ptzCameras && (
-        <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4 w-full sm:w-min">
-          <Heading size="sm">Control Panel</Heading>
-          {ptzCameras.map((camera) => (
-            <div className="p-4" key={camera}>
-              <Heading size="lg">{camera.replaceAll('_', ' ')}</Heading>
-              <CameraControlPanel camera={camera} />
-            </div>
-          ))}
-        </div>
-      )}
+        {ptzCameras && (
+          <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4 w-full sm:w-min xl:h-min">
+            <Heading size="sm">Control Panel</Heading>
+            {ptzCameras.map((camera) => (
+              <div className="p-4" key={camera}>
+                <Heading size="lg">{camera.replaceAll('_', ' ')}</Heading>
+                <CameraControlPanel camera={camera} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/routes/Birdseye.jsx
+++ b/web/src/routes/Birdseye.jsx
@@ -37,7 +37,7 @@ export default function Birdseye() {
     if ('MediaSource' in window) {
       player = (
         <Fragment>
-          <div className="max-w-5xl">
+          <div className="max-w-5xl xl:w-1/2">
             <MsePlayer camera="birdseye" />
           </div>
         </Fragment>
@@ -54,7 +54,7 @@ export default function Birdseye() {
   } else if (viewSource == 'webrtc' && config.birdseye.restream) {
     player = (
       <Fragment>
-        <div className="max-w-5xl">
+        <div className="max-w-5xl xl:w-1/2">
           <WebRtcPlayer camera="birdseye" />
         </div>
       </Fragment>
@@ -62,7 +62,7 @@ export default function Birdseye() {
   } else {
     player = (
       <Fragment>
-        <div className="max-w-7xl">
+        <div className="max-w-7xl xl:w-1/2">
           <JSMpegPlayer camera="birdseye" />
         </div>
       </Fragment>
@@ -95,7 +95,7 @@ export default function Birdseye() {
         {player}
 
         {ptzCameras && (
-          <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4 w-full sm:w-min xl:h-min">
+          <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4 w-full sm:w-min xl:h-min xl:w-1/2">
             <Heading size="sm">Control Panel</Heading>
             {ptzCameras.map((camera) => (
               <div className="p-4" key={camera}>

--- a/web/src/routes/Birdseye.jsx
+++ b/web/src/routes/Birdseye.jsx
@@ -6,6 +6,8 @@ import Heading from '../components/Heading';
 import WebRtcPlayer from '../components/WebRtcPlayer';
 import MsePlayer from '../components/MsePlayer';
 import useSWR from 'swr';
+import { useMemo } from 'preact/hooks';
+import CameraControlPanel from '../components/CameraControlPanel';
 
 export default function Birdseye() {
   const { data: config } = useSWR('config');
@@ -15,6 +17,16 @@ export default function Birdseye() {
     getDefaultLiveMode(config)
   );
   const sourceValues = ['mse', 'webrtc', 'jsmpeg'];
+
+  const ptzCameras = useMemo(() => {
+    if (!config) {
+      return [];
+    }
+
+    return Object.entries(config.cameras)
+      .filter(([_, conf]) => conf.onvif?.host)
+      .map(([_, camera]) => camera.name);
+  }, [config]);
 
   if (!config || !sourceIsLoaded) {
     return <ActivityIndicator />;
@@ -80,6 +92,18 @@ export default function Birdseye() {
       </div>
 
       {player}
+
+      {ptzCameras && (
+        <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4 w-fit">
+          <Heading size="sm">Control Panel</Heading>
+          {ptzCameras.map((camera) => (
+            <div key={camera}>
+              <Heading size="lg">{camera.replaceAll('_', ' ')}</Heading>
+              <CameraControlPanel camera={camera} />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/routes/Birdseye.jsx
+++ b/web/src/routes/Birdseye.jsx
@@ -94,7 +94,7 @@ export default function Birdseye() {
       {player}
 
       {ptzCameras && (
-        <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4 w-fit">
+        <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4 w-full sm:w-min">
           <Heading size="sm">Control Panel</Heading>
           {ptzCameras.map((camera) => (
             <div className="p-4" key={camera}>

--- a/web/src/routes/Camera.jsx
+++ b/web/src/routes/Camera.jsx
@@ -191,6 +191,7 @@ export default function Camera({ camera }) {
 
       {cameraConfig?.onvif?.host && (
         <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4">
+          <Heading size="sm">Control Panel</Heading>
           <CameraControlPanel camera={camera} />
         </div>
       )}

--- a/web/src/routes/Camera.jsx
+++ b/web/src/routes/Camera.jsx
@@ -15,6 +15,7 @@ import { useApiHost } from '../api';
 import useSWR from 'swr';
 import WebRtcPlayer from '../components/WebRtcPlayer';
 import MsePlayer from '../components/MsePlayer';
+import CameraControlPanel from '../components/CameraControlPanel';
 
 const emptyObject = Object.freeze({});
 
@@ -187,6 +188,12 @@ export default function Camera({ camera }) {
       <ButtonsTabbed viewModes={['live', 'debug']} currentViewMode={viewMode} setViewMode={setViewMode} />
 
       {player}
+
+      {cameraConfig?.onvif?.host && (
+        <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4">
+          <CameraControlPanel camera={camera} />
+        </div>
+      )}
 
       <div className="space-y-4">
         <Heading size="sm">Tracked objects</Heading>

--- a/web/src/routes/Camera.jsx
+++ b/web/src/routes/Camera.jsx
@@ -190,7 +190,7 @@ export default function Camera({ camera }) {
       {player}
 
       {cameraConfig?.onvif?.host && (
-        <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4 w-fit">
+        <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4 w-full sm:w-min">
           <Heading size="sm">Control Panel</Heading>
           <CameraControlPanel camera={camera} />
         </div>

--- a/web/src/routes/Camera.jsx
+++ b/web/src/routes/Camera.jsx
@@ -190,7 +190,7 @@ export default function Camera({ camera }) {
       {player}
 
       {cameraConfig?.onvif?.host && (
-        <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4">
+        <div className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow p-4 w-fit">
           <Heading size="sm">Control Panel</Heading>
           <CameraControlPanel camera={camera} />
         </div>


### PR DESCRIPTION
Adds support for Pan, Tilt, Zoom continuous moving as well as presets via websocket / MQTT and the webUI

### To-Do:

- [x] Handle basic ptz commands
- [x] HTTP endpoint with current ptz status
- [x] Frontend to move camera
- [x] Frontend to zoom camera
- [x] Frontend to move to camera presets
- [x] Handle auth errors
- [x] Don't connect to onvif when camera is disabled
- [x] Keyboard shortcuts
- [x] fix mobile long press
- [x] Add all ptz cameras to one control panel in birdseye view
- [x] Update docs

![Screen Shot 2023-02-08 at 07 06 21 AM](https://user-images.githubusercontent.com/14866235/217552681-080b4ad6-157a-4d46-8d92-87b0b1978d3e.png)