### PR TITLE
show/hide camera dash buttons in config

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -596,6 +596,10 @@ class CameraUiConfig(FrigateBaseModel):
     dashboard: bool = Field(
         default=True, title="Show this camera in Frigate dashboard UI."
     )
+    hidecambuttons: bool = Field(
+        default=False,
+        title="Hides this camera's Detect/Recordings/Snapshots toggle buttons in Frigate dashboard UI.",
+    )
 
 
 class CameraConfig(FrigateBaseModel):

--- a/web/src/routes/Cameras.jsx
+++ b/web/src/routes/Cameras.jsx
@@ -54,7 +54,9 @@ function Camera({ name, config }) {
     () => { return `${name.replaceAll('_', ' ')}` },
     [name]
   );
-  const icons = useMemo(
+
+  const hideIcons = config.ui.hidecambuttons;
+  const icons = hideIcons ? [] : useMemo(
     () => [
       {
         name: `Toggle detect ${detectValue === 'ON' ? 'off' : 'on'}`,


### PR DESCRIPTION
config option to hide record/snapshot/motion buttons from dashboard.

![image](https://github.com/blakeblackshear/frigate/assets/57186372/46f61893-7c07-466b-9fa1-7e7c60917ca4)

Perfect for those far too many instances of fat fingering one of the buttons while on mobile 😂

Best solution is a popup message to confirm instead of just outright hiding, but i think some users would appreciate just hiding the buttons completely.
