### PR TITLE
Name capture processes

### DIFF
--- a/frigate/video.py
+++ b/frigate/video.py
@@ -404,6 +404,9 @@ def capture_camera(name, config: CameraConfig, process_info):
     signal.signal(signal.SIGTERM, receiveSignal)
     signal.signal(signal.SIGINT, receiveSignal)
 
+    threading.current_thread().name = f"capture:{name}"
+    setproctitle(f"frigate.capture:{name}")
+
     frame_queue = process_info["frame_queue"]
     camera_watchdog = CameraWatchdog(
         name,


### PR DESCRIPTION
Helps on Linux when using `ps -ef` and related tools to see what processes are doing

```
root         273     108  0 18:57 ?        00:00:00 frigate.logger
root         280     108 13 18:57 ?        00:16:52 frigate.detector.coral
root         281     108  1 18:57 ?        00:01:18 frigate.output
root         288     108  2 18:57 ?        00:03:34 frigate.process:hikcam1
root         289     108  0 18:57 ?        00:00:29 frigate.process:hikcam2
root         297     108  0 18:57 ?        00:01:00 python3 -u -m frigate
root         299     108  0 18:57 ?        00:01:02 python3 -u -m frigate
```

becomes

```
root         273     108  0 18:57 ?        00:00:00 frigate.logger
root         280     108 13 18:57 ?        00:16:52 frigate.detector.coral
root         281     108  1 18:57 ?        00:01:18 frigate.output
root         288     108  2 18:57 ?        00:03:34 frigate.process:hikcam1
root         289     108  0 18:57 ?        00:00:29 frigate.process:hikcam2
root         297     108  0 18:57 ?        00:01:00 frigate.capture:hikcam1
root         299     108  0 18:57 ?        00:01:02 frigate.capture:hikcam2
```