### PR TITLE
Fix vaapi frame rate bug

### DIFF
--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -84,7 +84,7 @@ PRESETS_HW_ACCEL_DECODE = {
 PRESETS_HW_ACCEL_SCALE = {
     "preset-rpi-32-h264": "-r {} -s {}x{} -f rawvideo -pix_fmt yuv420p",
     "preset-rpi-64-h264": "-r {} -s {}x{} -f rawvideo -pix_fmt yuv420p",
-    "preset-vaapi": "-vf fps={},scale_vaapi=w={}:h={},hwdownload,format=yuv420p -f rawvideo",
+    "preset-vaapi": "-r {} -vf scale_vaapi=w={}:h={},hwdownload,format=yuv420p -f rawvideo",
     "preset-intel-qsv-h264": "-r {} -vf vpp_qsv=w={}:h={}:format=nv12,hwdownload,format=nv12,format=yuv420p -f rawvideo",
     "preset-intel-qsv-h265": "-r {} -vf vpp_qsv=w={}:h={}:format=nv12,hwdownload,format=nv12,format=yuv420p -f rawvideo",
     "preset-nvidia-h264": "-vf fps={},scale_cuda=w={}:h={}:format=nv12,hwdownload,format=nv12,format=yuv420p -f rawvideo",


### PR DESCRIPTION
Intels vaapi frame rate filter is ignored in some cases similar to the qsv frame rate filter. Use the ffmpeg base rate limiter instead