### PR TITLE
Hide birdseye width button on mobile devices

### DIFF
--- a/web/src/routes/Birdseye.jsx
+++ b/web/src/routes/Birdseye.jsx
@@ -81,7 +81,7 @@ export default function Birdseye() {
         </Heading>
 
         <button
-          className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded"
+          className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded sm:hidden"
           onClick={() => setIsMaxWidth(!isMaxWidth)}
         >
           Toggle width

--- a/web/src/routes/Birdseye.jsx
+++ b/web/src/routes/Birdseye.jsx
@@ -81,7 +81,7 @@ export default function Birdseye() {
         </Heading>
 
         <button
-          className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded sm:hidden"
+          className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded hidden md:inline"
           onClick={() => setIsMaxWidth(!isMaxWidth)}
         >
           Toggle width


### PR DESCRIPTION
Just realized this after using it, doesn't make sense to have it on mobile