### PR TITLE
Fix HA IP address and WebRTC port inferring

### DIFF
--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
@@ -10,7 +10,7 @@ s6-svc -O .
 function get_ip_and_port_from_supervisor() {
     local ip_address
     # Example: 192.168.1.10/24
-    local ip_regex='^([0-9]{1,3}\.{3}[0-9]{1,3})/[0-9]{1,2}$'
+    local ip_regex='^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})/[0-9]{1,2}$'
     if ip_address=$(
         curl -fsSL \
             -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
@@ -32,7 +32,7 @@ function get_ip_and_port_from_supervisor() {
             -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
             -H "Content-Type: application/json" \
             http://supervisor/addons/self/info |
-            jq --exit-status --raw-output '.data.network["22/tcp"]'
+            jq --exit-status --raw-output '.data.network["8555/tcp"]'
     ) && [[ "${webrtc_port}" =~ ${port_regex} ]]; then
         webrtc_port="${BASH_REMATCH[1]}"
         echo "[INFO] Got WebRTC port from supervisor: ${ip_address}" >&2

--- a/docker/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/rootfs/usr/local/go2rtc/create_config.py
@@ -40,6 +40,8 @@ if not go2rtc_config.get("webrtc", {}).get("candidates", []):
     default_candidates.append("stun:8555")
 
     go2rtc_config["webrtc"] = {"candidates": default_candidates}
+else:
+    print("[INFO] Not injecting WebRTC candidates into go2rtc config as it has been set manually")
 
 # need to replace ffmpeg command when using ffmpeg4
 if not os.path.exists(BTBN_PATH):


### PR DESCRIPTION
Now that I upgraded my own Frigate instance I got to test this more, and for some reason the regex worked in my previous test but didn't work in the Frigate container. This fixes it.

Also, I forgot the SSH port there instead of the WebRTC port because I was testing against the Terminal add-on.