### PR TITLE
Show other system processes in system page

### DIFF
--- a/frigate/util.py
+++ b/frigate/util.py
@@ -824,7 +824,14 @@ def get_cpu_stats() -> dict[str, dict]:
                 else:
                     mem_pct = stats[9]
 
-                usages[stats[0]] = {
+                idx = stats[0]
+
+                if stats[-1] == "go2rtc":
+                    idx = "go2rtc"
+                elif stats[-1] == "frigate.r+":
+                    idx = "recording"
+
+                usages[idx] = {
                     "cpu": stats[8],
                     "mem": mem_pct,
                 }

--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -345,6 +345,33 @@ export default function System() {
             </div>
           )}
 
+          <Heading size="lg">Other Processes</Heading>
+          <div data-testid="cameras" className="grid grid-cols-1 3xl:grid-cols-3 md:grid-cols-2 gap-4">
+            {['go2rtc', 'recording'].map((process) => (
+              <div key={process} className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow">
+                <div className="capitalize text-lg flex justify-between p-4">
+                  <div className="text-lg flex justify-between">{process}</div>
+                </div>
+                <div className="p-2">
+                  <Table className="w-full">
+                    <Thead>
+                      <Tr>
+                        <Th>CPU %</Th>
+                        <Th>Memory %</Th>
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      <Tr key="ffmpeg" index="0">
+                        <Td>{cpu_usages[process]?.['cpu'] || '- '}%</Td>
+                        <Td>{cpu_usages[process]?.['mem'] || '- '}%</Td>
+                      </Tr>
+                    </Tbody>
+                  </Table>
+                </div>
+              </div>
+            ))}
+          </div>
+
           <p>System stats update automatically every {config.mqtt.stats_interval} seconds.</p>
         </Fragment>
       )}


### PR DESCRIPTION
Here is a screenshot of what it looks like:

<img width="1239" alt="Screenshot 2023-04-26 at 7 33 28 PM" src="https://user-images.githubusercontent.com/14866235/234737365-651be123-5d58-487a-b64b-ab9dce36cfd6.png">

I couldn't think of a clean way to get the recording process PID and the name is consistent across installs running frigate so I think it works as is, but certainly open to better ideas