### PR TITLE
docker-compose.yml: remove `:ro` for `config.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - .:/workspace/frigate:cached
       - ./web/dist:/opt/frigate/web:cached
       - /etc/localtime:/etc/localtime:ro
-      - ./config/config.yml:/config/config.yml:ro
+      - ./config/config.yml:/config/config.yml
       - ./debug:/media/frigate
       # Create the trt-models folder using the documented method of generating TRT models
       # - ./debug/trt-models:/trt-models


### PR DESCRIPTION
This should be editable by default from the UI