### PR TITLE
fix tooltip not showing if too far left

### DIFF
--- a/web/src/components/Tooltip.jsx
+++ b/web/src/components/Tooltip.jsx
@@ -29,7 +29,7 @@ export default function Tooltip({ relativeTo, text }) {
       let newLeft = left - Math.round(tipWidth / 2);
       // too far right
       if (newLeft + tipWidth + TIP_SPACE > windowWidth - window.scrollX) {
-        newLeft = left - tipWidth - TIP_SPACE;
+        newLeft = Math.max(0, left - tipWidth - TIP_SPACE);
         newTop = top - Math.round(tipHeight / 2);
       }
       // too far left


### PR DESCRIPTION
quick fix for tooltips

**Before:**
https://github.com/blakeblackshear/frigate/assets/57186372/4fadbdfd-7e46-46b1-b991-0c65799d577b

**After:**
https://github.com/blakeblackshear/frigate/assets/57186372/23851e4e-e65a-4219-81c6-f74110697520

edit: i ment far right 🤦‍♂️
