### PR TITLE
Allow to override go2rtc binary in add-on

### DIFF
--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
@@ -54,8 +54,17 @@ if [[ ! -f "/dev/shm/go2rtc.yaml" ]]; then
     python3 /usr/local/go2rtc/create_config.py
 fi
 
+readonly config_path="/config"
+
+if [[ -x "${config_path}/go2rtc" ]]; then
+  readonly binary_path="${config_path}/go2rtc"
+  echo "[WARN] Using go2rtc binary from '${binary_path}' instead of the embedded one" >&2
+else
+  readonly binary_path="/usr/local/go2rtc/bin/go2rtc"
+fi
+
 echo "[INFO] Starting go2rtc..."
 
 # Replace the bash process with the go2rtc process, redirecting stderr to stdout
 exec 2>&1
-exec go2rtc -config=/dev/shm/go2rtc.yaml
+exec "${binary_path}" -config=/dev/shm/go2rtc.yaml


### PR DESCRIPTION
This adds a feature from the go2rtc add-on to the Frigate add-on:

- https://github.com/AlexxIT/go2rtc/blob/master/build/docker/run.sh

This is motived by this comment:

- https://github.com/blakeblackshear/frigate/pull/5814#issuecomment-1485786784

Which says that users can override go2rtc through bind mounts, but that's unfortunately not available to add-on users like me.

I'm happy to make changes if needed.