### PR TITLE
Fix computations in `false_positives.md`

### DIFF
--- a/docs/docs/guides/false_positives.md
+++ b/docs/docs/guides/false_positives.md
@@ -11,13 +11,13 @@ Similarly, the `min_ratio` and `max_ratio` values are compared against a given d
 
 For object filters in your configuration, any single detection below `min_score` will be ignored as a false positive. `threshold` is based on the median of the history of scores (padded to 3 values) for a tracked object. Consider the following frames when `min_score` is set to 0.6 and threshold is set to 0.85:
 
-| Frame | Current Score | Score History                     | Computed Score | Detected Object |
-| ----- | ------------- | --------------------------------- | -------------- | --------------- |
-| 1     | 0.7           | 0.0, 0, 0.7                       | 0.0            | No              |
-| 2     | 0.55          | 0.0, 0.7, 0.0                     | 0.0            | No              |
-| 3     | 0.85          | 0.7, 0.0, 0.85                    | 0.7            | No              |
-| 4     | 0.90          | 0.7, 0.85, 0.95, 0.90             | 0.875          | Yes             |
-| 5     | 0.88          | 0.7, 0.85, 0.95, 0.90, 0.88       | 0.88           | Yes             |
-| 6     | 0.95          | 0.7, 0.85, 0.95, 0.90, 0.88, 0.95 | 0.89           | Yes             |
+| Frame | Current Score | Score History                      | Computed Score | Detected Object |
+| ----- | ------------- | -----------------------------------| -------------- | --------------- |
+| 1     | 0.70          | 0.70                               | 0.0            | No              |
+| 2     | 0.55          | 0.70, 0.00                         | 0.0            | No              |
+| 3     | 0.85          | 0.70, 0.00, 0.85                   | 0.7            | No              |
+| 4     | 0.90          | 0.70, 0.00, 0.85, 0.90             | 0.85           | Yes             |
+| 5     | 0.88          | 0.70, 0.00, 0.85, 0.90, 0.88       | 0.88           | Yes             |
+| 6     | 0.95          | 0.70, 0.00, 0.85, 0.90, 0.88, 0.95 | 0.90           | Yes             |
 
 In frame 2, the score is below the `min_score` value, so Frigate ignores it and it becomes a 0.0. The computed score is the median of the score history (padding to at least 3 values), and only when that computed score crosses the `threshold` is the object marked as a true positive. That happens in frame 4 in the example.


### PR DESCRIPTION
1. The `Score History` values seem to have the wrong values from `Current Score` 
2. Got rid of the initial 0.0 values for frames 1 and 2. If  Otherwise, I'd suggest something closer to NULL than a numeric value.  
3. Added two decimal values for visual homogeneity
4. Corrected the median for frame 4 (median of 0, .85, .9) and frame 6 (median of .9, .88, .95)