### PR TITLE
Fix missing slash

### DIFF
--- a/docker/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/rootfs/usr/local/nginx/conf/nginx.conf
@@ -237,7 +237,7 @@ http {
         location ~* /api/.*\.(jpg|jpeg|png)$ {
             add_header 'Access-Control-Allow-Origin' '*';
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
-            rewrite ^/api/(.*)$ $1 break;
+            rewrite ^/api/(.*)$ /$1 break;
             proxy_pass http://frigate_api;
             proxy_pass_request_headers on;
             proxy_set_header Host $host;


### PR DESCRIPTION
Slash was missing causing strange behavior specifically in logs:
```
2023-07-04 23:22:50.384654470  2023/07/04 17:22:50 [warn] 148#148: *4 an upstream response is buffered to a temporary file /usr/local/nginx/proxy_temp/1/00/0000000001 while reading upstream, client: 10.233.66.118, server: , request: "GET /api/driveway/latest.jpg HTTP/1.1", upstream: "http://127.0.0.1:5001driveway/latest.jpg", host: "<upstream>"
```