### PR TITLE
refactor external events handler

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -252,7 +252,9 @@ class FrigateApp:
 
     def init_external_event_processor(self) -> None:
         self.external_event_processor = ExternalEventProcessor(
-            self.config, self.event_queue
+            self.config,
+            self.event_queue,
+            self.detected_frames_processor,
         )
 
     def init_web_server(self) -> None:

--- a/frigate/events/external.py
+++ b/frigate/events/external.py
@@ -10,7 +10,7 @@ from multiprocessing.queues import Queue
 from typing import Optional
 
 import cv2
-from flask import Response, current_app, jsonify, request
+from flask import Response, current_app, jsonify
 
 from frigate.config import CameraConfig, FrigateConfig
 from frigate.const import CLIPS_DIR

--- a/frigate/events/external.py
+++ b/frigate/events/external.py
@@ -10,21 +10,27 @@ from multiprocessing.queues import Queue
 from typing import Optional
 
 import cv2
-from flask import Response, current_app, jsonify
 
 from frigate.config import CameraConfig, FrigateConfig
 from frigate.const import CLIPS_DIR
 from frigate.events.maintainer import EventTypeEnum
+from frigate.object_processing import TrackedObjectProcessor
 from frigate.util import draw_box_with_label
 
 logger = logging.getLogger(__name__)
 
 
 class ExternalEventProcessor:
-    def __init__(self, config: FrigateConfig, queue: Queue) -> None:
+    def __init__(
+        self,
+        config: FrigateConfig,
+        queue: Queue,
+        detected_frames_processor: TrackedObjectProcessor,
+    ) -> None:
         self.config = config
         self.queue = queue
         self.default_thumbnail = None
