### PR TITLE
Upgrade s6-overlay from 3.1.2.1 to 3.1.3.0

### DIFF
--- a/docker/install_s6_overlay.sh
+++ b/docker/install_s6_overlay.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-s6_version="3.1.2.1"
+s6_version="3.1.3.0"
 
 if [[ "${TARGETARCH}" == "amd64" ]]; then
     s6_arch="x86_64"


### PR DESCRIPTION
https://github.com/just-containers/s6-overlay/releases/tag/v3.1.3.0