### PR TITLE
Change blueprint url to newest version.

### DIFF
--- a/docs/docs/guides/ha_notifications.md
+++ b/docs/docs/guides/ha_notifications.md
@@ -3,7 +3,7 @@ id: ha_notifications
 title: Home Assistant notifications
 ---
 
-The best way to get started with notifications for Frigate is to use the [Blueprint](https://community.home-assistant.io/t/frigate-mobile-app-notifications/311091). You can use the yaml generated from the Blueprint as a starting point and customize from there.
+The best way to get started with notifications for Frigate is to use the [Blueprint](https://community.home-assistant.io/t/frigate-mobile-app-notifications-2-0/559732). You can use the yaml generated from the Blueprint as a starting point and customize from there.
 
 It is generally recommended to trigger notifications based on the `frigate/events` mqtt topic. This provides the event_id needed to fetch [thumbnails/snapshots/clips](../integrations/home-assistant.md#notification-api) and other useful information to customize when and where you want to receive alerts. The data is published in the form of a change feed, which means you can reference the "previous state" of the object in the `before` section and the "current state" of the object in the `after` section. You can see an example [here](../integrations/mqtt.md#frigateevents).
 


### PR DESCRIPTION
When home assistant made the default values change last year it broke the original blueprint when it looked for the camera fps as no default was coded. I've been maintaining a fixed version with new features in hunterjms absence. Yesterday the mods split the thread so this is the latest post and blueprint now.