### PR TITLE
Do not show the loader during recordings api call

### DIFF
--- a/web/src/routes/Recording.jsx
+++ b/web/src/routes/Recording.jsx
@@ -30,7 +30,7 @@ export default function Recording({ camera, date, hour = '00', minute = '00', se
   // calculates the seek seconds by adding up all the seconds in the segments prior to the playback time
   const seekSeconds = useMemo(() => {
     if (!recordings) {
-      return 0;
+      return undefined;
     }
     const currentUnix = getUnixTime(currentDate);
 
@@ -103,6 +103,9 @@ export default function Recording({ camera, date, hour = '00', minute = '00', se
   }, [playlistIndex]);
 
   useEffect(() => {
+    if (seekSeconds === undefined) {
+      return;
+    }
     if (this.player) {
       // if the playlist has moved on to the next item, then reset
       if (this.player.playlist.currentItem() !== playlistIndex) {
@@ -145,7 +148,9 @@ export default function Recording({ camera, date, hour = '00', minute = '00', se
             player.playlist(playlist);
             player.playlist.autoadvance(0);
             player.playlist.currentItem(playlistIndex);
-            player.currentTime(seekSeconds);
+            if (seekSeconds !== undefined)  {
+              player.currentTime(seekSeconds);
+            }
             this.player = player;
           }
         }}

--- a/web/src/routes/Recording.jsx
+++ b/web/src/routes/Recording.jsx
@@ -114,7 +114,7 @@ export default function Recording({ camera, date, hour = '00', minute = '00', se
     }
   }, [seekSeconds, playlistIndex]);
 
-  if (!recordingsSummary || !recordings || !config) {
+  if (!recordingsSummary || !config) {
     return <ActivityIndicator />;
   }
 


### PR DESCRIPTION
Showing the loader during the recordings API call will rerender the recordings list and rerenders the video player. This means recordings list jumps back to top and I have to scroll back down, and video player has to be also restarted and the playback speed is back to 1x. This happens every time an event from a different hour is selected.

Not showing the loader during the recordings API call improves ux

Before change:
[Frigate-before.webm](https://user-images.githubusercontent.com/2674369/235769661-269e651a-d285-4add-98fc-7ac5133605eb.webm)

After change:
[Frigate-after.webm](https://user-images.githubusercontent.com/2674369/235769668-df8a72a9-b97c-42a7-83ea-2c41602a80e6.webm)
