### PR TITLE
check stream specific hwaccel_args for gpu stats

### DIFF
--- a/frigate/stats.py
+++ b/frigate/stats.py
@@ -121,7 +121,7 @@ async def set_gpu_stats(config: FrigateConfig, all_stats: dict[str, Any]) -> Non
 
         if args and args not in hwaccel_args:
             hwaccel_args.append(args)
-     
+
         for stream_input in camera.ffmpeg.inputs:
             args = stream_input.hwaccel_args
 

--- a/frigate/stats.py
+++ b/frigate/stats.py
@@ -122,14 +122,14 @@ async def set_gpu_stats(config: FrigateConfig, all_stats: dict[str, Any]) -> Non
         if args and args not in hwaccel_args:
             hwaccel_args.append(args)
      
-    for stream_input in camera.ffmpeg.inputs:
-        args = stream_input.hwaccel_args
+        for stream_input in camera.ffmpeg.inputs:
+            args = stream_input.hwaccel_args
 
-        if isinstance(args, list):
-            args = " ".join(args)
+            if isinstance(args, list):
+                args = " ".join(args)
 
-        if args and args not in hwaccel_args:
-            hwaccel_args.append(args)
+            if args and args not in hwaccel_args:
+                hwaccel_args.append(args)
 
     stats: dict[str, dict] = {}
 

--- a/frigate/stats.py
+++ b/frigate/stats.py
@@ -121,6 +121,15 @@ async def set_gpu_stats(config: FrigateConfig, all_stats: dict[str, Any]) -> Non
 
         if args and args not in hwaccel_args:
             hwaccel_args.append(args)
+     
+    for stream_input in camera.ffmpeg.inputs:
+        args = stream_input.hwaccel_args
+
+        if isinstance(args, list):
+            args = " ".join(args)
+
+        if args and args not in hwaccel_args:
+            hwaccel_args.append(args)
 
     stats: dict[str, dict] = {}
 


### PR DESCRIPTION
Previously only cameras were checked and parsed for the existance of hwaccel_args but it can also be stream specific only so i've added a check for that as well.