### PR TITLE
Feature: Allow Extra Configuration Keys

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -45,7 +45,11 @@ DEFAULT_DETECTORS = {"cpu": {"type": "cpu"}}
 
 class FrigateBaseModel(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = (
+            Extra.allow
+            if os.environ.get("FRIGATE_ALLOW_EXTRA") is not None
+            else Extra.forbid
+        )
 
 
 class LiveModeEnum(str, Enum):

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -45,11 +45,13 @@ DEFAULT_DETECTORS = {"cpu": {"type": "cpu"}}
 
 class FrigateBaseModel(BaseModel):
     class Config:
-        extra = (
-            Extra.allow
-            if os.environ.get("FRIGATE_ALLOW_EXTRA") is not None
-            else Extra.forbid
-        )
+        frigate_env_extra_var = os.environ.get("FRIGATE_ALLOW_EXTRA", "forbid")
+        if frigate_env_extra_var.lower() == "allow":
+            extra = Extra.allow
+        elif frigate_env_extra_var.lower() == "ignore":
+            extra = Extra.ignore
+        else:
+            extra = Extra.forbid
 
 
 class LiveModeEnum(str, Enum):


### PR DESCRIPTION
This pull request introduces a new feature that allows extra configuration options in Frigate. The feature is controlled by the FRIGATE_ALLOW_EXTRA environment variable.

- If FRIGATE_ALLOW_EXTRA is set to "allow", then extra fields in the configuration are allowed. This means that if your configuration contains fields that are not explicitly defined in the Frigate application, they will be accepted and not cause an error.
- If FRIGATE_ALLOW_EXTRA is set to "ignore", then extra fields in the configuration are ignored. This means that if your configuration contains fields that are not explicitly defined in the Frigate application, they will be silently ignored and not cause an error.
- If FRIGATE_ALLOW_EXTRA is set to any other value or not set at all, then extra fields in the configuration are forbidden. This means that if your configuration contains fields that are not explicitly defined in the Frigate application, they will cause an error.

This modification will be particularly useful for developers and advanced users who are testing new features. It allows them to run various versions of Frigate with the same configuration. By setting the FRIGATE_ALLOW_EXTRA environment variable, they can control how the application handles extra fields in the configuration. This flexibility can be beneficial when testing new features or versions that may introduce new configuration options, as it allows the same configuration to be used without causing errors due to unrecognized fields.