### PR TITLE
Make label colors consistent

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -968,7 +968,7 @@ class FrigateConfig(FrigateBaseModel):
         for _, camera in config.cameras.items():
             enabled_labels.update(camera.objects.track)
 
-        config.model.create_colormap(enabled_labels)
+        config.model.create_colormap(sorted(enabled_labels))
 
         for key, detector in config.detectors.items():
             detector_config: DetectorConfig = parse_obj_as(DetectorConfig, detector)


### PR DESCRIPTION
Looks like the sets are not sorted so on each restart each label has a different color. Sorting the list fixes this. Not sure if the behavior is an issue, but this will keep it consistent. 