### PR TITLE
Check ffmpeg version instead of checking for presence of BTBN_PATH

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -14,6 +14,11 @@ curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | \
 sudo mkdir -p /media/frigate
 sudo chown -R "$(id -u):$(id -g)" /media/frigate
 
+# When started as a service, LIBAVFORMAT_VERSION_MAJOR is defined in the
+# s6 service file. For dev, where frigate is started from an interactive
+# shell, we define it in .bashrc instead.
+echo 'export LIBAVFORMAT_VERSION_MAJOR=$(ffmpeg -version | grep -Po "libavformat\W+\K\d+")' >> $HOME/.bashrc
+
 make version
 
 cd web

--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
@@ -42,10 +42,9 @@ function migrate_db_path() {
     fi
 }
 
-LIBAVFORMAT_VERSION_MAJOR=$(ffmpeg -version | grep -Po 'libavformat\W+\K\d+') || echo "[ERROR] Failed to determine ffmpeg version"
-
 echo "[INFO] Preparing Frigate..."
 migrate_db_path
+export LIBAVFORMAT_VERSION_MAJOR=$(ffmpeg -version | grep -Po 'libavformat\W+\K\d+')
 
 echo "[INFO] Starting Frigate..."
 

--- a/docker/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
+++ b/docker/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
@@ -42,6 +42,8 @@ function migrate_db_path() {
     fi
 }
 
+LIBAVFORMAT_VERSION_MAJOR=$(ffmpeg -version | grep -Po 'libavformat\W+\K\d+') || echo "[ERROR] Failed to determine ffmpeg version"
+
 echo "[INFO] Preparing Frigate..."
 migrate_db_path
 

--- a/docker/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/rootfs/usr/local/go2rtc/create_config.py
@@ -7,8 +7,9 @@ import sys
 import yaml
 
 sys.path.insert(0, "/opt/frigate")
-from frigate.const import BIRDSEYE_PIPE, BTBN_PATH  # noqa: E402
+from frigate.const import BIRDSEYE_PIPE  # noqa: E402
 from frigate.ffmpeg_presets import (  # noqa: E402
+    LIBAVFORMAT_VERSION_MAJOR,
     parse_preset_hardware_acceleration_encode,
 )
 
@@ -71,7 +72,7 @@ elif go2rtc_config["rtsp"].get("default_query") is None:
     go2rtc_config["rtsp"]["default_query"] = "mp4"
 
 # need to replace ffmpeg command when using ffmpeg4
