### PR TITLE
feat(WORK IN PROGRESS): Add ArmNN and rknn2 detectors. Add docs about orange pi 5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -178,6 +178,11 @@ ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 ENV PATH="/usr/lib/btbn-ffmpeg/bin:/usr/local/go2rtc/bin:/usr/local/nginx/sbin:${PATH}"
 
+# Install mpp empowerred ffmpeg for arm64
+RUN --mount=type=tmpfs,target=/tmp --mount=type=tmpfs,target=/var/cache/apt \
+    --mount=type=bind,source=docker/mpp.sh,target=/deps/mpp.sh \
+    /deps/mpp.sh
+
 # Install dependencies
 RUN --mount=type=bind,source=docker/install_deps.sh,target=/deps/install_deps.sh \
     /deps/install_deps.sh

--- a/docker/build_nginx.sh
+++ b/docker/build_nginx.sh
@@ -9,11 +9,12 @@ RTMP_MODULE_VERSION="1.2.1"
 
 cp /etc/apt/sources.list /etc/apt/sources.list.d/sources-src.list
 sed -i 's|deb http|deb-src http|g' /etc/apt/sources.list.d/sources-src.list
-apt-get update
+apt-get -qq update
 
 apt-get -yqq build-dep nginx
 
-apt-get -yqq install --no-install-recommends ca-certificates wget
+# TODO: move all apt-get installs to dedicated script for having it in a single Docker layer = performance of reruns.
+apt-get -yqq install --no-install-recommends ca-certificates wget libaio-dev
 update-ca-certificates -f
 mkdir /tmp/nginx
 wget -nv https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
@@ -60,7 +61,6 @@ if [ "$ARCH" = "aarch64" ]; then
 fi
 
 ./configure --prefix=/usr/local/nginx \
-    --with-file-aio \
     --with-http_sub_module \
     --with-http_ssl_module \
     --with-threads \

--- a/docker/build_nginx.sh
+++ b/docker/build_nginx.sh
@@ -52,6 +52,13 @@ rm v${RTMP_MODULE_VERSION}.tar.gz
 
 cd /tmp/nginx
 
+ARCH=$(uname -m)
+CC_OPT="-O3 -Wno-error=implicit-fallthrough"
+
+if [ "$ARCH" = "aarch64" ]; then
+    CC_OPT="${CC_OPT} -march=armv8-a+crc"
+fi
+
 ./configure --prefix=/usr/local/nginx \
     --with-file-aio \
     --with-http_sub_module \
@@ -60,7 +67,7 @@ cd /tmp/nginx
     --add-module=../nginx-vod-module \
     --add-module=../nginx-secure-token-module \
     --add-module=../nginx-rtmp-module \
