### PR TITLE
typo in live config documentation

### DIFF
--- a/docs/docs/configuration/live.md
+++ b/docs/docs/configuration/live.md
@@ -59,7 +59,7 @@ cameras:
           roles:
             - detect
     live:
-      stream_name: test_cam_sub
+      stream_name: rtsp_cam_sub
 ```
 
 ### WebRTC extra configuration:


### PR DESCRIPTION
I believe that we should use defined rtsp_cam_sub, not test_cam_sub