### PR TITLE
Add dependabot auto merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,22 @@
+name: dependabot-auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Get Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.dependency-type == 'direct:development' && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I use this workflow on [vscode-shellcheck](https://github.com/vscode-shellcheck/vscode-shellcheck/) and it's quite nice.

It enables auto-merge for all dependabot PRs that targets development (not production) dependencies that has a minor or patch upgrade, not major.

This helps to reduce the dependabot flooding.

To be effective, the auto merge feature should be enabled in the repository configuration. And you should also make sure the required statuses are set in the branch protection to ensure auto merge will wait for these statuses to be passing before merging.