-if not os.path.exists(BTBN_PATH):
+if LIBAVFORMAT_VERSION_MAJOR < 59:
     if go2rtc_config.get("ffmpeg") is None:
         go2rtc_config["ffmpeg"] = {
             "rtsp": "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"

--- a/docker/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/rootfs/usr/local/go2rtc/create_config.py
@@ -9,7 +9,6 @@ import yaml
 sys.path.insert(0, "/opt/frigate")
 from frigate.const import BIRDSEYE_PIPE  # noqa: E402
 from frigate.ffmpeg_presets import (  # noqa: E402
-    LIBAVFORMAT_VERSION_MAJOR,
     parse_preset_hardware_acceleration_encode,
 )
 
@@ -72,7 +71,7 @@ elif go2rtc_config["rtsp"].get("default_query") is None:
     go2rtc_config["rtsp"]["default_query"] = "mp4"
 
 # need to replace ffmpeg command when using ffmpeg4
-if LIBAVFORMAT_VERSION_MAJOR < 59:
+if int(os.environ['LIBAVFORMAT_VERSION_MAJOR']) < 59:
     if go2rtc_config.get("ffmpeg") is None:
         go2rtc_config["ffmpeg"] = {
             "rtsp": "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"

--- a/docker/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/rootfs/usr/local/go2rtc/create_config.py
@@ -71,7 +71,7 @@ elif go2rtc_config["rtsp"].get("default_query") is None:
     go2rtc_config["rtsp"]["default_query"] = "mp4"
 
 # need to replace ffmpeg command when using ffmpeg4
-if int(os.environ['LIBAVFORMAT_VERSION_MAJOR']) < 59:
+if int(os.environ["LIBAVFORMAT_VERSION_MAJOR"]) < 59:
     if go2rtc_config.get("ffmpeg") is None:
         go2rtc_config["ffmpeg"] = {
             "rtsp": "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -11,7 +11,6 @@ YAML_EXT = (".yaml", ".yml")
 FRIGATE_LOCALHOST = "http://127.0.0.1:5000"
 PLUS_ENV_VAR = "PLUS_API_KEY"
 PLUS_API_HOST = "https://api.frigate.video"
-BTBN_PATH = "/usr/lib/btbn-ffmpeg"
 
 # Attributes
 

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -43,7 +43,9 @@ class LibvaGpuSelector:
 
 
 TIMEOUT_PARAM = (
-    "-timeout" if int(os.environ["LIBAVFORMAT_VERSION_MAJOR"]) >= 59 else "-stimeout"
+    "-timeout"
+    if int(os.getenv("LIBAVFORMAT_VERSION_MAJOR", "59")) >= 59
+    else "-stimeout"
 )
 
 _gpu_selector = LibvaGpuSelector()

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -42,7 +42,9 @@ class LibvaGpuSelector:
         return ""
 
 
-TIMEOUT_PARAM = "-timeout" if int(os.environ['LIBAVFORMAT_VERSION_MAJOR']) >= 59 else "-stimeout"
+TIMEOUT_PARAM = (
+    "-timeout" if int(os.environ["LIBAVFORMAT_VERSION_MAJOR"]) >= 59 else "-stimeout"
+)
 
 _gpu_selector = LibvaGpuSelector()
 _user_agent_args = [

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -2,10 +2,10 @@
 
 import logging
 import os
+import subprocess
 from enum import Enum
 from typing import Any
 
-from frigate.const import BTBN_PATH
 from frigate.util import vainfo_hwaccel
 from frigate.version import VERSION
 
@@ -43,7 +43,10 @@ class LibvaGpuSelector:
         return ""
 
 
-TIMEOUT_PARAM = "-timeout" if os.path.exists(BTBN_PATH) else "-stimeout"
+LIBAVFORMAT_VERSION_MAJOR = int(
+    subprocess.getoutput("ffmpeg -version | grep -Po 'libavformat\W+\K\d+'")
+)
+TIMEOUT_PARAM = "-timeout" if LIBAVFORMAT_VERSION_MAJOR >= 59 else "-stimeout"
 
 _gpu_selector = LibvaGpuSelector()
 _user_agent_args = [

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import subprocess
 from enum import Enum
 from typing import Any
 
@@ -43,10 +42,7 @@ class LibvaGpuSelector:
         return ""
 
 
-LIBAVFORMAT_VERSION_MAJOR = int(
-    subprocess.getoutput("ffmpeg -version | grep -Po 'libavformat\W+\K\d+'")
-)
-TIMEOUT_PARAM = "-timeout" if LIBAVFORMAT_VERSION_MAJOR >= 59 else "-stimeout"
+TIMEOUT_PARAM = "-timeout" if int(os.environ['LIBAVFORMAT_VERSION_MAJOR']) >= 59 else "-stimeout"
 
 _gpu_selector = LibvaGpuSelector()
 _user_agent_args = [


### PR DESCRIPTION
Frigate (the actual python app) assumes that if `/usr/lib/btbn-ffmpeg` exists, ffmpeg is version 5, and if not, ffmpeg is version 4. This assumption matches the provided Docker builds, but is a brittle coupling between Dockerfile and app - for example, it can break if the user follows the docs that suggest a custom ffmpeg (of unspecified version) can be mounted to `/usr/lib/btbn-ffmpeg`.

Now the ffmpeg version is directly queried from the ffmpeg binary on the path.