-    --with-cc-opt="-O3 -Wno-error=implicit-fallthrough"
+    --with-cc-opt="${CC_OPT}"
 
 make -j$(nproc) && make install
 rm -rf /usr/local/nginx/html /usr/local/nginx/conf/*.default

--- a/docker/build_nginx.sh
+++ b/docker/build_nginx.sh
@@ -56,7 +56,7 @@ ARCH=$(uname -m)
 CC_OPT="-O3 -Wno-error=implicit-fallthrough"
 
 if [ "$ARCH" = "aarch64" ]; then
-    CC_OPT="${CC_OPT} -march=armv8-a+crc"
+    CC_OPT="${CC_OPT} -march=armv8-a+crc -mfpu=neon-fp-armv8 -mfloat-abi=hard"
 fi
 
 ./configure --prefix=/usr/local/nginx \

--- a/docker/build_nginx.sh
+++ b/docker/build_nginx.sh
@@ -14,7 +14,7 @@ apt-get -qq update
 apt-get -yqq build-dep nginx
 
 # TODO: move all apt-get installs to dedicated script for having it in a single Docker layer = performance of reruns.
-apt-get -yqq install --no-install-recommends ca-certificates wget libaio-dev
+apt-get -yqq install --no-install-recommends ca-certificates wget libaio-dev libpcre3 libpcre3-dev
 update-ca-certificates -f
 mkdir /tmp/nginx
 wget -nv https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
@@ -57,7 +57,7 @@ ARCH=$(uname -m)
 CC_OPT="-O3 -Wno-error=implicit-fallthrough"
 
 if [ "$ARCH" = "aarch64" ]; then
-    CC_OPT="${CC_OPT} -march=armv8-a+crc -mfpu=neon-fp-armv8 -mfloat-abi=hard"
+    CC_OPT="${CC_OPT} -march=armv8-a+crc"
 fi
 
 ./configure --prefix=/usr/local/nginx \

--- a/docker/install_deps.sh
+++ b/docker/install_deps.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 
 apt-get -qq update
 
+# TODO: move all apt-get installs to dedicated script for having it in a single Docker layer = performance of reruns.
 apt-get -qq install --no-install-recommends -y \
     apt-transport-https \
     gnupg \

--- a/docker/install_deps.sh
+++ b/docker/install_deps.sh
@@ -47,6 +47,13 @@ if [[ "${TARGETARCH}" == "arm" ]]; then
 fi
 
 # ffmpeg -> arm64
+if command -v ffmpeg >/dev/null 2>&1; then
+    HAS_FFMPEG=1
+else
+    HAS_FFMPEG=0
+fi
+
+if [[ "${HAS_FFMPEG}" == 0 ]]; then
 if [[ "${TARGETARCH}" == "arm64" ]]; then
     # add raspberry pi repo
     gpg --no-default-keyring --keyring /usr/share/keyrings/raspbian.gpg --keyserver keyserver.ubuntu.com --recv-keys 82B129927FA3303E
@@ -54,6 +61,8 @@ if [[ "${TARGETARCH}" == "arm64" ]]; then
     apt-get -qq update
     apt-get -qq install --no-install-recommends --no-install-suggests -y ffmpeg
 fi
+fi
+
 
 # arch specific packages
 if [[ "${TARGETARCH}" == "amd64" ]]; then

--- a/docker/mpp.sh
+++ b/docker/mpp.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+apt-get -qq update
+apt install -y pkg-config
+
+if [ -e /usr/local/include/mpp/mpp.h ] || [ -e /usr/include/mpp/mpp.h ] || pkg-config --exists rockchip-mpp; then
+    HAS_MPP=1
+else
+# Install mpp from sources
+apt-get -qq update
+apt-get install -y git build-essential yasm pkg-config \
+libtool coreutils autoconf automake build-essential cmake \
+doxygen git graphviz imagemagick libasound2-dev libass-dev \
+libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev \
+libavutil-dev libfreetype6-dev libgmp-dev libmp3lame-dev \
+libopencore-amrnb-dev libopencore-amrwb-dev libopus-dev \
+librtmp-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev \
+libsdl2-net-dev libsdl2-ttf-dev libsnappy-dev libsoxr-dev \
+libssh-dev libssl-dev libtool libv4l-dev libva-dev libvdpau-dev \
+libvo-amrwbenc-dev libvorbis-dev libwebp-dev libx264-dev libx265-dev \
+libxcb-shape0-dev libxcb-shm0-dev libxcb-xfixes0-dev libxcb1-dev \
+libxml2-dev lzma-dev meson nasm pkg-config python3-dev \
+python3-pip texinfo wget yasm zlib1g-dev libdrm-dev libaom-dev libdav1d-dev \
+libmp3lame-dev
+
+cd /tmp
+git clone https://github.com/rockchip-linux/mpp.git
+cd mpp
+mkdir build || true && cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../
+make -j$(nproc)
+make install
+ldconfig
+
+fi
+
+# TODO: consider moving ffmpeg compillation to a dedicated ffmpeg.sh script
+if command -v ffmpeg >/dev/null 2>&1; then
+    HAS_FFMPEG=1
+else
+    HAS_FFMPEG=0
+fi
+
+if [[ "${HAS_FFMPEG}" == 1 ]]; then
+# To avoid possible race condition.
+    apt -y remove ffmpeg
+fi
+# Compile ffmpeg
+
+cd /tmp
+git clone https://github.com/FFmpeg/FFmpeg.git
+cd FFmpeg
+
+PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" ./configure \
+    --enable-rkmpp \
+    --extra-cflags="-I/usr/local/include" \
+    --extra-ldflags="-L/usr/local/lib" \
+    --extra-libs="-lpthread -lm -latomic" \
+    --arch=arm64 \
+    --enable-gmp \
+    --enable-gpl \
+    --enable-libaom \
+    --enable-libass \
+    --enable-libdav1d \
+    --enable-libdrm \
+    --enable-libfreetype \
+    --enable-libmp3lame \
+    --enable-libopencore-amrnb \
+    --enable-libopencore-amrwb \
+    --enable-libopus \
+    --enable-librtmp \
+    --enable-libsnappy \
+    --enable-libsoxr \
+    --enable-libssh \
+    --enable-libvorbis \
+    --enable-libvpx \
+    --enable-libzimg \
+    --enable-libwebp \
+    --enable-libx264 \
+    --enable-libx265 \
+    --enable-libxml2 \
+    --enable-nonfree \
+    --enable-version3 \
+    --target-os=linux \
+    --enable-pthreads \
+    --enable-openssl \
+    --enable-hardcoded-tables
+
+make -j$(nproc)
+make install
+ldconfig
+
+cd /tmp
+rm -rf mpp
+rm -rf FFmpeg

--- a/docker/mpp.sh
+++ b/docker/mpp.sh
@@ -10,6 +10,7 @@ if [ -e /usr/local/include/mpp/mpp.h ] || [ -e /usr/include/mpp/mpp.h ] || pkg-c
 else
 # Install mpp from sources
 apt-get -qq update
+# TODO: move all apt-get installs to dedicated script for having it in a single Docker layer = performance of reruns.
 apt-get install -y git build-essential yasm pkg-config \
 libtool coreutils autoconf automake build-essential cmake \
 doxygen git graphviz imagemagick libasound2-dev libass-dev \

--- a/docker/mpp.sh
+++ b/docker/mpp.sh
@@ -36,8 +36,8 @@ EXTRA_CFLAGS=""
 EXTRA_CXXFLAGS=""
 
 if [ "$ARCH" = "aarch64" ]; then
-    EXTRA_CFLAGS="-march=armv8-a+crc -mfpu=neon-fp-armv8 -mfloat-abi=hard"
-    EXTRA_CXXFLAGS="-march=armv8-a+crc -mfpu=neon-fp-armv8 -mfloat-abi=hard"
+    EXTRA_CFLAGS="-march=armv8-a+crc"
+    EXTRA_CXXFLAGS="-march=armv8-a+crc"
 fi
 
 cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_C_FLAGS="${EXTRA_CFLAGS}" -DCMAKE_CXX_FLAGS="${EXTRA_CXXFLAGS}" ../
@@ -69,7 +69,7 @@ EXTRA_CFLAGS="-I/usr/local/include"
 EXTRA_LDFLAGS="-L/usr/local/lib"
 
 if [ "$ARCH" = "aarch64" ]; then
-    EXTRA_CFLAGS="${EXTRA_CFLAGS} -march=armv8-a+crc -mfpu=neon-fp-armv8 -mfloat-abi=hard"
+    EXTRA_CFLAGS="${EXTRA_CFLAGS} -march=armv8-a+crc"
 fi
 
 PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" ./configure \
@@ -94,7 +94,6 @@ PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" ./configure \
     --enable-libsoxr \
     --enable-libssh \
     --enable-libvorbis \
-    --enable-libzimg \
     --enable-libwebp \
     --enable-libx264 \
     --enable-libx265 \

--- a/docker/mpp.sh
+++ b/docker/mpp.sh
@@ -53,10 +53,18 @@ cd /tmp
 git clone https://github.com/FFmpeg/FFmpeg.git
 cd FFmpeg
 
+ARCH=$(uname -m)
+EXTRA_CFLAGS="-I/usr/local/include"
+EXTRA_LDFLAGS="-L/usr/local/lib"
+
+if [ "$ARCH" = "aarch64" ]; then
+    EXTRA_CFLAGS="${EXTRA_CFLAGS} -march=armv8-a+crc"
+fi
+
 PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" ./configure \
     --enable-rkmpp \
-    --extra-cflags="-I/usr/local/include" \
-    --extra-ldflags="-L/usr/local/lib" \
+    --extra-cflags="${EXTRA_CFLAGS}" \
+    --extra-ldflags="${EXTRA_LDFLAGS}" \
     --extra-libs="-lpthread -lm -latomic" \
     --arch=arm64 \
     --enable-gmp \

--- a/docker/mpp.sh
+++ b/docker/mpp.sh
@@ -29,7 +29,17 @@ cd /tmp
 git clone https://github.com/rockchip-linux/mpp.git
 cd mpp
 mkdir build || true && cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local ../
+
+ARCH=$(uname -m)
+EXTRA_CFLAGS=""
+EXTRA_CXXFLAGS=""
+
+if [ "$ARCH" = "aarch64" ]; then
+    EXTRA_CFLAGS="-march=armv8-a+crc -mfpu=neon-fp-armv8 -mfloat-abi=hard"
+    EXTRA_CXXFLAGS="-march=armv8-a+crc -mfpu=neon-fp-armv8 -mfloat-abi=hard"
+fi
+
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_C_FLAGS="${EXTRA_CFLAGS}" -DCMAKE_CXX_FLAGS="${EXTRA_CXXFLAGS}" ../
 make -j$(nproc)
 make install
 ldconfig
@@ -58,7 +68,7 @@ EXTRA_CFLAGS="-I/usr/local/include"
 EXTRA_LDFLAGS="-L/usr/local/lib"
 
 if [ "$ARCH" = "aarch64" ]; then
-    EXTRA_CFLAGS="${EXTRA_CFLAGS} -march=armv8-a+crc"
+    EXTRA_CFLAGS="${EXTRA_CFLAGS} -march=armv8-a+crc -mfpu=neon-fp-armv8 -mfloat-abi=hard"
 fi
 
 PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" ./configure \
@@ -83,7 +93,6 @@ PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" ./configure \
     --enable-libsoxr \
     --enable-libssh \
     --enable-libvorbis \
-    --enable-libvpx \
     --enable-libzimg \
     --enable-libwebp \
     --enable-libx264 \

--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -138,6 +138,29 @@ model:
   labelmap_path: /path/to/coco_80cl.txt
 ```
 
+### ArmNN detector ( orange pi 5 )
+
+You need to put ArmNN binaries for them to be located in a way, when `/usr/lib/ArmNN-linux-aarch64/libarmnnDelegate.so` is correct.
+Download binaries from https://github.com/ARM-software/armnn/releases for your platform
+
+
+```yaml
+detectors:
+  armnn:
+    type: armnn
+    num_threads: 8
+#    model:
+#      path: //cpu_model.tflite  # used by default. 
+
+model:
+  width: 320
+  height: 320
+
+```
+
+In order for GPU to work you need to have `armnn-latest-all` installed as well as `clinfo` should show
+output for the GPU support. See (hardware acceleration)[hardware_acceleration.md].
+
 ### Intel NCS2 VPU and Myriad X Setup
 
 Intel produces a neural net inference accelleration chip called Myriad X. This chip was sold in their Neural Compute Stick 2 (NCS2) which has been discontinued. If intending to use the MYRIAD device for accelleration, additional setup is required to pass through the USB device. The host needs a udev rule installed to handle the NCS2 device.

--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -159,7 +159,7 @@ model:
 ```
 
 In order for GPU to work you need to have `armnn-latest-all` installed as well as `clinfo` should show
-output for the GPU support. See (hardware acceleration)[hardware_acceleration.md].
+output for the GPU support. See [hardware acceleration](hardware_acceleration.md).
 
 ### Intel NCS2 VPU and Myriad X Setup
 

--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -15,6 +15,78 @@ ffmpeg:
   hwaccel_args: preset-rpi-64-h264
 ```
 
+### Orange Pi 5 ( ArmNN )
+
+Ensure you have installed
+
+```sh
+ffmpeg/jammy,now 7:4.4.2-0ubuntu0.22.04.1+rkmpp20230207 arm64 [installed,upgradable to: 7:5.1.2-3]
+libavcodec58/jammy,now 7:4.4.2-0ubuntu0.22.04.1+rkmpp20230207 arm64 [installed,automatic]
+libavdevice58/jammy,now 7:4.4.2-0ubuntu0.22.04.1+rkmpp20230207 arm64 [installed,automatic]
+libavfilter7/jammy,now 7:4.4.2-0ubuntu0.22.04.1+rkmpp20230207 arm64 [installed,automatic]
+libavformat58/jammy,now 7:4.4.2-0ubuntu0.22.04.1+rkmpp20230207 arm64 [installed,automatic]
+libavutil56/jammy,now 7:4.4.2-0ubuntu0.22.04.1+rkmpp20230207 arm64 [installed,automatic]
+libpostproc55/jammy,now 7:4.4.2-0ubuntu0.22.04.1+rkmpp20230207 arm64 [installed,automatic]
+librockchip-mpp1/jammy,now 1.5.0-1+git230210.c145c84~jammy1 arm64 [installed,automatic]
+libswresample3/jammy,now 7:4.4.2-0ubuntu0.22.04.1+rkmpp20230207 arm64 [installed,automatic]
+libswscale5/jammy,now 7:4.4.2-0ubuntu0.22.04.1+rkmpp20230207 arm64 [installed,automatic]
+```
+from https://github.com/orangepi-xunlong/rk-rootfs-build/tree/rk3588_packages_jammy
+
+```yaml
+ffmpeg:
+  hwaccel_args: -hwaccel drm -hwaccel_device /dev/dri/renderD128 -c:v h264_rkmpp
+```
+
+Also, for the CPU and GPU accelleration you should use `armnn` detector on this board [see](detectors.md)
+
+Install packages [see tutorials](https://github.com/ARM-software/armnn/blob/branches/armnn_23_02/InstallationViaAptRepository.md)
+
+```sh
+armnn-latest-all/jammy,now 23.02-1~ubuntu22.04 arm64 [installed]
+armnn-latest-cpu-gpu-ref/jammy,now 23.02-1~ubuntu22.04 arm64 [installed]
+armnn-latest-cpu-gpu/jammy,now 23.02-1~ubuntu22.04 arm64 [installed]
+armnn-latest-cpu/jammy,now 23.02-1~ubuntu22.04 arm64 [installed]
+armnn-latest-gpu/jammy,now 23.02-1~ubuntu22.04 arm64 [installed]
+armnn-latest-ref/jammy,now 23.02-1~ubuntu22.04 arm64 [installed]
+libarmnn-cpuacc-backend32/jammy,now 23.02-1~ubuntu22.04 arm64 [installed,automatic]
+libarmnn-cpuref-backend32/jammy,now 23.02-1~ubuntu22.04 arm64 [installed,automatic]
+libarmnn-gpuacc-backend32/jammy,now 23.02-1~ubuntu22.04 arm64 [installed,automatic]
+libarmnn22/unstable,now 20.08-12 arm64 [installed,automatic]
+libarmnn32/jammy,now 23.02-1~ubuntu22.04 arm64 [installed,automatic]
+libarmnnaclcommon22/unstable,now 20.08-12 arm64 [installed]
+libarmnnaclcommon32/jammy,now 23.02-1~ubuntu22.04 arm64 [installed,automatic]
+libarmnntfliteparser24/jammy,now 23.02-1~ubuntu22.04 arm64 [installed,automatic]
+```
+
+In order for the GPU to work install packages
+
+```sh
+libmali-g610-x11/jammy,now 1.0.2.4 arm64 [installed]
+libmali-valhall-g610-g6p0-x11-gbm/now 1.9-1 arm64 [installed,local]
+```
+
+for Ubuntu
+
+```sh
+apt install ocl-icd-opencl-dev
+mkdir -p /etc/OpenCL/vendors/
+dpkg -i libmali-valhall-g610-g6p0-x11_1.9-1_arm64.deb
+```
+
+`clinfo | grep 'Device Name'` should show you a full output of available data about Mali GPU
+
+```sh
+root@23cfa5ff7203:/opt/frigate# clinfo | grep 'Device Name'
+  Device Name                                     Mali-LODX r0p0
+    Device Name                                   Mali-LODX r0p0
+    Device Name                                   Mali-LODX r0p0
+    Device Name                                   Mali-LODX r0p0
+```
+
+
+
+
 ### Intel-based CPUs (<10th Generation) via VAAPI
 
 VAAPI supports automatic profile selection so it will work automatically with both H.264 and H.265 streams. VAAPI is recommended for all generations of Intel-based CPUs if QSV does not work.

--- a/frigate/detectors/plugins/armnn_tfl.py
+++ b/frigate/detectors/plugins/armnn_tfl.py
@@ -1,0 +1,78 @@
+import logging
+import numpy as np
+
+from frigate.detectors.detection_api import DetectionApi
+from frigate.detectors.detector_config import BaseDetectorConfig
+from typing import Literal
+from pydantic import Extra, Field
+
+try:
+    from tflite_runtime.interpreter import Interpreter
+except ModuleNotFoundError:
+    from tensorflow.lite.python.interpreter import Interpreter
+
+logger = logging.getLogger(__name__)
+
+DETECTOR_KEY = "armnn"
+
+
+class ArmNNDetectorConfig(BaseDetectorConfig):
+    type: Literal[DETECTOR_KEY]
+    num_threads: int = Field(default=8, title="Number of detection threads")
+
+
+def load_armnn_delegate(library_path, options=None):
+    try:
+        from tflite_runtime.interpreter import load_delegate
+    except ModuleNotFoundError:
+        from tensorflow.lite.python.interpreter import load_delegate
+
+    if options is None:
+        options = {"backends": "CpuAcc,GpuAcc,CpuRef", "logging-severity": "info"}
+
+    return load_delegate(library_path, options=options)
+
+
+class ArmNNTfl(DetectionApi):
+    type_key = DETECTOR_KEY
+
+    def __init__(self, detector_config: ArmNNDetectorConfig):
+        armnn_delegate = load_armnn_delegate("/usr/lib/ArmNN-linux-aarch64/libarmnnDelegate.so")
+
+        self.interpreter = Interpreter(
+            model_path=detector_config.model.path or "/cpu_model.tflite",
+            num_threads=detector_config.num_threads or 8,
+            experimental_delegates=[armnn_delegate],
+        )
+
+        self.interpreter.allocate_tensors()
+
+        self.tensor_input_details = self.interpreter.get_input_details()
+        self.tensor_output_details = self.interpreter.get_output_details()
+
+    def detect_raw(self, tensor_input):
+        self.interpreter.set_tensor(self.tensor_input_details[0]["index"], tensor_input)
+        self.interpreter.invoke()
+
+        boxes = self.interpreter.tensor(self.tensor_output_details[0]["index"])()[0]
+        class_ids = self.interpreter.tensor(self.tensor_output_details[1]["index"])()[0]
+        scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[0]
+        count = int(
+            self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
+        )
+
+        detections = np.zeros((20, 6), np.float32)
+
+        for i in range(count):
+            if scores[i] < 0.4 or i == 20:
+                break
+            detections[i] = [
+                class_ids[i],
+                float(scores[i]),
+                boxes[i][0],
+                boxes[i][1],
+                boxes[i][2],
+                boxes[i][3],
+            ]
+
+        return detections


### PR DESCRIPTION
TODO: - add https://github.com/rockchip-linux/rknpu2 support
There is yolov5 support already in examples


I was able to add `armnn` detector
See docs https://github.com/ARM-software/armnn#arm-nn

**Arm NN** is the **most performant** machine learning (ML) inference engine for Android and Linux, accelerating ML
on **Arm Cortex-A CPUs and Arm Mali GPUs**. 


Some proofs

During detection
![image](https://user-images.githubusercontent.com/563412/225289668-cbab080e-03c5-48d4-9367-86e91088c489.png)

Events screen
![image](https://user-images.githubusercontent.com/563412/225289808-12e5b837-bb4b-43c4-910a-2802ec5bf8ab.png)


Frigate log

```
2023-03-15 18:02:23.859197722  Info: ArmNN v32.0.0
2023-03-15 18:02:23.912813995  INFO: TfLiteArmnnDelegate: Created TfLite ArmNN delegate.
2023-03-15 18:02:23.920861496  Info: ArmnnSubgraph creation
2023-03-15 18:02:23.921845559  Info: Parse nodes to ArmNN time: 1.36 ms
2023-03-15 18:02:23.928672169  Info: Optimize ArmnnSubgraph time: 6.78 ms
2023-03-15 18:02:23.938988206  Info: Load ArmnnSubgraph time: 10.21 ms
2023-03-15 18:02:23.938998706  Info: Overall ArmnnSubgraph creation time: 18.55 ms
2023-03-15 18:47:46.976453964  Info: Execution time: 85.86 ms.
2023-03-15 18:47:47.051249177  Info: Execution time: 66.77 ms.
2023-03-15 18:47:47.095818136  Info: Execution time: 36.33 ms.
2023-03-15 18:47:47.135602818  Info: Execution time: 30.93 ms.
2023-03-15 18:47:47.173205671  Info: Execution time: 28.05 ms.
2023-03-15 18:47:47.774321566  Info: Execution time: 64.16 ms.
2023-03-15 18:47:47.856035512  Info: Execution time: 68.95 ms.
2023-03-15 18:47:47.897944775  Info: Execution time: 32.51 ms.
2023-03-15 18:47:48.144896242  Info: Execution time: 66.46 ms.
2023-03-15 18:47:48.208655015  Info: Execution time: 51.46 ms.
...
```

clinfo output

```sh
root@23cfa5ff7203:/opt/frigate# clinfo
Number of platforms                               1
  Platform Name                                   ARM Platform
  Platform Vendor                                 ARM
  Platform Version                                OpenCL 2.1 v1.g6p0-01eac0.efb75e2978d783a80fe78be1bfb0efc1
  Platform Profile                                FULL_PROFILE
  Platform Extensions                             cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_byte_addressable_store cl_khr_3d_image_writes cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_fp16 cl_khr_icd cl_khr_egl_image cl_khr_image2d_from_buffer cl_khr_depth_images cl_khr_subgroups cl_khr_subgroup_extended_types cl_khr_subgroup_non_uniform_vote cl_khr_subgroup_ballot cl_khr_il_program cl_khr_priority_hints cl_khr_create_command_queue cl_khr_spirv_no_integer_wrap_decoration cl_khr_extended_versioning cl_khr_device_uuid cl_arm_core_id cl_arm_printf cl_arm_non_uniform_work_group_size cl_arm_import_memory cl_arm_import_memory_dma_buf cl_arm_import_memory_host cl_arm_integer_dot_product_int8 cl_arm_integer_dot_product_accumulate_int8 cl_arm_integer_dot_product_accumulate_saturate_int8 cl_arm_scheduling_controls cl_arm_controlled_kernel_termination cl_ext_cxx_for_opencl
  Platform Extensions function suffix             ARM
  Platform Host timer resolution                  1ns

  Platform Name                                   ARM Platform
Number of devices                                 1
arm_release_ver of this libmali is 'g6p0-01eac0', rk_so_ver is '5'.
  Device Name                                     Mali-LODX r0p0
  Device Vendor                                   ARM
  Device Vendor ID                                0xa8670000
  Device Version                                  OpenCL 2.1 v1.g6p0-01eac0.efb75e2978d783a80fe78be1bfb0efc1
  Device UUID                                     000067a8-0100-0000-0000-000000000000
  Driver UUID                                     d9495bef-ea91-7c52-8a43-8a3c2f7b49cc
  Valid Device LUID                               No
  Device LUID                                     0000-000000000000
  Device Node Mask                                0
  Device Numeric Version                          0x801000 (2.1.0)
  Driver Version                                  2.1
  Device OpenCL C Version                         OpenCL C 2.0 v1.g6p0-01eac0.efb75e2978d783a80fe78be1bfb0efc1
  Device OpenCL C Numeric Version                 0x800000 (2.0.0)
  Device C++ for OpenCL Numeric Version           0x400000 (1.0.0)
  Device Type                                     GPU
  Device Profile                                  FULL_PROFILE
  Device Available                                Yes
  Compiler Available                              Yes
  Linker Available                                Yes
  Max compute units                               4
  Available core IDs (ARM)                        0, 2, 16, 18
  Max clock frequency                             1000MHz
  Device Partition                                (core)
    Max number of sub-devices                     0
    Supported partition types                     None
    Supported affinity domains                    (n/a)
  Max work item dimensions                        3
  Max work item sizes                             1024x1024x1024
  Max work group size                             1024
  Preferred work group size multiple (kernel)     16
  Max sub-groups per work group                   64
  Preferred / native vector sizes                 
    char                                                16 / 4       
    short                                                8 / 2       
    int                                                  4 / 1       
    long                                                 2 / 1       
    half                                                 8 / 2        (cl_khr_fp16)
    float                                                4 / 1       
    double                                               0 / 0        (n/a)
  Half-precision Floating-point support           (cl_khr_fp16)
    Denormals                                     Yes
    Infinity and NANs                             Yes
    Round to nearest                              Yes
    Round to zero                                 Yes
    Round to infinity                             Yes
    IEEE754-2008 fused multiply-add               Yes
    Support is emulated in software               No
  Single-precision Floating-point support         (core)
    Denormals                                     Yes
    Infinity and NANs                             Yes
    Round to nearest                              Yes
    Round to zero                                 Yes
    Round to infinity                             Yes
    IEEE754-2008 fused multiply-add               Yes
    Support is emulated in software               No
    Correctly-rounded divide and sqrt operations  No
  Double-precision Floating-point support         (n/a)
  Address bits                                    64, Little-Endian
  Global memory size                              8055271424 (7.502GiB)
  Error Correction support                        No
  Max memory allocation                           8055271424 (7.502GiB)
  Unified memory for Host and Device              Yes
  Shared Virtual Memory (SVM) capabilities        (core)
    Coarse-grained buffer sharing                 Yes
    Fine-grained buffer sharing                   No
    Fine-grained system sharing                   No
    Atomics                                       No
  Minimum alignment for any data type             128 bytes
  Alignment of base address                       1024 bits (128 bytes)
  Preferred alignment for atomics                 
    SVM                                           0 bytes
    Global                                        0 bytes
    Local                                         0 bytes
  Max size for global variable                    65536 (64KiB)
  Preferred total size of global vars             0
  Global Memory cache type                        Read/Write
  Global Memory cache size                        1048576 (1024KiB)
  Global Memory cache line size                   64 bytes
  Image support                                   Yes
    Max number of samplers per kernel             16
    Max size for 1D images from buffer            65536 pixels
    Max 1D or 2D image array size                 2048 images
    Base address alignment for 2D image buffers   32 bytes
    Pitch alignment for 2D image buffers          64 pixels
    Max 2D image size                             65536x65536 pixels
    Max 3D image size                             65536x65536x65536 pixels
    Max number of read image args                 128
    Max number of write image args                64
    Max number of read/write image args           64
  Max number of pipe args                         16
  Max active pipe reservations                    1
  Max pipe packet size                            1024
  Local memory type                               Global
  Local memory size                               32768 (32KiB)
  Max number of constant args                     128
  Max constant buffer size                        8055271424 (7.502GiB)
  Max size of kernel argument                     1024
  Queue properties (on host)                      
    Out-of-order execution                        Yes
    Profiling                                     Yes
  Queue properties (on device)                    
    Out-of-order execution                        Yes
    Profiling                                     Yes
    Preferred size                                2097152 (2MiB)
    Max size                                      16777216 (16MiB)
  Max queues on device                            1
  Max events on device                            1024
  Controlled termination caps. (ARM)              Controlled Success, Controlled Failurure
  Prefer user sync for interop                    No
  Profiling timer resolution                      1000ns
  Execution capabilities                          
    Run OpenCL kernels                            Yes
    Run native kernels                            No
    Sub-group independent forward progress        Yes
    Scheduling controls (ARM)                     Kernel batching, Work-group batch size, Work-group batch size modifier, Register allocation
    Supported reg allocs (ARM)                    32, 64
    Max warps/CU (ARM)                            <printDeviceInfo:211: get CL_DEVICE_MAX_WARP_COUNT_ARM : error -30>
    IL version                                    SPIR-V_1.0
    ILs with version                              SPIR-V                                                           0x400000 (1.0.0)
  printf() buffer size                            1048576 (1024KiB)
  Built-in kernels                                (n/a)
  Built-in kernels with version                   (n/a)
  Device Extensions                               cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_byte_addressable_store cl_khr_3d_image_writes cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_fp16 cl_khr_icd cl_khr_egl_image cl_khr_image2d_from_buffer cl_khr_depth_images cl_khr_subgroups cl_khr_subgroup_extended_types cl_khr_subgroup_non_uniform_vote cl_khr_subgroup_ballot cl_khr_il_program cl_khr_priority_hints cl_khr_create_command_queue cl_khr_spirv_no_integer_wrap_decoration cl_khr_extended_versioning cl_khr_device_uuid cl_arm_core_id cl_arm_printf cl_arm_non_uniform_work_group_size cl_arm_import_memory cl_arm_import_memory_dma_buf cl_arm_import_memory_host cl_arm_integer_dot_product_int8 cl_arm_integer_dot_product_accumulate_int8 cl_arm_integer_dot_product_accumulate_saturate_int8 cl_arm_scheduling_controls cl_arm_controlled_kernel_termination cl_ext_cxx_for_opencl
  Device Extensions with Version                  cl_khr_global_int32_base_atomics                                 0x400000 (1.0.0)
                                                  cl_khr_global_int32_extended_atomics                             0x400000 (1.0.0)
                                                  cl_khr_local_int32_base_atomics                                  0x400000 (1.0.0)
                                                  cl_khr_local_int32_extended_atomics                              0x400000 (1.0.0)
                                                  cl_khr_byte_addressable_store                                    0x400000 (1.0.0)
                                                  cl_khr_3d_image_writes                                           0x400000 (1.0.0)
                                                  cl_khr_int64_base_atomics                                        0x400000 (1.0.0)
                                                  cl_khr_int64_extended_atomics                                    0x400000 (1.0.0)
                                                  cl_khr_fp16                                                      0x400000 (1.0.0)
                                                  cl_khr_icd                                                       0x400000 (1.0.0)
                                                  cl_khr_egl_image                                                 0x400000 (1.0.0)
                                                  cl_khr_image2d_from_buffer                                       0x400000 (1.0.0)
                                                  cl_khr_depth_images                                              0x400000 (1.0.0)
                                                  cl_khr_subgroups                                                 0x400000 (1.0.0)
                                                  cl_khr_subgroup_extended_types                                   0x400000 (1.0.0)
                                                  cl_khr_subgroup_non_uniform_vote                                 0x400000 (1.0.0)
                                                  cl_khr_subgroup_ballot                                           0x400000 (1.0.0)
                                                  cl_khr_il_program                                                0x400000 (1.0.0)
                                                  cl_khr_priority_hints                                            0x400000 (1.0.0)
                                                  cl_khr_create_command_queue                                      0x400000 (1.0.0)
                                                  cl_khr_spirv_no_integer_wrap_decoration                          0x400000 (1.0.0)
                                                  cl_khr_extended_versioning                                       0x400000 (1.0.0)
                                                  cl_khr_device_uuid                                               0x400000 (1.0.0)
                                                  cl_arm_core_id                                                   0x400000 (1.0.0)
                                                  cl_arm_printf                                                    0x400000 (1.0.0)
                                                  cl_arm_non_uniform_work_group_size                               0x400000 (1.0.0)
                                                  cl_arm_import_memory                                             0x400000 (1.0.0)
                                                  cl_arm_import_memory_dma_buf                                     0x400000 (1.0.0)
                                                  cl_arm_import_memory_host                                        0x400000 (1.0.0)
                                                  cl_arm_integer_dot_product_int8                                  0x400000 (1.0.0)
                                                  cl_arm_integer_dot_product_accumulate_int8                       0x400000 (1.0.0)
                                                  cl_arm_integer_dot_product_accumulate_saturate_int8              0x400000 (1.0.0)
                                                  cl_arm_scheduling_controls                                         0x3000 (0.3.0)
                                                  cl_arm_controlled_kernel_termination                             0x400000 (1.0.0)
                                                  cl_ext_cxx_for_opencl                                            0x400000 (1.0.0)

NULL platform behavior
  clGetPlatformInfo(NULL, CL_PLATFORM_NAME, ...)  ARM Platform
  clGetDeviceIDs(NULL, CL_DEVICE_TYPE_ALL, ...)   Success [ARM]
  clCreateContext(NULL, ...) [default]            Success [ARM]
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_DEFAULT)  Success (1)
    Platform Name                                 ARM Platform
    Device Name                                   Mali-LODX r0p0
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_CPU)  No devices found in platform
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_GPU)  Success (1)
    Platform Name                                 ARM Platform
    Device Name                                   Mali-LODX r0p0
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_ACCELERATOR)  No devices found in platform
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_CUSTOM)  No devices found in platform
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_ALL)  Success (1)
    Platform Name                                 ARM Platform
    Device Name                                   Mali-LODX r0p0

ICD loader properties
  ICD loader Name                                 OpenCL ICD Loader
  ICD loader Vendor                               OCL Icd free software
  ICD loader Version                              2.3.1
  ICD loader Profile                              OpenCL 3.0
root@23cfa5ff7203:/opt/frigate# clinfo | grep Device Name
grep: Name: No such file or directory
root@23cfa5ff7203:/opt/frigate# clinfo | grep 'Device Name'
  Device Name                                     Mali-LODX r0p0
    Device Name                                   Mali-LODX r0p0
    Device Name                                   Mali-LODX r0p0
    Device Name                                   Mali-LODX r0p0
root@23cfa5ff7203:/opt/frigate# clinfo | grep ARM          
  Platform Name                                   ARM Platform
  Platform Vendor                                 ARM
  Platform Extensions function suffix             ARM
  Platform Name                                   ARM Platform
  Device Vendor                                   ARM
  Available core IDs (ARM)                        0, 2, 16, 18
  Controlled termination caps. (ARM)              Controlled Success, Controlled Failurure
    Scheduling controls (ARM)                     Kernel batching, Work-group batch size, Work-group batch size modifier, Register allocation
    Supported reg allocs (ARM)                    32, 64
    Max warps/CU (ARM)                            <printDeviceInfo:211: get CL_DEVICE_MAX_WARP_COUNT_ARM : error -30>
  clGetPlatformInfo(NULL, CL_PLATFORM_NAME, ...)  ARM Platform
  clGetDeviceIDs(NULL, CL_DEVICE_TYPE_ALL, ...)   Success [ARM]
  clCreateContext(NULL, ...) [default]            Success [ARM]
    Platform Name                                 ARM Platform
    Platform Name                                 ARM Platform
    Platform Name                                 ARM Platform
root@23cfa5ff7203:/opt/frigate# clinfo
Number of platforms                               1
  Platform Name                                   ARM Platform
  Platform Vendor                                 ARM
  Platform Version                                OpenCL 2.1 v1.g6p0-01eac0.efb75e2978d783a80fe78be1bfb0efc1
  Platform Profile                                FULL_PROFILE
  Platform Extensions                             cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_byte_addressable_store cl_khr_3d_image_writes cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_fp16 cl_khr_icd cl_khr_egl_image cl_khr_image2d_from_buffer cl_khr_depth_images cl_khr_subgroups cl_khr_subgroup_extended_types cl_khr_subgroup_non_uniform_vote cl_khr_subgroup_ballot cl_khr_il_program cl_khr_priority_hints cl_khr_create_command_queue cl_khr_spirv_no_integer_wrap_decoration cl_khr_extended_versioning cl_khr_device_uuid cl_arm_core_id cl_arm_printf cl_arm_non_uniform_work_group_size cl_arm_import_memory cl_arm_import_memory_dma_buf cl_arm_import_memory_host cl_arm_integer_dot_product_int8 cl_arm_integer_dot_product_accumulate_int8 cl_arm_integer_dot_product_accumulate_saturate_int8 cl_arm_scheduling_controls cl_arm_controlled_kernel_termination cl_ext_cxx_for_opencl
  Platform Extensions function suffix             ARM
  Platform Host timer resolution                  1ns

  Platform Name                                   ARM Platform
Number of devices                                 1
arm_release_ver of this libmali is 'g6p0-01eac0', rk_so_ver is '5'.
  Device Name                                     Mali-LODX r0p0
  Device Vendor                                   ARM
  Device Vendor ID                                0xa8670000
  Device Version                                  OpenCL 2.1 v1.g6p0-01eac0.efb75e2978d783a80fe78be1bfb0efc1
  Device UUID                                     000067a8-0100-0000-0000-000000000000
  Driver UUID                                     d9495bef-ea91-7c52-8a43-8a3c2f7b49cc
  Valid Device LUID                               No
  Device LUID                                     0000-000000000000
  Device Node Mask                                0
  Device Numeric Version                          0x801000 (2.1.0)
  Driver Version                                  2.1
  Device OpenCL C Version                         OpenCL C 2.0 v1.g6p0-01eac0.efb75e2978d783a80fe78be1bfb0efc1
  Device OpenCL C Numeric Version                 0x800000 (2.0.0)
  Device C++ for OpenCL Numeric Version           0x400000 (1.0.0)
  Device Type                                     GPU
  Device Profile                                  FULL_PROFILE
  Device Available                                Yes
  Compiler Available                              Yes
  Linker Available                                Yes
  Max compute units                               4
  Available core IDs (ARM)                        0, 2, 16, 18
  Max clock frequency                             1000MHz
  Device Partition                                (core)
    Max number of sub-devices                     0
    Supported partition types                     None
    Supported affinity domains                    (n/a)
  Max work item dimensions                        3
  Max work item sizes                             1024x1024x1024
  Max work group size                             1024
  Preferred work group size multiple (kernel)     16
  Max sub-groups per work group                   64
  Preferred / native vector sizes                 
    char                                                16 / 4       
    short                                                8 / 2       
    int                                                  4 / 1       
    long                                                 2 / 1       
    half                                                 8 / 2        (cl_khr_fp16)
    float                                                4 / 1       
    double                                               0 / 0        (n/a)
  Half-precision Floating-point support           (cl_khr_fp16)
    Denormals                                     Yes
    Infinity and NANs                             Yes
    Round to nearest                              Yes
    Round to zero                                 Yes
    Round to infinity                             Yes
    IEEE754-2008 fused multiply-add               Yes
    Support is emulated in software               No
  Single-precision Floating-point support         (core)
    Denormals                                     Yes
    Infinity and NANs                             Yes
    Round to nearest                              Yes
    Round to zero                                 Yes
    Round to infinity                             Yes
    IEEE754-2008 fused multiply-add               Yes
    Support is emulated in software               No
    Correctly-rounded divide and sqrt operations  No
  Double-precision Floating-point support         (n/a)
  Address bits                                    64, Little-Endian
  Global memory size                              8055271424 (7.502GiB)
  Error Correction support                        No
  Max memory allocation                           8055271424 (7.502GiB)
  Unified memory for Host and Device              Yes
  Shared Virtual Memory (SVM) capabilities        (core)
    Coarse-grained buffer sharing                 Yes
    Fine-grained buffer sharing                   No
    Fine-grained system sharing                   No
    Atomics                                       No
  Minimum alignment for any data type             128 bytes
  Alignment of base address                       1024 bits (128 bytes)
  Preferred alignment for atomics                 
    SVM                                           0 bytes
    Global                                        0 bytes
    Local                                         0 bytes
  Max size for global variable                    65536 (64KiB)
  Preferred total size of global vars             0
  Global Memory cache type                        Read/Write
  Global Memory cache size                        1048576 (1024KiB)
  Global Memory cache line size                   64 bytes
  Image support                                   Yes
    Max number of samplers per kernel             16
    Max size for 1D images from buffer            65536 pixels
    Max 1D or 2D image array size                 2048 images
    Base address alignment for 2D image buffers   32 bytes
    Pitch alignment for 2D image buffers          64 pixels
    Max 2D image size                             65536x65536 pixels
    Max 3D image size                             65536x65536x65536 pixels
    Max number of read image args                 128
    Max number of write image args                64
    Max number of read/write image args           64
  Max number of pipe args                         16
  Max active pipe reservations                    1
  Max pipe packet size                            1024
  Local memory type                               Global
  Local memory size                               32768 (32KiB)
  Max number of constant args                     128
  Max constant buffer size                        8055271424 (7.502GiB)
  Max size of kernel argument                     1024
  Queue properties (on host)                      
    Out-of-order execution                        Yes
    Profiling                                     Yes
  Queue properties (on device)                    
    Out-of-order execution                        Yes
    Profiling                                     Yes
    Preferred size                                2097152 (2MiB)
    Max size                                      16777216 (16MiB)
  Max queues on device                            1
  Max events on device                            1024
  Controlled termination caps. (ARM)              Controlled Success, Controlled Failurure
  Prefer user sync for interop                    No
  Profiling timer resolution                      1000ns
  Execution capabilities                          
    Run OpenCL kernels                            Yes
    Run native kernels                            No
    Sub-group independent forward progress        Yes
    Scheduling controls (ARM)                     Kernel batching, Work-group batch size, Work-group batch size modifier, Register allocation
    Supported reg allocs (ARM)                    32, 64
    Max warps/CU (ARM)                            <printDeviceInfo:211: get CL_DEVICE_MAX_WARP_COUNT_ARM : error -30>
    IL version                                    SPIR-V_1.0
    ILs with version                              SPIR-V                                                           0x400000 (1.0.0)
  printf() buffer size                            1048576 (1024KiB)
  Built-in kernels                                (n/a)
  Built-in kernels with version                   (n/a)
  Device Extensions                               cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_byte_addressable_store cl_khr_3d_image_writes cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_fp16 cl_khr_icd cl_khr_egl_image cl_khr_image2d_from_buffer cl_khr_depth_images cl_khr_subgroups cl_khr_subgroup_extended_types cl_khr_subgroup_non_uniform_vote cl_khr_subgroup_ballot cl_khr_il_program cl_khr_priority_hints cl_khr_create_command_queue cl_khr_spirv_no_integer_wrap_decoration cl_khr_extended_versioning cl_khr_device_uuid cl_arm_core_id cl_arm_printf cl_arm_non_uniform_work_group_size cl_arm_import_memory cl_arm_import_memory_dma_buf cl_arm_import_memory_host cl_arm_integer_dot_product_int8 cl_arm_integer_dot_product_accumulate_int8 cl_arm_integer_dot_product_accumulate_saturate_int8 cl_arm_scheduling_controls cl_arm_controlled_kernel_termination cl_ext_cxx_for_opencl
  Device Extensions with Version                  cl_khr_global_int32_base_atomics                                 0x400000 (1.0.0)
                                                  cl_khr_global_int32_extended_atomics                             0x400000 (1.0.0)
                                                  cl_khr_local_int32_base_atomics                                  0x400000 (1.0.0)
                                                  cl_khr_local_int32_extended_atomics                              0x400000 (1.0.0)
                                                  cl_khr_byte_addressable_store                                    0x400000 (1.0.0)
                                                  cl_khr_3d_image_writes                                           0x400000 (1.0.0)
                                                  cl_khr_int64_base_atomics                                        0x400000 (1.0.0)
                                                  cl_khr_int64_extended_atomics                                    0x400000 (1.0.0)
                                                  cl_khr_fp16                                                      0x400000 (1.0.0)
                                                  cl_khr_icd                                                       0x400000 (1.0.0)
                                                  cl_khr_egl_image                                                 0x400000 (1.0.0)
                                                  cl_khr_image2d_from_buffer                                       0x400000 (1.0.0)
                                                  cl_khr_depth_images                                              0x400000 (1.0.0)
                                                  cl_khr_subgroups                                                 0x400000 (1.0.0)
                                                  cl_khr_subgroup_extended_types                                   0x400000 (1.0.0)
                                                  cl_khr_subgroup_non_uniform_vote                                 0x400000 (1.0.0)
                                                  cl_khr_subgroup_ballot                                           0x400000 (1.0.0)
                                                  cl_khr_il_program                                                0x400000 (1.0.0)
                                                  cl_khr_priority_hints                                            0x400000 (1.0.0)
                                                  cl_khr_create_command_queue                                      0x400000 (1.0.0)
                                                  cl_khr_spirv_no_integer_wrap_decoration                          0x400000 (1.0.0)
                                                  cl_khr_extended_versioning                                       0x400000 (1.0.0)
                                                  cl_khr_device_uuid                                               0x400000 (1.0.0)
                                                  cl_arm_core_id                                                   0x400000 (1.0.0)
                                                  cl_arm_printf                                                    0x400000 (1.0.0)
                                                  cl_arm_non_uniform_work_group_size                               0x400000 (1.0.0)
                                                  cl_arm_import_memory                                             0x400000 (1.0.0)
                                                  cl_arm_import_memory_dma_buf                                     0x400000 (1.0.0)
                                                  cl_arm_import_memory_host                                        0x400000 (1.0.0)
                                                  cl_arm_integer_dot_product_int8                                  0x400000 (1.0.0)
                                                  cl_arm_integer_dot_product_accumulate_int8                       0x400000 (1.0.0)
                                                  cl_arm_integer_dot_product_accumulate_saturate_int8              0x400000 (1.0.0)
                                                  cl_arm_scheduling_controls                                         0x3000 (0.3.0)
                                                  cl_arm_controlled_kernel_termination                             0x400000 (1.0.0)
                                                  cl_ext_cxx_for_opencl                                            0x400000 (1.0.0)

NULL platform behavior
  clGetPlatformInfo(NULL, CL_PLATFORM_NAME, ...)  ARM Platform
  clGetDeviceIDs(NULL, CL_DEVICE_TYPE_ALL, ...)   Success [ARM]
  clCreateContext(NULL, ...) [default]            Success [ARM]
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_DEFAULT)  Success (1)
    Platform Name                                 ARM Platform
    Device Name                                   Mali-LODX r0p0
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_CPU)  No devices found in platform
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_GPU)  Success (1)
    Platform Name                                 ARM Platform
    Device Name                                   Mali-LODX r0p0
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_ACCELERATOR)  No devices found in platform
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_CUSTOM)  No devices found in platform
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_ALL)  Success (1)
    Platform Name                                 ARM Platform
    Device Name                                   Mali-LODX r0p0

ICD loader properties
  ICD loader Name                                 OpenCL ICD Loader
  ICD loader Vendor                               OCL Icd free software
  ICD loader Version                              2.3.1
  ICD loader Profile                              OpenCL 3.0
```