### PR TITLE
Events Page: Added option to override browser time format and style

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -86,6 +86,9 @@ class UIConfig(FrigateBaseModel):
     timeStyle: DateTimeStyleEnum = Field(
         default=DateTimeStyleEnum.medium, title="Override UI timeStyle."
     )
+    strftime_fmt: Optional[str] = Field(
+        None, title="Override date and time format using strftime syntax."
+    )
 
 
 class TelemetryConfig(FrigateBaseModel):

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -65,11 +65,13 @@ class LiveModeEnum(str, Enum):
     mse = "mse"
     webrtc = "webrtc"
 
+
 class DateTimeStyleEnum(str, Enum):
     full = "full"
     long = "long"
     medium = "medium"
     short = "short"
+
 
 class UIConfig(FrigateBaseModel):
     live_mode: LiveModeEnum = Field(
@@ -78,8 +80,13 @@ class UIConfig(FrigateBaseModel):
     timezone: Optional[str] = Field(title="Override UI timezone.")
     use_experimental: bool = Field(default=False, title="Experimental UI")
     use12hour: Optional[bool] = Field(title="Override UI time format.")
-    dateStyle: DateTimeStyleEnum = Field(default=DateTimeStyleEnum.short, title="Override UI dateStyle.")
-    timeStyle: DateTimeStyleEnum = Field(default=DateTimeStyleEnum.medium, title="Override UI timeStyle.")
+    dateStyle: DateTimeStyleEnum = Field(
+        default=DateTimeStyleEnum.short, title="Override UI dateStyle."
+    )
+    timeStyle: DateTimeStyleEnum = Field(
+        default=DateTimeStyleEnum.medium, title="Override UI timeStyle."
+    )
+
 
 class TelemetryConfig(FrigateBaseModel):
     version_check: bool = Field(default=True, title="Enable latest version check.")

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -72,6 +72,7 @@ class UIConfig(FrigateBaseModel):
     )
     timezone: Optional[str] = Field(title="Override UI timezone.")
     use_experimental: bool = Field(default=False, title="Experimental UI")
+    use12hour: Optional[bool] = Field(title="Override UI time format.")
 
 
 class TelemetryConfig(FrigateBaseModel):

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -65,6 +65,11 @@ class LiveModeEnum(str, Enum):
     mse = "mse"
     webrtc = "webrtc"
 
+class DateTimeStyleEnum(str, Enum):
+    full = "full"
+    long = "long"
+    medium = "medium"
+    short = "short"
 
 class UIConfig(FrigateBaseModel):
     live_mode: LiveModeEnum = Field(
@@ -73,7 +78,8 @@ class UIConfig(FrigateBaseModel):
     timezone: Optional[str] = Field(title="Override UI timezone.")
     use_experimental: bool = Field(default=False, title="Experimental UI")
     use12hour: Optional[bool] = Field(title="Override UI time format.")
-
+    dateStyle: DateTimeStyleEnum = Field(default=DateTimeStyleEnum.short, title="Override UI dateStyle.")
+    timeStyle: DateTimeStyleEnum = Field(default=DateTimeStyleEnum.medium, title="Override UI timeStyle.")
 
 class TelemetryConfig(FrigateBaseModel):
     version_check: bool = Field(default=True, title="Enable latest version check.")

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -80,14 +80,14 @@ class UIConfig(FrigateBaseModel):
     timezone: Optional[str] = Field(title="Override UI timezone.")
     use_experimental: bool = Field(default=False, title="Experimental UI")
     use12hour: Optional[bool] = Field(title="Override UI time format.")
-    dateStyle: DateTimeStyleEnum = Field(
+    date_style: DateTimeStyleEnum = Field(
         default=DateTimeStyleEnum.short, title="Override UI dateStyle."
     )
-    timeStyle: DateTimeStyleEnum = Field(
+    time_style: DateTimeStyleEnum = Field(
         default=DateTimeStyleEnum.medium, title="Override UI timeStyle."
     )
     strftime_fmt: Optional[str] = Field(
-        None, title="Override date and time format using strftime syntax."
+        default=None, title="Override date and time format using strftime syntax."
     )
 
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@cycjimmy/jsmpeg-player": "^6.0.5",
         "axios": "^1.2.2",
+        "copy-to-clipboard": "3.3.3",
         "date-fns": "^2.29.3",
         "idb-keyval": "^6.2.0",
         "immer": "^9.0.16",
@@ -19,6 +20,7 @@
         "preact-router": "^4.1.0",
         "react": "npm:@preact/compat@^17.1.2",
         "react-dom": "npm:@preact/compat@^17.1.2",
+        "strftime": "^0.10.1",
         "swr": "^1.3.0",
         "video.js": "^7.20.3",
         "videojs-playlist": "^5.0.0",
@@ -3367,6 +3369,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
       }
     },
     "node_modules/core-js": {
@@ -8547,6 +8557,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/strftime": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.1.tgz",
+      "integrity": "sha512-nVvH6JG8KlXFPC0f8lojLgEsPA18lRpLZ+RrJh/NkQV2tqOgZfbas8gcU8SFgnnqR3rWzZPYu6N2A3xzs/8rQg==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
     "node_modules/strict-event-emitter": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
@@ -8900,6 +8918,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/totalist": {
       "version": "3.0.0",
@@ -12150,6 +12173,14 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true
+    },
+    "copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "core-js": {
       "version": "3.26.0",
@@ -15868,6 +15899,11 @@
         }
       }
     },
