### PR TITLE
deepstack: pass api key in request

### DIFF
--- a/frigate/detectors/plugins/deepstack.py
+++ b/frigate/detectors/plugins/deepstack.py
@@ -50,7 +50,10 @@ class DeepStack(DetectionApi):
             image_bytes = output.getvalue()
         data = {"api_key": self.api_key}
         response = requests.post(
-            self.api_url, files={"image": image_bytes}, timeout=self.api_timeout
+            self.api_url,
+            data=data,
+            files={"image": image_bytes},
+            timeout=self.api_timeout,
         )
         response_json = response.json()
         detections = np.zeros((20, 6), np.float32)


### PR DESCRIPTION
The POST data was prepared, but not passed into the request call.

followup for #6143 
cc @skrashevich  

noticed in #6575 