### PR TITLE
Optimize restream docs

### DIFF
--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -106,16 +106,20 @@ If available, recommended settings are:
 According to [this discussion](https://github.com/blakeblackshear/frigate/issues/3235#issuecomment-1135876973), the http video streams seem to be the most reliable for Reolink.
 
 ```yaml
+go2rtc:
+  reolink: ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=username&password=password#video=copy#audio=copy#audio=opus
+  reolink_sub: ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user=username&password=password
+
 cameras:
   reolink:
     ffmpeg:
-      input_args: preset-http-reolink
       inputs:
-        - path: http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=username&password=password
+        - path: rtsp://127.0.0.1:8554/reolink?video=copy&audio=aac
+          input_args: preset-rtsp-restream
           roles:
             - record
-            - rtmp
-        - path: http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user=username&password=password
+        - path: rtsp://127.0.0.1:8554/reolink?video=copy
+          input_args: preset-rtsp-restream
           roles:
             - detect
     detect:

--- a/docs/docs/configuration/live.md
+++ b/docs/docs/configuration/live.md
@@ -30,7 +30,9 @@ However, chances are that your camera already provides at least one usable audio
 ```yaml
 go2rtc:
   streams:
-    test_cam: ffmpeg:rtsp://192.168.1.5:554/live0#video=copy#audio=copy#audio=opus
+    test_cam: 
+      - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
+      - ffmpeg:test_cam#audio=opus # <- copy of the stream which transcodes audio to opus
 ```
 
 Which will reuse your camera AAC audio, while also adding one track in OPUS format.

--- a/docs/docs/configuration/live.md
+++ b/docs/docs/configuration/live.md
@@ -19,6 +19,8 @@ Live view options can be selected while viewing the live stream. The options are
 
 MSE Requires AAC audio, WebRTC requires PCMU/PCMA, or opus audio. If you want to support both MSE and WebRTC then your restream config needs to use ffmpeg to set both.
 
+#### RTSP Streams
+
 ```yaml
 go2rtc:
   streams:
@@ -37,13 +39,23 @@ go2rtc:
 
 Which will reuse your camera AAC audio, while also adding one track in OPUS format.
 
-If your camera uses RTSP and supports the audio type for the live view you want to use, then you can pass the camera stream to go2rtc without ffmpeg.
+#### HTTP Streams
 
 ```yaml
 go2rtc:
   streams:
-    test_cam: rtsp://192.168.1.5:554/live0
+    test_cam: ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=username&password=password#video=copy#audio=aac#audio=opus
 ```
+
+However, chances are that your camera already provides at least one usable audio type, so you just need restream to add the missing one. For example, if your camera outputs audio in AAC format:
+
+```yaml
+go2rtc:
+  streams:
+    test_cam: ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=username&password=password#video=copy#audio=copy#audio=opus
+```
+
+Which will reuse your camera AAC audio, while also adding one track in OPUS format.
 
 ### Setting Stream For Live UI
 

--- a/docs/docs/configuration/live.md
+++ b/docs/docs/configuration/live.md
@@ -17,45 +17,17 @@ Live view options can be selected while viewing the live stream. The options are
 
 ### Audio Support
 
-MSE Requires AAC audio, WebRTC requires PCMU/PCMA, or opus audio. If you want to support both MSE and WebRTC then your restream config needs to use ffmpeg to set both.
-
-#### RTSP Streams
+MSE Requires AAC audio, WebRTC requires PCMU/PCMA, or opus audio. If you want to support both MSE and WebRTC then your restream config needs to make sure both are enabled.
 
 ```yaml
 go2rtc:
   streams:
-    test_cam: ffmpeg:rtsp://192.168.1.5:554/live0#video=copy#audio=aac#audio=opus
+    rtsp_cam: # <- for RTSP streams
+      - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio
+      - ffmpeg:rtsp_cam#audio=opus # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
+    http_cam: # <- for http streams
+      - "ffmpeg:http://192.168.50.155/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=user&password=password#video=copy#audio=copy#audio=opus" # <- http streams must use ffmpeg to set all types
 ```
-
-However, chances are that your camera already provides at least one usable audio type, so you just need restream to add the missing one. For example, if your camera outputs audio in AAC format:
-
-```yaml
-go2rtc:
-  streams:
-    test_cam: 
-      - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:test_cam#audio=opus # <- copy of the stream which transcodes audio to opus
-```
-
-Which will reuse your camera AAC audio, while also adding one track in OPUS format.
-
-#### HTTP Streams
-
-```yaml
-go2rtc:
-  streams:
-    test_cam: ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=username&password=password#video=copy#audio=aac#audio=opus
-```
-
-However, chances are that your camera already provides at least one usable audio type, so you just need restream to add the missing one. For example, if your camera outputs audio in AAC format:
-
-```yaml
-go2rtc:
-  streams:
-    test_cam: ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=username&password=password#video=copy#audio=copy#audio=opus
-```
-
-Which will reuse your camera AAC audio, while also adding one track in OPUS format.
 
 ### Setting Stream For Live UI
 
@@ -64,12 +36,12 @@ There may be some cameras that you would prefer to use the sub stream for live v
 ```yaml
 go2rtc:
   streams:
-    test_cam: 
+    rtsp_cam: 
       - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:test_cam#audio=opus # <- copy of the stream which transcodes audio to opus
-    test_cam_sub:
+      - ffmpeg:rtsp_cam#audio=opus # <- copy of the stream which transcodes audio to opus
+    rtsp_cam_sub:
       - rtsp://192.168.1.5:554/substream # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:test_cam_sub#audio=opus # <- copy of the stream which transcodes audio to opus
+      - ffmpeg:rtsp_cam_sub#audio=opus # <- copy of the stream which transcodes audio to opus
 
 cameras:
   test_cam:

--- a/docs/docs/configuration/live.md
+++ b/docs/docs/configuration/live.md
@@ -52,8 +52,12 @@ There may be some cameras that you would prefer to use the sub stream for live v
 ```yaml
 go2rtc:
   streams:
-    test_cam: ffmpeg:rtsp://192.168.1.5:554/live0#video=copy#audio=aac#audio=opus
-    test_cam_sub: ffmpeg:rtsp://192.168.1.5:554/substream#video=copy#audio=aac#audio=opus
+    test_cam: 
+      - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
+      - ffmpeg:test_cam#audio=opus # <- copy of the stream which transcodes audio to opus
+    test_cam_sub:
+      - rtsp://192.168.1.5:554/substream # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
+      - ffmpeg:test_cam_sub#audio=opus # <- copy of the stream which transcodes audio to opus
 
 cameras:
   test_cam:

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -21,7 +21,9 @@ In previous Frigate versions RTMP was used for re-streaming. RTMP has disadvanta
 
 Some cameras only support one active connection or you may just want to have a single connection open to the camera. The RTSP restream allows this to be possible.
 
-### With Single Stream
+### RTSP Streams
+
+#### With Single Stream
 
 One connection is made to the camera. One for the restream, `detect` and `record` connect to the restream.
 
@@ -45,7 +47,7 @@ cameras:
             - detect
 ```
 
-### With Sub Stream
+#### With Sub Stream
 
 Two connections are made to the camera. One for the sub stream, one for the restream, `record` connects to the restream.
 
@@ -58,6 +60,59 @@ go2rtc:
     test_cam_sub:
       - rtsp://192.168.1.5:554/substream # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
       - ffmpeg:test_cam_sub#audio=opus # <- copy of the stream which transcodes audio to opus
+
+cameras:
+  test_cam:
+    ffmpeg:
+      output_args:
+        record: preset-record-generic-audio-copy
+      inputs:
+        - path: rtsp://127.0.0.1:8554/test_cam?video=copy&audio=aac # <--- the name here must match the name of the camera in restream
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+        - path: rtsp://127.0.0.1:8554/test_cam_sub?video=copy&audio=aac # <--- the name here must match the name of the camera_sub in restream
+          input_args: preset-rtsp-restream
+          roles:
+            - detect
+```
+
+### HTTP/RTMP Streams
+
+
+#### With Single Stream
+
+One connection is made to the camera. One for the restream, `detect` and `record` connect to the restream.
+
+```yaml
+go2rtc:
+  streams:
+    test_cam: 
+      - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
+      - ffmpeg:test_cam#audio=opus # <- copy of the stream which transcodes audio to opus
+
+cameras:
+  test_cam:
+    ffmpeg:
+      output_args:
+        record: preset-record-generic-audio-copy
+      inputs:
+        - path: rtsp://127.0.0.1:8554/test_cam?video=copy&audio=aac # <--- the name here must match the name of the camera in restream
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+            - detect
+```
+
+#### With Sub Stream
+
+Two connections are made to the camera. One for the sub stream, one for the restream, `record` connects to the restream.
+
+```yaml
+go2rtc:
+  streams:
+    test_cam: ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=username&password=password#video=copy#audio=copy#audio=opus
+    test_cam_sub: ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user=username&password=password#video=copy#audio=copy#audio=opus
 
 cameras:
   test_cam:

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -28,7 +28,9 @@ One connection is made to the camera. One for the restream, `detect` and `record
 ```yaml
 go2rtc:
   streams:
-    test_cam: ffmpeg:rtsp://192.168.1.5:554/live0#video=copy#audio=aac#audio=opus
+    test_cam: 
+      - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
+      - ffmpeg:test_cam#audio=opus # <- copy of the stream which transcodes audio to opus
 
 cameras:
   test_cam:
@@ -50,8 +52,12 @@ Two connections are made to the camera. One for the sub stream, one for the rest
 ```yaml
 go2rtc:
   streams:
-    test_cam: ffmpeg:rtsp://192.168.1.5:554/live0#video=copy#audio=aac#audio=opus
-    test_cam_sub: ffmpeg:rtsp://192.168.1.5:554/substream#video=copy#audio=aac#audio=opus
+    test_cam: 
+      - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
+      - ffmpeg:test_cam#audio=opus # <- copy of the stream which transcodes audio to opus
+    test_cam_sub:
+      - rtsp://192.168.1.5:554/substream # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
+      - ffmpeg:test_cam_sub#audio=opus # <- copy of the stream which transcodes audio to opus
 
 cameras:
   test_cam:

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -21,26 +21,36 @@ In previous Frigate versions RTMP was used for re-streaming. RTMP has disadvanta
 
 Some cameras only support one active connection or you may just want to have a single connection open to the camera. The RTSP restream allows this to be possible.
 
-### RTSP Streams
-
-#### With Single Stream
+### With Single Stream
 
 One connection is made to the camera. One for the restream, `detect` and `record` connect to the restream.
 
 ```yaml
 go2rtc:
   streams:
-    test_cam: 
-      - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:test_cam#audio=opus # <- copy of the stream which transcodes audio to opus
+    rtsp_cam: # <- for RTSP streams
+      - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio
+      - ffmpeg:rtsp_cam#audio=opus # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
+    http_cam: # <- for http streams
+      - "ffmpeg:http://192.168.50.155/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=user&password=password#video=copy#audio=copy#audio=opus" # <- http streams must use ffmpeg to set all types
 
 cameras:
-  test_cam:
+  rtsp_cam:
     ffmpeg:
       output_args:
         record: preset-record-generic-audio-copy
       inputs:
-        - path: rtsp://127.0.0.1:8554/test_cam?video=copy&audio=aac # <--- the name here must match the name of the camera in restream
+        - path: rtsp://127.0.0.1:8554/rtsp_cam?video=copy&audio=aac # <--- the name here must match the name of the camera in restream
+          input_args: preset-rtsp-restream
+          roles:
+            - record
+            - detect
+  http_cam:
+    ffmpeg:
+      output_args:
+        record: preset-record-generic-audio-copy
+      inputs:
+        - path: rtsp://127.0.0.1:8554/htp_cam?video=copy&audio=aac # <--- the name here must match the name of the camera in restream
           input_args: preset-rtsp-restream
           roles:
             - record
@@ -54,77 +64,41 @@ Two connections are made to the camera. One for the sub stream, one for the rest
 ```yaml
 go2rtc:
   streams:
-    test_cam: 
+    rtsp_cam: 
       - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:test_cam#audio=opus # <- copy of the stream which transcodes audio to opus
-    test_cam_sub:
+      - ffmpeg:rtsp_cam#audio=opus # <- copy of the stream which transcodes audio to opus
+    rtsp_cam_sub:
       - rtsp://192.168.1.5:554/substream # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:test_cam_sub#audio=opus # <- copy of the stream which transcodes audio to opus
+      - ffmpeg:rtsp_cam_sub#audio=opus # <- copy of the stream which transcodes audio to opus
+    http_cam:
+      - "ffmpeg:http://192.168.50.155/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=user&password=password#video=copy#audio=copy#audio=opus" # <- http streams must use ffmpeg to set all types
+    http_cam_sub:
+      - "ffmpeg:http://192.168.50.155/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user=user&password=password#video=copy#audio=copy#audio=opus" # <- http streams must use ffmpeg to set all types
 
 cameras:
-  test_cam:
+  rtsp_cam:
     ffmpeg:
       output_args:
         record: preset-record-generic-audio-copy
       inputs:
-        - path: rtsp://127.0.0.1:8554/test_cam?video=copy&audio=aac # <--- the name here must match the name of the camera in restream
+        - path: rtsp://127.0.0.1:8554/rtsp_cam?video=copy&audio=aac # <--- the name here must match the name of the camera in restream
           input_args: preset-rtsp-restream
           roles:
             - record
-        - path: rtsp://127.0.0.1:8554/test_cam_sub?video=copy&audio=aac # <--- the name here must match the name of the camera_sub in restream
+        - path: rtsp://127.0.0.1:8554/rtsp_cam_sub?video=copy&audio=aac # <--- the name here must match the name of the camera_sub in restream
           input_args: preset-rtsp-restream
           roles:
             - detect
-```
-
-### HTTP/RTMP Streams
-
-
-#### With Single Stream
-
-One connection is made to the camera. One for the restream, `detect` and `record` connect to the restream.
-
-```yaml
-go2rtc:
-  streams:
-    test_cam: 
-      - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:test_cam#audio=opus # <- copy of the stream which transcodes audio to opus
-
-cameras:
-  test_cam:
+  http_cam:
     ffmpeg:
       output_args:
         record: preset-record-generic-audio-copy
       inputs:
-        - path: rtsp://127.0.0.1:8554/test_cam?video=copy&audio=aac # <--- the name here must match the name of the camera in restream
+        - path: rtsp://127.0.0.1:8554/http_cam?video=copy&audio=aac # <--- the name here must match the name of the camera in restream
           input_args: preset-rtsp-restream
           roles:
             - record
-            - detect
-```
-
-#### With Sub Stream
-
-Two connections are made to the camera. One for the sub stream, one for the restream, `record` connects to the restream.
-
-```yaml
-go2rtc:
-  streams:
-    test_cam: ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=username&password=password#video=copy#audio=copy#audio=opus
-    test_cam_sub: ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user=username&password=password#video=copy#audio=copy#audio=opus
-
-cameras:
-  test_cam:
-    ffmpeg:
-      output_args:
-        record: preset-record-generic-audio-copy
-      inputs:
-        - path: rtsp://127.0.0.1:8554/test_cam?video=copy&audio=aac # <--- the name here must match the name of the camera in restream
-          input_args: preset-rtsp-restream
-          roles:
-            - record
-        - path: rtsp://127.0.0.1:8554/test_cam_sub?video=copy&audio=aac # <--- the name here must match the name of the camera_sub in restream
+        - path: rtsp://127.0.0.1:8554/http_cam_sub?video=copy&audio=aac # <--- the name here must match the name of the camera_sub in restream
           input_args: preset-rtsp-restream
           roles:
             - detect

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -50,7 +50,7 @@ cameras:
       output_args:
         record: preset-record-generic-audio-copy
       inputs:
-        - path: rtsp://127.0.0.1:8554/htp_cam?video=copy&audio=aac # <--- the name here must match the name of the camera in restream
+        - path: rtsp://127.0.0.1:8554/http_cam?video=copy&audio=aac # <--- the name here must match the name of the camera in restream
           input_args: preset-rtsp-restream
           roles:
             - record


### PR DESCRIPTION
It's better to use

```
go2rtc:
  streams:
    test_cam:
      - rtsp://192.168.1.5:554/live0
      - ffmpeg:test_cam#audio=aac  # or audio=opus
```
 
Because:

1. Start will be faster. FFmpeg has high start time for RTSP with video. Usual: 2 * keyframe time.
2. Go2rtc may not run ffmpeg if first source already has suitable video+audio 
Start ffmpeg with only audio will be fast.