### PR TITLE
configurable ffmpeg timeout

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -189,6 +189,11 @@ ffmpeg:
     record: preset-record-generic
     # Optional: output args for rtmp streams (default: shown below)
     rtmp: preset-rtmp-generic
+  # Optional: Time in seconds to wait before ffmpeg retries connecting to the camera. (default: shown below)
+  # If set too low, frigate will retry a connection to the camera's stream too frequently, using up the limited streams some cameras can allow at once
+  # If set too high, then if a ffmpeg crash or camera stream timeout occurs, you could potentially lose up to a maximum of retry_interval second(s) of footage
+  # NOTE: this can be a useful setting for Wireless / Battery cameras to reduce how much footage is potentially lost during a connection timeout.
+  retry_interval: 10
 
 # Optional: Detect configuration
 # NOTE: Can be overridden at the camera level

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -463,6 +463,9 @@ class FfmpegConfig(FrigateBaseModel):
         default_factory=FfmpegOutputArgsConfig,
         title="FFmpeg output arguments per role.",
     )
+    timeout: float = Field(
+        default=10.0, title="Time in seconds in-between ffmpeg health checks."
+    )
 
 
 class CameraRoleEnum(str, Enum):

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -463,7 +463,7 @@ class FfmpegConfig(FrigateBaseModel):
         default_factory=FfmpegOutputArgsConfig,
         title="FFmpeg output arguments per role.",
     )
-    timeout: float = Field(
+    healthcheck_interval: float = Field(
         default=10.0, title="Time in seconds in-between ffmpeg health checks."
     )
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -463,8 +463,8 @@ class FfmpegConfig(FrigateBaseModel):
         default_factory=FfmpegOutputArgsConfig,
         title="FFmpeg output arguments per role.",
     )
-    healthcheck_interval: float = Field(
-        default=10.0, title="Time in seconds in-between ffmpeg health checks."
+    retry_interval: float = Field(
+        default=10.0, title="Time in seconds in-between FFmpeg health checks."
     )
 
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -464,7 +464,8 @@ class FfmpegConfig(FrigateBaseModel):
         title="FFmpeg output arguments per role.",
     )
     retry_interval: float = Field(
-        default=10.0, title="Time in seconds in-between FFmpeg health checks."
+        default=10.0,
+        title="Time in seconds to wait before FFmpeg retries connecting to the camera.",
     )
 
 

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -251,8 +251,9 @@ class CameraWatchdog(threading.Thread):
                 }
             )
 
-        time.sleep(10)
-        while not self.stop_event.wait(10):
+        sleeptime = self.config.ffmpeg.timeout
+        time.sleep(sleeptime)
+        while not self.stop_event.wait(sleeptime):
             now = datetime.datetime.now().timestamp()
 
             if not self.capture_thread.is_alive():

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -232,6 +232,7 @@ class CameraWatchdog(threading.Thread):
         self.frame_shape = self.config.frame_shape_yuv
         self.frame_size = self.frame_shape[0] * self.frame_shape[1]
         self.stop_event = stop_event
+        self.sleeptime = self.config.ffmpeg.healthcheck_interval
 
     def run(self):
         self.start_ffmpeg_detect()
@@ -251,9 +252,8 @@ class CameraWatchdog(threading.Thread):
                 }
             )
 
-        sleeptime = self.config.ffmpeg.timeout
-        time.sleep(sleeptime)
-        while not self.stop_event.wait(sleeptime):
+        time.sleep(self.sleeptime)
+        while not self.stop_event.wait(self.sleeptime):
             now = datetime.datetime.now().timestamp()
 
             if not self.capture_thread.is_alive():

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -232,7 +232,7 @@ class CameraWatchdog(threading.Thread):
         self.frame_shape = self.config.frame_shape_yuv
         self.frame_size = self.frame_shape[0] * self.frame_shape[1]
         self.stop_event = stop_event
-        self.sleeptime = self.config.ffmpeg.healthcheck_interval
+        self.sleeptime = self.config.ffmpeg.retry_interval
 
     def run(self):
         self.start_ffmpeg_detect()


### PR DESCRIPTION
With the default hard-coded 10 seconds, there is a chance to lose a whole 10 seconds of footage when a **battery camera** activates.
If you configure the timeout to 1 second, now the maximum amount of footage lost is 1 second of footage.
_Edit: forgot to mention, of course there is ffmpeg negotiation time when opening rtsp stream. For me my machine takes 2-3 extra seconds for this._

This can increase the rate of which ffmpeg processes spawn by 10x but in my testing none of these processes linger even after months of operation and consume almost no cpu when spawned.

Obviously not the best solution, but hardcoding 10 seconds isnt either 😉