### PR TITLE
Dynamic Image Size Support for DeepStack Detector

### DIFF
--- a/frigate/detectors/plugins/deepstack.py
+++ b/frigate/detectors/plugins/deepstack.py
@@ -33,9 +33,6 @@ class DeepStack(DetectionApi):
         self.api_key = detector_config.api_key
         self.labels = detector_config.model.merged_labelmap
 
-        self.h = detector_config.model.height
-        self.w = detector_config.model.width
-
     def get_label_index(self, label_value):
         if label_value.lower() == "truck":
             label_value = "car"
@@ -47,6 +44,7 @@ class DeepStack(DetectionApi):
     def detect_raw(self, tensor_input):
         image_data = np.squeeze(tensor_input).astype(np.uint8)
         image = Image.fromarray(image_data)
+        self.w, self.h = image.size
         with io.BytesIO() as output:
             image.save(output, format="JPEG")
             image_bytes = output.getvalue()


### PR DESCRIPTION
This pull request updates the DeepStack detector implementation by dynamically setting the width and height of the input image, instead of using fixed values. This change enhances the detector's inference speed up to 1.3-1.7x 