### PR TITLE
Fix Frigate stuck at finishing when restarting from UI

### DIFF
--- a/frigate/util.py
+++ b/frigate/util.py
@@ -628,8 +628,13 @@ def clipped(obj, frame_shape):
 
 
 def restart_frigate():
-    # S6 overlay is configured to exit once the Frigate process exits
-    os.kill(os.getpid(), signal.SIGTERM)
+    proc = psutil.Process(1)
+    # if this is running via s6, sigterm pid 1
+    if proc.name() == "s6-svscan":
+        proc.terminate()
+    # otherwise, just try and exit frigate
+    else:
+        os.kill(os.getpid(), signal.SIGTERM)
 
 
 class EventsPerSecond:


### PR DESCRIPTION
This basically reverts the restart logic to how it was before https://github.com/blakeblackshear/frigate/pull/5135.

The thing is: s6 will only apply the timeout of 2 minutes when waiting for Frigate to finish when the shutdown was initiated by s6.

I tested, and it works.