### PR TITLE
bug: fix locks/accounting in LimitedQueue

### DIFF
--- a/frigate/video.py
+++ b/frigate/video.py
@@ -1025,21 +1025,17 @@ def process_frames(
                 f"debug/frames/{camera_name}-{'{:.6f}'.format(frame_time)}.jpg",
                 bgr_frame,
             )
-        # add to the queue if not full
-        if detected_objects_queue.full():
-            frame_manager.delete(f"{camera_name}{frame_time}")
-            continue
-        else:
-            fps_tracker.update()
-            fps.value = fps_tracker.eps()
-            detected_objects_queue.put(
-                (
-                    camera_name,
-                    frame_time,
-                    detections,
-                    motion_boxes,
-                    regions,
-                )
+        # add to the queue, blocking in case the queue is full.
+        fps_tracker.update()
+        fps.value = fps_tracker.eps()
+        detected_objects_queue.put(
+            (
+                camera_name,
+                frame_time,
+                detections,
+                motion_boxes,
+                regions,
             )
-            detection_fps.value = object_detector.fps.eps()
-            frame_manager.close(f"{camera_name}{frame_time}")
+        )
+        detection_fps.value = object_detector.fps.eps()
+        frame_manager.close(f"{camera_name}{frame_time}")


### PR DESCRIPTION
This PR fixes some bugs with locks and accounting in LimitedQueue.

These bugs were causing issues documented in #7081 and #6986

In `video.py`, we change the behavior to not check if the queue is full. If block=True and the underlying queue properly supports Timeout=None, we should block indefinitely if the queue is full.

In `builtin.py` we change the behavior of the LimitedQueue:

First, we remove unnecessary accounting of the size. The underlying fast_fifo already keeps track of the size. This allows us to remove the lock for `get` and to use the underlying implementation instead of our own for qsize().

Second, we add handling of Timeout=None. First, to handle the maxsize, we lock and retry if the queue is full on item size.

Finally, we add similar retry handling logic to deal with the fast_fifo queue being full and throwing, handling that by catching and retrying. We use the DEFAULT_TIMEOUT, because fast_fifo doesn't properly handle Timeout=None(see https://github.com/alex-petrenko/faster-fifo/issues/42). 

This should fix #7081

