### PR TITLE
Add Go2RTC Version to System Dashboard

### DIFF
--- a/docker/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/rootfs/usr/local/nginx/conf/nginx.conf
@@ -204,6 +204,15 @@ http {
             proxy_set_header Host $host;
         }
 
+        location ~* /api/go2rtc([/]?.*)$ {
+            proxy_pass http://go2rtc;
+            rewrite ^/api/go2rtc(.*)$ /api$1 break;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $host;
+        }
+
         location ~* /api/.*\.(jpg|jpeg|png)$ {
             add_header 'Access-Control-Allow-Origin' '*';
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';

--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -39,6 +39,8 @@ export default function System() {
   const cameraNames = Object.keys(cameras || emptyObject);
   const processesNames = Object.keys(processes || emptyObject);
 
+  const { data: go2rtc } = useSWR('go2rtc');
+
   const onHandleFfprobe = async (camera, e) => {
     if (e) {
       e.stopPropagation();
@@ -93,14 +95,16 @@ export default function System() {
           System <span className="text-sm">{service.version}</span>
         </Heading>
         {config && (
-          <Link
-            className="p-1 text-blue-500 hover:underline"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="/live/webrtc/"
-          >
-            go2rtc dashboard
-          </Link>
+          <span class="p-1">go2rtc {go2rtc && ( `${go2rtc.version} ` ) }
+            <Link
+              className="text-blue-500 hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="/live/webrtc/"
+            >
+              dashboard
+            </Link>
+          </span>
         )}
       </div>
 


### PR DESCRIPTION
This pull request integrate the Go2RTC version information into the System dashboard. It adds a new location block in the Nginx configuration for the Go2RTC API and fetches the Go2RTC version within the System component, displaying it next to the existing Frigate system version

<img width="1411" alt="image" src="https://user-images.githubusercontent.com/15078499/236361578-7b852e40-c790-4680-bd6a-3dce3d5f5569.png">
