### PR TITLE
Performance improvement: add small delay to reduce CPU usage on empty queues

### DIFF
--- a/frigate/object_detection.py
+++ b/frigate/object_detection.py
@@ -5,8 +5,8 @@ import os
 import queue
 import signal
 import threading
-from abc import ABC, abstractmethod
 import time
+from abc import ABC, abstractmethod
 
 import numpy as np
 from setproctitle import setproctitle

--- a/frigate/object_detection.py
+++ b/frigate/object_detection.py
@@ -6,6 +6,7 @@ import queue
 import signal
 import threading
 from abc import ABC, abstractmethod
+import time
 
 import numpy as np
 from setproctitle import setproctitle
@@ -106,6 +107,7 @@ def run_detector(
         try:
             connection_id = detection_queue.get(timeout=1)
         except queue.Empty:
+            time.sleep(0.01)  # short delay to reduce CPU usage when the queue is empty
             continue
         input_frame = frame_manager.get(
             connection_id,

--- a/frigate/output.py
+++ b/frigate/output.py
@@ -8,6 +8,7 @@ import queue
 import signal
 import subprocess as sp
 import threading
+import time
 import traceback
 from wsgiref.simple_server import make_server
 
@@ -598,6 +599,7 @@ def output_frames(config: FrigateConfig, video_output_queue):
                 regions,
             ) = video_output_queue.get(True, 1)
         except queue.Empty:
+            time.sleep(0.01)  # short delay to reduce CPU usage when the queue is empty
             continue
 
         frame_id = f"{camera}{frame_time}"

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -750,6 +750,7 @@ def process_frames(
         try:
             frame_time = frame_queue.get(True, 1)
         except queue.Empty:
+            time.sleep(0.01)  # short delay to reduce CPU usage when the queue is empty
             continue
 
         current_frame_time.value = frame_time


### PR DESCRIPTION
This pull request introduces a minor delay in the object detection, output, and video modules of Frigate. The delay is triggered when the queue is empty, which helps to reduce CPU usage. This is a performance enhancement that should make the system more efficient under certain conditions.

NB: The performance impact can vary depending on the system scheduler used. In some cases, theoretically, the performance impact may be negative. Need to be tested on different systems and environments 