### PR TITLE
Migrate away from deprecated np.float

### DIFF
--- a/frigate/motion.py
+++ b/frigate/motion.py
@@ -20,8 +20,8 @@ class MotionDetector:
             config.frame_height,
             config.frame_height * frame_shape[1] // frame_shape[0],
         )
-        self.avg_frame = np.zeros(self.motion_frame_size, np.float)
-        self.avg_delta = np.zeros(self.motion_frame_size, np.float)
+        self.avg_frame = np.zeros(self.motion_frame_size, np.float32)
+        self.avg_delta = np.zeros(self.motion_frame_size, np.float32)
         self.motion_frame_count = 0
         self.frame_counter = 0
         resized_mask = cv2.resize(


### PR DESCRIPTION
It is an alias for the python float type, and got deprecated in 1.20 and was removed in 1.24. The rest of the project already uses float32 (single), so I believe this is also correct here, as opposed to float64 (double).

https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations