### PR TITLE
Autotracking fixes

### DIFF
--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -98,13 +98,12 @@ class PtzAutoTrackerThread(threading.Thread):
             for camera_name, cam in self.config.cameras.items():
                 if cam.onvif.autotracking.enabled:
                     self.ptz_autotracker.camera_maintenance(camera_name)
-                    time.sleep(1)
                 else:
                     # disabled dynamically by mqtt
                     if self.ptz_autotracker.tracked_object.get(camera_name):
                         self.ptz_autotracker.tracked_object[camera_name] = None
                         self.ptz_autotracker.tracked_object_previous[camera_name] = None
-            time.sleep(0.1)
+            time.sleep(1)
         logger.info("Exiting autotracker...")
 
 

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -207,7 +207,10 @@ class PtzAutoTracker:
                 self.onvif._move_relative(camera, pan, tilt, 1)
 
                 # Wait until the camera finishes moving
-                self.camera_metrics[camera]["ptz_stopped"].wait()
+                while not self.camera_metrics[camera]["ptz_stopped"].is_set():
+                    # check if ptz is moving
+                    self.onvif.get_camera_status(camera)
+                    time.sleep(1 / (self.config.cameras[camera].detect.fps / 2))
 
             except queue.Empty:
                 time.sleep(0.1)

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -198,6 +198,12 @@ class PtzAutoTracker:
                     move_data = self.move_queues[camera].get()
                     pan, tilt = move_data
 
+                # check if ptz is moving
+                self.onvif.get_camera_status(camera)
+
+                # Wait until the camera finishes moving
+                self.camera_metrics[camera]["ptz_stopped"].wait()
+
                 self.onvif._move_relative(camera, pan, tilt, 1)
 
                 # Wait until the camera finishes moving
@@ -229,9 +235,6 @@ class PtzAutoTracker:
         camera_config = self.config.cameras[camera]
 
         if camera_config.onvif.autotracking.enabled:
-            # check if ptz is moving
-            self.onvif.get_camera_status(camera)
-
             # either this is a brand new object that's on our camera, has our label, entered the zone, is not a false positive,
             # and is not initially motionless - or one we're already tracking, which assumes all those things are already true
             if (

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -234,7 +234,10 @@ class PtzAutoTracker:
     def autotrack_object(self, camera, obj):
         camera_config = self.config.cameras[camera]
 
-        if camera_config.onvif.autotracking.enabled:
+        if (
+            camera_config.onvif.autotracking.enabled
+            and self.camera_metrics[camera]["ptz_stopped"].is_set()
+        ):
             # either this is a brand new object that's on our camera, has our label, entered the zone, is not a false positive,
             # and is not initially motionless - or one we're already tracking, which assumes all those things are already true
             if (

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -229,10 +229,10 @@ class PtzAutoTracker:
     def autotrack_object(self, camera, obj):
         camera_config = self.config.cameras[camera]
 
-        # check if ptz is moving
-        self.onvif.get_camera_status(camera)
-
         if camera_config.onvif.autotracking.enabled:
+            # check if ptz is moving
+            self.onvif.get_camera_status(camera)
+
             # either this is a brand new object that's on our camera, has our label, entered the zone, is not a false positive,
             # and is not initially motionless - or one we're already tracking, which assumes all those things are already true
             if (

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -247,14 +247,7 @@ class OnvifController:
             "Zoom": 0,
         }
 
-        # move pan and tilt separately
         move_request.Translation.PanTilt.x = pan
-        move_request.Translation.PanTilt.y = 0
-        move_request.Translation.Zoom.x = 0
-
-        onvif.get_service("ptz").RelativeMove(move_request)
-
-        move_request.Translation.PanTilt.x = 0
         move_request.Translation.PanTilt.y = tilt
         move_request.Translation.Zoom.x = 0
 

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -350,7 +350,7 @@ class OnvifController:
         status_request = self.cams[camera_name]["status_request"]
         status = onvif.get_service("ptz").GetStatus(status_request)
 
-        if status.MoveStatus.PanTilt == "IDLE" or status.MoveStatus.Zoom == "IDLE":
+        if status.MoveStatus.PanTilt == "IDLE" and status.MoveStatus.Zoom == "IDLE":
             self.cams[camera_name]["active"] = False
             self.camera_metrics[camera_name]["ptz_stopped"].set()
         else:


### PR DESCRIPTION
Updates to ptz autotracking:

- [x] Only check camera status if autotracking is enabled. Fixes https://github.com/blakeblackshear/frigate/issues/7094
- [x] Logic updates - only update tracked object position when camera is stopped
- [x] Both PanTilt *and* Zoom should be idle to mark the ptz as *ptz_stopped*
- [x] No need to move pan and tilt separately

Tested on live people currently outside my house and it's working well.
