### PR TITLE
Add docs for getting intel_gpu_top to work without privileged mode

### DIFF
--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -17,7 +17,7 @@ ffmpeg:
 
 ### Intel-based CPUs
 
-#### Intel-based CPUs (<10th Generation) via VAAPI
+#### Via VAAPI
 
 VAAPI supports automatic profile selection so it will work automatically with both H.264 and H.265 streams. VAAPI is recommended for all generations of Intel-based CPUs if QSV does not work.
 
@@ -28,7 +28,7 @@ ffmpeg:
 
 **NOTICE**: With some of the processors, like the J4125, the default driver `iHD` doesn't seem to work correctly for hardware acceleration. You may need to change the driver to `i965` by adding the following environment variable `LIBVA_DRIVER_NAME=i965` to your docker-compose file or [in the frigate.yml for HA OS users](advanced.md#environment_vars).
 
-#### Intel-based CPUs (>=10th Generation) via Quicksync
+####  Via Quicksync (>=10th Generation only)
 
 QSV must be set specifically based on the video encoding of the stream.
 
@@ -48,7 +48,10 @@ ffmpeg:
 
 #### Docker Configuration
 
-Additional configuration is needed for the Docker container to be able to access the `intel_gpu_top` command for GPU stats. Two possible changes need to be made: 1) Adding the `CAP_PERFMON` capability and 2) Setting the `perf_event_paranoid` low enough to allow access to the perfomance event system.
+Additional configuration is needed for the Docker container to be able to access the `intel_gpu_top` command for GPU stats. Three possible changes can be made:
+1. Run the container as privileged.
+2. Adding the `CAP_PERFMON` capability.
+3. Setting the `perf_event_paranoid` low enough to allow access to the perfomance event system.
 
 ##### CAP_PERFMON
 

--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -46,7 +46,7 @@ ffmpeg:
   hwaccel_args: preset-intel-qsv-h265
 ```
 
-#### Docker Configuration - intel_gpu_top
+#### Configuring Intel GPU Stats in Docker
 
 Additional configuration is needed for the Docker container to be able to access the `intel_gpu_top` command for GPU stats. Three possible changes can be made:
 
@@ -130,7 +130,7 @@ A more complete list of cards and their compatible drivers is available in the [
 
 If your distribution does not offer NVIDIA driver packages, you can [download them here](https://www.nvidia.com/en-us/drivers/unix/).
 
-#### Docker Configuration - Nvidia GPU
+#### Configuring Nvidia GPUs in Docker
 
 Additional configuration is needed for the Docker container to be able to access the NVIDIA GPU. The supported method for this is to install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker) and specify the GPU to Docker. How you do this depends on how Docker is being run:
 


### PR DESCRIPTION
This is similar to #5801. I was able to get `intel_gpu_top` to work on my dockerized install without requiring `--privileged`.

I'll admit, I'm not great at writing docs, but I wanted to let people know this was possible.