### PR TITLE
Prevent recordings from being turned on if disabled in config

### DIFF
--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -182,7 +182,7 @@ class Dispatcher:
         if payload == "ON":
             if not self.config.cameras[camera_name].record.enabled_in_config:
                 logger.error(
-                    f"Recordings are not enabled in the config, they can not be enabled after startup."
+                    f"Recordings must be enabled in the config to be turned on via MQTT."
                 )
                 return
 

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -186,7 +186,6 @@ class Dispatcher:
                 )
                 return
 
-
             if not record_settings.enabled:
                 logger.info(f"Turning on recordings for {camera_name}")
                 record_settings.enabled = True

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -180,7 +180,17 @@ class Dispatcher:
         record_settings = self.config.cameras[camera_name].record
 
         if payload == "ON":
+<<<<<<< Updated upstream
             if not record_settings.enabled:
+=======
+            if not self.config.cameras[camera_name].record.enabled_in_config:
+                logger.error(
+                    f"Recordings are not enabled in the config, they can not be enabled after startup."
+                )
+                return
+
+            if not self.record_metrics[camera_name]["record_enabled"].value:
+>>>>>>> Stashed changes
                 logger.info(f"Turning on recordings for {camera_name}")
                 record_settings.enabled = True
         elif payload == "OFF":

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -180,17 +180,14 @@ class Dispatcher:
         record_settings = self.config.cameras[camera_name].record
 
         if payload == "ON":
-<<<<<<< Updated upstream
-            if not record_settings.enabled:
-=======
             if not self.config.cameras[camera_name].record.enabled_in_config:
                 logger.error(
                     f"Recordings are not enabled in the config, they can not be enabled after startup."
                 )
                 return
 
-            if not self.record_metrics[camera_name]["record_enabled"].value:
->>>>>>> Stashed changes
+
+            if not record_settings.enabled:
                 logger.info(f"Turning on recordings for {camera_name}")
                 record_settings.enabled = True
         elif payload == "OFF":

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -172,6 +172,9 @@ class RecordConfig(FrigateBaseModel):
     events: EventsConfig = Field(
         default_factory=EventsConfig, title="Event specific settings."
     )
+    enabled_in_config: Optional[bool] = Field(
+        title="Keep track of original state of recording."
+    )
 
 
 class MotionConfig(FrigateBaseModel):
@@ -952,6 +955,21 @@ class FrigateConfig(FrigateBaseModel):
             for input in camera_config.ffmpeg.inputs:
                 input.path = input.path.format(**FRIGATE_ENV_VARS)
 
+<<<<<<< Updated upstream
+=======
+            # ONVIF substitution
+            if camera_config.onvif.user or camera_config.onvif.password:
+                camera_config.onvif.user = camera_config.onvif.user.format(
+                    **FRIGATE_ENV_VARS
+                )
+                camera_config.onvif.password = camera_config.onvif.password.format(
+                    **FRIGATE_ENV_VARS
+                )
+
+            # set config recording value
+            camera_config.record.enabled_in_config = camera_config.record.enabled
+
+>>>>>>> Stashed changes
             # Add default filters
             object_keys = camera_config.objects.track
             if camera_config.objects.filters is None:

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -955,21 +955,9 @@ class FrigateConfig(FrigateBaseModel):
             for input in camera_config.ffmpeg.inputs:
                 input.path = input.path.format(**FRIGATE_ENV_VARS)
 
-<<<<<<< Updated upstream
-=======
-            # ONVIF substitution
-            if camera_config.onvif.user or camera_config.onvif.password:
-                camera_config.onvif.user = camera_config.onvif.user.format(
-                    **FRIGATE_ENV_VARS
-                )
-                camera_config.onvif.password = camera_config.onvif.password.format(
-                    **FRIGATE_ENV_VARS
-                )
-
             # set config recording value
             camera_config.record.enabled_in_config = camera_config.record.enabled
 
->>>>>>> Stashed changes
             # Add default filters
             object_keys = camera_config.objects.track
             if camera_config.objects.filters is None:

