### PR TITLE
Fix min region size not being divisible by 4

### DIFF
--- a/frigate/video.py
+++ b/frigate/video.py
@@ -102,11 +102,7 @@ def get_min_region_size(model_config: ModelConfig) -> int:
     if half % 4 == 0:
         return half
 
-    while True:
-        half += 1
-
-        if half % 4 == 0:
-            return half
+    return int((half + 3) / 4) * 4
 
 
 def create_tensor_input(frame, model_config: ModelConfig, region):

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -14,7 +14,7 @@ import cv2
 import numpy as np
 from setproctitle import setproctitle
 
-from frigate.config import CameraConfig, DetectConfig
+from frigate.config import CameraConfig, DetectConfig, ModelConfig
 from frigate.const import ALL_ATTRIBUTE_LABELS, ATTRIBUTE_LABEL_MAP, CACHE_DIR
 from frigate.detectors.detector_config import PixelFormatEnum
 from frigate.log import LogPipe
@@ -95,7 +95,21 @@ def filtered(obj, objects_to_track, object_filters):
     return False
 
 
-def create_tensor_input(frame, model_config, region):
+def get_min_region_size(model_config: ModelConfig) -> int:
+    """Get the min region size and ensure it is divisible by 4."""
+    half = int(max(model_config.height, model_config.width) / 2)
+
+    if half % 4 == 0:
+        return half
+
+    while True:
+        half += 1
+
+        if half % 4 == 0:
+            return half
+
+
+def create_tensor_input(frame, model_config: ModelConfig, region):
     if model_config.input_pixel_format == PixelFormatEnum.rgb:
         cropped_frame = yuv_region_2_rgb(frame, region)
     elif model_config.input_pixel_format == PixelFormatEnum.bgr:
@@ -719,7 +733,7 @@ def process_frames(
     camera_name: str,
     frame_queue: mp.Queue,
     frame_shape,
-    model_config,
+    model_config: ModelConfig,
     detect_config: DetectConfig,
     frame_manager: FrameManager,
     motion_detector: MotionDetector,
@@ -743,7 +757,7 @@ def process_frames(
 
     startup_scan_counter = 0
 
-    region_min_size = int(max(model_config.height, model_config.width) / 2)
+    region_min_size = get_min_region_size(model_config)
 
     while not stop_event.is_set():
         if exit_on_empty and frame_queue.empty():


### PR DESCRIPTION
Fixes https://github.com/blakeblackshear/frigate/issues/6855

This is happening because in [d81dd60](https://github.com/blakeblackshear/frigate/commit/d81dd60fefda1c05a968047b8296e62df65df9dc) the regions can now be half the size of the model input (300x300 in openvino case)

However, the yuv crops must be a multiple of 4 in resolution which results in a mismatch between the yuv crop and the region size:

https://github.com/blakeblackshear/frigate/blob/12d4a47e3d97248f961858bbf5d83a5fdf8386a8/frigate/util.py#L323-L326