### PR TITLE
Use detect output args with hwaccel presets

### DIFF
--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -120,13 +120,13 @@ PRESETS_HW_ACCEL_DECODE = {
 }
 
 PRESETS_HW_ACCEL_SCALE = {
-    "preset-rpi-32-h264": "-r {0} -s {1}x{2} -f rawvideo -pix_fmt yuv420p",
-    "preset-rpi-64-h264": "-r {0} -s {1}x{2} -f rawvideo -pix_fmt yuv420p",
-    "preset-vaapi": "-r {0} -vf fps={0},scale_vaapi=w={1}:h={2},hwdownload,format=yuv420p -f rawvideo",
-    "preset-intel-qsv-h264": "-r {0} -vf vpp_qsv=framerate={0}:w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p -f rawvideo",
-    "preset-intel-qsv-h265": "-r {0} -vf vpp_qsv=framerate={0}:w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p -f rawvideo",
-    "preset-nvidia-h264": "-r {0} -vf fps={0},scale_cuda=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p -f rawvideo",
-    "preset-nvidia-h265": "-r {0} -vf fps={0},scale_cuda=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p -f rawvideo",
+    "preset-rpi-32-h264": "-r {0} -s {1}x{2}",
+    "preset-rpi-64-h264": "-r {0} -s {1}x{2}",
+    "preset-vaapi": "-r {0} -vf fps={0},scale_vaapi=w={1}:h={2},hwdownload,format=yuv420p",
+    "preset-intel-qsv-h264": "-r {0} -vf vpp_qsv=framerate={0}:w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
+    "preset-intel-qsv-h265": "-r {0} -vf vpp_qsv=framerate={0}:w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
+    "preset-nvidia-h264": "-r {0} -vf fps={0},scale_cuda=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
+    "preset-nvidia-h265": "-r {0} -vf fps={0},scale_cuda=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
     "default": "-r {0} -s {1}x{2}",
 }
 
@@ -166,7 +166,9 @@ def parse_preset_hardware_acceleration_scale(
     scale = PRESETS_HW_ACCEL_SCALE.get(arg, "")
 
     if scale:
-        return scale.format(fps, width, height).split(" ")
+        scale = scale.format(fps, width, height).split(" ")
+        scale.extend(detect_args)
+        return scale
     else:
         scale = scale.format(fps, width, height).split(" ")
         scale.extend(detect_args)


### PR DESCRIPTION
I have found that having -pix_fmt when already setting the pix fmt with the -vf filter does not cause any issues or change resource usage. This change makes the structure consistent whether or not hwaccel presets are used, and it means detect -> output_args will always be applied instead of silently not working when using hwaccel presets