### PR TITLE
Revert "Update ffmpeg args with low risk improvements (#5519)"

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -165,7 +165,7 @@ birdseye:
 # More information about presets at https://docs.frigate.video/configuration/ffmpeg_presets
 ffmpeg:
   # Optional: global ffmpeg args (default: shown below)
-  global_args: -hide_banner -loglevel warning -threads 1
+  global_args: -hide_banner -loglevel warning
   # Optional: global hwaccel args (default: shown below)
   # NOTE: See hardware acceleration docs for your specific device
   hwaccel_args: []
@@ -174,7 +174,7 @@ ffmpeg:
   # Optional: global output args
   output_args:
     # Optional: output args for detect streams (default: shown below)
-    detect: -threads 1 -f rawvideo -pix_fmt yuv420p
+    detect: -f rawvideo -pix_fmt yuv420p
     # Optional: output args for record streams (default: shown below)
     record: preset-record-generic
     # Optional: output args for rtmp streams (default: shown below)

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -395,16 +395,9 @@ class BirdseyeCameraConfig(BaseModel):
     )
 
 
-FFMPEG_GLOBAL_ARGS_DEFAULT = ["-hide_banner", "-loglevel", "warning", "-threads", "1"]
+FFMPEG_GLOBAL_ARGS_DEFAULT = ["-hide_banner", "-loglevel", "warning"]
 FFMPEG_INPUT_ARGS_DEFAULT = "preset-rtsp-generic"
-DETECT_FFMPEG_OUTPUT_ARGS_DEFAULT = [
-    "-threads",
-    "1",
-    "-f",
-    "rawvideo",
-    "-pix_fmt",
-    "yuv420p",
-]
+DETECT_FFMPEG_OUTPUT_ARGS_DEFAULT = ["-f", "rawvideo", "-pix_fmt", "yuv420p"]
 RTMP_FFMPEG_OUTPUT_ARGS_DEFAULT = "preset-rtmp-generic"
 RECORD_FFMPEG_OUTPUT_ARGS_DEFAULT = "preset-record-generic"
 


### PR DESCRIPTION
This reverts commit 52459bf34865ecba2fc278cec201ca15b5208799.

Several users are reporting that it prevents the record process from segmenting files properly.