### PR TITLE
Add more generalised tags to GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           target: frigate
           tags: |
             ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}
+            ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Build and push TensorRT
@@ -64,4 +65,5 @@ jobs:
           target: frigate-tensorrt
           tags: |
             ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt
+            ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ github.ref_name }}-tensorrt
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
   multi_arch_build:
     runs-on: ubuntu-latest
     name: Image Build
-    permissions:
-      packages: write
     steps:
       - name: Remove unnecessary files
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
   multi_arch_build:
     runs-on: ubuntu-latest
     name: Image Build
+    permissions:
+      packages: write
     steps:
       - name: Remove unnecessary files
         run: |


### PR DESCRIPTION
Hi,

This PR adds `dev` and `dev-tensorrt` tags to the packages built by the CI workflow for those people who like to live on the bleeding edge, and so they don't have to check the repo for the latest tag every time they want to update.

Commit 9f259d88997fd66b059b02b49e1fe01fe0276d8e was just so I could test it on my own fork, I could remove it if needed.

Thanks,
Steve