### PR TITLE
Add rtsp ffmpeg restream preset without low_delay/nobuffer

### DIFF
--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -241,6 +241,13 @@ PRESETS_INPUT = {
         "-flags",
         "low_delay",
     ],
+    "preset-rtsp-restream-safe": _user_agent_args
+    + [
+        "-rtsp_transport",
+        "tcp",
+        TIMEOUT_PARAM,
+        "5000000",
+    ],    
     "preset-rtsp-udp": _user_agent_args
     + [
         "-avoid_negative_ts",

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -247,7 +247,7 @@ PRESETS_INPUT = {
         "tcp",
         TIMEOUT_PARAM,
         "5000000",
-    ],    
+    ],
     "preset-rtsp-udp": _user_agent_args
     + [
         "-avoid_negative_ts",


### PR DESCRIPTION
The change to introduce these flags in https://github.com/blakeblackshear/frigate/pull/5231 breaks streaming from 2x of my Revotech cameras, as raised on https://github.com/blakeblackshear/frigate/discussions/5267.

As I would rather not maintain custom flags for these cameras, proposing to add another preset which should mirror the existing `preset-rtsp-restream` but without the challenging flags.

Happy to discuss alternative solutions