### PR TITLE
fix edgetpu device type "None" not working

### DIFF
--- a/frigate/detectors/plugins/edgetpu_tfl.py
+++ b/frigate/detectors/plugins/edgetpu_tfl.py
@@ -27,14 +27,17 @@ class EdgeTpuTfl(DetectionApi):
     type_key = DETECTOR_KEY
 
     def __init__(self, detector_config: EdgeTpuDetectorConfig):
-        device_config = {"device": "usb"}
+        device_config = {}
         if detector_config.device is not None:
             device_config = {"device": detector_config.device}
 
         edge_tpu_delegate = None
 
         try:
-            logger.info(f"Attempting to load TPU as {device_config['device']}")
+            device_type = (
+                device_config["device"] if "device" in device_config else "auto"
+            )
+            logger.info(f"Attempting to load TPU as {device_type}")
             edge_tpu_delegate = load_delegate("libedgetpu.so.1.0", device_config)
             logger.info("TPU found")
             self.interpreter = Interpreter(


### PR DESCRIPTION
fix edgetpu device type "None" (auto)

from docu:
https://docs.frigate.video/configuration/detectors#edge-tpu-detector
```
The EdgeTPU device can be specified using the "device" attribute 
according to the Documentation for the TensorFlow Lite Python API.
If not set, the delegate will use the first device it finds.
```

but the code currently forces the device type to usb, which will not detect pci devices.
this is a problem in hybrid use cases where sometimes a pci and sometimes a USB device is available.

based on pycoral:
https://github.com/google-coral/pycoral/blob/ae743b0b234d66d784826ccfbb4607a69dc1a2a8/pycoral/utils/edgetpu.py#L87C32-L87C32