### PR TITLE
Fix confusing storage display when calculating per camera usage

### DIFF
--- a/web/src/routes/Storage.jsx
+++ b/web/src/routes/Storage.jsx
@@ -128,7 +128,7 @@ export default function Storage() {
                   <Tbody>
                     <Tr>
                       <Td>{Math.round(camera['usage_percent'] ?? 0)}%</Td>
-                      <Td>{camera['bandwidth'] ? getUnitSize(camera['bandwidth']) : 'Calculating...'}/hr</Td>
+                      <Td>{camera['bandwidth'] ? `${getUnitSize(camera['bandwidth'])}/hr` : 'Calculating...'}</Td>
                     </Tr>
                   </Tbody>
                 </Table>


### PR DESCRIPTION
When storage usage per camera is being calculated, this is displayed with v0.12.0-rc1:

![image](https://user-images.githubusercontent.com/318490/227714471-937cd036-102e-4946-86a7-d572b2ffe287.png)
