### PR TITLE
Add feature/option to rotate cameras

### DIFF
--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -48,3 +48,28 @@ cameras:
 ```
 
 For camera model specific settings check the [camera specific](camera_specific.md) infos.
+
+## Rotate Cameras
+
+Cameras can be rotate to '90', '180' or '270' (-90) degrees by using `rotate: XX`.
+The camera will only rotate to valid arguments: '90', '180' or '270', invalid arguments disable the rotation.
+
+```yaml
+mqtt:
+  host: mqtt.server.com
+cameras:
+  back:
+    enabled: True
+    ffmpeg:
+      inputs:
+        - path: rtsp://viewer:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2
+          roles:
+            - detect
+            - record
+    rotate: 90
+    detect:
+      width: 1280
+      height: 720
+```
+
+The default value is '0', no rotation enable.

--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -51,7 +51,7 @@ For camera model specific settings check the [camera specific](camera_specific.m
 
 ## Rotate Cameras
 
-This field is totally optional, **the recomendation is use the _go2rtc_** to rotate the stream as a restream so the rotation is only done once instead of doing one for every rol defined in the camera (e.g. detect and record).
+This field is totally optional, **the recomendation is use the _go2rtc_** to rotate the stream as a restream so the rotation is only done once instead of doing one for every role defined in the camera (e.g. detect and record).
 
 Cameras can be rotate to '90', '180' or '270' (-90) degrees by using `rotate: XX`.
 The camera will only rotate to valid arguments: '90', '180' or '270', invalid arguments disable the rotation.

--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -66,7 +66,7 @@ cameras:
           roles:
             - detect
             - record
-    rotate: 90
+      rotate: 90
     detect:
       width: 1280
       height: 720

--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -51,6 +51,8 @@ For camera model specific settings check the [camera specific](camera_specific.m
 
 ## Rotate Cameras
 
+This field is totally optional, **the recomendation is use the _go2rtc_** to rotate the stream as a restream so the rotation is only done once instead of doing one for every rol defined in the camera (e.g. detect and record).
+
 Cameras can be rotate to '90', '180' or '270' (-90) degrees by using `rotate: XX`.
 The camera will only rotate to valid arguments: '90', '180' or '270', invalid arguments disable the rotation.
 

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -427,8 +427,8 @@ cameras:
       # Optional: camera specific output args (default: inherit)
       # output_args:
 
-    # Optional: rotation for this camera, allowed values are: 90, 180 or 270 (-90). (default: shown below)
-    rotate: 0
+      # Optional: rotation for this camera, allowed values are: 90, 180 or 270 (-90). (default: shown below)
+      rotate: 0
 
     # Optional: timeout for highest scoring image before allowing it
     # to be replaced by a newer image. (default: shown below)

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -427,6 +427,9 @@ cameras:
       # Optional: camera specific output args (default: inherit)
       # output_args:
 
+    # Optional: rotation for this camera, allowed values are: 90, 180 or 270 (-90). (default: shown below)
+    rotate: 0
+
     # Optional: timeout for highest scoring image before allowing it
     # to be replaced by a newer image. (default: shown below)
     best_image_timeout: 60

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -576,6 +576,7 @@ class CameraUiConfig(FrigateBaseModel):
 class CameraConfig(FrigateBaseModel):
     name: Optional[str] = Field(title="Camera name.", regex=REGEX_CAMERA_NAME)
     enabled: bool = Field(default=True, title="Enable camera.")
+    rotate: int = Field(default=0, title="Rotate camera: 0º, 90º, 180º or 270º(-90º)")
     ffmpeg: CameraFfmpegConfig = Field(title="FFmpeg configuration for the camera.")
     best_image_timeout: int = Field(
         default=60,
@@ -674,6 +675,7 @@ class CameraConfig(FrigateBaseModel):
                 self.detect.fps,
                 self.detect.width,
                 self.detect.height,
+                self.rotate,
             )
 
             ffmpeg_output_args = scale_detect_args + ffmpeg_output_args + ["pipe:"]

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -690,7 +690,11 @@ class CameraConfig(FrigateBaseModel):
             )
         if "record" in ffmpeg_input.roles and self.record.enabled:
             record_args = get_ffmpeg_arg_list(
-                parse_preset_output_record(self.ffmpeg.output_args.record)
+                parse_preset_output_record(
+                    self.ffmpeg.output_args.record,
+                    ffmpeg_input.hwaccel_args or self.ffmpeg.hwaccel_args,
+                    self.rotate,
+                )
                 or self.ffmpeg.output_args.record
             )
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -462,6 +462,7 @@ class CameraInput(FrigateBaseModel):
 
 class CameraFfmpegConfig(FfmpegConfig):
     inputs: List[CameraInput] = Field(title="Camera inputs.")
+    rotate: int = Field(default=0, title="Rotate camera: 0º, 90º, 180º or 270º(-90º)")
 
     @validator("inputs")
     def validate_roles(cls, v):
@@ -576,7 +577,6 @@ class CameraUiConfig(FrigateBaseModel):
 class CameraConfig(FrigateBaseModel):
     name: Optional[str] = Field(title="Camera name.", regex=REGEX_CAMERA_NAME)
     enabled: bool = Field(default=True, title="Enable camera.")
-    rotate: int = Field(default=0, title="Rotate camera: 0º, 90º, 180º or 270º(-90º)")
     ffmpeg: CameraFfmpegConfig = Field(title="FFmpeg configuration for the camera.")
     best_image_timeout: int = Field(
         default=60,
@@ -675,7 +675,7 @@ class CameraConfig(FrigateBaseModel):
                 self.detect.fps,
                 self.detect.width,
                 self.detect.height,
-                self.rotate,
+                self.ffmpeg.rotate,
             )
 
             ffmpeg_output_args = scale_detect_args + ffmpeg_output_args + ["pipe:"]
@@ -693,7 +693,7 @@ class CameraConfig(FrigateBaseModel):
                 parse_preset_output_record(
                     self.ffmpeg.output_args.record,
                     ffmpeg_input.hwaccel_args or self.ffmpeg.hwaccel_args,
-                    self.rotate,
+                    self.ffmpeg.rotate,
                 )
                 or self.ffmpeg.output_args.record
             )

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -205,7 +205,11 @@ def _parse_rotation_scale(
     else:  # Rotation not need or not supported
         return ""
 
-    return PRESETS_HW_ACCEL_SCALE_ROTATION.get(arg, "").get(mode, "").format(transpose)
+    return (
+        PRESETS_HW_ACCEL_SCALE_ROTATION.get(arg, {"detect": "", "record": ""})
+        .get(mode, "")
+        .format(transpose)
+    )
 
 
 def parse_preset_hardware_acceleration_scale(

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -151,12 +151,12 @@ PRESETS_HW_ACCEL_SCALE_ROTATION = {
         "record": " -vf vpp_qsv=transpose={0}",
     },
     "preset-nvidia-h264": {
-        "detect": "transpose={0},",
-        "record": " -vf transpose={0}",
+        "detect": "hwdownload,format=nv12,transpose={0},hwupload,",  # Currently SW rotation
+        "record": " -vf hwdownload,format=nv12,transpose={0},hwupload",  # Currently SW rotation
     },
     "preset-nvidia-h265": {
-        "detect": "transpose={0},",
-        "record": " -vf transpose={0}",
+        "detect": "hwdownload,format=nv12,transpose={0},hwupload,",  # Currently SW rotation
+        "record": " -vf hwdownload,format=nv12,transpose={0},hwupload",  # Currently SW rotation
     },
     "default": {
         "detect": " -vf transpose={0}",

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -126,7 +126,7 @@ PRESETS_HW_ACCEL_SCALE = {
     "preset-intel-qsv-h265": "-r {0} -vf vpp_qsv=framerate={0}:{3}w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
     "preset-nvidia-h264": "-r {0} -vf fps={0},{3}scale_cuda=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
     "preset-nvidia-h265": "-r {0} -vf fps={0},{3}scale_cuda=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
-    "default": "-r {0} -s {1}x{2}",
+    "default": "-r {0}{3} -s {1}x{2}",
 }
 
 PRESETS_HW_ACCEL_SCALE_ROTATION = {
@@ -218,7 +218,7 @@ def parse_preset_hardware_acceleration_scale(
 ) -> list[str]:
     """Return the correct scaling preset or default preset if none is set."""
     if not isinstance(arg, str) or " " in arg:
-        scale = PRESETS_HW_ACCEL_SCALE["default"].format(fps, width, height).split(" ")
+        scale = PRESETS_HW_ACCEL_SCALE["default"].format(fps, width, height, "").split(" ")
         scale.extend(detect_args)
         return scale
 
@@ -432,6 +432,8 @@ def parse_preset_output_record(arg: Any, hw_acc: Any, rotate: int) -> list[str]:
     """Return the correct preset if in preset format otherwise return None."""
     if not isinstance(arg, str):
         return None
+    if not isinstance(hw_acc, str):
+        hw_acc = "default"
 
     preset_record_video_audio = PRESETS_RECORD_VIDEO_AUDIO.get(arg, None)
     if not preset_record_video_audio:

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -56,11 +56,11 @@ PRESETS_FFMPEG_HW_ACCEL = {
     "preset-rpi-32-h264": "h264_v4l2m2m",
     "preset-rpi-64-h264": "h264_v4l2m2m",
     "preset-vaapi": "h264_vaapi",
-    "preset-intel-qsv-h264": "h264_qsv",     # From Sandy Bridge (gen 6)
-    "preset-intel-qsv-h265": "h264_qsv",     # From Sandy Bridge (gen 6)
+    "preset-intel-qsv-h264": "h264_qsv",  # From Sandy Bridge (gen 6)
+    "preset-intel-qsv-h265": "h264_qsv",  # From Sandy Bridge (gen 6)
     "preset-nvidia-h264": "h264_nvenc",
     "preset-nvidia-h265": "h264_nvenc",
-    "default":  "libx264",  # SW codecs
+    "default": "libx264",  # SW codecs
 }
 
 PRESETS_HW_ACCEL_DECODE = {
@@ -198,14 +198,14 @@ def _parse_rotation_scale(
     elif rotate == 180:
         if arg.startswith("preset-vaapi") or arg.startswith("preset-intel-qsv"):
             transpose = "reverse"
-        else: # No 'reverse' option suported, then 2 'clocks' rotations
-            transpose =  "clock,transpose=clock"
+        else:  # No 'reverse' option suported, then 2 'clocks' rotations
+            transpose = "clock,transpose=clock"
     elif rotate == 270:
-        transpose =  "cclock"
-    else : # Rotation not need or not supported
+        transpose = "cclock"
+    else:  # Rotation not need or not supported
         return ""
 
-    return PRESETS_HW_ACCEL_SCALE_ROTATION.get(arg, "").get(mode).format(transpose)
+    return PRESETS_HW_ACCEL_SCALE_ROTATION.get(arg, "").get(mode, "").format(transpose)
 
 
 def parse_preset_hardware_acceleration_scale(
@@ -218,11 +218,13 @@ def parse_preset_hardware_acceleration_scale(
 ) -> list[str]:
     """Return the correct scaling preset or default preset if none is set."""
     if not isinstance(arg, str) or " " in arg:
-        scale = PRESETS_HW_ACCEL_SCALE["default"].format(fps, width, height, "").split(" ")
+        scale = (
+            PRESETS_HW_ACCEL_SCALE["default"].format(fps, width, height, "").split(" ")
+        )
         scale.extend(detect_args)
         return scale
 
-    transpose =_parse_rotation_scale(arg, "detect", rotate)
+    transpose = _parse_rotation_scale(arg, "detect", rotate)
 
     scale = PRESETS_HW_ACCEL_SCALE.get(arg, "")
 
@@ -440,9 +442,9 @@ def parse_preset_output_record(arg: Any, hw_acc: Any, rotate: int) -> list[str]:
         return None
 
     audio = preset_record_video_audio["audio"]
-    
+
     video = preset_record_video_audio["video"]
-    transpose =_parse_rotation_scale(hw_acc, "record", rotate)
+    transpose = _parse_rotation_scale(hw_acc, "record", rotate)
     if transpose != "" or not "copy" in video:
         encode = PRESETS_FFMPEG_HW_ACCEL.get(hw_acc, "libx264")
         video = transpose + " -c:v " + encode

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -388,31 +388,31 @@ def parse_preset_input(arg: Any, detect_fps: int) -> list[str]:
     return PRESETS_INPUT.get(arg, None)
 
 
-PRESETS_RECORD_OUTPUT = "-f segment -segment_time 10 -segment_format mp4 -reset_timestamps 1 -strftime 1"
+PRESETS_RECORD_OUTPUT = "-f segment -segment_time 10 -segment_format mp4 -reset_timestamps 1 -strftime 1 {0} {1}"
 PRESETS_RECORD_VIDEO_AUDIO = {
     "preset-record-generic": {
-        "video": " -c:v copy",
-        "audio": " -an",
+        "video": "-c:v copy",
+        "audio": "-an",
     },
     "preset-record-generic-audio-aac": {
-        "video": " -c:v copy",
-        "audio": " -c:a aac",
+        "video": "-c:v copy",
+        "audio": "-c:a aac",
     },
     "preset-record-generic-audio-copy": {
-        "video": " -c:v copy",
-        "audio": " -c:a copy",
+        "video": "-c:v copy",
+        "audio": "-c:a copy",
     },
     "preset-record-mjpeg": {
-        "video": " -c:v libx264",
-        "audio": " -an",
+        "video": "-c:v libx264",
+        "audio": "-an",
     },
     "preset-record-jpeg": {
-        "video": " -c:v libx264",
-        "audio": " -an",
+        "video": "-c:v libx264",
+        "audio": "-an",
     },
     "preset-record-ubiquiti": {
-        "video": " -c:v copy",
-        "audio": " -ar 44100 -c:a aac",
+        "video": "-c:v copy",
+        "audio": "-ar 44100 -c:a aac",
     },
 }
 
@@ -430,10 +430,10 @@ def parse_preset_output_record(arg: Any, hw_acc: Any, rotate: int) -> list[str]:
     
     video = preset_record_video_audio["video"]
     transpose =_parse_rotation_scale(hw_acc, "record", rotate)
-    if transpose != "" or not "copy" in video:
+    if transpose != "":
         video = transpose + " -c:v libx264"
 
-    return (PRESETS_RECORD_OUTPUT + video + audio).split(" ")
+    return PRESETS_RECORD_OUTPUT.format(video, audio).split(" ")
 
 
 PRESETS_RTMP_OUTPUT = {

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -52,6 +52,17 @@ _user_agent_args = [
     f"FFmpeg Frigate/{VERSION}",
 ]
 
+PRESETS_FFMPEG_HW_ACCEL = {
+    "preset-rpi-32-h264": "h264_v4l2m2m",
+    "preset-rpi-64-h264": "h264_v4l2m2m",
+    "preset-vaapi": "h264_vaapi",
+    "preset-intel-qsv-h264": "h264_qsv",     # From Sandy Bridge (gen 6)
+    "preset-intel-qsv-h265": "h264_qsv",     # From Sandy Bridge (gen 6)
+    "preset-nvidia-h264": "h264_nvenc",
+    "preset-nvidia-h265": "h264_nvenc",
+    "default":  "libx264",  # SW codecs
+}
+
 PRESETS_HW_ACCEL_DECODE = {
     "preset-rpi-32-h264": ["-c:v", "h264_v4l2m2m"],
     "preset-rpi-64-h264": ["-c:v", "h264_v4l2m2m"],
@@ -430,8 +441,9 @@ def parse_preset_output_record(arg: Any, hw_acc: Any, rotate: int) -> list[str]:
     
     video = preset_record_video_audio["video"]
     transpose =_parse_rotation_scale(hw_acc, "record", rotate)
-    if transpose != "":
-        video = transpose + " -c:v libx264"
+    if transpose != "" or not "copy" in video:
+        encode = PRESETS_FFMPEG_HW_ACCEL.get(hw_acc, "libx264")
+        video = transpose + " -c:v " + encode
 
     return PRESETS_RECORD_OUTPUT.format(video, audio).split(" ")
 

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -307,7 +307,7 @@ class TestFfmpegPresets(unittest.TestCase):
         assert "preset-record-generic-audio-aac" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
-        assert "-vf transpose=clock -c:v libx264 -c:a aac" in (
+        assert "-vf transpose=clock -c:v h264_nvenc -c:a aac" in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
 
@@ -327,7 +327,7 @@ class TestFfmpegPresets(unittest.TestCase):
         assert "preset-rpi-64-h264" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
-        assert "-vf transpose=clock,transpose=clock -c:v libx264 -c:a aac" in (
+        assert "-vf transpose=clock,transpose=clock -c:v h264_v4l2m2m -c:a aac" in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
 
@@ -347,7 +347,7 @@ class TestFfmpegPresets(unittest.TestCase):
         assert "preset-vaapi" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
-        assert "-vf transpose_vaapi=reverse -c:v libx264 -c:a aac" in (
+        assert "-vf transpose_vaapi=reverse -c:v h264_vaapi -c:a aac" in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
 
@@ -367,7 +367,7 @@ class TestFfmpegPresets(unittest.TestCase):
         assert "preset-intel-qsv-h264" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
-        assert "-vf vpp_qsv=transpose=reverse -c:v libx264 -c:a aac" in (
+        assert "-vf vpp_qsv=transpose=reverse -c:v h264_qsv -c:a aac" in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
 
@@ -387,7 +387,7 @@ class TestFfmpegPresets(unittest.TestCase):
         assert "preset-nvidia-h264" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
-        assert "-vf transpose=cclock -c:v libx264 -c:a aac" in (
+        assert "-vf transpose=cclock -c:v h264_nvenc -c:a aac" in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
 
@@ -408,6 +408,22 @@ class TestFfmpegPresets(unittest.TestCase):
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
         assert "-c:v copy -c:a aac" in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+
+    def test_ffmpeg_output_record_preset_hw_accel(self):
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-rpi-32-h264"
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
+            "record"
+        ] = "preset-record-mjpeg"
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-record-generic-audio-aac" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert "-c:v h264_v4l2m2m -an" in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
 

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -86,9 +86,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_hwaccel_rotate_90_preset(self):
-        self.default_ffmpeg["cameras"]["back"][
-            "rotate"
-        ] = 90
+        self.default_ffmpeg["cameras"]["back"]["rotate"] = 90
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-nvidia-h264"
@@ -108,9 +106,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_hwaccel_rotate_180_preset(self):
-        self.default_ffmpeg["cameras"]["back"][
-            "rotate"
-        ] = 180
+        self.default_ffmpeg["cameras"]["back"]["rotate"] = 180
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-rpi-64-h264"
@@ -119,21 +115,17 @@ class TestFfmpegPresets(unittest.TestCase):
             "width": 2560,
             "fps": 10,
         }
-
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-rpi-64-h264" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
-        assert (
-            "-r 10 -vf transpose=clock,transpose=clock -s 2560x1920"
-            in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
+        assert "-r 10 -vf transpose=clock,transpose=clock -s 2560x1920" in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
 
     def test_ffmpeg_hwaccel_rotate_180_vaapi_preset(self):
-        self.default_ffmpeg["cameras"]["back"][
-            "rotate"
-        ] = 180
+        self.default_ffmpeg["cameras"]["back"]["rotate"] = 180
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-vaapi"
@@ -142,7 +134,6 @@ class TestFfmpegPresets(unittest.TestCase):
             "width": 2560,
             "fps": 10,
         }
-
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-vaapi" not in (
@@ -154,9 +145,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_hwaccel_rotate_180_qsv_preset(self):
-        self.default_ffmpeg["cameras"]["back"][
-            "rotate"
-        ] = 180
+        self.default_ffmpeg["cameras"]["back"]["rotate"] = 180
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-intel-qsv-h264"
@@ -165,7 +154,6 @@ class TestFfmpegPresets(unittest.TestCase):
             "width": 2560,
             "fps": 10,
         }
-
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-intel-qsv-h264" not in (
@@ -177,9 +165,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_hwaccel_rotate_270_preset(self):
-        self.default_ffmpeg["cameras"]["back"][
-            "rotate"
-        ] = 270
+        self.default_ffmpeg["cameras"]["back"]["rotate"] = 270
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-nvidia-h264"
@@ -199,9 +185,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_hwaccel_rotate_wrong_preset(self):
-        self.default_ffmpeg["cameras"]["back"][
-            "rotate"
-        ] = 20
+        self.default_ffmpeg["cameras"]["back"]["rotate"] = 20
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-nvidia-h264"
@@ -244,7 +228,7 @@ class TestFfmpegPresets(unittest.TestCase):
         assert "preset-rtmp-generic" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
-        assert (" ".join(parse_preset_input("preset-rtmp-generic", 5))) in (
+        assert " ".join(parse_preset_input("preset-rtmp-generic", 5)) in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
 
@@ -292,16 +276,13 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_output_record_rotate_90_preset(self):
-        self.default_ffmpeg["cameras"]["back"][
-            "rotate"
-        ] = 90
+        self.default_ffmpeg["cameras"]["back"]["rotate"] = 90
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-nvidia-h264"
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
             "record"
         ] = "preset-record-generic-audio-aac"
-
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-record-generic-audio-aac" not in (
@@ -312,16 +293,13 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_output_record_rotate_180_preset(self):
-        self.default_ffmpeg["cameras"]["back"][
-            "rotate"
-        ] = 180
+        self.default_ffmpeg["cameras"]["back"]["rotate"] = 180
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-rpi-64-h264"
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
             "record"
         ] = "preset-record-generic-audio-aac"
-
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-rpi-64-h264" not in (
@@ -332,16 +310,13 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_output_record_rotate_180_vaapi_preset(self):
-        self.default_ffmpeg["cameras"]["back"][
-            "rotate"
-        ] = 180
+        self.default_ffmpeg["cameras"]["back"]["rotate"] = 180
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-vaapi"
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
             "record"
         ] = "preset-record-generic-audio-aac"
-
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-vaapi" not in (
@@ -352,16 +327,13 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_output_record_rotate_180_qsv_preset(self):
-        self.default_ffmpeg["cameras"]["back"][
-            "rotate"
-        ] = 180
+        self.default_ffmpeg["cameras"]["back"]["rotate"] = 180
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-intel-qsv-h264"
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
             "record"
         ] = "preset-record-generic-audio-aac"
-
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-intel-qsv-h264" not in (
@@ -372,16 +344,13 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_output_record_rotate_270_preset(self):
-        self.default_ffmpeg["cameras"]["back"][
-            "rotate"
-        ] = 270
+        self.default_ffmpeg["cameras"]["back"]["rotate"] = 270
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-nvidia-h264"
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
             "record"
         ] = "preset-record-generic-audio-aac"
-
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-nvidia-h264" not in (
@@ -392,16 +361,13 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_output_record_rotate_wrong_preset(self):
-        self.default_ffmpeg["cameras"]["back"][
-            "rotate"
-        ] = 20
+        self.default_ffmpeg["cameras"]["back"]["rotate"] = 20
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-nvidia-h264"
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
             "record"
         ] = "preset-record-generic-audio-aac"
-
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-nvidia-h264" not in (

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -85,6 +85,141 @@ class TestFfmpegPresets(unittest.TestCase):
             in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
         )
 
+    def test_ffmpeg_hwaccel_rotate_90_preset(self):
+        self.default_ffmpeg["cameras"]["back"][
+            "rotate"
+        ] = 90
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-nvidia-h264"
+        self.default_ffmpeg["cameras"]["back"]["detect"] = {
+            "height": 1920,
+            "width": 2560,
+            "fps": 10,
+        }
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-nvidia-h264" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert (
+            "fps=10,transpose=clock,scale_cuda=w=2560:h=1920:format=nv12,hwdownload,format=nv12,format=yuv420p"
+            in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
+        )
+
+    def test_ffmpeg_hwaccel_rotate_180_preset(self):
+        self.default_ffmpeg["cameras"]["back"][
+            "rotate"
+        ] = 180
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-rpi-64-h264"
+        self.default_ffmpeg["cameras"]["back"]["detect"] = {
+            "height": 1920,
+            "width": 2560,
+            "fps": 10,
+        }
+
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-rpi-64-h264" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert (
+            "-r 10 -vf transpose=clock,transpose=clock -s 2560x1920"
+            in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
+        )
+
+    def test_ffmpeg_hwaccel_rotate_180_vaapi_preset(self):
+        self.default_ffmpeg["cameras"]["back"][
+            "rotate"
+        ] = 180
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-vaapi"
+        self.default_ffmpeg["cameras"]["back"]["detect"] = {
+            "height": 1920,
+            "width": 2560,
+            "fps": 10,
+        }
+
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-vaapi" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert (
+            "-r 10 -vf fps=10,transpose_vaapi=reverse,scale_vaapi=w=2560:h=1920,hwdownload,format=yuv420p"
+            in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
+        )
+
+    def test_ffmpeg_hwaccel_rotate_180_qsv_preset(self):
+        self.default_ffmpeg["cameras"]["back"][
+            "rotate"
+        ] = 180
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-intel-qsv-h264"
+        self.default_ffmpeg["cameras"]["back"]["detect"] = {
+            "height": 1920,
+            "width": 2560,
+            "fps": 10,
+        }
+
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-intel-qsv-h264" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert (
+            "-r 10 -vf vpp_qsv=framerate=10:transpose=reverse:w=2560:h=1920:format=nv12,hwdownload,format=nv12,format=yuv420p"
+            in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
+        )
+
+    def test_ffmpeg_hwaccel_rotate_270_preset(self):
+        self.default_ffmpeg["cameras"]["back"][
+            "rotate"
+        ] = 270
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-nvidia-h264"
+        self.default_ffmpeg["cameras"]["back"]["detect"] = {
+            "height": 1920,
+            "width": 2560,
+            "fps": 10,
+        }
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-nvidia-h264" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert (
+            "fps=10,transpose=cclock,scale_cuda=w=2560:h=1920:format=nv12,hwdownload,format=nv12,format=yuv420p"
+            in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
+        )
+
+    def test_ffmpeg_hwaccel_rotate_wrong_preset(self):
+        self.default_ffmpeg["cameras"]["back"][
+            "rotate"
+        ] = 20
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-nvidia-h264"
+        self.default_ffmpeg["cameras"]["back"]["detect"] = {
+            "height": 1920,
+            "width": 2560,
+            "fps": 10,
+        }
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-nvidia-h264" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert (
+            "fps=10,scale_cuda=w=2560:h=1920:format=nv12,hwdownload,format=nv12,format=yuv420p"
+            in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
+        )
+
     def test_default_ffmpeg_input_arg_preset(self):
         frigate_config = FrigateConfig(**self.default_ffmpeg)
 

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -291,6 +291,126 @@ class TestFfmpegPresets(unittest.TestCase):
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
 
+    def test_ffmpeg_output_record_rotate_90_preset(self):
+        self.default_ffmpeg["cameras"]["back"][
+            "rotate"
+        ] = 90
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-nvidia-h264"
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
+            "record"
+        ] = "preset-record-generic-audio-aac"
+
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-record-generic-audio-aac" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert "-vf transpose=clock -c:v libx264 -c:a aac" in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+
+    def test_ffmpeg_output_record_rotate_180_preset(self):
+        self.default_ffmpeg["cameras"]["back"][
+            "rotate"
+        ] = 180
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-rpi-64-h264"
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
+            "record"
+        ] = "preset-record-generic-audio-aac"
+
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-rpi-64-h264" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert "-vf transpose=clock,transpose=clock -c:v libx264 -c:a aac" in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+
+    def test_ffmpeg_output_record_rotate_180_vaapi_preset(self):
+        self.default_ffmpeg["cameras"]["back"][
+            "rotate"
+        ] = 180
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-vaapi"
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
+            "record"
+        ] = "preset-record-generic-audio-aac"
+
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-vaapi" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert "-vf transpose_vaapi=reverse -c:v libx264 -c:a aac" in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+
+    def test_ffmpeg_output_record_rotate_180_qsv_preset(self):
+        self.default_ffmpeg["cameras"]["back"][
+            "rotate"
+        ] = 180
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-intel-qsv-h264"
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
+            "record"
+        ] = "preset-record-generic-audio-aac"
+
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-intel-qsv-h264" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert "-vf vpp_qsv=transpose=reverse -c:v libx264 -c:a aac" in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+
+    def test_ffmpeg_output_record_rotate_270_preset(self):
+        self.default_ffmpeg["cameras"]["back"][
+            "rotate"
+        ] = 270
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-nvidia-h264"
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
+            "record"
+        ] = "preset-record-generic-audio-aac"
+
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-nvidia-h264" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert "-vf transpose=cclock -c:v libx264 -c:a aac" in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+
+    def test_ffmpeg_output_record_rotate_wrong_preset(self):
+        self.default_ffmpeg["cameras"]["back"][
+            "rotate"
+        ] = 20
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
+            "hwaccel_args"
+        ] = "preset-nvidia-h264"
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
+            "record"
+        ] = "preset-record-generic-audio-aac"
+
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-nvidia-h264" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert "-c:v copy -c:a aac" in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+
     def test_ffmpeg_output_rtmp_preset(self):
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
             "rtmp"

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -101,7 +101,7 @@ class TestFfmpegPresets(unittest.TestCase):
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
         assert (
-            "fps=10,transpose=clock,scale_cuda=w=2560:h=1920:format=nv12,hwdownload,format=nv12,format=yuv420p"
+            "fps=10,hwdownload,format=nv12,transpose=clock,hwupload,scale_cuda=w=2560:h=1920:format=nv12,hwdownload,format=nv12,format=yuv420p"
             in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
         )
 
@@ -180,7 +180,7 @@ class TestFfmpegPresets(unittest.TestCase):
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
         assert (
-            "fps=10,transpose=cclock,scale_cuda=w=2560:h=1920:format=nv12,hwdownload,format=nv12,format=yuv420p"
+            "fps=10,hwdownload,format=nv12,transpose=cclock,hwupload,scale_cuda=w=2560:h=1920:format=nv12,hwdownload,format=nv12,format=yuv420p"
             in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
         )
 
@@ -288,8 +288,9 @@ class TestFfmpegPresets(unittest.TestCase):
         assert "preset-record-generic-audio-aac" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
-        assert "-vf transpose=clock -c:v h264_nvenc -c:a aac" in (
-            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        assert (
+            "-vf hwdownload,format=nv12,transpose=clock,hwupload -c:v h264_nvenc -c:a aac"
+            in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
         )
 
     def test_ffmpeg_output_record_rotate_180_preset(self):
@@ -356,8 +357,9 @@ class TestFfmpegPresets(unittest.TestCase):
         assert "preset-nvidia-h264" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
-        assert "-vf transpose=cclock -c:v h264_nvenc -c:a aac" in (
-            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        assert (
+            "-vf hwdownload,format=nv12,transpose=cclock,hwupload -c:v h264_nvenc -c:a aac"
+            in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
         )
 
     def test_ffmpeg_output_record_rotate_wrong_preset(self):

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -86,7 +86,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_hwaccel_rotate_90_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["rotate"] = 90
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["rotate"] = 90
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-nvidia-h264"
@@ -106,7 +106,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_hwaccel_rotate_180_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["rotate"] = 180
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["rotate"] = 180
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-rpi-64-h264"
@@ -125,7 +125,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_hwaccel_rotate_180_vaapi_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["rotate"] = 180
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["rotate"] = 180
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-vaapi"
@@ -145,7 +145,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_hwaccel_rotate_180_qsv_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["rotate"] = 180
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["rotate"] = 180
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-intel-qsv-h264"
@@ -165,7 +165,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_hwaccel_rotate_270_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["rotate"] = 270
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["rotate"] = 270
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-nvidia-h264"
@@ -185,7 +185,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_hwaccel_rotate_wrong_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["rotate"] = 20
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["rotate"] = 20
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-nvidia-h264"
@@ -276,7 +276,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_output_record_rotate_90_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["rotate"] = 90
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["rotate"] = 90
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-nvidia-h264"
@@ -293,7 +293,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_output_record_rotate_180_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["rotate"] = 180
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["rotate"] = 180
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-rpi-64-h264"
@@ -310,7 +310,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_output_record_rotate_180_vaapi_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["rotate"] = 180
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["rotate"] = 180
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-vaapi"
@@ -327,7 +327,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_output_record_rotate_180_qsv_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["rotate"] = 180
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["rotate"] = 180
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-intel-qsv-h264"
@@ -344,7 +344,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_output_record_rotate_270_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["rotate"] = 270
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["rotate"] = 270
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-nvidia-h264"
@@ -361,7 +361,7 @@ class TestFfmpegPresets(unittest.TestCase):
         )
 
     def test_ffmpeg_output_record_rotate_wrong_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["rotate"] = 20
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["rotate"] = 20
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"][
             "hwaccel_args"
         ] = "preset-nvidia-h264"

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -420,10 +420,23 @@ class TestFfmpegPresets(unittest.TestCase):
         ] = "preset-record-mjpeg"
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         frigate_config.cameras["back"].create_ffmpeg_cmds()
-        assert "preset-record-generic-audio-aac" not in (
+        assert "preset-record-mjpeg" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
         assert "-c:v h264_v4l2m2m -an" in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+
+    def test_ffmpeg_output_record_preset_no_hw_accel(self):
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
+            "record"
+        ] = "preset-record-mjpeg"
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        frigate_config.cameras["back"].create_ffmpeg_cmds()
+        assert "preset-record-mjpeg" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        assert "-c:v libx264 -an" in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
 


### PR DESCRIPTION
Added field in the configuration file to rotate camera: **0** (default), **90**, **180** or **270** (-90º) degrees.
Enable this feature to detect and record output.
Update the documentation.
Add new test to _test_ffmpeg_presets_.