### PR TITLE
Bugfix: improve error handling in Deepstack detector

### DIFF
--- a/frigate/detectors/plugins/deepstack.py
+++ b/frigate/detectors/plugins/deepstack.py
@@ -56,8 +56,11 @@ class DeepStack(DetectionApi):
         )
         response_json = response.json()
         detections = np.zeros((20, 6), np.float32)
+        if response_json.get("predictions") is None:
+            logger.debug(f"Error in parsing response json: {response_json}")
+            return detections
 
-        for i, detection in enumerate(response_json["predictions"]):
+        for i, detection in enumerate(response_json.get("predictions")):
             logger.debug(f"Response: {detection}")
             if detection["confidence"] < 0.4:
                 logger.debug(f"Break due to confidence < 0.4")


### PR DESCRIPTION
Fix issue where the 'predictions' field might be missing in the response JSON. Previously, this cause an error during parsing and crash the detection process.