### PR TITLE
Add VAAPI MJPEG stream preset and update FFmpeg command for hardware acceleration

### DIFF
--- a/docs/docs/configuration/ffmpeg_presets.md
+++ b/docs/docs/configuration/ffmpeg_presets.md
@@ -16,6 +16,7 @@ See [the hwaccel docs](/configuration/hardware_acceleration.md) for more info on
 | preset-rpi-32-h264    | 32 bit Rpi with h264 stream  |                                                       |
 | preset-rpi-64-h264    | 64 bit Rpi with h264 stream  |                                                       |
 | preset-vaapi          | Intel & AMD VAAPI            | Check hwaccel docs to ensure correct driver is chosen |
+| preset-vaapi-jpeg     | VAAPI mjpeg stream           | Check hwaccel docs to ensure correct driver is chosen |
 | preset-intel-qsv-h264 | Intel QSV with h264 stream   | If issues occur recommend using vaapi preset instead  |
 | preset-intel-qsv-h265 | Intel QSV with h265 stream   | If issues occur recommend using vaapi preset instead  |
 | preset-nvidia-h264    | Nvidia GPU with h264 stream  |                                                       |

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -65,6 +65,16 @@ PRESETS_HW_ACCEL_DECODE = {
         "-hwaccel_output_format",
         "vaapi",
     ],
+    "preset-vaapi-jpeg": [
+        "-hwaccel_flags",
+        "allow_profile_mismatch",
+        "-hwaccel",
+        "vaapi",
+        "-hwaccel_device",
+        _gpu_selector.get_selected_gpu(),
+        "-hwaccel_output_format",
+        "vaapi",
+    ],
     "preset-intel-qsv-h264": [
         "-hwaccel",
         "qsv",
@@ -122,10 +132,11 @@ PRESETS_HW_ACCEL_ENCODE = {
     "preset-rpi-32-h264": "ffmpeg -hide_banner {0} -c:v h264_v4l2m2m {1}",
     "preset-rpi-64-h264": "ffmpeg -hide_banner {0} -c:v h264_v4l2m2m {1}",
     "preset-vaapi": "ffmpeg -hide_banner -hwaccel vaapi -hwaccel_output_format vaapi -hwaccel_device {2} {0} -c:v h264_vaapi -g 50 -bf 0 -profile:v high -level:v 4.1 -sei:v 0 -an -vf format=vaapi|nv12,hwupload {1}",
+    "preset-vaapi-jpeg": "ffmpeg -hide_banner -hwaccel vaapi -hwaccel_output_format vaapi -hwaccel_device {2} {0} -c:v mjpeg_vaapi -g 50 -bf 0 -profile:v high -level:v 4.1 -sei:v 0 -an -vf format=vaapi|nv12,hwupload {1}",
     "preset-intel-qsv-h264": "ffmpeg -hide_banner {0} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {1}",
-    "preset-intel-qsv-h265": "ffmpeg -hide_banner {0} -c:v h264_qsv -g 50 -bf 0 -profile:v high -level:v 4.1 -async_depth:v 1 {1}",
+    "preset-intel-qsv-h265": "ffmpeg -hide_banner {0} -c:v hevc_qsv -g 50 -bf 0 -profile:v main -level:v 4.1 -async_depth:v 1 {1}",
     "preset-nvidia-h264": "ffmpeg -hide_banner {0} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {1}",
-    "preset-nvidia-h265": "ffmpeg -hide_banner {0} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {1}",
+    "preset-nvidia-h265": "ffmpeg -hide_banner {0} -c:v hevc_nvenc -g 50 -profile:v main -level:v auto -preset:v p2 -tune:v ll {1}",
     "default": "ffmpeg -hide_banner {0} -c:v libx264 -g 50 -profile:v high -level:v 4.1 -preset:v superfast -tune:v zerolatency {1}",
 }
 


### PR DESCRIPTION
This pull request introduces a new VAAPI MJPEG stream preset, allowing for hardware acceleration decoding with VAAPI support. Additionally, it updates the corresponding FFmpeg commands for Intel QSV and Nvidia h265 hardware acceleration. This enhancement optimizes performance and reduces CPU usage for supported devices.

These changes require tests on the appropriate equipment. Unfortunately, I don't have all possible hardwares for complex testing