### PR TITLE
Add any option to birdseye

### DIFF
--- a/docs/docs/configuration/birdseye.md
+++ b/docs/docs/configuration/birdseye.md
@@ -8,7 +8,7 @@ Birdseye offers different modes to customize which cameras show under which circ
  - **continuous:** All cameras are always included
  - **motion:** Cameras that have detected motion within the last 30 seconds are included
  - **objects:** Cameras that have tracked an active object within the last 30 seconds are included
- - **all:** Cameras that have tracked an active object or detected motion within the last 30 seconds are included
+ - **any:** Cameras that have tracked an active object or detected motion within the last 30 seconds are included
 
 ### Custom Birdseye Icon
 

--- a/docs/docs/configuration/birdseye.md
+++ b/docs/docs/configuration/birdseye.md
@@ -8,6 +8,7 @@ Birdseye offers different modes to customize which cameras show under which circ
  - **continuous:** All cameras are always included
  - **motion:** Cameras that have detected motion within the last 30 seconds are included
  - **objects:** Cameras that have tracked an active object within the last 30 seconds are included
+ - **all:** Cameras that have tracked an active object or detected motion within the last 30 seconds are included
 
 ### Custom Birdseye Icon
 

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -128,6 +128,7 @@ birdseye:
   # Optional: Mode of the view. Available options are: objects, motion, and continuous
   #   objects - cameras are included if they have had a tracked object within the last 30 seconds
   #   motion - cameras are included if motion was detected in the last 30 seconds
+  #   any - cameras are included if motion or objects were detected within the last 30 seconds
   #   continuous - all cameras are included always
   mode: objects
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -312,6 +312,7 @@ class ObjectConfig(FrigateBaseModel):
 class BirdseyeModeEnum(str, Enum):
     objects = "objects"
     motion = "motion"
+    any = "any"
     continuous = "continuous"
 
 

--- a/frigate/output.py
+++ b/frigate/output.py
@@ -200,6 +200,10 @@ class BirdsEyeFrameManager:
         if mode == BirdseyeModeEnum.objects and object_box_count > 0:
             return True
 
+        if mode == BirdseyeModeEnum.any and ( object_box_count > 0 or motion_box_count > 0):
+            return True
+
+
     def update_frame(self):
         # determine how many cameras are tracking objects within the last 30 seconds
         active_cameras = set(


### PR DESCRIPTION
Adding an `any` option to Birdseye that is a combination of both motion and object.

I prefer to use motion for my Birdseye streams, however, it doesn't show me my dogs when they're sleeping. This should allow for the best of both. 

I'm welcome to any feedback on the naming as well as `any` was the best I could think of. 