### PR TITLE
Upgrade s6-overlay from 3.1.4.0 to 3.1.4.1

### DIFF
--- a/docker/install_s6_overlay.sh
+++ b/docker/install_s6_overlay.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-s6_version="3.1.4.0"
+s6_version="3.1.4.1"
 
 if [[ "${TARGETARCH}" == "amd64" ]]; then
     s6_arch="x86_64"


### PR DESCRIPTION
Nothing worrying here, only a small patch release.