### PR TITLE
Only set colors for enabled objects

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -962,6 +962,12 @@ class FrigateConfig(FrigateBaseModel):
             camera_config.create_ffmpeg_cmds()
             config.cameras[name] = camera_config
 
+        # get list of unique enabled labels for tracking
+        enabled_labels = set(config.objects.track)
+
+        for _, camera in config.cameras.items():
+            enabled_labels.update(camera.objects.track)
+
         for key, detector in config.detectors.items():
             detector_config: DetectorConfig = parse_obj_as(DetectorConfig, detector)
             if detector_config.model is None:
@@ -986,6 +992,7 @@ class FrigateConfig(FrigateBaseModel):
                 config.model.dict(exclude_unset=True),
             )
             detector_config.model = ModelConfig.parse_obj(merged_model)
+            detector_config.model.create_colormap(enabled_labels)
             config.detectors[key] = detector_config
 
         return config

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -968,6 +968,8 @@ class FrigateConfig(FrigateBaseModel):
         for _, camera in config.cameras.items():
             enabled_labels.update(camera.objects.track)
 
+        config.model.create_colormap(enabled_labels)
+
         for key, detector in config.detectors.items():
             detector_config: DetectorConfig = parse_obj_as(DetectorConfig, detector)
             if detector_config.model is None:
@@ -992,7 +994,6 @@ class FrigateConfig(FrigateBaseModel):
                 config.model.dict(exclude_unset=True),
             )
             detector_config.model = ModelConfig.parse_obj(merged_model)
-            detector_config.model.create_colormap(enabled_labels)
             config.detectors[key] = detector_config
 
         return config

--- a/frigate/detectors/detector_config.py
+++ b/frigate/detectors/detector_config.py
@@ -55,11 +55,13 @@ class ModelConfig(BaseModel):
             **load_labels(config.get("labelmap_path", "/labelmap.txt")),
             **config.get("labelmap", {}),
         }
-
-        cmap = plt.cm.get_cmap("tab10", len(self._merged_labelmap.keys()))
-
         self._colormap = {}
-        for key, val in self._merged_labelmap.items():
+
+    def create_colormap(self, enabled_labels: set[str]) -> None:
+        """Get a list of colors for enabled labels."""
+        cmap = plt.cm.get_cmap("tab10", len(enabled_labels))
+
+        for key, val in enumerate(enabled_labels):
             self._colormap[val] = tuple(int(round(255 * c)) for c in cmap(key)[:3])
 
     class Config:


### PR DESCRIPTION
https://github.com/blakeblackshear/frigate/pull/4932 made it so models with shorter label lists get filled to 91 items. This affected the colors that are assigned for labels making every object have the same color when using models with short label lists.

This change makes it so only enabled objects are assigned colors.