### PR TITLE
Add "" to go2rtc docs examples

### DIFF
--- a/docs/docs/configuration/live.md
+++ b/docs/docs/configuration/live.md
@@ -24,10 +24,10 @@ go2rtc:
   streams:
     rtsp_cam: # <- for RTSP streams
       - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio
-      - ffmpeg:rtsp_cam#audio=opus # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
+      - "ffmpeg:rtsp_cam#audio=opus" # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
     http_cam: # <- for http streams
       - http://192.168.50.155/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=user&password=password # <- stream which supports video & aac audio
-      - ffmpeg:http_cam#audio=opus # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
+      - "ffmpeg:http_cam#audio=opus" # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
 ```
 
 ### Setting Stream For Live UI
@@ -39,10 +39,10 @@ go2rtc:
   streams:
     rtsp_cam: 
       - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:rtsp_cam#audio=opus # <- copy of the stream which transcodes audio to opus
+      - "ffmpeg:rtsp_cam#audio=opus" # <- copy of the stream which transcodes audio to opus
     rtsp_cam_sub:
       - rtsp://192.168.1.5:554/substream # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:rtsp_cam_sub#audio=opus # <- copy of the stream which transcodes audio to opus
+      - "ffmpeg:rtsp_cam_sub#audio=opus" # <- copy of the stream which transcodes audio to opus
 
 cameras:
   test_cam:

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -30,10 +30,10 @@ go2rtc:
   streams:
     rtsp_cam: # <- for RTSP streams
       - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio
-      - ffmpeg:rtsp_cam#audio=opus # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
+      - "ffmpeg:rtsp_cam#audio=opus" # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
     http_cam: # <- for other streams
       - http://192.168.50.155/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=user&password=password # <- stream which supports video & aac audio
-      - ffmpeg:http_cam#audio=opus # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
+      - "ffmpeg:http_cam#audio=opus" # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
 
 cameras:
   rtsp_cam:
@@ -67,16 +67,16 @@ go2rtc:
   streams:
     rtsp_cam: 
       - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:rtsp_cam#audio=opus # <- copy of the stream which transcodes audio to opus
+      - "ffmpeg:rtsp_cam#audio=opus" # <- copy of the stream which transcodes audio to opus
     rtsp_cam_sub:
       - rtsp://192.168.1.5:554/substream # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:rtsp_cam_sub#audio=opus # <- copy of the stream which transcodes audio to opus
+      - "ffmpeg:rtsp_cam_sub#audio=opus" # <- copy of the stream which transcodes audio to opus
     http_cam:
       - http://192.168.50.155/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=user&password=password # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:http_cam#audio=opus # <- copy of the stream which transcodes audio to opus
+      - "ffmpeg:http_cam#audio=opus" # <- copy of the stream which transcodes audio to opus
     http_cam_sub:
       - http://192.168.50.155/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user=user&password=password # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - ffmpeg:http_cam_sub#audio=opus # <- copy of the stream which transcodes audio to opus
+      - "ffmpeg:http_cam_sub#audio=opus" # <- copy of the stream which transcodes audio to opus
 
 cameras:
   rtsp_cam:


### PR DESCRIPTION
Placed `ffmpeg:http_cam#audio=opus` in quotes so it doesn't appear as commented out in docs.