### PR TITLE
Fix config missing after leaving and coming back

### DIFF
--- a/web/src/routes/Config.jsx
+++ b/web/src/routes/Config.jsx
@@ -48,7 +48,7 @@ export default function Config() {
       return;
     }
 
-    if (window.editor) {
+    if (document.getElementById('container').children.length > 0) {
       // we don't need to recreate the editor if it already exists
       return;
     }


### PR DESCRIPTION
Instead of checking if the editor exists, we need to check if the editor has been added to the document already.