### PR TITLE
Expose dBFS when doing audio analysis

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -259,6 +259,7 @@ class FrigateApp:
             self.onvif_controller,
             self.external_event_processor,
             self.plus_api,
+            self.dispatcher,
         )
 
     def init_onvif(self) -> None:

--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -167,8 +167,21 @@ class AudioEventMaintainer(threading.Thread):
         if not self.feature_metrics[self.config.name]["audio_enabled"].value:
             return
 
-        waveform = (audio / AUDIO_MAX_BIT_RANGE).astype(np.float32)
+        audio_as_float = audio.astype(np.float32)
+        waveform = audio_as_float / AUDIO_MAX_BIT_RANGE
         model_detections = self.detector.detect(waveform)
+
+        # Calculate RMS (Root-Mean-Square) which represents the average signal amplitude
+        # Note: np.float32 isn't serializable, we must use np.float64 to publish the message
+        rms = np.sqrt(np.mean(np.absolute(audio_as_float**2))).astype(np.float64)
+
+        # Transform RMS to dBFS (decibels relative to full scale)
+        dBFS = 20 * np.log10(np.abs(rms) / AUDIO_MAX_BIT_RANGE)
+
+        requests.post(
+            f"http://127.0.0.1:5000/api/{self.config.name}/metadata",
+            json={"dBFS": dBFS, "rms": rms},
+        )
 
         for label, score, _ in model_detections:
             if label not in self.config.audio.listen:

--- a/frigate/test/test_http.py
+++ b/frigate/test/test_http.py
@@ -121,6 +121,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
         id2 = "7890.random"
@@ -157,6 +158,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
 
@@ -178,6 +180,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
         bad_id = "654321.other"
@@ -198,6 +201,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
 
@@ -220,6 +224,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
 
@@ -246,6 +251,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
         sub_label = "sub"
@@ -281,6 +287,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
         sub_label = "sub"
@@ -306,6 +313,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             PlusApi(),
+            None,
         )
 
         with app.test_client() as client:
@@ -323,6 +331,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
 
@@ -343,6 +352,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             PlusApi(),
+            None,
         )
         mock_stats.return_value = self.test_stats
 


### PR DESCRIPTION
Note: Built on top of https://github.com/blakeblackshear/frigate/pull/6848

This PR publishes the audio volume (in [dBFS](https://en.wikipedia.org/wiki/DBFS)) via the configured publishers.

The intention is to use this metadata to trigger automations (low or high thresholds, meaning that something is louder or quieter than expected) and we could even add a sound level indicator to the lovelace cards like baby monitors do

![image](https://github.com/blakeblackshear/frigate/assets/1238288/76fe4521-a923-4715-8699-57f6e3c7b17f)

This is just a draft and I'm sure I'm breaking patterns here, so happy to improve based on your feedback