### PR TITLE
Fix mem usage reporting when using docker limits

### DIFF
--- a/frigate/util.py
+++ b/frigate/util.py
@@ -737,12 +737,66 @@ def escape_special_characters(path: str) -> str:
         # path does not have user:pass
         return path
 
+def get_cgroups_version() -> str:
+    """Determine what version of cgroups is enabled"""
+    
+    stat_command = ["stat", "-fc", "%T", "/sys/fs/cgroup"]
+
+    p = sp.run(
+        stat_command,
+        encoding="ascii",
+        capture_output=True,
+    )
+
+    if p.returncode == 0:
+        value: str = p.stdout.strip().lower()
+
+        if value == "cgroup2fs":
+            return "cgroup2"
+        elif value == "tmpfs":
+            return "cgroup"
+        else:
+            logger.debug(f"Could not determine cgroups version: unhandled filesystem {value}")
+    else:
+        logger.debug(f"Could not determine cgroups version:  {p.stderr}")
+    
+    return "unknown"
+
+
+def get_docker_memlimit_bytes() -> int:
+    """Get mem limit in bytes set in docker if present. Returns -1 if no limit detected"""
+
+    # check running a supported cgroups version
+    if (get_cgroups_version() == "cgroup2"):
+
+        memlimit_command = ["cat", "/sys/fs/cgroup/memory.max"]
+
+        p = sp.run(
+            memlimit_command,
+            encoding="ascii",
+            capture_output=True,
+        )
+
+        if p.returncode == 0:
+            value: str = p.stdout.strip()
+
+            if value.isnumeric():
+                return int(value)
+            elif value.lower() == "max":
+                return -1
+        else:
+            logger.debug(f"Unable to get docker memlimit: {p.stderr}")
+            
+    return -1
+
 
 def get_cpu_stats() -> dict[str, dict]:
     """Get cpu usages for each process id"""
     usages = {}
     # -n=2 runs to ensure extraneous values are not included
     top_command = ["top", "-b", "-n", "2"]
+
+    docker_memlimit = get_docker_memlimit_bytes() / 1024
 
     p = sp.run(
         top_command,
@@ -759,9 +813,18 @@ def get_cpu_stats() -> dict[str, dict]:
         for line in lines:
             stats = list(filter(lambda a: a != "", line.strip().split(" ")))
             try:
+
+                if docker_memlimit > 0:
+                    memRes = int(stats[5])
+                    memPct = str(
+                        round((float(memRes) / float(docker_memlimit)) * 100, 1)
+                    )
+                else:
+                    memPct = stats[9]
+
                 usages[stats[0]] = {
                     "cpu": stats[8],
-                    "mem": stats[9],
+                    "mem": memPct,
                 }
             except:
                 continue

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -818,16 +818,16 @@ def get_cpu_stats() -> dict[str, dict]:
             try:
 
                 if docker_memlimit > 0:
-                    memRes = int(stats[5])
-                    memPct = str(
-                        round((float(memRes) / float(docker_memlimit)) * 100, 1)
+                    mem_res = int(stats[5])
+                    mem_pct = str(
+                        round((float(mem_res) / float(docker_memlimit)) * 100, 1)
                     )
                 else:
-                    memPct = stats[9]
+                    mem_pct = stats[9]
 
                 usages[stats[0]] = {
                     "cpu": stats[8],
-                    "mem": memPct,
+                    "mem": mem_pct,
                 }
             except:
                 continue

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -737,9 +737,10 @@ def escape_special_characters(path: str) -> str:
         # path does not have user:pass
         return path
 
+
 def get_cgroups_version() -> str:
     """Determine what version of cgroups is enabled"""
-    
+
     stat_command = ["stat", "-fc", "%T", "/sys/fs/cgroup"]
 
     p = sp.run(
@@ -756,10 +757,12 @@ def get_cgroups_version() -> str:
         elif value == "tmpfs":
             return "cgroup"
         else:
-            logger.debug(f"Could not determine cgroups version: unhandled filesystem {value}")
+            logger.debug(
+                f"Could not determine cgroups version: unhandled filesystem {value}"
+            )
     else:
         logger.debug(f"Could not determine cgroups version:  {p.stderr}")
-    
+
     return "unknown"
 
 
@@ -767,7 +770,7 @@ def get_docker_memlimit_bytes() -> int:
     """Get mem limit in bytes set in docker if present. Returns -1 if no limit detected"""
 
     # check running a supported cgroups version
-    if (get_cgroups_version() == "cgroup2"):
+    if get_cgroups_version() == "cgroup2":
 
         memlimit_command = ["cat", "/sys/fs/cgroup/memory.max"]
 
@@ -786,7 +789,7 @@ def get_docker_memlimit_bytes() -> int:
                 return -1
         else:
             logger.debug(f"Unable to get docker memlimit: {p.stderr}")
-            
+
     return -1
 
 


### PR DESCRIPTION
Fixes #5004 

This identifies if we are running in a container with a memory limit set. If so, rather than taking the %MEM from `top` directly, it calculates it as (resident memory / docker limit).

It seems the base container is different to the production builds - the path changes slightly. I've handled both cases for now.

[edit]
After some local testing, my expectation is that this will work with Docker engine 20.10 (released December 2020) on suitably modern hosts, but not WSL2 on Windows without extra configuraiton.