### PR TITLE
Use reolink preset for http go2rtc input args

### DIFF
--- a/docker/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/rootfs/usr/local/go2rtc/create_config.py
@@ -68,7 +68,7 @@ elif go2rtc_config["rtsp"].get("default_query") is None:
 # set ffmpeg defaults
 if go2rtc_config.get("ffmpeg") is None:
     go2rtc_config["ffmpeg"] = {
-        "http": f"{parse_preset_input['preset-http-reolink'].join(' ')} -i {{input}}"
+        "http": f"{' '.join(parse_preset_input('preset-http-reolink'))} -i {{input}}"
     }
 
     if not os.path.exists(BTBN_PATH):
@@ -78,7 +78,7 @@ if go2rtc_config.get("ffmpeg") is None:
         ] = "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"
 else:
     if go2rtc_config["ffmpeg"].get("http") is None:
-        go2rtc_config["ffmpeg"]["http"] = f"{parse_preset_input['preset-http-reolink'].join(' ')} -i {{input}}"
+        go2rtc_config["ffmpeg"]["http"] = f"{' '.join(parse_preset_input('preset-http-reolink'))} -i {{input}}"
 
     if not os.path.exists(BTBN_PATH) and go2rtc_config["ffmpeg"].get("rtsp") is None:
         # need to replace ffmpeg command when using ffmpeg4

--- a/docker/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/rootfs/usr/local/go2rtc/create_config.py
@@ -8,8 +8,8 @@ import yaml
 sys.path.insert(0, "/opt/frigate")
 from frigate.const import BIRDSEYE_PIPE, BTBN_PATH
 from frigate.ffmpeg_presets import (
+    PRESETS_INPUT,
     parse_preset_hardware_acceleration_encode,
-    parse_preset_input,
 )
 
 sys.path.remove("/opt/frigate")
@@ -68,7 +68,7 @@ elif go2rtc_config["rtsp"].get("default_query") is None:
 # set ffmpeg defaults
 if go2rtc_config.get("ffmpeg") is None:
     go2rtc_config["ffmpeg"] = {
-        "http": f"{' '.join(parse_preset_input('preset-http-reolink'))} -i {{input}}"
+        "http": f"{' '.join(PRESETS_INPUT['preset-http-reolink'])} -i {{input}}"
     }
 
     if not os.path.exists(BTBN_PATH):
@@ -78,7 +78,9 @@ if go2rtc_config.get("ffmpeg") is None:
         ] = "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"
 else:
     if go2rtc_config["ffmpeg"].get("http") is None:
-        go2rtc_config["ffmpeg"]["http"] = f"{' '.join(parse_preset_input('preset-http-reolink'))} -i {{input}}"
+        go2rtc_config["ffmpeg"][
+            "http"
+        ] = f"{' '.join(PRESETS_INPUT['preset-http-reolink'])} -i {{input}}"
 
     if not os.path.exists(BTBN_PATH) and go2rtc_config["ffmpeg"].get("rtsp") is None:
         # need to replace ffmpeg command when using ffmpeg4

--- a/docker/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/rootfs/usr/local/go2rtc/create_config.py
@@ -7,7 +7,11 @@ import yaml
 
 sys.path.insert(0, "/opt/frigate")
 from frigate.const import BIRDSEYE_PIPE, BTBN_PATH
-from frigate.ffmpeg_presets import parse_preset_hardware_acceleration_encode
+from frigate.ffmpeg_presets import (
+    parse_preset_hardware_acceleration_encode,
+    parse_preset_input,
+)
+
 sys.path.remove("/opt/frigate")
 
 
@@ -61,13 +65,23 @@ if go2rtc_config.get("rtsp") is None:
 elif go2rtc_config["rtsp"].get("default_query") is None:
     go2rtc_config["rtsp"]["default_query"] = "mp4"
 
-# need to replace ffmpeg command when using ffmpeg4
-if not os.path.exists(BTBN_PATH):
-    if go2rtc_config.get("ffmpeg") is None:
-        go2rtc_config["ffmpeg"] = {
-            "rtsp": "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"
-        }
-    elif go2rtc_config["ffmpeg"].get("rtsp") is None:
+# set ffmpeg defaults
+if go2rtc_config.get("ffmpeg") is None:
+    go2rtc_config["ffmpeg"] = {
+        "http": f"{parse_preset_input['preset-http-reolink'].join(' ')} -i {{input}}"
+    }
+
+    if not os.path.exists(BTBN_PATH):
+        # need to replace ffmpeg command when using ffmpeg4
+        go2rtc_config["ffmpeg"][
+            "rtsp"
+        ] = "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"
+else:
+    if go2rtc_config["ffmpeg"].get("http") is None:
+        go2rtc_config["ffmpeg"]["http"] = f"{parse_preset_input['preset-http-reolink'].join(' ')} -i {{input}}"
+
+    if not os.path.exists(BTBN_PATH) and go2rtc_config["ffmpeg"].get("rtsp") is None:
+        # need to replace ffmpeg command when using ffmpeg4
         go2rtc_config["ffmpeg"][
             "rtsp"
         ] = "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -49,7 +49,7 @@ TIMEOUT_PARAM = "-timeout" if os.path.exists(BTBN_PATH) else "-stimeout"
 _gpu_selector = LibvaGpuSelector()
 _user_agent_args = [
     "-user_agent",
-    f"FFmpeg Frigate/{VERSION}",
+    f'"FFmpeg Frigate/{VERSION}"',
 ]
 
 PRESETS_HW_ACCEL_DECODE = {


### PR DESCRIPTION
In frigate 0.11 it was found that the nobuffer arg caused issues with reolink and other http streams. Go2rtc sets this and I believe that may be part of the stability issues when using with ffmpeg. 