### PR TITLE
Rewrite encoding logic and cleanup vaapi presets

### DIFF
--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -25,7 +25,7 @@ ffmpeg:
 
 ```yaml
 ffmpeg:
-  hwaccel_args: preset-intel-vaapi
+  hwaccel_args: preset-vaapi
 ```
 **NOTICE**: With some of the processors, like the J4125, the default driver `iHD` doesn't seem to work correctly for hardware acceleration. You may need to change the driver to `i965` by adding the following environment variable `LIBVA_DRIVER_NAME=i965` to your docker-compose file or [in the frigate.yml for HA OS users](advanced.md#environment_vars).
 
@@ -42,7 +42,7 @@ ffmpeg:
 
 ```yaml
 ffmpeg:
-  hwaccel_args: preset-amd-vaapi
+  hwaccel_args: preset-vaapi
 ```
 
 ### NVIDIA GPU

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -114,7 +114,6 @@ PRESETS_HW_ACCEL_SCALE = {
 }
 
 PRESETS_HW_ACCEL_ENCODE = {
-    "preset-vaapi": "ffmpeg -hide_banner -vaapi_device /dev/dri/renderD128 {0} -vf 'format=yuv420p,hwupload' -c:v h264_vaapi -g 50 -bf 0 -profile:v high -level:v 4.1 -sei:v 0 {1}",
     "preset-intel-qsv-h264": "ffmpeg -hide_banner {0} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {1}",
     "preset-intel-qsv-h265": "ffmpeg -hide_banner {0} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {1}",
     "preset-nvidia-h264": "ffmpeg -hide_banner {0} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {1}",

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -115,11 +115,11 @@ PRESETS_HW_ACCEL_SCALE = {
 
 PRESETS_HW_ACCEL_ENCODE = {
     "preset-vaapi": "ffmpeg -hide_banner -vaapi_device /dev/dri/renderD128 {0} -vf 'format=yuv420p,hwupload' -c:v h264_vaapi -g 50 -bf 0 -profile:v high -level:v 4.1 -sei:v 0 {1}",
-    "preset-intel-qsv-h264": "ffmepg -hide_banner {0} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {1}",
-    "preset-intel-qsv-h265": "ffmepg -hide_banner {0} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {1}",
-    "preset-nvidia-h264": "ffmepg -hide_banner {0} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {1}",
-    "preset-nvidia-h265": "ffmepg -hide_banner {0} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {1}",
-    "default": "ffmepg -hide_banner {0} -c:v libx264 -g 50 -profile:v high -level:v 4.1 -preset:v superfast -tune:v zerolatency {1}",
+    "preset-intel-qsv-h264": "ffmpeg -hide_banner {0} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {1}",
+    "preset-intel-qsv-h265": "ffmpeg -hide_banner {0} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {1}",
+    "preset-nvidia-h264": "ffmpeg -hide_banner {0} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {1}",
+    "preset-nvidia-h265": "ffmpeg -hide_banner {0} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {1}",
+    "default": "ffmpeg -hide_banner {0} -c:v libx264 -g 50 -profile:v high -level:v 4.1 -preset:v superfast -tune:v zerolatency {1}",
 }
 
 

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -114,12 +114,12 @@ PRESETS_HW_ACCEL_SCALE = {
 }
 
 PRESETS_HW_ACCEL_ENCODE = {
-    "preset-vaapi": "ffmpeg -hide_banner -vaapi_device /dev/dri/renderD128 {} -vf 'format=yuv420p,hwupload' -c:v h264_vaapi -g 50 -bf 0 -profile:v high -level:v 4.1 -sei:v 0 {}",
-    "preset-intel-qsv-h264": "ffmepg -hide_banner {} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {}",
-    "preset-intel-qsv-h265": "ffmepg -hide_banner {} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {}",
-    "preset-nvidia-h264": "ffmepg -hide_banner {} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {}",
-    "preset-nvidia-h265": "ffmepg -hide_banner {} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {}",
-    "default": "ffmepg -hide_banner {} -c:v libx264 -g 50 -profile:v high -level:v 4.1 -preset:v superfast -tune:v zerolatency {}",
+    "preset-vaapi": "ffmpeg -hide_banner -vaapi_device /dev/dri/renderD128 {0} -vf 'format=yuv420p,hwupload' -c:v h264_vaapi -g 50 -bf 0 -profile:v high -level:v 4.1 -sei:v 0 {1}",
+    "preset-intel-qsv-h264": "ffmepg -hide_banner {0} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {1}",
+    "preset-intel-qsv-h265": "ffmepg -hide_banner {0} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {1}",
+    "preset-nvidia-h264": "ffmepg -hide_banner {0} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {1}",
+    "preset-nvidia-h265": "ffmepg -hide_banner {0} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {1}",
+    "default": "ffmepg -hide_banner {0} -c:v libx264 -g 50 -profile:v high -level:v 4.1 -preset:v superfast -tune:v zerolatency {1}",
 }
 
 
@@ -154,9 +154,9 @@ def parse_preset_hardware_acceleration_scale(
 def parse_preset_hardware_acceleration_encode(arg: Any, input: str, output: str) -> str:
     """Return the correct scaling preset or default preset if none is set."""
     if not isinstance(arg, str):
-        return PRESETS_HW_ACCEL_ENCODE["default"] % (input, output)
+        return PRESETS_HW_ACCEL_ENCODE["default"].format(input, output)
 
-    return PRESETS_HW_ACCEL_ENCODE.get(arg, PRESETS_HW_ACCEL_ENCODE["default"]) % (
+    return PRESETS_HW_ACCEL_ENCODE.get(arg, PRESETS_HW_ACCEL_ENCODE["default"]).format(
         input,
         output,
     )

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -156,7 +156,10 @@ def parse_preset_hardware_acceleration_encode(arg: Any, input: str, output: str)
     if not isinstance(arg, str):
         return PRESETS_HW_ACCEL_ENCODE["default"] % (input, output)
 
-    return PRESETS_HW_ACCEL_ENCODE.get(arg, PRESETS_HW_ACCEL_ENCODE["default"]) % (input, output)
+    return PRESETS_HW_ACCEL_ENCODE.get(arg, PRESETS_HW_ACCEL_ENCODE["default"]) % (
+        input,
+        output,
+    )
 
 
 PRESETS_INPUT = {

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -12,7 +12,7 @@ _user_agent_args = [
 PRESETS_HW_ACCEL_DECODE = {
     "preset-rpi-32-h264": ["-c:v", "h264_v4l2m2m"],
     "preset-rpi-64-h264": ["-c:v", "h264_v4l2m2m"],
-    "preset-intel-vaapi": [
+    "preset-vaapi": [
         "-hwaccel_flags",
         "allow_profile_mismatch",
         "-hwaccel",
@@ -41,16 +41,6 @@ PRESETS_HW_ACCEL_DECODE = {
         "qsv",
         "-c:v",
         "hevc_qsv",
-    ],
-    "preset-amd-vaapi": [
-        "-hwaccel_flags",
-        "allow_profile_mismatch",
-        "-hwaccel",
-        "vaapi",
-        "-hwaccel_device",
-        "/dev/dri/renderD128",
-        "-hwaccel_output_format",
-        "vaapi",
     ],
     "preset-nvidia-h264": [
         "-hwaccel",
@@ -85,7 +75,7 @@ PRESETS_HW_ACCEL_DECODE = {
 }
 
 PRESETS_HW_ACCEL_SCALE = {
-    "preset-intel-vaapi": [
+    "preset-vaapi": [
         "-vf",
         "fps={},scale_vaapi=w={}:h={},hwdownload,format=yuv420p",
         "-f",
@@ -100,12 +90,6 @@ PRESETS_HW_ACCEL_SCALE = {
     "preset-intel-qsv-h265": [
         "-vf",
         "vpp_qsv=framerate={}:scale_mode=1:w={}:h={}:detail=50:denoise=100:deinterlace=2:format=nv12,hwdownload,format=nv12,format=yuv420p",
-        "-f",
-        "rawvideo",
-    ],
-    "preset-amd-vaapi": [
-        "-vf",
-        "fps={},scale_vaapi=w={}:h={},hwdownload,format=yuv420p",
         "-f",
         "rawvideo",
     ],
@@ -130,7 +114,7 @@ PRESETS_HW_ACCEL_SCALE = {
 }
 
 PRESETS_HW_ACCEL_ENCODE = {
-    "preset-intel-vaapi": [
+    "preset-vaapi": [
         "-c:v",
         "h264_vaapi",
         "-g",
@@ -171,20 +155,6 @@ PRESETS_HW_ACCEL_ENCODE = {
         "4.1",
         "-async_depth:v",
         "1",
-    ],
-    "preset-amd-vaapi": [
-        "-c:v",
-        "h264_vaapi",
-        "-g",
-        "50",
-        "-bf",
-        "0",
-        "-profile:v",
-        "high",
-        "-level:v",
-        "4.1",
-        "-sei:v",
-        "0",
     ],
     "preset-nvidia-h264": [
         "-c:v",

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -114,90 +114,12 @@ PRESETS_HW_ACCEL_SCALE = {
 }
 
 PRESETS_HW_ACCEL_ENCODE = {
-    "preset-vaapi": [
-        "-c:v",
-        "h264_vaapi",
-        "-g",
-        "50",
-        "-bf",
-        "0",
-        "-profile:v",
-        "high",
-        "-level:v",
-        "4.1",
-        "-sei:v",
-        "0",
-    ],
-    "preset-intel-qsv-h264": [
-        "-c:v",
-        "h264_qsv",
-        "-g",
-        "50",
-        "-bf",
-        "0",
-        "-profile:v",
-        "high",
-        "-level:v",
-        "4.1",
-        "-async_depth:v",
-        "1",
-    ],
-    "preset-intel-qsv-h265": [
-        "-c:v",
-        "h264_qsv",
-        "-g",
-        "50",
-        "-bf",
-        "0",
-        "-profile:v",
-        "high",
-        "-level:v",
-        "4.1",
-        "-async_depth:v",
-        "1",
-    ],
-    "preset-nvidia-h264": [
-        "-c:v",
-        "h264_nvenc",
-        "-g",
-        "50",
-        "-profile:v",
-        "high",
-        "-level:v",
-        "auto",
-        "-preset:v",
-        "p2",
-        "-tune:v",
-        "ll",
-    ],
-    "preset-nvidia-h265": [
-        "-c:v",
-        "h264_nvenc",
-        "-g",
-        "50",
-        "-profile:v",
-        "high",
-        "-level:v",
-        "auto",
-        "-preset:v",
-        "p2",
-        "-tune:v",
-        "ll",
-    ],
-    "default": [
-        "-c:v",
-        "libx264",
-        "-g",
-        "50",
-        "-profile:v",
-        "high",
-        "-level:v",
-        "4.1",
-        "-preset:v",
-        "superfast",
-        "-tune:v",
-        "zerolatency",
-    ],
+    "preset-vaapi": "ffmpeg -hide_banner -vaapi_device /dev/dri/renderD128 {} -vf 'format=yuv420p,hwupload' -c:v h264_vaapi -g 50 -bf 0 -profile:v high -level:v 4.1 -sei:v 0 {}",
+    "preset-intel-qsv-h264": "ffmepg -hide_banner {} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {}",
+    "preset-intel-qsv-h265": "ffmepg -hide_banner {} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {}",
+    "preset-nvidia-h264": "ffmepg -hide_banner {} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {}",
+    "preset-nvidia-h265": "ffmepg -hide_banner {} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {}",
+    "default": "ffmepg -hide_banner {} -c:v libx264 -g 50 -profile:v high -level:v 4.1 -preset:v superfast -tune:v zerolatency {}",
 }
 
 
@@ -229,12 +151,12 @@ def parse_preset_hardware_acceleration_scale(
     return scale
 
 
-def parse_preset_hardware_acceleration_encode(arg: Any) -> list[str]:
+def parse_preset_hardware_acceleration_encode(arg: Any, input: str, output: str) -> str:
     """Return the correct scaling preset or default preset if none is set."""
     if not isinstance(arg, str):
-        return PRESETS_HW_ACCEL_ENCODE["default"]
+        return PRESETS_HW_ACCEL_ENCODE["default"] % (input, output)
 
-    return PRESETS_HW_ACCEL_ENCODE.get(arg, PRESETS_HW_ACCEL_ENCODE["default"])
+    return PRESETS_HW_ACCEL_ENCODE.get(arg, PRESETS_HW_ACCEL_ENCODE["default"]) % (input, output)
 
 
 PRESETS_INPUT = {

--- a/frigate/restream.py
+++ b/frigate/restream.py
@@ -47,7 +47,7 @@ class RestreamApi:
         if self.config.restream.birdseye:
             self.relays[
                 "birdseye"
-            ] = f"exec:ffmpeg -hide_banner -f rawvideo -pix_fmt yuv420p -video_size {self.config.birdseye.width}x{self.config.birdseye.height} -r 10 -i {BIRDSEYE_PIPE} {' '.join(parse_preset_hardware_acceleration_encode(self.config.ffmpeg.hwaccel_args))} -rtsp_transport tcp -f rtsp {{output}}"
+            ] = f"exec:{parse_preset_hardware_acceleration_encode(self.config.ffmpeg.hwaccel_args, f'-f rawvideo -pix_fmt yuv420p -video_size {self.config.birdseye.width}x{self.config.birdseye.height} -r 10 -i {BIRDSEYE_PIPE}', '-rtsp_transport tcp -f rtsp {output}')}"
 
         for name, path in self.relays.items():
             params = {"src": path, "name": name}


### PR DESCRIPTION
- No need for two vaapi presets when they are the same, moving to preset-vaapi
- Remove vaapi hardware encoding since it is buggy for this rawvideo yuv420p encoding to rtsp (works for mp4, not rtsp)