### PR TITLE
Restart ffmpeg if process exceeds detect fps by 10

### DIFF
--- a/frigate/video.py
+++ b/frigate/video.py
@@ -282,7 +282,7 @@ class CameraWatchdog(threading.Thread):
                     self.logger.info("Waiting for ffmpeg to exit gracefully...")
                     self.ffmpeg_detect_process.communicate(timeout=30)
                 except sp.TimeoutExpired:
-                    self.logger.info("FFmpeg didnt exit. Force killing...")
+                    self.logger.info("FFmpeg did not exit. Force killing...")
                     self.ffmpeg_detect_process.kill()
                     self.ffmpeg_detect_process.communicate()
 

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -269,7 +269,7 @@ class CameraWatchdog(threading.Thread):
                     self.logger.info("Waiting for ffmpeg to exit gracefully...")
                     self.ffmpeg_detect_process.communicate(timeout=30)
                 except sp.TimeoutExpired:
-                    self.logger.info("FFmpeg didnt exit. Force killing...")
+                    self.logger.info("FFmpeg did not exit. Force killing...")
                     self.ffmpeg_detect_process.kill()
                     self.ffmpeg_detect_process.communicate()
             elif self.camera_fps.value >= (self.config.detect.fps + 10):

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -272,6 +272,19 @@ class CameraWatchdog(threading.Thread):
                     self.logger.info("FFmpeg didnt exit. Force killing...")
                     self.ffmpeg_detect_process.kill()
                     self.ffmpeg_detect_process.communicate()
+            elif self.camera_fps.value >= (self.config.detect.fps + 10):
+                self.camera_fps.value = 0
+                self.logger.info(
+                    f"{self.camera_name} exceeded fps limit. Exiting ffmpeg..."
+                )
+                self.ffmpeg_detect_process.terminate()
+                try:
+                    self.logger.info("Waiting for ffmpeg to exit gracefully...")
+                    self.ffmpeg_detect_process.communicate(timeout=30)
+                except sp.TimeoutExpired:
+                    self.logger.info("FFmpeg didnt exit. Force killing...")
+                    self.ffmpeg_detect_process.kill()
+                    self.ffmpeg_detect_process.communicate()
 
             for p in self.ffmpeg_other_processes:
                 poll = p["process"].poll()


### PR DESCRIPTION
I found that using go2rtc as a source for detect can occasionally lead to a broken stream which doesn't exit and keeps sending the same frame over and over leading to 100+ fps and high CPU usage. Might be a go2rtc issue but figure it is worth catching here anyway as it could happen with cameras as well.

![Screen Shot 2023-01-29 at 11 11 50 AM](https://user-images.githubusercontent.com/14866235/215347658-05290af1-1b9b-4ee4-affd-ed0148a40220.png)