### PR TITLE
Handle multi-word time zones

### DIFF
--- a/frigate/http.py
+++ b/frigate/http.py
@@ -1088,14 +1088,14 @@ def vod_ts(camera_name, start_ts, end_ts):
 @bp.route("/vod/<year_month>/<day>/<hour>/<camera_name>")
 def vod_hour_no_timezone(year_month, day, hour, camera_name):
     return vod_hour(
-        year_month, day, hour, camera_name, get_localzone_name().replace("/", "_")
+        year_month, day, hour, camera_name, get_localzone_name().replace("/", ",")
     )
 
 
 # TODO make this nicer when vod module is removed
 @bp.route("/vod/<year_month>/<day>/<hour>/<camera_name>/<tz_name>")
 def vod_hour(year_month, day, hour, camera_name, tz_name):
-    tz_name = tz_name.replace("_", "/")
+    tz_name = tz_name.replace(",", "/")
     parts = year_month.split("-")
     start_date = datetime(
         int(parts[0]), int(parts[1]), int(day), int(hour), tzinfo=pytz.timezone(tz_name)

--- a/web/src/routes/Recording.jsx
+++ b/web/src/routes/Recording.jsx
@@ -71,7 +71,7 @@ export default function Recording({ camera, date, hour = '00', minute = '00', se
             {
               src: `${apiHost}vod/${year}-${month}/${day}/${h.hour}/${camera}/${timezone.replaceAll(
                 '/',
-                '_'
+                ','
               )}/master.m3u8`,
               type: 'application/vnd.apple.mpegurl',
             },


### PR DESCRIPTION
#4656 added a path param to specify time zones, however the commit failed to account for multi-word time zones that contain "_" such as America/Los_Angeles.

No tzdata time zones contain the comma in their names.