### PR TITLE
System page: add last updated time ago

### DIFF
--- a/frigate/stats.py
+++ b/frigate/stats.py
@@ -53,6 +53,7 @@ def stats_init(
         "detectors": detectors,
         "started": int(time.time()),
         "latest_frigate_version": get_latest_version(config),
+        "last_updated": int(time.time()),
     }
     return stats_tracking
 
@@ -244,6 +245,7 @@ def stats_snapshot(
         "latest_version": stats_tracking["latest_frigate_version"],
         "storage": {},
         "temperatures": get_temperatures(),
+        "last_updated": int(time.time()),
     }
 
     for path in [RECORD_DIR, CLIPS_DIR, CACHE_DIR, "/dev/shm"]:

--- a/frigate/types.py
+++ b/frigate/types.py
@@ -29,3 +29,4 @@ class StatsTrackingTypes(TypedDict):
     detectors: dict[str, ObjectDetectProcess]
     started: int
     latest_frigate_version: str
+    last_updated: int

--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -9,6 +9,7 @@ import axios from 'axios';
 import { Table, Tbody, Thead, Tr, Th, Td } from '../components/Table';
 import { useState } from 'preact/hooks';
 import Dialog from '../components/Dialog';
+import TimeAgo from '../components/TimeAgo';
 import copy from 'copy-to-clipboard';
 
 const emptyObject = Object.freeze({});
@@ -83,6 +84,12 @@ export default function System() {
       <Heading>
         System <span className="text-sm">{service.version}</span>
       </Heading>
+
+      {service.last_updated && (
+        <p>
+          <span>Last refreshed: <TimeAgo time={service.last_updated * 1000} dense /></span>
+        </p>
+      )}
 
       {state.showFfprobe && (
         <Dialog>
@@ -247,11 +254,11 @@ export default function System() {
                           <Td>{cameras[camera]['pid'] || '- '}</Td>
 
                           {(() => {
-                            if (cameras[camera]['pid'] && cameras[camera]['detection_enabled'] == 1) 
+                            if (cameras[camera]['pid'] && cameras[camera]['detection_enabled'] == 1)
                               return <Td>{cameras[camera]['detection_fps']} ({cameras[camera]['skipped_fps']} skipped)</Td>
-                            else if (cameras[camera]['pid'] && cameras[camera]['detection_enabled'] == 0) 
+                            else if (cameras[camera]['pid'] && cameras[camera]['detection_enabled'] == 0)
                               return <Td>disabled</Td>
-                            
+
                             return <Td>- </Td>
                           })()}
 


### PR DESCRIPTION
I've been noticed that sometimes the system page seems to stop loading - proposing a straightforward time ago component to make it a little clearer.

![image](https://user-images.githubusercontent.com/24962424/213941690-f81e4603-7ccc-4594-8df3-045a271fd291.png)