+        self.detected_frames_processor = detected_frames_processor
 
     def create_manual_event(
         self,
@@ -130,51 +136,56 @@ class ExternalEventProcessor:
         ret, jpg = cv2.imencode(".jpg", thumb)
         return base64.b64encode(jpg.tobytes()).decode("utf-8")
 
+    def create_event(self, camera_name: str, label: str, body: dict[str, any] = {}):
+        if not camera_name or not self.config.cameras.get(camera_name):
+            return {
+                "success": False,
+                "error": 404,
+                "message": f"{camera_name} is not a valid camera.",
+            }
 
-def create_event(camera_name: str, label: str, body: dict[str, any] = {}) -> Response:
-    if not camera_name or not current_app.frigate_config.cameras.get(camera_name):
-        return jsonify(
-            {"success": False, "message": f"{camera_name} is not a valid camera."}, 404
-        )
+        if not label:
+            return {
+                "success": False,
+                "error": 404,
+                "message": f"{label} must be set.",
+            }
 
-    if not label:
-        return jsonify({"success": False, "message": f"{label} must be set."}, 404)
+        try:
+            frame = self.detected_frames_processor.get_current_frame(camera_name)
 
-    try:
-        frame = current_app.detected_frames_processor.get_current_frame(camera_name)
+            event_id = self.external_processor.create_manual_event(
+                camera_name,
+                label,
+                body.get("sub_label", None),
+                body.get("duration", 30),
+                body.get("include_recording", True),
+                body.get("draw", {}),
+                frame,
+            )
+        except Exception as e:
+            logger.error(f"The error is {e}")
+            return {
+                "success": False,
+                "error": 404,
+                "message": f"An unknown error occurred: {e}",
+            }
 
-        event_id = current_app.external_processor.create_manual_event(
-            camera_name,
-            label,
-            body.get("sub_label", None),
-            body.get("duration", 30),
-            body.get("include_recording", True),
-            body.get("draw", {}),
-            frame,
-        )
-    except Exception as e:
-        logger.error(f"The error is {e}")
-        return jsonify(
-            {"success": False, "message": f"An unknown error occurred: {e}"}, 404
-        )
-
-    return jsonify(
-        {
+        return {
             "success": True,
             "message": "Successfully created event.",
             "event_id": event_id,
-        },
-        200,
-    )
+        }
 
+    def end_event(self, event_id: str, body: dict[str, any] = {}):
+        try:
+            end_time = body.get("end_time", datetime.now().timestamp())
+            self.finish_manual_event(event_id, end_time)
+        except Exception:
+            return {
+                "success": False,
+                "error": 404,
+                "message": f"{event_id} must be set and valid.",
+            }
 
-def end_event(event_id: str, body: dict[str, any] = {}) -> Response:
-    try:
-        end_time = body.get("end_time", datetime.now().timestamp())
-        current_app.external_processor.finish_manual_event(event_id, end_time)
-    except Exception:
-        return jsonify(
-            {"success": False, "message": f"{event_id} must be set and valid."}, 404
-        )
-
-    return jsonify({"success": True, "message": "Event successfully ended."}, 200)
+        return {"success": True, "message": "Event successfully ended."}

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -30,7 +30,7 @@ from tzlocal import get_localzone_name
 
 from frigate.config import FrigateConfig
 from frigate.const import CLIPS_DIR, MAX_SEGMENT_DURATION, RECORD_DIR
-from frigate.events.external import ExternalEventProcessor
+from frigate.events.external import ExternalEventProcessor, create_event, end_event
 from frigate.models import Event, Recordings, Timeline
 from frigate.object_processing import TrackedObject
 from frigate.plus import PlusApi
@@ -849,55 +849,13 @@ def events():
 
 
 @bp.route("/events/<camera_name>/<label>/create", methods=["POST"])
-def create_event(camera_name, label):
-    if not camera_name or not current_app.frigate_config.cameras.get(camera_name):
-        return jsonify(
-            {"success": False, "message": f"{camera_name} is not a valid camera."}, 404
-        )
-
-    if not label:
-        return jsonify({"success": False, "message": f"{label} must be set."}, 404)
-
-    json: dict[str, any] = request.get_json(silent=True) or {}
-
-    try:
-        frame = current_app.detected_frames_processor.get_current_frame(camera_name)
-
-        event_id = current_app.external_processor.create_manual_event(
-            camera_name,
-            label,
-            json.get("sub_label", None),
-            json.get("duration", 30),
-            json.get("include_recording", True),
-            json.get("draw", {}),
-            frame,
-        )
-    except Exception as e:
-        logger.error(f"The error is {e}")
-        return jsonify(
-            {"success": False, "message": f"An unknown error occurred: {e}"}, 404
-        )
-
-    return jsonify(
-        {
-            "success": True,
-            "message": "Successfully created event.",
-            "event_id": event_id,
-        },
-        200,
-    )
+def create_event_handler(camera_name, label):
+    return create_event(camera_name, label)
 
 
 @bp.route("/events/<event_id>/end", methods=["PUT"])
-def end_event(event_id):
-    try:
-        current_app.external_processor.finish_manual_event(event_id)
-    except Exception:
-        return jsonify(
-            {"success": False, "message": f"{event_id} must be set and valid."}, 404
-        )
-
-    return jsonify({"success": True, "message": "Event successfully ended."}, 200)
+def end_event_handler(event_id):
+    return end_event(event_id)
 
 
 @bp.route("/config")

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -850,12 +850,14 @@ def events():
 
 @bp.route("/events/<camera_name>/<label>/create", methods=["POST"])
 def create_event_handler(camera_name, label):
-    return create_event(camera_name, label)
+    json: dict[str, any] = request.get_json(silent=True) or {}
+    return create_event(camera_name, label, json)
 
 
 @bp.route("/events/<event_id>/end", methods=["PUT"])
 def end_event_handler(event_id):
-    return end_event(event_id)
+    json: dict[str, any] = request.get_json(silent=True) or {}
+    return end_event(event_id, json)
 
 
 @bp.route("/config")

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -30,7 +30,7 @@ from tzlocal import get_localzone_name
 
 from frigate.config import FrigateConfig
 from frigate.const import CLIPS_DIR, MAX_SEGMENT_DURATION, RECORD_DIR
-from frigate.events.external import ExternalEventProcessor, create_event, end_event
+from frigate.events.external import ExternalEventProcessor
 from frigate.models import Event, Recordings, Timeline
 from frigate.object_processing import TrackedObject
 from frigate.plus import PlusApi
@@ -851,13 +851,13 @@ def events():
 @bp.route("/events/<camera_name>/<label>/create", methods=["POST"])
 def create_event_handler(camera_name, label):
     json: dict[str, any] = request.get_json(silent=True) or {}
-    return create_event(camera_name, label, json)
+    return current_app.external_processor.create_event(camera_name, label, json)
 
 
 @bp.route("/events/<event_id>/end", methods=["PUT"])
 def end_event_handler(event_id):
     json: dict[str, any] = request.get_json(silent=True) or {}
-    return end_event(event_id, json)
+    return current_app.external_processor.end_event(event_id, json)
 
 
 @bp.route("/config")


### PR DESCRIPTION
separate logic and API handlers. It's now possible to create "external" events without requesting the http server.

For example, possible changes on audio-events:

```patch
---
 frigate/events/audio.py | 16 +++++++---------
 1 file changed, 7 insertions(+), 9 deletions(-)

diff --git a/frigate/events/audio.py b/frigate/events/audio.py
index 0decb001b..f1354e633 100644
--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -21,6 +21,7 @@
     AUDIO_SAMPLE_RATE,
     CACHE_DIR,
 )
+from frigate.events.external import create_event, end_event
 from frigate.ffmpeg_presets import parse_preset_input
 from frigate.log import LogPipe
 from frigate.object_detection import load_labels
@@ -184,10 +185,7 @@ def handle_detection(self, label: str, score: float) -> None:
                 "last_detection"
             ] = datetime.datetime.now().timestamp()
         else:
-            resp = requests.post(
-                f"http://127.0.0.1:5000/api/events/{self.config.name}/{label}/create",
-                json={"duration": None},
-            )
+            resp = create_event(self.config.name, label, {"duration": None})
 
             if resp.status_code == 200:
                 event_id = resp.json()[0]["event_id"]
@@ -205,11 +203,11 @@ def expire_detections(self) -> None:
                 now - detection.get("last_detection", now)
                 > self.config.audio.max_not_heard
             ):
-                resp = requests.put(
-                    f"http://127.0.0.1/api/events/{detection['id']}/end",
-                    json={
-                        "end_time": detection["last_detection"]
-                        + self.config.record.events.post_capture
+                resp = end_event(
+                    detection["id"],
+                    {
+                        "end_time": detection["last_detection"] * 1
+                        + self.config.record.events.post_capture * 1
                     },
                 )
                 if resp.status_code == 200:
```