### PR TITLE
System page: fix timeago error due to drift

### DIFF
--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -87,7 +87,9 @@ export default function System() {
 
       {service.last_updated && (
         <p>
-          <span>Last refreshed: <TimeAgo time={service.last_updated * 1000} dense /></span>
+          <span>
+            Last refreshed: <TimeAgo time={(service.last_updated - 5) * 1000} dense />
+          </span>
         </p>
       )}
 
@@ -255,11 +257,15 @@ export default function System() {
 
                           {(() => {
                             if (cameras[camera]['pid'] && cameras[camera]['detection_enabled'] == 1)
-                              return <Td>{cameras[camera]['detection_fps']} ({cameras[camera]['skipped_fps']} skipped)</Td>
+                              return (
+                                <Td>
+                                  {cameras[camera]['detection_fps']} ({cameras[camera]['skipped_fps']} skipped)
+                                </Td>
+                              );
                             else if (cameras[camera]['pid'] && cameras[camera]['detection_enabled'] == 0)
-                              return <Td>disabled</Td>
+                              return <Td>disabled</Td>;
 
-                            return <Td>- </Td>
+                            return <Td>- </Td>;
                           })()}
 
                           <Td>{cpu_usages[cameras[camera]['pid']]?.['cpu'] || '- '}%</Td>


### PR DESCRIPTION
Occasionally the last updated can be "Invalid Time", despite a valid epoch value being provided. Looking at the timeago component this seems to be because my server time and browser time are out of sync by a couple of seconds, which isn't unusual. Adding a 5 second grace period as an easy fix, given that anything under 60 seconds displays "just now" anyway.