### PR TITLE
Show object attributes when hovering or tapping timeline bounding box

### DIFF
--- a/web/src/components/TimelineEventOverlay.jsx
+++ b/web/src/components/TimelineEventOverlay.jsx
@@ -57,8 +57,8 @@ export default function TimelineEventOverlay({ event, eventOverlay, cameraConfig
       {isHovering && (
         <div className="absolute bg-slate-800 p-4 block text-white text-lg" style={getHoverStyle()}>
           <div className="font-bold text-xl">{event.label} attributes:</div>
-          <div>{`Object Area: ${getObjectArea()} px`}</div>
-          <div>{`Object Ratio: ${getObjectRatio()}`}</div>
+          <div>{`Area: ${getObjectArea()} px`}</div>
+          <div>{`Ratio: ${getObjectRatio()}`}</div>
         </div>
       )}
     </Fragment>

--- a/web/src/components/TimelineEventOverlay.jsx
+++ b/web/src/components/TimelineEventOverlay.jsx
@@ -1,6 +1,5 @@
 import { Fragment, h } from 'preact';
-import { useCallback, useState } from 'preact/hooks';
-import Heading from './Heading';
+import { useState } from 'preact/hooks';
 
 export default function TimelineEventOverlay({ event, eventOverlay, cameraConfig }) {
   const boxLeftEdge = Math.round(eventOverlay.data.box[0] * 100);
@@ -31,9 +30,9 @@ export default function TimelineEventOverlay({ event, eventOverlay, cameraConfig
   };
 
   const getObjectRatio = () => {
-    const width = eventOverlay.data.box[2];
-    const height = eventOverlay.data.box[3];
-    return Math.round(100 * width / height) / 100;
+    const width = eventOverlay.data.box[2] * 100;
+    const height = eventOverlay.data.box[3] * 100;
+    return Math.round(100 * (width / height)) / 100;
   };
 
   return (

--- a/web/src/components/TimelineEventOverlay.jsx
+++ b/web/src/components/TimelineEventOverlay.jsx
@@ -42,6 +42,8 @@ export default function TimelineEventOverlay({ event, eventOverlay, cameraConfig
         className="absolute border-4 border-red-600"
         onMouseEnter={() => setIsHovering(true)}
         onMouseLeave={() => setIsHovering(false)}
+        onTouchStart={() => setIsHovering(true)}
+        onTouchEnd={() => setIsHovering(false)}
         style={{
           left: `${boxLeftEdge}%`,
           top: `${boxTopEdge}%`,

--- a/web/src/components/TimelineEventOverlay.jsx
+++ b/web/src/components/TimelineEventOverlay.jsx
@@ -1,0 +1,65 @@
+import { Fragment, h } from 'preact';
+import { useCallback, useState } from 'preact/hooks';
+import Heading from './Heading';
+
+export default function TimelineEventOverlay({ event, eventOverlay, cameraConfig }) {
+  const boxLeftEdge = Math.round(eventOverlay.data.box[0] * 100);
+  const boxTopEdge = Math.round(eventOverlay.data.box[1] * 100);
+  const boxRightEdge = Math.round((1 - eventOverlay.data.box[2] - eventOverlay.data.box[0]) * 100);
+  const boxBottomEdge = Math.round((1 - eventOverlay.data.box[3] - eventOverlay.data.box[1]) * 100);
+
+  const [isHovering, setIsHovering] = useState(false);
+  const getHoverStyle = () => {
+    if (boxLeftEdge < 15) {
+      // show object stats on right side
+      return {
+        left: `${boxLeftEdge + eventOverlay.data.box[2] * 100 + 1}%`,
+        top: `${boxTopEdge}%`,
+      };
+    }
+
+    return {
+      right: `${boxRightEdge + eventOverlay.data.box[2] * 100 + 1}%`,
+      top: `${boxTopEdge}%`,
+    };
+  };
+
+  const getObjectArea = () => {
+    const width = eventOverlay.data.box[2] * cameraConfig.detect.width;
+    const height = eventOverlay.data.box[3] * cameraConfig.detect.height;
+    return Math.round(width * height);
+  };
+
+  const getObjectRatio = () => {
+    const width = eventOverlay.data.box[2];
+    const height = eventOverlay.data.box[3];
+    return Math.round(100 * width / height) / 100;
+  };
+
+  return (
+    <Fragment>
+      <div
+        className="absolute border-4 border-red-600"
+        onMouseEnter={() => setIsHovering(true)}
+        onMouseLeave={() => setIsHovering(false)}
+        style={{
+          left: `${boxLeftEdge}%`,
+          top: `${boxTopEdge}%`,
+          right: `${boxRightEdge}%`,
+          bottom: `${boxBottomEdge}%`,
+        }}
+      >
+        {eventOverlay.class_type == 'entered_zone' ? (
+          <div className="absolute w-2 h-2 bg-yellow-500 left-[50%] -translate-x-1/2 translate-y-3/4 bottom-0" />
+        ) : null}
+      </div>
+      {isHovering && (
+        <div className="absolute bg-slate-800 p-4 block text-white text-lg" style={getHoverStyle()}>
+          <div className="font-bold text-xl">{event.label} attributes:</div>
+          <div>{`Object Area: ${getObjectArea()} px`}</div>
+          <div>{`Object Ratio: ${getObjectRatio()}`}</div>
+        </div>
+      )}
+    </Fragment>
+  );
+}

--- a/web/src/components/TimelineEventOverlay.jsx
+++ b/web/src/components/TimelineEventOverlay.jsx
@@ -30,8 +30,8 @@ export default function TimelineEventOverlay({ event, eventOverlay, cameraConfig
   };
 
   const getObjectRatio = () => {
-    const width = eventOverlay.data.box[2] * 100;
-    const height = eventOverlay.data.box[3] * 100;
+    const width = eventOverlay.data.box[2] * cameraConfig.detect.width;
+    const height = eventOverlay.data.box[3] * cameraConfig.detect.height;
     return Math.round(100 * (width / height)) / 100;
   };
 

--- a/web/src/components/TimelineEventOverlay.jsx
+++ b/web/src/components/TimelineEventOverlay.jsx
@@ -1,7 +1,7 @@
 import { Fragment, h } from 'preact';
 import { useState } from 'preact/hooks';
 
-export default function TimelineEventOverlay({ event, eventOverlay, cameraConfig }) {
+export default function TimelineEventOverlay({ eventOverlay, cameraConfig }) {
   const boxLeftEdge = Math.round(eventOverlay.data.box[0] * 100);
   const boxTopEdge = Math.round(eventOverlay.data.box[1] * 100);
   const boxRightEdge = Math.round((1 - eventOverlay.data.box[2] - eventOverlay.data.box[0]) * 100);
@@ -55,8 +55,7 @@ export default function TimelineEventOverlay({ event, eventOverlay, cameraConfig
         ) : null}
       </div>
       {isHovering && (
-        <div className="absolute bg-slate-800 p-4 block text-white text-lg" style={getHoverStyle()}>
-          <div className="font-bold text-xl">{event.label} attributes:</div>
+        <div className="absolute bg-white dark:bg-slate-800 p-4 block dark:text-white text-lg" style={getHoverStyle()}>
           <div>{`Area: ${getObjectArea()} px`}</div>
           <div>{`Ratio: ${getObjectRatio()}`}</div>
         </div>

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -29,6 +29,7 @@ import { formatUnixTimestampToDateTime, getDurationFromTimestamps } from '../uti
 import TimeAgo from '../components/TimeAgo';
 import Timepicker from '../components/TimePicker';
 import TimelineSummary from '../components/TimelineSummary';
+import TimelineEventOverlay from '../components/TimelineEventOverlay';
 
 const API_LIMIT = 25;
 
@@ -717,23 +718,11 @@ export default function Events({ path, ...props }) {
                                   }}
                                 >
                                   {eventOverlay ? (
-                                    <div
-                                      className="absolute border-4 border-red-600"
-                                      style={{
-                                        left: `${Math.round(eventOverlay.data.box[0] * 100)}%`,
-                                        top: `${Math.round(eventOverlay.data.box[1] * 100)}%`,
-                                        right: `${Math.round(
-                                          (1 - eventOverlay.data.box[2] - eventOverlay.data.box[0]) * 100
-                                        )}%`,
-                                        bottom: `${Math.round(
-                                          (1 - eventOverlay.data.box[3] - eventOverlay.data.box[1]) * 100
-                                        )}%`,
-                                      }}
-                                    >
-                                      {eventOverlay.class_type == 'entered_zone' ? (
-                                        <div className="absolute w-2 h-2 bg-yellow-500 left-[50%] -translate-x-1/2 translate-y-3/4 bottom-0" />
-                                      ) : null}
-                                    </div>
+                                    <TimelineEventOverlay
+                                      event={event}
+                                      eventOverlay={eventOverlay}
+                                      cameraConfig={config.cameras[event.camera]}
+                                    />
                                   ) : null}
                                 </VideoPlayer>
                               </div>

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -719,7 +719,6 @@ export default function Events({ path, ...props }) {
                                 >
                                   {eventOverlay ? (
                                     <TimelineEventOverlay
-                                      event={event}
                                       eventOverlay={eventOverlay}
                                       cameraConfig={config.cameras[event.camera]}
                                     />

--- a/web/src/routes/Events.jsx
+++ b/web/src/routes/Events.jsx
@@ -29,6 +29,7 @@ import { formatUnixTimestampToDateTime, getDurationFromTimestamps } from '../uti
 import TimeAgo from '../components/TimeAgo';
 import Timepicker from '../components/TimePicker';
 import TimelineSummary from '../components/TimelineSummary';
+import TimelineEventOverlay from '../components/TimelineEventOverlay';
 
 const API_LIMIT = 25;
 
@@ -721,23 +722,11 @@ export default function Events({ path, ...props }) {
                                   }}
                                 >
                                   {eventOverlay ? (
-                                    <div
-                                      className="absolute border-4 border-red-600"
-                                      style={{
-                                        left: `${Math.round(eventOverlay.data.box[0] * 100)}%`,
-                                        top: `${Math.round(eventOverlay.data.box[1] * 100)}%`,
-                                        right: `${Math.round(
-                                          (1 - eventOverlay.data.box[2] - eventOverlay.data.box[0]) * 100
-                                        )}%`,
-                                        bottom: `${Math.round(
-                                          (1 - eventOverlay.data.box[3] - eventOverlay.data.box[1]) * 100
-                                        )}%`,
-                                      }}
-                                    >
-                                      {eventOverlay.class_type == 'entered_zone' ? (
-                                        <div className="absolute w-2 h-2 bg-yellow-500 left-[50%] -translate-x-1/2 translate-y-3/4 bottom-0" />
-                                      ) : null}
-                                    </div>
+                                    <TimelineEventOverlay
+                                      event={event}
+                                      eventOverlay={eventOverlay}
+                                      cameraConfig={config.cameras[event.camera]}
+                                    />
                                   ) : null}
                                 </VideoPlayer>
                               </div>


### PR DESCRIPTION
Here is an example:

![Screen Shot 2023-06-21 at 16 20 54 PM](https://github.com/blakeblackshear/frigate/assets/14866235/ce19811d-d078-4ccf-92ca-f3946d84996f)
