### PR TITLE
fix: don't assume build platform is amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -227,8 +227,8 @@ CMD ["sleep", "infinity"]
 
 
 # Frigate web build
-# force this to run on amd64 because QEMU is painfully slow
-FROM --platform=linux/amd64 node:16 AS web-build
+# This should be architecture agnostic, so speed up the build on multiarch by not using QEMU.
+FROM --platform=$BUILDPLATFORM node:16 AS web-build
 
 WORKDIR /work
 COPY web/package.json web/package-lock.json ./


### PR DESCRIPTION
Currently, the dockefile forces the web build to run on AMD64, assuming the build platform is AMD64. 

This isn't great when the build platform actually is ARM64. This patch changes the Dockerfile to use the $BUILDPLATFORM variable so that the actual build platform is selected instead.