### PR TITLE
Bugfix: timestamp value read from .vacuum

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -196,7 +196,7 @@ class FrigateApp:
         if os.path.exists(f"{CONFIG_DIR}/.vacuum"):
             with open(f"{CONFIG_DIR}/.vacuum") as f:
                 try:
-                    timestamp = int(f.readline())
+                    timestamp = round(float(f.readline()))
                 except Exception:
                     timestamp = 0
 


### PR DESCRIPTION
For prevent errors caused by float values and executing "vacuum" at every run