### PR TITLE
Add config option to disable version check

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -491,4 +491,9 @@ ui:
   timezone: None
   # Optional: Use an experimental recordings / camera view UI (default: shown below)
   experimental_ui: False
+
+# Optional: Telemetry configuration
+telemetry:
+  # Optional: Enable the latest version outbound check (default: shown below)
+  version_check: True
 ```

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -495,5 +495,6 @@ ui:
 # Optional: Telemetry configuration
 telemetry:
   # Optional: Enable the latest version outbound check (default: shown below)
+  # NOTE: If you use the HomeAssistant integration, disabling this will prevent it from reporting new versions
   version_check: True
 ```

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -155,7 +155,9 @@ class FrigateApp:
         self.db.bind(models)
 
     def init_stats(self) -> None:
-        self.stats_tracking = stats_init(self.camera_metrics, self.detectors)
+        self.stats_tracking = stats_init(
+            self.config, self.camera_metrics, self.detectors
+        )
 
     def init_web_server(self) -> None:
         self.flask_app = create_app(

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -74,6 +74,10 @@ class UIConfig(FrigateBaseModel):
     use_experimental: bool = Field(default=False, title="Experimental UI")
 
 
+class TelemetryConfig(FrigateBaseModel):
+    version_check: bool = Field(default=True, title="Enable latest version check.")
+
+
 class MqttConfig(FrigateBaseModel):
     enabled: bool = Field(title="Enable MQTT Communication.", default=True)
     host: str = Field(default="", title="MQTT Host")
@@ -818,6 +822,9 @@ class FrigateConfig(FrigateBaseModel):
         default_factory=dict, title="Frigate environment variables."
     )
     ui: UIConfig = Field(default_factory=UIConfig, title="UI configuration.")
+    telemetry: TelemetryConfig = Field(
+        default_factory=TelemetryConfig, title="Telemetry configuration."
+    )
     model: ModelConfig = Field(
         default_factory=ModelConfig, title="Detection model configuration."
     )

--- a/frigate/stats.py
+++ b/frigate/stats.py
@@ -22,7 +22,11 @@ from frigate.object_detection import ObjectDetectProcess
 logger = logging.getLogger(__name__)
 
 
-def get_latest_version() -> str:
+def get_latest_version(config: FrigateConfig) -> str:
+
+    if not config.telemetry.version_check:
+        return "disabled"
+
     try:
         request = requests.get(
             "https://api.github.com/repos/blakeblackshear/frigate/releases/latest",
@@ -40,6 +44,7 @@ def get_latest_version() -> str:
 
 
 def stats_init(
+    config: FrigateConfig,
     camera_metrics: dict[str, CameraMetricsTypes],
     detectors: dict[str, ObjectDetectProcess],
 ) -> StatsTrackingTypes:
@@ -47,7 +52,7 @@ def stats_init(
         "camera_metrics": camera_metrics,
         "detectors": detectors,
         "started": int(time.time()),
-        "latest_frigate_version": get_latest_version(),
+        "latest_frigate_version": get_latest_version(config),
     }
     return stats_tracking
 


### PR DESCRIPTION
Some of us like to tightly control outbound network communication, particularly where IP cameras and related infrastructure are concerned.

I've noticed that by default Frigate does an outbound HTTP request to github to get the current release version. As far as I can tell this is only used in the stats API endpoint.

For those of us who would prefer to avoid outbound network traffic, this option allows disabling it, whereupon the version number will be "disabled" rather than "unknown". The config option defaults to enabled to preserve existing behaviour.