+    "strftime": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.1.tgz",
+      "integrity": "sha512-nVvH6JG8KlXFPC0f8lojLgEsPA18lRpLZ+RrJh/NkQV2tqOgZfbas8gcU8SFgnnqR3rWzZPYu6N2A3xzs/8rQg=="
+    },
     "strict-event-emitter": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
@@ -16153,6 +16189,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "totalist": {
       "version": "3.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -18,17 +18,18 @@
     "date-fns": "^2.29.3",
     "idb-keyval": "^6.2.0",
     "immer": "^9.0.16",
+    "monaco-yaml": "^4.0.2",
     "preact": "^10.11.3",
     "preact-async-route": "^2.2.1",
     "preact-router": "^4.1.0",
     "react": "npm:@preact/compat@^17.1.2",
     "react-dom": "npm:@preact/compat@^17.1.2",
-    "vite-plugin-monaco-editor": "^1.1.0",
-    "monaco-yaml": "^4.0.2",
+    "strftime": "^0.10.1",
     "swr": "^1.3.0",
     "video.js": "^7.20.3",
     "videojs-playlist": "^5.0.0",
-    "videojs-seek-buttons": "^3.0.1"
+    "videojs-seek-buttons": "^3.0.1",
+    "vite-plugin-monaco-editor": "^1.1.0"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.5.0",

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -508,7 +508,7 @@ export default function Events({ path, ...props }) {
                         </div>
                         <div className="text-sm flex">
                           <Clock className="h-5 w-5 mr-2 inline" />
-                          {formatUnixTimestampToDateTime(event.start_time, locale, timezone)}
+                          {formatUnixTimestampToDateTime(event.start_time, locale, timezone, config.ui?.use12hour)}
                           <div className="hidden md:inline">
                             <span className="m-1">-</span>
                             <TimeAgo time={event.start_time * 1000} dense />

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -287,9 +287,6 @@ export default function Events({ path, ...props }) {
     return <ActivityIndicator />;
   }
 
-  const timezone = config.ui?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const locale = window.navigator?.language || 'en-US';
-
   return (
     <div className="space-y-4 p-2 px-4 w-full">
       <Heading>Events</Heading>
@@ -508,7 +505,7 @@ export default function Events({ path, ...props }) {
                         </div>
                         <div className="text-sm flex">
                           <Clock className="h-5 w-5 mr-2 inline" />
-                          {formatUnixTimestampToDateTime(event.start_time, locale, timezone, config.ui?.use12hour)}
+                          {formatUnixTimestampToDateTime(event.start_time, { ...config.ui })}
                           <div className="hidden md:inline">
                             <span className="m-1">-</span>
                             <TimeAgo time={event.start_time * 1000} dense />

--- a/web/src/utils/dateUtil.ts
+++ b/web/src/utils/dateUtil.ts
@@ -25,26 +25,27 @@ export const getNowYesterdayInLong = (): number => {
  * @param timezone: string
  * @returns string - dateTime or 'Invalid time' if unixTimestamp is not provided
  */
-export const formatUnixTimestampToDateTime = (
-  unixTimestamp: number,
-  locale: string,
-  timezone: string,
-  use12HourFormat: boolean
-): string => {
+interface DateTimeStyle {
+  timezone: string;
+  use12hour: boolean | undefined;
+  dateStyle: 'full' | 'long' | 'medium' | 'short';
+  timeStyle: 'full' | 'long' | 'medium' | 'short';
+}
+
+export const formatUnixTimestampToDateTime = (unixTimestamp: number, config: DateTimeStyle): string => {
+  const { timezone, use12hour, dateStyle, timeStyle } = config;
+  const locale = window.navigator?.language || 'en-US';
+
   if (isNaN(unixTimestamp)) {
     return 'Invalid time';
   }
   try {
     const date = new Date(unixTimestamp * 1000);
     const formatter = new Intl.DateTimeFormat(locale, {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-      hour: use12HourFormat ? 'numeric' : '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      timeZone: timezone,
-      hour12: use12HourFormat !== null ? use12HourFormat : undefined,
+      dateStyle,
+      timeStyle,
+      timeZone: timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+      hour12: use12hour !== null ? use12hour : undefined,
     });
     return formatter.format(date);
   } catch (error) {

--- a/web/src/utils/dateUtil.ts
+++ b/web/src/utils/dateUtil.ts
@@ -25,7 +25,12 @@ export const getNowYesterdayInLong = (): number => {
  * @param timezone: string
  * @returns string - dateTime or 'Invalid time' if unixTimestamp is not provided
  */
-export const formatUnixTimestampToDateTime = (unixTimestamp: number, locale: string, timezone: string): string => {
+export const formatUnixTimestampToDateTime = (
+  unixTimestamp: number,
+  locale: string,
+  timezone: string,
+  use12HourFormat: boolean
+): string => {
   if (isNaN(unixTimestamp)) {
     return 'Invalid time';
   }
@@ -35,10 +40,11 @@ export const formatUnixTimestampToDateTime = (unixTimestamp: number, locale: str
       day: '2-digit',
       month: '2-digit',
       year: 'numeric',
-      hour: '2-digit',
+      hour: use12HourFormat ? 'numeric' : '2-digit',
       minute: '2-digit',
       second: '2-digit',
       timeZone: timezone,
+      hour12: use12HourFormat !== null ? use12HourFormat : undefined,
     });
     return formatter.format(date);
   } catch (error) {

--- a/web/src/utils/dateUtil.ts
+++ b/web/src/utils/dateUtil.ts
@@ -38,13 +38,13 @@ export const getNowYesterdayInLong = (): number => {
 interface DateTimeStyle {
   timezone: string;
   use12hour: boolean | undefined;
-  dateStyle: 'full' | 'long' | 'medium' | 'short';
-  timeStyle: 'full' | 'long' | 'medium' | 'short';
+  date_style: 'full' | 'long' | 'medium' | 'short';
+  time_style: 'full' | 'long' | 'medium' | 'short';
   strftime_fmt: string;
 }
 
 export const formatUnixTimestampToDateTime = (unixTimestamp: number, config: DateTimeStyle): string => {
-  const { timezone, use12hour, dateStyle, timeStyle, strftime_fmt } = config;
+  const { timezone, use12hour, date_style, time_style, strftime_fmt } = config;
   const locale = window.navigator?.language || 'en-US';
 
   if (isNaN(unixTimestamp)) {
@@ -61,8 +61,8 @@ export const formatUnixTimestampToDateTime = (unixTimestamp: number, config: Dat
 
     // else use Intl.DateTimeFormat
     const formatter = new Intl.DateTimeFormat(locale, {
-      dateStyle,
-      timeStyle,
+      dateStyle: date_style,
+      timeStyle: time_style,
       timeZone: timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
       hour12: use12hour !== null ? use12hour : undefined,
     });

--- a/web/src/utils/dateUtil.ts
+++ b/web/src/utils/dateUtil.ts
@@ -1,7 +1,8 @@
+import strftime from 'strftime';
+import { fromUnixTime, intervalToDuration, formatDuration } from 'date-fns';
 export const longToDate = (long: number): Date => new Date(long * 1000);
 export const epochToLong = (date: number): number => date / 1000;
 export const dateToLong = (date: Date): number => epochToLong(date.getTime());
-import { fromUnixTime, intervalToDuration, formatDuration } from 'date-fns';
 
 const getDateTimeYesterday = (dateTime: Date): Date => {
   const twentyFourHoursInMilliseconds = 24 * 60 * 60 * 1000;
@@ -17,23 +18,33 @@ export const getNowYesterdayInLong = (): number => {
 };
 
 /**
- * This function takes in a unix timestamp, locale, timezone,
- * and returns a dateTime string.
- * If unixTimestamp is not provided, it returns 'Invalid time'
- * @param unixTimestamp: number
- * @param locale: string
- * @param timezone: string
- * @returns string - dateTime or 'Invalid time' if unixTimestamp is not provided
+ * This function takes in a Unix timestamp, configuration options for date/time display, and an optional strftime format string,
+ * and returns a formatted date/time string.
+ *
+ * If the Unix timestamp is not provided, it returns "Invalid time".
+ *
+ * The configuration options determine how the date and time are formatted.
+ * The `timezone` option allows you to specify a specific timezone for the output, otherwise the user's browser timezone will be used.
+ * The `use12hour` option allows you to display time in a 12-hour format if true, and 24-hour format if false.
+ * The `dateStyle` and `timeStyle` options allow you to specify pre-defined formats for displaying the date and time.
+ * The `strftime_fmt` option allows you to specify a custom format using the strftime syntax.
+ *
+ * If both `strftime_fmt` and `dateStyle`/`timeStyle` are provided, `strftime_fmt` takes precedence.
+ *
+ * @param unixTimestamp The Unix timestamp to format
+ * @param config An object containing the configuration options for date/time display
+ * @returns The formatted date/time string, or "Invalid time" if the Unix timestamp is not provided or invalid.
  */
 interface DateTimeStyle {
   timezone: string;
   use12hour: boolean | undefined;
   dateStyle: 'full' | 'long' | 'medium' | 'short';
   timeStyle: 'full' | 'long' | 'medium' | 'short';
+  strftime_fmt: string;
 }
 
 export const formatUnixTimestampToDateTime = (unixTimestamp: number, config: DateTimeStyle): string => {
-  const { timezone, use12hour, dateStyle, timeStyle } = config;
+  const { timezone, use12hour, dateStyle, timeStyle, strftime_fmt } = config;
   const locale = window.navigator?.language || 'en-US';
 
   if (isNaN(unixTimestamp)) {
@@ -41,6 +52,14 @@ export const formatUnixTimestampToDateTime = (unixTimestamp: number, config: Dat
   }
   try {
     const date = new Date(unixTimestamp * 1000);
+
+    // use strftime_fmt if defined in config file
+    if (strftime_fmt) {
+      const strftime_locale = strftime.localizeByIdentifier(locale);
+      return strftime_locale(strftime_fmt, date);
+    }
+
+    // else use Intl.DateTimeFormat
     const formatter = new Intl.DateTimeFormat(locale, {
       dateStyle,
       timeStyle,


### PR DESCRIPTION
Implements #5476

new optional ui config entries:
```yaml
ui:
  use12hour: false     # true | false
  dateStyle: 'short'   # 'full' | 'long' | 'medium' | 'short
  timeStyle: 'medium'  # 'full' | 'long' | 'medium' | 'short
```

Would be nice if someone else could test and provide feedback.
one issue, when "full" is used (highly unlikely) it will clutter the mobile view, but at least it gives the user the option.

A few examples:

```
ui:
  dateStyle: 'full' 
  timeStyle: 'full'
```
![image](https://user-images.githubusercontent.com/7771916/219879747-b7922af9-45bc-474a-b85d-28376235a49a.png)


```
(default)
ui:
  dateStyle: 'short' 
  timeStyle: 'medium'
```
![image](https://user-images.githubusercontent.com/7771916/219879625-7671dd0a-43c0-48c5-bdcb-12276d984938.png)


```
ui:
  use12hour: true
  dateStyle: 'short' 
  timeStyle: 'medium'
```
![image](https://user-images.githubusercontent.com/7771916/219879666-32bf5881-123b-452f-81d5-80396e17c50e.png)



```
ui:
  use12hour: true
  dateStyle: 'short' 
  timeStyle: 'short'
```
![image](https://user-images.githubusercontent.com/7771916/219879931-ab5c8432-1e45-4560-b895-f1ad892c0d96.png)


