### PR TITLE
Performance optimisation: refactoring and interpolation method update

### DIFF
--- a/frigate/motion/frigate_motion.py
+++ b/frigate/motion/frigate_motion.py
@@ -30,7 +30,7 @@ class FrigateMotionDetector(MotionDetector):
         resized_mask = cv2.resize(
             config.mask,
             dsize=(self.motion_frame_size[1], self.motion_frame_size[0]),
-            interpolation=cv2.INTER_LINEAR,
+            interpolation=cv2.INTER_NEAREST,
         )
         self.mask = np.where(resized_mask == [0])
         self.save_images = False

--- a/frigate/motion/improved_motion.py
+++ b/frigate/motion/improved_motion.py
@@ -34,7 +34,7 @@ class ImprovedMotionDetector(MotionDetector):
         resized_mask = cv2.resize(
             config.mask,
             dsize=(self.motion_frame_size[1], self.motion_frame_size[0]),
-            interpolation=cv2.INTER_LINEAR,
+            interpolation=cv2.INTER_NEAREST,
         )
         self.mask = np.where(resized_mask == [0])
         self.save_images = False


### PR DESCRIPTION
This pull request contains two patches aimed at optimising the performance:

The first patch refactors the copy_yuv_to_position() function in frigate/util.py. It introduces helper functions to streamline the process of clearing and resizing/copying YUV channels, which simplifies the code and potentially improves performance.
The second patch changes the interpolation method from cv2.INTER_LINEAR to cv2.INTER_NEAREST in the motion detection classes (frigate/motion/frigate_motion.py and frigate/motion/improved_motion.py). This change could potentially enhance the speed of motion detection.