### PR TITLE
Print webrtc info to stderr

### DIFF
--- a/docker/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/rootfs/usr/local/go2rtc/create_config.py
@@ -40,8 +40,6 @@ if not go2rtc_config.get("webrtc", {}).get("candidates", []):
     default_candidates.append("stun:8555")
 
     go2rtc_config["webrtc"] = {"candidates": default_candidates}
-else:
-    print("[INFO] Not injecting WebRTC candidates into go2rtc config as it has been set manually")
 
 # need to replace ffmpeg command when using ffmpeg4
 if not os.path.exists(BTBN_PATH):

--- a/docker/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/rootfs/usr/local/go2rtc/create_config.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 import yaml
 
 
@@ -40,6 +41,8 @@ if not go2rtc_config.get("webrtc", {}).get("candidates", []):
     default_candidates.append("stun:8555")
 
     go2rtc_config["webrtc"] = {"candidates": default_candidates}
+else:
+    print("[INFO] Not injecting WebRTC candidates into go2rtc config as it has been set manually", file=sys.stderr)
 
 # need to replace ffmpeg command when using ffmpeg4
 if not os.path.exists(BTBN_PATH):


### PR DESCRIPTION
This causes go2rtc to be unable to parse the config due to the extra data included in output