### PR TITLE
Add enabling/disabling camera capture via MQTT

### DIFF
--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -112,6 +112,14 @@ Topic to turn recordings for a camera on and off. Expected values are `ON` and `
 
 Topic with current state of recordings for a camera. Published values are `ON` and `OFF`.
 
+### `frigate/<camera_name>/capture/set`
+
+Topic to turn capture for a camera on and off. Expected values are `ON` and `OFF`.
+
+### `frigate/<camera_name>/capture/state`
+
+Topic with current state of capture for a camera. Published values are `ON` and `OFF`.
+
 ### `frigate/<camera_name>/snapshots/set`
 
 Topic to turn snapshots for a camera on and off. Expected values are `ON` and `OFF`.

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -109,6 +109,9 @@ class FrigateApp:
                 "camera_fps": mp.Value("d", 0.0),
                 "skipped_fps": mp.Value("d", 0.0),
                 "process_fps": mp.Value("d", 0.0),
+                "capture_enabled": mp.Value(
+                    "i", self.config.cameras[camera_name].capture_enabled
+                ),
                 "detection_enabled": mp.Value(
                     "i", self.config.cameras[camera_name].detect.enabled
                 ),

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -103,10 +103,11 @@ class Dispatcher:
         # Send SIGUSR1 to resume, SIGUSR2 to pause
         new_state = True if payload == "ON" else False if payload == "OFF" else None
         if new_state is not None:
-            sig = signal.SIGUSR1 if new_state else signal.SIGUSR2
             self.config.cameras[camera_name].capture_enabled = new_state
-            os.kill(capture_proc.pid, sig)
             self.publish(f"{camera_name}/capture/state", payload, retain=True)
+            if capture_proc and capture_proc.pid:
+                sig = signal.SIGUSR1 if new_state else signal.SIGUSR2
+                os.kill(capture_proc.pid, sig)
 
     def _on_detect_command(self, camera_name: str, payload: str) -> None:
         """Callback for detect topic."""

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -98,14 +98,14 @@ class Dispatcher:
     def _on_capture_command(self, camera_name: str, payload: str) -> None:
         """Callback for detect topic."""
         logger.info(f"Received capture command [{payload}] for [{camera_name}]")
-        capture_proc = self.camera_metrics[camera_name]['capture_process']
+        capture_proc = self.camera_metrics[camera_name]["capture_process"]
 
         # Send SIGUSR1 to resume, SIGUSR2 to pause
         new_state = True if payload == "ON" else False if payload == "OFF" else None
         if new_state is not None:
             sig = signal.SIGUSR1 if new_state else signal.SIGUSR2
             self.config.cameras[camera_name].capture_enabled = new_state
-            os.kill( capture_proc.pid, sig )
+            os.kill(capture_proc.pid, sig)
             self.publish(f"{camera_name}/capture/state", payload, retain=True)
 
     def _on_detect_command(self, camera_name: str, payload: str) -> None:

--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -61,7 +61,7 @@ class MqttClient(Communicator):  # type: ignore[misc]
             )
             self.publish(
                 f"{camera_name}/capture/state",
-                "ON",
+                "ON" if camera.capture_enabled else "OFF",
                 retain=True,
             )
             self.publish(

--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -60,6 +60,11 @@ class MqttClient(Communicator):  # type: ignore[misc]
                 retain=True,
             )
             self.publish(
+                f"{camera_name}/capture/state",
+                "ON",
+                retain=True,
+            )
+            self.publish(
                 f"{camera_name}/improve_contrast/state",
                 "ON" if camera.motion.improve_contrast else "OFF",  # type: ignore[union-attr]
                 retain=True,
@@ -141,6 +146,7 @@ class MqttClient(Communicator):  # type: ignore[misc]
 
         # register callbacks
         callback_types = [
+            "capture",
             "recordings",
             "snapshots",
             "detect",

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -580,6 +580,7 @@ class CameraUiConfig(FrigateBaseModel):
 class CameraConfig(FrigateBaseModel):
     name: Optional[str] = Field(title="Camera name.", regex=REGEX_CAMERA_NAME)
     enabled: bool = Field(default=True, title="Enable camera.")
+    capture_enabled: bool = Field(default=True, title="Capture enabled.")
     ffmpeg: CameraFfmpegConfig = Field(title="FFmpeg configuration for the camera.")
     best_image_timeout: int = Field(
         default=60,

--- a/frigate/types.py
+++ b/frigate/types.py
@@ -8,6 +8,7 @@ from frigate.object_detection import ObjectDetectProcess
 
 class CameraMetricsTypes(TypedDict):
     camera_fps: Synchronized
+    capture_enabled: Synchronized
     capture_process: Optional[Process]
     detection_enabled: Synchronized
     detection_fps: Synchronized

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -636,7 +636,10 @@ def restart_frigate():
     else:
         os.kill(os.getpid(), signal.SIGTERM)
 
-def terminate_process(proc: sp.Popen, logger_inst: logging.Logger = None, timeout: float = 30.0):
+
+def terminate_process(
+    proc: sp.Popen, logger_inst: logging.Logger = None, timeout: float = 30.0
+):
     logger_inst = logger_inst or logger
     if proc is not None and proc.poll() == None:
         proc_name: str = proc.args[0]
@@ -649,7 +652,6 @@ def terminate_process(proc: sp.Popen, logger_inst: logging.Logger = None, timeou
             logger_inst.info(f"{proc_name}didn't exit. Force killing...")
             proc.kill()
             proc.communicate()
-
 
 
 class EventsPerSecond:

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -641,7 +641,7 @@ def terminate_process(
     proc: sp.Popen, logger_inst: logging.Logger = None, timeout: float = 30.0
 ):
     logger_inst = logger_inst or logger
-    if proc is not None and proc.poll() == None:
+    if proc is not None and proc.poll() is None:
         proc_name: str = proc.args[0]
         logger_inst.info(f"Terminating the existing {proc_name} process...")
         proc.terminate()

--- a/frigate/util.py
+++ b/frigate/util.py
@@ -636,6 +636,21 @@ def restart_frigate():
     else:
         os.kill(os.getpid(), signal.SIGTERM)
 
+def terminate_process(proc: sp.Popen, logger_inst: logging.Logger = None, timeout: float = 30.0):
+    logger_inst = logger_inst or logger
+    if proc is not None and proc.poll() == None:
+        proc_name: str = proc.args[0]
+        logger_inst.info(f"Terminating the existing {proc_name} process...")
+        proc.terminate()
+        try:
+            logger_inst.info(f"Waiting for {proc_name} to exit gracefully...")
+            proc.communicate(timeout=timeout)
+        except sp.TimeoutExpired:
+            logger_inst.info(f"{proc_name}didn't exit. Force killing...")
+            proc.kill()
+            proc.communicate()
+
+
 
 class EventsPerSecond:
     def __init__(self, max_events=1000):

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -400,8 +400,8 @@ def capture_camera(name, config: CameraConfig, process_info):
     def run_capture():
         frame_queue = process_info["frame_queue"]
         prev_sig = None
-        logger.info(f"{name}: capture starting")
         while prev_sig not in stop_sigs:
+            logger.info(f"{name}: capture starting")
             camera_watchdog = CameraWatchdog(
                 name,
                 config,
@@ -425,8 +425,6 @@ def capture_camera(name, config: CameraConfig, process_info):
                 # Abort on a STOP signal
                 if( prev_sig := sig_queue.get() ) in stop_sigs:
                     break
-
-            logger.info(f"{name}: capture resuming")
 
     # Run a background thread to prevent deadlock in signal handlers
     capture_thread = threading.Thread(target=run_capture)

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -113,10 +113,11 @@ def create_tensor_input(frame, model_config, region):
     # Expand dimensions since the model expects images to have shape: [1, height, width, 3]
     return np.expand_dims(cropped_frame, axis=0)
 
+
 def start_or_restart_ffmpeg(
     ffmpeg_cmd, logger, logpipe: LogPipe, frame_size=None, ffmpeg_process=None
 ):
-    terminate_process( ffmpeg_process, logger_inst=logger )
+    terminate_process(ffmpeg_process, logger_inst=logger)
 
     if frame_size is None:
         process = sp.Popen(
@@ -386,12 +387,12 @@ def capture_camera(name, config: CameraConfig, process_info):
 
     def receiveSignal(signalNumber, frame):
         logger.info(f"{name} Received signal {signalNumber}")
-        sig_queue.put( signalNumber )
+        sig_queue.put(signalNumber)
         if signalNumber in (stop_sigs + pause_sigs):
             stop_event.set()
 
     signal.signal(signal.SIGTERM, receiveSignal)
-    signal.signal(signal.SIGINT,  receiveSignal)
+    signal.signal(signal.SIGINT, receiveSignal)
     signal.signal(signal.SIGUSR1, receiveSignal)
     signal.signal(signal.SIGUSR2, receiveSignal)
 
@@ -407,7 +408,7 @@ def capture_camera(name, config: CameraConfig, process_info):
             # Pause here until stopped or resumed
             while not sig_queue.empty() or prev_sig not in resume_sigs:
                 # Abort on a STOP signal
-                if( prev_sig := sig_queue.get() ) in stop_sigs:
+                if (prev_sig := sig_queue.get()) in stop_sigs:
                     break
 
             logger.info(f"{name}: capture starting")


### PR DESCRIPTION
Adds new MQTT topic,

  frigate/<camera>/capture/state

to dynamically enable or disable capturing from a camera.

The ffmpeg process is terminated when the capture state is OFF and is resumed when the capture state is ON.