### PR TITLE
Docs: replace Double Take integration to maintained fork

### DIFF
--- a/docs/docs/integrations/third_party_extensions.md
+++ b/docs/docs/integrations/third_party_extensions.md
@@ -13,7 +13,8 @@ Please use your own knowledge to assess and vet them before you install anything
 
 :::
 
-## [Double Take](https://github.com/jakowenko/double-take)
+## [Double Take](https://github.com/skrashevich/double-take)
 
-[Double Take](https://github.com/jakowenko/double-take) provides an unified UI and API for processing and training images for facial recognition.
+[Double Take](https://github.com/skrashevich/double-take) provides an unified UI and API for processing and training images for facial recognition.
 It supports automatically setting the sub labels in Frigate for person objects that are detected and recognized.
+This is a fork (with fixed errors and new features) of [original Double Take](https://github.com/jakowenko/double-take) project which, unfortunately, isn't being maintained by author.


### PR DESCRIPTION
The original project doesn't seem to be maintained by the author anymore :(