### PR TITLE
Refactor ff queue size

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -200,10 +200,12 @@ class FrigateApp:
     def init_queues(self) -> None:
         # Queues for clip processing
         self.event_queue: Queue = ff.Queue(
-            DEFAULT_QUEUE_BUFFER_SIZE * sum(camera.enabled for camera in self.config.cameras.values())
+            DEFAULT_QUEUE_BUFFER_SIZE
+            * sum(camera.enabled for camera in self.config.cameras.values())
         )
         self.event_processed_queue: Queue = ff.Queue(
-            DEFAULT_QUEUE_BUFFER_SIZE * sum(camera.enabled for camera in self.config.cameras.values())
+            DEFAULT_QUEUE_BUFFER_SIZE
+            * sum(camera.enabled for camera in self.config.cameras.values())
         )
         self.video_output_queue: Queue = mp.Queue(
             maxsize=sum(camera.enabled for camera in self.config.cameras.values()) * 2
@@ -216,12 +218,14 @@ class FrigateApp:
 
         # Queue for recordings info
         self.recordings_info_queue: Queue = ff.Queue(
-            DEFAULT_QUEUE_BUFFER_SIZE * sum(camera.enabled for camera in self.config.cameras.values())
+            DEFAULT_QUEUE_BUFFER_SIZE
+            * sum(camera.enabled for camera in self.config.cameras.values())
         )
 
         # Queue for timeline events
         self.timeline_queue: Queue = ff.Queue(
-            DEFAULT_QUEUE_BUFFER_SIZE * sum(camera.enabled for camera in self.config.cameras.values())
+            DEFAULT_QUEUE_BUFFER_SIZE
+            * sum(camera.enabled for camera in self.config.cameras.values())
         )
 
     def init_database(self) -> None:

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -199,8 +199,12 @@ class FrigateApp:
 
     def init_queues(self) -> None:
         # Queues for clip processing
-        self.event_queue: Queue = ff.Queue(DEFAULT_QUEUE_BUFFER_SIZE)
-        self.event_processed_queue: Queue = ff.Queue(DEFAULT_QUEUE_BUFFER_SIZE)
+        self.event_queue: Queue = ff.Queue(
+            DEFAULT_QUEUE_BUFFER_SIZE * len(self.config.cameras.keys())
+        )
+        self.event_processed_queue: Queue = ff.Queue(
+            DEFAULT_QUEUE_BUFFER_SIZE * len(self.config.cameras.keys())
+        )
         self.video_output_queue: Queue = mp.Queue(
             maxsize=len(self.config.cameras.keys()) * 2
         )
@@ -211,10 +215,14 @@ class FrigateApp:
         )
 
         # Queue for recordings info
-        self.recordings_info_queue: Queue = ff.Queue(DEFAULT_QUEUE_BUFFER_SIZE)
+        self.recordings_info_queue: Queue = ff.Queue(
+            DEFAULT_QUEUE_BUFFER_SIZE * len(self.config.cameras.keys())
+        )
 
         # Queue for timeline events
-        self.timeline_queue: Queue = ff.Queue(DEFAULT_QUEUE_BUFFER_SIZE)
+        self.timeline_queue: Queue = ff.Queue(
+            DEFAULT_QUEUE_BUFFER_SIZE * len(self.config.cameras.keys())
+        )
 
     def init_database(self) -> None:
         def vacuum_db(db: SqliteExtDatabase) -> None:

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -200,28 +200,28 @@ class FrigateApp:
     def init_queues(self) -> None:
         # Queues for clip processing
         self.event_queue: Queue = ff.Queue(
-            DEFAULT_QUEUE_BUFFER_SIZE * len(self.config.cameras.keys())
+            DEFAULT_QUEUE_BUFFER_SIZE * sum(camera.enabled for camera in self.config.cameras.values())
         )
         self.event_processed_queue: Queue = ff.Queue(
-            DEFAULT_QUEUE_BUFFER_SIZE * len(self.config.cameras.keys())
+            DEFAULT_QUEUE_BUFFER_SIZE * sum(camera.enabled for camera in self.config.cameras.values())
         )
         self.video_output_queue: Queue = mp.Queue(
-            maxsize=len(self.config.cameras.keys()) * 2
+            maxsize=sum(camera.enabled for camera in self.config.cameras.values()) * 2
         )
 
         # Queue for cameras to push tracked objects to
         self.detected_frames_queue: Queue = mp.Queue(
-            maxsize=len(self.config.cameras.keys()) * 2
+            maxsize=sum(camera.enabled for camera in self.config.cameras.values()) * 2
         )
 
         # Queue for recordings info
         self.recordings_info_queue: Queue = ff.Queue(
-            DEFAULT_QUEUE_BUFFER_SIZE * len(self.config.cameras.keys())
+            DEFAULT_QUEUE_BUFFER_SIZE * sum(camera.enabled for camera in self.config.cameras.values())
         )
 
         # Queue for timeline events
         self.timeline_queue: Queue = ff.Queue(
-            DEFAULT_QUEUE_BUFFER_SIZE * len(self.config.cameras.keys())
+            DEFAULT_QUEUE_BUFFER_SIZE * sum(camera.enabled for camera in self.config.cameras.values())
         )
 
     def init_database(self) -> None:

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -49,4 +49,4 @@ MAX_PLAYLIST_SECONDS = 7200  # support 2 hour segments for a single playlist to 
 
 # Queue Values
 
-DEFAULT_QUEUE_BUFFER_SIZE = 2000 * 1000  # 2MB
+DEFAULT_QUEUE_BUFFER_SIZE = 1000 * 1000  # 1MB

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -900,7 +900,7 @@ def create_event(camera_name, label):
     except Exception as e:
         return make_response(
             jsonify({"success": False, "message": f"An unknown error occurred: {e}"}),
-            404,
+            500,
         )
 
     return make_response(


### PR DESCRIPTION
I am still seeing audio events failing due to the events queue being too large. I think it is more logical to make the size of these based on the number of cameras in the config. 