### PR TITLE
Integrate ccache into libusb and nginx build scripts for improved build speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,11 +64,11 @@ ARG DEBIAN_FRONTEND
 
 # Build libUSB without udev.  Needed for Openvino NCS2 support
 WORKDIR /opt
-RUN apt-get update && apt-get install -y unzip build-essential automake libtool
+RUN apt-get update && apt-get install -y unzip build-essential automake libtool ccache
 RUN wget -q https://github.com/libusb/libusb/archive/v1.0.25.zip -O v1.0.25.zip && \
     unzip v1.0.25.zip && cd libusb-1.0.25 && \
     ./bootstrap.sh && \
-    ./configure --disable-udev --enable-shared && \
+    ./configure CC='ccache gcc' CCX='ccache g++' --disable-udev --enable-shared && \
     make -j $(nproc --all)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libusb-1.0-0-dev && \

--- a/docker/build_nginx.sh
+++ b/docker/build_nginx.sh
@@ -15,6 +15,8 @@ apt-get -yqq build-dep nginx
 
 apt-get -yqq install --no-install-recommends ca-certificates wget
 update-ca-certificates -f
+apt install -y ccache
+CC="ccache gcc"
 mkdir /tmp/nginx
 wget -nv https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
 tar -zxf nginx-${NGINX_VERSION}.tar.gz -C /tmp/nginx --strip-components=1

--- a/docker/build_nginx.sh
+++ b/docker/build_nginx.sh
@@ -16,7 +16,9 @@ apt-get -yqq build-dep nginx
 apt-get -yqq install --no-install-recommends ca-certificates wget
 update-ca-certificates -f
 apt install -y ccache
-CC="ccache gcc"
+
+export PATH="/usr/lib/ccache:$PATH"
+
 mkdir /tmp/nginx
 wget -nv https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
 tar -zxf nginx-${NGINX_VERSION}.tar.gz -C /tmp/nginx --strip-components=1
@@ -64,5 +66,5 @@ cd /tmp/nginx
     --add-module=../nginx-rtmp-module \
     --with-cc-opt="-O3 -Wno-error=implicit-fallthrough"
 
-make -j$(nproc) && make install
+make CC="ccache gcc" -j$(nproc) && make install
 rm -rf /usr/local/nginx/html /usr/local/nginx/conf/*.default


### PR DESCRIPTION
This pull request introduces the use of ccache in the build scripts for libusb and nginx. The changes include the installation of ccache and its integration into the build process. This is expected to speed up the build process by caching the output of C/C++ compilation to reuse when the same source files are compiled again. The changes are made in the Dockerfile and the build_nginx.sh script.