### PR TITLE
Serve actual docs on frigate host

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 README.md
-docs/
+docs/node_modules
+docs/build
 .gitignore
 debug
 config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,13 @@ WORKDIR /rootfs/usr/local/go2rtc/bin
 RUN wget -qO go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/v1.5.0/go2rtc_linux_${TARGETARCH}" \
     && chmod +x go2rtc
 
+FROM --platform=$BUILDPLATFORM node:16 AS docs-build
+ADD ./docs /docs
+ADD labelmap.txt /
+WORKDIR /docs
+RUN sed -i'' "s/baseUrl: '\/',/baseUrl: '\/docs\/',/" ./docusaurus.config.js
+RUN npm install
+RUN npm run build
 
 ####
 #
@@ -246,6 +253,7 @@ WORKDIR /opt/frigate/
 COPY frigate frigate/
 COPY migrations migrations/
 COPY --from=web-build /work/dist/ web/
+COPY --from=docs-build /docs/build/ web/docs/
 
 # Frigate final container
 FROM deps AS frigate

--- a/web/src/Sidebar.jsx
+++ b/web/src/Sidebar.jsx
@@ -6,6 +6,7 @@ import { ENV } from './env';
 import { useMemo } from 'preact/hooks'
 import useSWR from 'swr';
 import NavigationDrawer, { Destination, Separator } from './components/NavigationDrawer';
+import { baseUrl } from './api/baseUrl';
 
 export default function Sidebar() {
   const { data: config } = useSWR('config');
@@ -57,7 +58,7 @@ export default function Sidebar() {
           <Separator />
         </Fragment>
       ) : null}
-      <Destination className="self-end" href="https://docs.frigate.video" text="Documentation" />
+      <Destination className="self-end" href={baseUrl+"/docs"} text="Documentation" />
       <Destination className="self-end" href="https://github.com/blakeblackshear/frigate" text="GitHub" />
     </NavigationDrawer>
   );


### PR DESCRIPTION
...and update link to it in Sidebar.

Because it's make sense when the documentation corresponds to the current running build, not the last stable one