### PR TITLE
Rework storage page to show sizes with relevant units

### DIFF
--- a/web/src/routes/Storage.jsx
+++ b/web/src/routes/Storage.jsx
@@ -23,6 +23,7 @@ export default function Storage() {
   }
 
   const getUnitSize = (MB) => {
+    if (isNaN(MB) || MB < 0) return 'Invalid number';
     if (MB < 1024) return `${MB} MB`;
 
     return `${(MB / 1024).toFixed(2)} GB`;

--- a/web/src/routes/Storage.jsx
+++ b/web/src/routes/Storage.jsx
@@ -22,6 +22,12 @@ export default function Storage() {
     return <ActivityIndicator />;
   }
 
+  const getUnitSize = (MB) => {
+    if (MB < 1024) return `${MB} MB`;
+
+    return `${(MB / 1024).toFixed(2)} GB`;
+  };
+
   let storage_usage;
   if (
     service &&
@@ -31,13 +37,13 @@ export default function Storage() {
       <Fragment>
         <Tr>
           <Td>Recordings</Td>
-          <Td>{service['storage']['/media/frigate/recordings']['used']}</Td>
-          <Td>{service['storage']['/media/frigate/recordings']['total']}</Td>
+          <Td>{getUnitSize(service['storage']['/media/frigate/recordings']['used'])}</Td>
+          <Td>{getUnitSize(service['storage']['/media/frigate/recordings']['total'])}</Td>
         </Tr>
         <Tr>
           <Td>Snapshots</Td>
-          <Td>{service['storage']['/media/frigate/clips']['used']}</Td>
-          <Td>{service['storage']['/media/frigate/clips']['total']}</Td>
+          <Td>{getUnitSize(service['storage']['/media/frigate/clips']['used'])}</Td>
+          <Td>{getUnitSize(service['storage']['/media/frigate/clips']['total'])}</Td>
         </Tr>
       </Fragment>
     );
@@ -46,8 +52,8 @@ export default function Storage() {
       <Fragment>
         <Tr>
           <Td>Recordings & Snapshots</Td>
-          <Td>{service['storage']['/media/frigate/recordings']['used']}</Td>
-          <Td>{service['storage']['/media/frigate/recordings']['total']}</Td>
+          <Td>{getUnitSize(service['storage']['/media/frigate/recordings']['used'])}</Td>
+          <Td>{getUnitSize(service['storage']['/media/frigate/recordings']['total'])}</Td>
         </Tr>
       </Fragment>
     );
@@ -67,8 +73,8 @@ export default function Storage() {
                 <Thead>
                   <Tr>
                     <Th>Location</Th>
-                    <Th>Used MB</Th>
-                    <Th>Total MB</Th>
+                    <Th>Used</Th>
+                    <Th>Total</Th>
                   </Tr>
                 </Thead>
                 <Tbody>{storage_usage}</Tbody>
@@ -82,20 +88,20 @@ export default function Storage() {
                 <Thead>
                   <Tr>
                     <Th>Location</Th>
-                    <Th>Used MB</Th>
-                    <Th>Total MB</Th>
+                    <Th>Used</Th>
+                    <Th>Total</Th>
                   </Tr>
                 </Thead>
                 <Tbody>
                   <Tr>
                     <Td>/dev/shm</Td>
-                    <Td>{service['storage']['/dev/shm']['used']}</Td>
-                    <Td>{service['storage']['/dev/shm']['total']}</Td>
+                    <Td>{getUnitSize(service['storage']['/dev/shm']['used'])}</Td>
+                    <Td>{getUnitSize(service['storage']['/dev/shm']['total'])}</Td>
                   </Tr>
                   <Tr>
                     <Td>/tmp/cache</Td>
-                    <Td>{service['storage']['/tmp/cache']['used']}</Td>
-                    <Td>{service['storage']['/tmp/cache']['total']}</Td>
+                    <Td>{getUnitSize(service['storage']['/tmp/cache']['used'])}</Td>
+                    <Td>{getUnitSize(service['storage']['/tmp/cache']['total'])}</Td>
                   </Tr>
                 </Tbody>
               </Table>
@@ -121,7 +127,7 @@ export default function Storage() {
                   <Tbody>
                     <Tr>
                       <Td>{Math.round(camera['usage_percent'] ?? 0)}%</Td>
-                      <Td>{camera['bandwidth'] ? camera['bandwidth'] : 'Calculating...'} MB/hr</Td>
+                      <Td>{camera['bandwidth'] ? getUnitSize(camera['bandwidth']) : 'Calculating...'}/hr</Td>
                     </Tr>
                   </Tbody>
                 </Table>


### PR DESCRIPTION
Resolves #5069.
This pull request adds a new function `getUnitSize` that takes a value in MegaByte and returns a string with the appropriate unit (MB or GB) based on the input value.

Examples:

```
getUnitSize(512) => "512 MB"
getUnitSize(2048) => "2.00 GB"
```
