### PR TITLE
System page: add detector process mem%

### DIFF
--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -144,6 +144,7 @@ export default function System() {
                         <Th>P-ID</Th>
                         <Th>Inference Speed</Th>
                         <Th>CPU %</Th>
+                        <Th>Memory %</Th>
                       </Tr>
                     </Thead>
                     <Tbody>
@@ -151,6 +152,7 @@ export default function System() {
                         <Td>{detectors[detector]['pid']}</Td>
                         <Td>{detectors[detector]['inference_speed']} ms</Td>
                         <Td>{cpu_usages[detectors[detector]['pid']]?.['cpu'] || '- '}%</Td>
+                        <Td>{cpu_usages[detectors[detector]['pid']]?.['mem'] || '- '}%</Td>
                       </Tr>
                     </Tbody>
                   </Table>


### PR DESCRIPTION
For completeness as a potentially interesting metric. 

On OpenVINO this can be 200MB i.e. a reasonable portion of total non-shareable memory use (ffmpeg processes look like they add up to a lot, but a good amount is shared).