### PR TITLE
System page: fix 0 FPS for disabled camera

### DIFF
--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -246,11 +246,14 @@ export default function System() {
                           <Td>Detect</Td>
                           <Td>{cameras[camera]['pid'] || '- '}</Td>
 
-                          {cameras[camera]['detection_enabled'] == 1 ? (
-                            <Td>{cameras[camera]['detection_fps']} ({cameras[camera]['skipped_fps']} skipped)</Td>
-                          ) : (
-                            <Td>disabled</Td>
-                          )}
+                          {(() => {
+                            if (cameras[camera]['pid'] && cameras[camera]['detection_enabled'] == 1) 
+                              return <Td>{cameras[camera]['detection_fps']} ({cameras[camera]['skipped_fps']} skipped)</Td>
+                            else if (cameras[camera]['pid'] && cameras[camera]['detection_enabled'] == 0) 
+                              return <Td>disabled</Td>
+                            
+                            return <Td>- </Td>
+                          })()}
 
                           <Td>{cpu_usages[cameras[camera]['pid']]?.['cpu'] || '- '}%</Td>
                           <Td>{cpu_usages[cameras[camera]['pid']]?.['mem'] || '- '}%</Td>


### PR DESCRIPTION
This is a very minor UI to fix to change this:

<img width="530" alt="image" src="https://user-images.githubusercontent.com/24962424/213319759-b70032c3-9974-4012-a2bb-be21086ff139.png">

to this for disabled cameras:

<img width="534" alt="image" src="https://user-images.githubusercontent.com/24962424/213319788-978353e8-bfd4-4ef9-9f32-1fa28fd83db7.png">

It doesn't seem like the stats API exposes the enabled/disabled state of the camera at the minute, but this was a trivial change so popped it in.
