### PR TITLE
Edit dsize order

### DIFF
--- a/frigate/video.py
+++ b/frigate/video.py
@@ -104,7 +104,7 @@ def create_tensor_input(frame, model_config, region):
     if cropped_frame.shape != (model_config.height, model_config.width, 3):
         cropped_frame = cv2.resize(
             cropped_frame,
-            dsize=(model_config.height, model_config.width),
+            dsize=(model_config.width, model_config.height),
             interpolation=cv2.INTER_LINEAR,
         )
 


### PR DESCRIPTION
I found it would raise error if the width and height of model are different.

The dsize is opposite.
<pre>
2023-04-20 08:50:25.333558278  Traceback (most recent call last):                                                                                                                     [19/1834]2023-04-20 08:50:25.333599259    File "/usr/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
2023-04-20 08:50:25.333600541      self.run()
2023-04-20 08:50:25.333610069    File "/usr/lib/python3.9/multiprocessing/process.py", line 108, in run
2023-04-20 08:50:25.333611196      self._target(*self._args, **self._kwargs)
2023-04-20 08:50:25.333623317    File "/opt/frigate/frigate/video.py", line 479, in track_camera
2023-04-20 08:50:25.333624200      process_frames(
2023-04-20 08:50:25.333634196    File "/opt/frigate/frigate/video.py", line 723, in process_frames
2023-04-20 08:50:25.333635026      detect(
2023-04-20 08:50:25.333645250    File "/opt/frigate/frigate/video.py", line 545, in detect
2023-04-20 08:50:25.333646195      region_detections = object_detector.detect(tensor_input)
2023-04-20 08:50:25.333656037    File "/opt/frigate/frigate/object_detection.py", line 208, in detect
2023-04-20 08:50:25.333657028      self.np_shm[:] = tensor_input[:]
2023-04-20 08:50:25.333676033  ValueError: could not broadcast input array from shape (1,288,512,3) into shape (1,512,288,3)
</pre>


[Reszie](https://docs.opencv.org/3.4/da/d54/group__imgproc__transform.html#ga47a974309e9102f5f08231edc7e7529d)