--- a/web/__test__/handlers.js
+++ b/web/__test__/handlers.js
@@ -16,7 +16,7 @@ export const handlers = [
           front: {
             name: 'front',
             objects: { track: ['taco', 'cat', 'dog'] },
-            record: { enabled: true },
+            record: { enabled: true, enabled_in_config: true },
             detect: { width: 1280, height: 720 },
             snapshots: {},
             restream: { enabled: true, jsmpeg: { height: 720 } },
@@ -25,7 +25,7 @@ export const handlers = [
           side: {
             name: 'side',
             objects: { track: ['taco', 'cat', 'dog'] },
-            record: { enabled: false },
+            record: { enabled: false, enabled_in_config: true },
             detect: { width: 1280, height: 720 },
             snapshots: {},
             restream: { enabled: true, jsmpeg: { height: 720 } },

--- a/web/src/routes/Cameras.jsx
+++ b/web/src/routes/Cameras.jsx
@@ -65,7 +65,7 @@ function Camera({ name, config }) {
         },
       },
       {
-        name: config.record.enabled_in_config ? `Toggle recordings ${recordValue === 'ON' ? 'off' : 'on'}` : 'Recordings can not be enabled, please enable in config.',
+        name: config.record.enabled_in_config ? `Toggle recordings ${recordValue === 'ON' ? 'off' : 'on'}` : 'Recordings must be enabled in the config to be turned on in the UI.',
         icon: ClipIcon,
         color: config.record.enabled_in_config ? (recordValue === 'ON' ? 'blue' : 'gray') : 'red',
         onClick: () => {

--- a/web/src/routes/Cameras.jsx
+++ b/web/src/routes/Cameras.jsx
@@ -16,12 +16,12 @@ export default function Cameras() {
     <ActivityIndicator />
   ) : (
     <div className="grid grid-cols-1 3xl:grid-cols-3 md:grid-cols-2 gap-4 p-2 px-4">
-      <SortedCameras unsortedCameras={config.cameras} />
+      <SortedCameras config={config} unsortedCameras={config.cameras} />
     </div>
   );
 }
 
-function SortedCameras({ unsortedCameras }) {
+function SortedCameras({ config, unsortedCameras }) {
   const sortedCameras = useMemo(
     () =>
       Object.entries(unsortedCameras)
@@ -33,13 +33,13 @@ function SortedCameras({ unsortedCameras }) {
   return (
     <Fragment>
       {sortedCameras.map(([camera, conf]) => (
-        <Camera key={camera} name={camera} conf={conf} />
+        <Camera key={camera} name={camera} config={config.cameras[camera]} conf={conf} />
       ))}
     </Fragment>
   );
 }
 
-function Camera({ name }) {
+function Camera({ name, config }) {
   const { payload: detectValue, send: sendDetect } = useDetectState(name);
   const { payload: recordValue, send: sendRecordings } = useRecordingsState(name);
   const { payload: snapshotValue, send: sendSnapshots } = useSnapshotsState(name);
@@ -65,11 +65,13 @@ function Camera({ name }) {
         },
       },
       {
-        name: `Toggle recordings ${recordValue === 'ON' ? 'off' : 'on'}`,
+        name: config.record.enabled_in_config ? `Toggle recordings ${recordValue === 'ON' ? 'off' : 'on'}` : 'Recordings can not be enabled, please enable in config.',
         icon: ClipIcon,
-        color: recordValue === 'ON' ? 'blue' : 'gray',
+        color: config.record.enabled_in_config ? (recordValue === 'ON' ? 'blue' : 'gray') : 'red',
         onClick: () => {
-          sendRecordings(recordValue === 'ON' ? 'OFF' : 'ON', true);
+          if (config.record.enabled_in_config) {
+            sendRecordings(recordValue === 'ON' ? 'OFF' : 'ON', true);
+          }
         },
       },
       {
@@ -81,7 +83,7 @@ function Camera({ name }) {
         },
       },
     ],
-    [detectValue, sendDetect, recordValue, sendRecordings, snapshotValue, sendSnapshots]
+    [config, detectValue, sendDetect, recordValue, sendRecordings, snapshotValue, sendSnapshots]
   );
 
   return (


### PR DESCRIPTION
Recordings must be enabled in the config for recordings to be created. If they are enabled in the UI after startup recordings will not be stored and this often confuses users. This change will make it impossible to enable recordings and will give logs and webUI messaging to make this more clear.

![Screen Shot 2023-05-14 at 12 34 24 PM](https://github.com/blakeblackshear/frigate/assets/14866235/b366e906-87a9-4466-9847-6fce4e461080)

