### PR TITLE
Fixed extension of config file

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -3,7 +3,7 @@ id: index
 title: Configuration File
 ---
 
-For Home Assistant Addon installations, the config file needs to be in the root of your Home Assistant config directory (same location as `configuration.yaml`) and named `frigate.yaml`.
+For Home Assistant Addon installations, the config file needs to be in the root of your Home Assistant config directory (same location as `configuration.yaml`). It can be named `frigate.yml` or `frigate.yaml`, but if both files exist the addon will prefer `frigate.yaml` and ignore the contents of `frigate.yml`.
 
 For all other installation types, the config file should be mapped to `/config/config.yml` inside the container.
 

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -3,7 +3,7 @@ id: index
 title: Configuration File
 ---
 
-For Home Assistant Addon installations, the config file needs to be in the root of your Home Assistant config directory (same location as `configuration.yaml`) and named `frigate.yml`.
+For Home Assistant Addon installations, the config file needs to be in the root of your Home Assistant config directory (same location as `configuration.yaml`) and named `frigate.yaml`.
 
 For all other installation types, the config file should be mapped to `/config/config.yml` inside the container.
 

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -3,7 +3,7 @@ id: index
 title: Configuration File
 ---
 
-For Home Assistant Addon installations, the config file needs to be in the root of your Home Assistant config directory (same location as `configuration.yaml`). It can be named `frigate.yml` or `frigate.yaml`, but if both files exist the addon will prefer `frigate.yaml` and ignore the contents of `frigate.yml`.
+For Home Assistant Addon installations, the config file needs to be in the root of your Home Assistant config directory (same location as `configuration.yaml`). It can be named `frigate.yml` or `frigate.yaml`, but if both files exist `frigate.yaml` will be preferred and `frigate.yml` will be ignored.
 
 For all other installation types, the config file should be mapped to `/config/config.yml` inside the container.
 


### PR DESCRIPTION
Using frigate.yml as the config file for the HA addon gives a validation error, the same contents in frigate.yaml work.
```

1 validation error for FrigateConfig
__root__
  FrigateConfig expected dict not NoneType (type=type_error)
```