### PR TITLE
Fix tmpfs filling up due to nginx file descriptors

### DIFF
--- a/frigate/record.py
+++ b/frigate/record.py
@@ -411,6 +411,10 @@ class RecordingCleanup(threading.Thread):
             logger.debug(f"Checking tmp clip {p}.")
             if p.stat().st_mtime < (datetime.datetime.now().timestamp() - 60 * 1):
                 logger.debug("Deleting tmp clip.")
+
+                # empty contents of file before unlinking https://github.com/blakeblackshear/frigate/issues/4769
+                with open(p, "w"):
+                    pass
                 p.unlink(missing_ok=True)
 
     def expire_recordings(self):


### PR DESCRIPTION
fixes https://github.com/blakeblackshear/frigate/issues/4769
fixes https://github.com/blakeblackshear/frigate/issues/5240

the problem is when calling the .mp4 endpoint the file will be cleaned up but the nginx process continues to access it which means linux will not free up the space used by that file when python unlinks it.

After trying many different nginx configs without success, I have found that the best solution is to write the file as empty before python unlinks it.