### PR TITLE
Birdseye Autolayout

### DIFF
--- a/frigate/output.py
+++ b/frigate/output.py
@@ -249,6 +249,8 @@ class BirdsEyeFrameManager:
                 return
             channel_dims = self.cameras[camera]["channel_dims"]
 
+        logger.error(f"Copy to yuv {position}")
+
         copy_yuv_to_position(
             self.frame,
             [position[1], position[0]],
@@ -274,14 +276,13 @@ class BirdsEyeFrameManager:
             camera_layout: list[list[any]] = []
             camera_layout.append([])
             x = 0
-            x_i = 0
             y = 0
             y_i = 0
             max_height = 0
             for camera in cameras_to_add:
                 detect_config = self.config.cameras[camera].detect
 
-                if self.config.cameras[camera].detect.width * coefficient <= canvas[0]:
+                if (x + self.config.cameras[camera].detect.width * coefficient) <= canvas[0]:
                     # insert if camera can fit on current row
                     camera_layout[y_i].append(
                         (
@@ -297,7 +298,6 @@ class BirdsEyeFrameManager:
                     y_i += 1
                     camera_layout.append([])
                     x = 0
-                    x_i = 0
                     camera_layout[y_i].append(
                         (
                             camera,
@@ -390,8 +390,8 @@ class BirdsEyeFrameManager:
             reverse=True,
         )
 
-        canvas_width = self.frame_shape[1]
-        canvas_height = self.frame_shape[0]
+        canvas_width = self.config.birdseye.width
+        canvas_height = self.config.birdseye.height
         coefficient = 1
 
         layout_candidate, total_height = calculate_layout(
@@ -400,7 +400,7 @@ class BirdsEyeFrameManager:
 
         if total_height > canvas_height:
             coefficient = canvas_height / total_height
-            layout_candidate = calculate_layout(
+            layout_candidate, total_height = calculate_layout(
                 (canvas_width, canvas_height), active_cameras_to_add, coefficient
             )
 
@@ -408,6 +408,7 @@ class BirdsEyeFrameManager:
 
         for row in self.camera_layout:
             for position in row:
+                logger.error(f"Position is {position}")
                 self.copy_to_position(
                     position[1], position[0], self.cameras[position[0]]["current_frame"]
                 )

--- a/frigate/output.py
+++ b/frigate/output.py
@@ -211,7 +211,7 @@ class BirdsEyeFrameManager:
                 ),
             )
             self.cameras[camera] = {
-                "dimensions": (settings.detect.width, settings.detect.height),
+                "dimensions": [settings.detect.width, settings.detect.height],
                 "last_active_frame": 0.0,
                 "current_frame": 0.0,
                 "layout_frame": 0.0,
@@ -276,12 +276,21 @@ class BirdsEyeFrameManager:
             """Calculate the optimal layout for cameras."""
             camera_layout: list[list[any]] = []
             camera_layout.append([])
+            canvas_aspect = canvas[0] / canvas[1]
             x = 0
             y = 0
             y_i = 0
             max_height = 0
             for camera in cameras_to_add:
-                if (x + self.cameras[camera]["settings"][0] * coefficient) <= canvas[0]:
+                camera_dims = self.cameras[camera]["dimensions"]
+                camera_aspect = camera_dims[0] / camera_dims[1]
+
+                # if the camera aspect ratio is less than canvas aspect ratio, it needs to be scaled down to fit
+                if camera_aspect < canvas_aspect:
+                    camera_dims[0] *= camera_aspect / canvas_aspect
+                    camera_dims[1] *= camera_aspect / canvas_aspect
+
+                if (x + camera_dims[0] * coefficient) <= canvas[0]:
                     # insert if camera can fit on current row
                     camera_layout[y_i].append(
                         (
@@ -289,15 +298,15 @@ class BirdsEyeFrameManager:
                             (
                                 x,
                                 y,
-                                int(self.cameras[camera]["settings"][0] * coefficient),
-                                int(self.cameras[camera]["settings"][1] * coefficient),
+                                int(camera_dims[0] * coefficient),
+                                int(camera_dims[1] * coefficient),
                             ),
                         )
                     )
-                    x += int(self.cameras[camera]["settings"][0] * coefficient)
+                    x += int(camera_dims[0] * coefficient)
                     max_height = max(
                         max_height,
-                        int(self.cameras[camera]["settings"][1] * coefficient),
+                        int(camera_dims[1] * coefficient),
                     )
                 else:
                     # move on to the next row and insert
@@ -311,12 +320,12 @@ class BirdsEyeFrameManager:
                             (
                                 x,
                                 y,
-                                int(self.cameras[camera]["settings"][0] * coefficient),
-                                int(self.cameras[camera]["settings"][1] * coefficient),
+                                int(camera_dims[0] * coefficient),
+                                int(camera_dims[1] * coefficient),
                             ),
                         )
                     )
-                    x += int(self.cameras[camera]["settings"][0] * coefficient)
+                    x += int(camera_dims[0] * coefficient)
 
             return (camera_layout, y + max_height)
 

--- a/frigate/output.py
+++ b/frigate/output.py
@@ -1,7 +1,6 @@
 import datetime
 import glob
 import logging
-import math
 import multiprocessing as mp
 import os
 import queue

--- a/frigate/output.py
+++ b/frigate/output.py
@@ -282,7 +282,7 @@ class BirdsEyeFrameManager:
             y_i = 0
             max_height = 0
             for camera in cameras_to_add:
-                camera_dims = self.cameras[camera]["dimensions"]
+                camera_dims = self.cameras[camera]["dimensions"].copy()
                 camera_aspect = camera_dims[0] / camera_dims[1]
 
                 # if the camera aspect ratio is less than canvas aspect ratio, it needs to be scaled down to fit

--- a/frigate/output.py
+++ b/frigate/output.py
@@ -433,10 +433,12 @@ class BirdsEyeFrameManager:
                         coefficient,
                     )
 
-                    if total_height <= canvas_height:
+                    if (canvas_height * 0.9) < total_height <= canvas_height:
                         break
-
-                    coefficient -= 0.1
+                    elif total_height < canvas_height * 0.8:
+                        coefficient += 0.1
+                    else:
+                        coefficient -= 0.1
 
                 self.camera_layout = layout_candidate
 

--- a/frigate/output.py
+++ b/frigate/output.py
@@ -7,7 +7,6 @@ import queue
 import signal
 import subprocess as sp
 import threading
-import traceback
 from wsgiref.simple_server import make_server
 
 import cv2
@@ -523,23 +522,19 @@ def output_frames(config: FrigateConfig, video_output_queue):
                 for ws in websocket_server.manager
             )
         ):
