### PR TITLE
Update libyolo_layer.so path for HA compatibility

### DIFF
--- a/frigate/detectors/plugins/tensorrt.py
+++ b/frigate/detectors/plugins/tensorrt.py
@@ -77,7 +77,7 @@ class TensorRtDetector(DetectionApi):
         try:
             trt.init_libnvinfer_plugins(self.trt_logger, "")
 
-            ctypes.cdll.LoadLibrary("/trt-models/libyolo_layer.so")
+            ctypes.cdll.LoadLibrary("/config/trt-models/libyolo_layer.so")
         except OSError as e:
             logger.error(
                 "ERROR: failed to load libraries. %s",


### PR DESCRIPTION
Frigate HA add-on map  /usr/share/hassio/homeassistant  to /config in the container By compying trt-models folder into homeassistant folder, libyolo_layer.so can be accessed by the plugin "out of the box" throught /config/trt-models

Better for homeassistant compatibility.