### PR TITLE
[Rework RelativeModal] calculate available window height

### DIFF
--- a/web/src/components/MultiSelect.jsx
+++ b/web/src/components/MultiSelect.jsx
@@ -17,6 +17,8 @@ export default function MultiSelect({ className, title, options, selection, onTo
     return selection == 'all' || selection.split(',').indexOf(item) > -1;
   };
 
+  const menuHeight = Math.round(window.innerHeight * 0.55);
+
   return (
     <div className={`${className} p-2`} ref={popupRef}>
       <div className="flex justify-between min-w-[120px]" onClick={() => setState({ showMenu: true })}>
@@ -24,7 +26,11 @@ export default function MultiSelect({ className, title, options, selection, onTo
         <ArrowDropdown className="w-6" />
       </div>
       {state.showMenu ? (
-        <Menu className={`overflow-auto`} relativeTo={popupRef} onDismiss={() => setState({ showMenu: false })}>
+        <Menu
+          className={`max-h-[${menuHeight}px] overflow-auto`}
+          relativeTo={popupRef}
+          onDismiss={() => setState({ showMenu: false })}
+        >
           <div className="flex flex-wrap justify-between items-center">
             <Heading className="p-4 justify-center" size="md">
               {title}

--- a/web/src/components/MultiSelect.jsx
+++ b/web/src/components/MultiSelect.jsx
@@ -7,54 +7,59 @@ import Button from './Button';
 import CameraIcon from '../icons/Camera';
 
 export default function MultiSelect({ className, title, options, selection, onToggle, onShowAll, onSelectSingle }) {
-
   const popupRef = useRef(null);
 
   const [state, setState] = useState({
     showMenu: false,
   });
 
-  const isOptionSelected = (item) => { return selection == "all" || selection.split(',').indexOf(item) > -1; }
-
-  const menuHeight = Math.round(window.innerHeight * 0.55);
+  const isOptionSelected = (item) => {
+    return selection == 'all' || selection.split(',').indexOf(item) > -1;
+  };
 
   return (
     <div className={`${className} p-2`} ref={popupRef}>
-      <div
-        className="flex justify-between min-w-[120px]"
-        onClick={() => setState({ showMenu: true })}
-      >
+      <div className="flex justify-between min-w-[120px]" onClick={() => setState({ showMenu: true })}>
         <label>{title}</label>
         <ArrowDropdown className="w-6" />
       </div>
       {state.showMenu ? (
-        <Menu className={`max-h-[${menuHeight}px] overflow-scroll`} relativeTo={popupRef} onDismiss={() => setState({ showMenu: false })}>
+        <Menu className={`overflow-auto`} relativeTo={popupRef} onDismiss={() => setState({ showMenu: false })}>
           <div className="flex flex-wrap justify-between items-center">
-            <Heading className="p-4 justify-center" size="md">{title}</Heading>
-            <Button tabindex="false" className="mx-4" onClick={() => onShowAll() }>
+            <Heading className="p-4 justify-center" size="md">
+              {title}
+            </Heading>
+            <Button tabindex="false" className="mx-4" onClick={() => onShowAll()}>
               Show All
             </Button>
           </div>
           {options.map((item) => (
             <div className="flex flex-grow" key={item}>
               <label
-                className={`flex flex-shrink space-x-2 p-1 my-1 min-w-[176px] hover:bg-gray-200 dark:hover:bg-gray-800 dark:hover:text-white cursor-pointer capitalize text-sm`}>
+                className={`flex flex-shrink space-x-2 p-1 my-1 min-w-[176px] hover:bg-gray-200 dark:hover:bg-gray-800 dark:hover:text-white cursor-pointer capitalize text-sm`}
+              >
                 <input
                   className="mx-4 m-0 align-middle"
                   type="checkbox"
                   checked={isOptionSelected(item)}
-                  onChange={() => onToggle(item)} />
-                {item.replaceAll("_", " ")}
+                  onChange={() => onToggle(item)}
+                />
+                {item.replaceAll('_', ' ')}
               </label>
               <div className="justify-right">
-                <Button color={isOptionSelected(item) ? "blue" : "black"} type="text" className="max-h-[35px] mx-2" onClick={() => onSelectSingle(item)}>
+                <Button
+                  color={isOptionSelected(item) ? 'blue' : 'black'}
+                  type="text"
+                  className="max-h-[35px] mx-2"
+                  onClick={() => onSelectSingle(item)}
+                >
                   <CameraIcon />
                 </Button>
               </div>
             </div>
           ))}
         </Menu>
-      ): null}
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/RelativeModal.jsx
+++ b/web/src/components/RelativeModal.jsx
@@ -57,7 +57,7 @@ export default function RelativeModal({
         x: relativeToX,
         y: relativeToY,
         width: relativeToWidth,
-        // height: relativeToHeight,
+        height: relativeToHeight,
       } = relativeTo.current.getBoundingClientRect();
 
       const _width = widthRelative ? relativeToWidth : menuWidth;
@@ -78,10 +78,13 @@ export default function RelativeModal({
         newLeft = windowWidth - width - WINDOW_PADDING;
       }
 
-      // too close to bottom
-      if (top + menuHeight > windowHeight - WINDOW_PADDING + window.scrollY) {
-        // If the pop-up modal would extend beyond the bottom of the visible window,
-        // reposition the modal to appear above the clicked icon instead
+      // This condition checks if the menu overflows the bottom of the page and
+      // if there's enough space to position the menu above the clicked icon.
+      // If both conditions are met, the menu will be positioned above the clicked icon
+      if (
+        top + menuHeight > windowHeight - WINDOW_PADDING + window.scrollY &&
+        top - menuHeight - relativeToHeight >= WINDOW_PADDING
+      ) {
         newTop = top - menuHeight;
       }
 
@@ -89,10 +92,10 @@ export default function RelativeModal({
         newTop = WINDOW_PADDING;
       }
 
-      // This calculation checks if there's enough space to display the menu.
+      // This calculation checks if there's enough space below the clicked icon for the menu to fit.
       // If there is, it sets the maxHeight to null(meaning no height constraint). If not, it calculates the maxHeight based on the remaining space in the window
       const maxHeight =
-        windowHeight - WINDOW_PADDING * 2 > menuHeight
+        windowHeight - WINDOW_PADDING * 2 - top > menuHeight
           ? null
           : windowHeight - WINDOW_PADDING * 2 - top + window.scrollY;
 
@@ -121,7 +124,7 @@ export default function RelativeModal({
       <div data-testid="scrim" key="scrim" className="fixed inset-0 z-10" onClick={handleDismiss} />
       <div
         key="menu"
-        className={`z-10 bg-white dark:bg-gray-700 dark:text-white absolute shadow-lg rounded w-auto h-auto transition-transform transition-opacity duration-75 transform scale-90 opacity-0 overflow-x-hidden overflow-y-auto ${
+        className={`z-10 bg-white dark:bg-gray-700 dark:text-white absolute shadow-lg rounded w-auto h-auto transition-transform duration-75 transform scale-90 opacity-0 overflow-x-hidden overflow-y-auto ${
           show ? 'scale-100 opacity-100' : ''
         } ${className}`}
         onKeyDown={handleKeydown}

--- a/web/src/components/RelativeModal.jsx
+++ b/web/src/components/RelativeModal.jsx
@@ -89,7 +89,13 @@ export default function RelativeModal({
         newTop = WINDOW_PADDING;
       }
 
-      const maxHeight = windowHeight - WINDOW_PADDING * 2 > menuHeight ? null : windowHeight - WINDOW_PADDING * 2;
+      // This calculation checks if there's enough space to display the menu.
+      // If there is, it sets the maxHeight to null(meaning no height constraint). If not, it calculates the maxHeight based on the remaining space in the window
+      const maxHeight =
+        windowHeight - WINDOW_PADDING * 2 > menuHeight
+          ? null
+          : windowHeight - WINDOW_PADDING * 2 - top + window.scrollY;
+
       const newPosition = { left: newLeft, top: newTop, maxHeight };
       if (widthRelative) {
         newPosition.width = relativeToWidth;

--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -111,7 +111,7 @@ export default function System() {
 
       {state.showFfprobe && (
         <Dialog>
-          <div className="p-4 mb-2 max-h-96 whitespace-pre-line overflow-scroll">
+          <div className="p-4 mb-2 max-h-96 whitespace-pre-line overflow-auto">
             <Heading size="lg">Ffprobe Output</Heading>
             {state.ffprobe != '' ? (
               <div>
@@ -175,7 +175,7 @@ export default function System() {
 
       {state.showVainfo && (
         <Dialog>
-          <div className="p-4 overflow-scroll whitespace-pre-line">
+          <div className="p-4 overflow-auto whitespace-pre-line">
             <Heading size="lg">Vainfo Output</Heading>
             {state.vainfo != '' ? (
               <div className="mb-2 max-h-96 whitespace-pre-line">


### PR DESCRIPTION
I was able to re-produce the issue reported in #5997
The main issue is calculation of available window space for the dropdown menu that is calculated in the RelativeModal.jsx.

Changes: 
- Added a condition check to determine if there's enough space to position the menu above the clicked icon, and if not, position it below the icon.
- Modified the calculation of maxHeight by using the top value in the condition check for available window height, ensuring the dropdown menu fits within the remaining space.

Tested with 200 camera items on various diffrent window zoom size. 

**Important:** I dont have any events currently so im not able to test if the download menu on the last event appears correctly above the icon as this was an issue earlier. I will be able to check this tomorrow if nobody else has validated it by then.

@kdill00 are you able to test this pr and report back the results?


![image](https://user-images.githubusercontent.com/7771916/231253716-d2944c41-c51b-4220-96aa-a6b6023fa274.png)
![image](https://user-images.githubusercontent.com/7771916/231253728-e126f232-3815-4a9e-b7d8-2cbbd5f43caf.png)
![image](https://user-images.githubusercontent.com/7771916/231253748-2ff3bbf3-6e61-4a44-8364-a91a758e21c4.png)