-            try:
-                if birdseye_manager.update(
-                    camera,
-                    len([o for o in current_tracked_objects if not o["stationary"]]),
-                    len(motion_boxes),
-                    frame_time,
-                    frame,
-                ):
-                    frame_bytes = birdseye_manager.frame.tobytes()
+            if birdseye_manager.update(
+                camera,
+                len([o for o in current_tracked_objects if not o["stationary"]]),
+                len(motion_boxes),
+                frame_time,
+                frame,
+            ):
+                frame_bytes = birdseye_manager.frame.tobytes()
 
-                    if config.birdseye.restream:
-                        birdseye_buffer[:] = frame_bytes
+                if config.birdseye.restream:
+                    birdseye_buffer[:] = frame_bytes
 
-                    converters["birdseye"].write(frame_bytes)
-            except Exception as e:
-                logger.error(f"Crash happened :: {e}")
-                logger.error(traceback.format_exc())
+                converters["birdseye"].write(frame_bytes)
 
         if camera in previous_frames:
             frame_manager.delete(f"{camera}{previous_frames[camera]}")


### PR DESCRIPTION
This PR works to attempt to fill in the full birdseye canvas with camera as opposed to the grid layout. This is especially useful for cameras like my hikvision panoramic which essentially takes up the same space as 2 16:9 cameras. There are a few behavior changes relative to the previous implementation:

- the birdseye aspect ratio matters, this should match the aspect ratio of the majority of your cameras so they fit nicely into the layout
- the birdseye resolution matters, the auto layout implementation will attempt to put all cameras in based on their native detect resolution and then scale down if there is not enough height available. 
- the order of the cameras matters and can be customized to better fit what is optimal

![Screen Shot 2023-06-07 at 10 45 34 AM](https://github.com/blakeblackshear/frigate/assets/14866235/f809907b-d654-44ca-a27b-967be903d084)
