### PR TITLE
System page: various minor UI tweaks

### DIFF
--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -144,13 +144,15 @@ export default function System() {
                         <Th>P-ID</Th>
                         <Th>Detection Start</Th>
                         <Th>Inference Speed</Th>
+                        <Th>CPU %</Th>
                       </Tr>
                     </Thead>
                     <Tbody>
                       <Tr>
                         <Td>{detectors[detector]['pid']}</Td>
                         <Td>{detectors[detector]['detection_start']}</Td>
-                        <Td>{detectors[detector]['inference_speed']}</Td>
+                        <Td>{detectors[detector]['inference_speed']} ms</Td>
+                        <Td>{cpu_usages[detectors[detector]['pid']]?.['cpu'] || '- '}%</Td>
                       </Tr>
                     </Tbody>
                   </Table>
@@ -220,20 +222,27 @@ export default function System() {
                         <Tr>
                           <Th>Process</Th>
                           <Th>P-ID</Th>
-                          <Th>fps</Th>
-                          <Th>Cpu %</Th>
+                          <Th>FPS</Th>
+                          <Th>CPU %</Th>
                           <Th>Memory %</Th>
                         </Tr>
                       </Thead>
                       <Tbody>
-                        <Tr key="capture" index="0">
+                        <Tr key="ffmpeg" index="0">
+                          <Td>ffmpeg</Td>
+                          <Td>{cameras[camera]['ffmpeg_pid'] || '- '}</Td>
+                          <Td>{cameras[camera]['camera_fps'] || '- '}</Td>
+                          <Td>{cpu_usages[cameras[camera]['ffmpeg_pid']]?.['cpu'] || '- '}%</Td>
+                          <Td>{cpu_usages[cameras[camera]['ffmpeg_pid']]?.['mem'] || '- '}%</Td>
+                        </Tr>                        
+                        <Tr key="capture" index="1">
                           <Td>Capture</Td>
                           <Td>{cameras[camera]['capture_pid'] || '- '}</Td>
                           <Td>{cameras[camera]['process_fps'] || '- '}</Td>
                           <Td>{cpu_usages[cameras[camera]['capture_pid']]?.['cpu'] || '- '}%</Td>
                           <Td>{cpu_usages[cameras[camera]['capture_pid']]?.['mem'] || '- '}%</Td>
                         </Tr>
-                        <Tr key="detect" index="1">
+                        <Tr key="detect" index="2">
                           <Td>Detect</Td>
                           <Td>{cameras[camera]['pid'] || '- '}</Td>
                           <Td>
@@ -241,13 +250,6 @@ export default function System() {
                           </Td>
                           <Td>{cpu_usages[cameras[camera]['pid']]?.['cpu'] || '- '}%</Td>
                           <Td>{cpu_usages[cameras[camera]['pid']]?.['mem'] || '- '}%</Td>
-                        </Tr>
-                        <Tr key="ffmpeg" index="2">
-                          <Td>ffmpeg</Td>
-                          <Td>{cameras[camera]['ffmpeg_pid'] || '- '}</Td>
-                          <Td>{cameras[camera]['camera_fps'] || '- '}</Td>
-                          <Td>{cpu_usages[cameras[camera]['ffmpeg_pid']]?.['cpu'] || '- '}%</Td>
-                          <Td>{cpu_usages[cameras[camera]['ffmpeg_pid']]?.['mem'] || '- '}%</Td>
                         </Tr>
                       </Tbody>
                     </Table>

--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -142,7 +142,6 @@ export default function System() {
                     <Thead>
                       <Tr>
                         <Th>P-ID</Th>
-                        <Th>Detection Status</Th>
                         <Th>Inference Speed</Th>
                         <Th>CPU %</Th>
                       </Tr>
@@ -150,7 +149,6 @@ export default function System() {
                     <Tbody>
                       <Tr>
                         <Td>{detectors[detector]['pid']}</Td>
-                        <Td>{detectors[detector]['detection_start'] > 0 ? ('running') : ('idle')}</Td>
                         <Td>{detectors[detector]['inference_speed']} ms</Td>
                         <Td>{cpu_usages[detectors[detector]['pid']]?.['cpu'] || '- '}%</Td>
                       </Tr>

--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -187,7 +187,7 @@ export default function System() {
                       <Table className="w-full">
                         <Thead>
                           <Tr>
-                            <Th>Gpu %</Th>
+                            <Th>GPU %</Th>
                             <Th>Memory %</Th>
                           </Tr>
                         </Thead>

--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -142,7 +142,7 @@ export default function System() {
                     <Thead>
                       <Tr>
                         <Th>P-ID</Th>
-                        <Th>Detection Start</Th>
+                        <Th>Detection Status</Th>
                         <Th>Inference Speed</Th>
                         <Th>CPU %</Th>
                       </Tr>
@@ -150,7 +150,7 @@ export default function System() {
                     <Tbody>
                       <Tr>
                         <Td>{detectors[detector]['pid']}</Td>
-                        <Td>{detectors[detector]['detection_start']}</Td>
+                        <Td>{detectors[detector]['detection_start'] > 0 ? ('running') : ('idle')}</Td>
                         <Td>{detectors[detector]['inference_speed']} ms</Td>
                         <Td>{cpu_usages[detectors[detector]['pid']]?.['cpu'] || '- '}%</Td>
                       </Tr>


### PR DESCRIPTION
First PR, thank you for the excellent software!

Per discussion with Nick M on https://github.com/blakeblackshear/frigate/discussions/4978, this is a tiny PR to implement some minor UI changes to the System page. These were changes I could make without rebuilding core; there are more suggested changes on the discussion thread that would require backend changes as well which I will send a PR for separately once I have everything set up.

Changes:

-Add a CPU% column to the Detectors cards. I have tested this with CPU detectors and OpenVINO in CPU mode. I don't have the ability to run a GPU detector at present, so would appreciate a test by someone to ensure it doesn't break anything (it shouldn't).
-Added "ms" after inference speed value to make it clear what the number means
-Capitalized FPS, CPU acronyms
-Reordered per-camera table to follow data flow of ffmpeg => capture => detect