### PR TITLE
Use browser timezone if not specified in config

### DIFF
--- a/web/src/utils/dateUtil.ts
+++ b/web/src/utils/dateUtil.ts
@@ -56,7 +56,7 @@ export const formatUnixTimestampToDateTime = (unixTimestamp: number, config: Dat
 
     // use strftime_fmt if defined in config file
     if (strftime_fmt) {
-      const strftime_locale = strftime.timezone(getUTCOffset(date, timezone)).localizeByIdentifier(locale);
+      const strftime_locale = strftime.timezone(getUTCOffset(date, timezone || Intl.DateTimeFormat().resolvedOptions().timeZone)).localizeByIdentifier(locale);
       return strftime_locale(strftime_fmt, date);
     }
 


### PR DESCRIPTION
This fixes the bug where "strftime_fmt" is specified but timezone is omitted from the config. If timezone is missing from the config, we should use the browser timezone.

Related issues: https://github.com/blakeblackshear/frigate/discussions/5621 and https://github.com/blakeblackshear/frigate/issues/5928