### PR TITLE
Cleanup Detector labelmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,8 @@ RUN wget -qO cpu_model.tflite https://github.com/google-coral/test_data/raw/rele
 COPY labelmap.txt .
 # Copy OpenVino model
 COPY --from=ov-converter /models/public/ssdlite_mobilenet_v2/FP16 openvino-model
-RUN wget -q https://github.com/openvinotoolkit/open_model_zoo/raw/master/data/dataset_classes/coco_91cl_bkgr.txt -O openvino-model/coco_91cl_bkgr.txt
+RUN wget -q https://github.com/openvinotoolkit/open_model_zoo/raw/master/data/dataset_classes/coco_91cl_bkgr.txt -O openvino-model/coco_91cl_bkgr.txt && \
+    sed -i 's/truck/car/g' openvino-model/coco_91cl_bkgr.txt
 
 
 

--- a/docker/tensorrt_models.sh
+++ b/docker/tensorrt_models.sh
@@ -32,6 +32,3 @@ do
     python3 onnx_to_tensorrt.py -m ${model}
     cp /tensorrt_demos/yolo/${model}.trt ${OUTPUT_FOLDER}/${model}.trt;
 done
-
-# Download Labelmap
-wget -q https://github.com/openvinotoolkit/open_model_zoo/raw/master/data/dataset_classes/coco_91cl.txt -O ${OUTPUT_FOLDER}/coco_91cl.txt

--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -226,7 +226,6 @@ detectors:
 
 model:
   path: /trt-models/yolov7-tiny-416.trt
-  labelmap_path: /trt-models/coco_91cl.txt
   input_tensor: nchw
   input_pixel_format: rgb
   width: 416

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -706,15 +706,17 @@ def load_labels(path, encoding="utf-8"):
       Dictionary mapping indices to labels.
     """
     with open(path, "r", encoding=encoding) as f:
+        labels = {index: "unknown" for index in range(91)}
         lines = f.readlines()
         if not lines:
             return {}
 
         if lines[0].split(" ", maxsplit=1)[0].isdigit():
             pairs = [line.split(" ", maxsplit=1) for line in lines]
-            return {int(index): label.strip() for index, label in pairs}
+            labels.update({int(index): label.strip() for index, label in pairs})
         else:
-            return {index: line.strip() for index, line in enumerate(lines)}
+            labels.update({index: line.strip() for index, line in enumerate(lines)})
+        return labels
 
 
 def clean_camera_user_pass(line: str) -> str:

--- a/labelmap.txt
+++ b/labelmap.txt
@@ -9,6 +9,7 @@
 8  boat
 9  traffic light
 10  fire hydrant
+11  street sign
 12  stop sign
 13  parking meter
 14  bench
@@ -22,8 +23,11 @@
 22  bear
 23  zebra
 24  giraffe
+25  hat
 26  backpack
 27  umbrella
+28  shoe
+29  eye glasses
 30  handbag
 31  tie
 32  suitcase
@@ -38,6 +42,7 @@
 41  surfboard
 42  tennis racket
 43  bottle
+44  plate
 45  wine glass
 46  cup
 47  fork
@@ -58,8 +63,12 @@
 62  couch
 63  potted plant
 64  bed
+65  mirror
 66  dining table
+67  window
+68  desk
 69  toilet
+70  door
 71  tv
 72  laptop
 73  mouse
@@ -71,6 +80,7 @@
 79  toaster
 80  sink
 81  refrigerator
+82  blender
 83  book
 84  clock
 85  vase
@@ -78,3 +88,4 @@
 87  teddy bear
 88  hair drier
 89  toothbrush
+90  hair brush


### PR DESCRIPTION
1. Fixup OpenVino labelmap to use Car instead of Truck
2. Add missing indexes to default labelmap.txt
3. Remove TensorRT-specific labelmap, use default.
4. Fill any empty label indexes with "unknown"