### PR TITLE
go2rtc v1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN --mount=type=tmpfs,target=/tmp --mount=type=tmpfs,target=/var/cache/apt \
 FROM wget AS go2rtc
 ARG TARGETARCH
 WORKDIR /rootfs/usr/local/go2rtc/bin
-RUN wget -qO go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/v1.5.0/go2rtc_linux_${TARGETARCH}" \
+RUN wget -qO go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/v1.6.0/go2rtc_linux_${TARGETARCH}" \
     && chmod +x go2rtc
 
 

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -120,7 +120,7 @@ NOTE: The folder that is mapped from the host needs to be the folder that contai
 
 ## Custom go2rtc version
 
-Frigate currently includes go2rtc v1.5.0, there may be certain cases where you want to run a different version of go2rtc.
+Frigate currently includes go2rtc v1.6.0, there may be certain cases where you want to run a different version of go2rtc.
 
 To do this:
 

--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -141,7 +141,7 @@ go2rtc:
       - rtspx://192.168.1.1:7441/abcdefghijk
 ```
 
-[See the go2rtc docs for more information](https://github.com/AlexxIT/go2rtc/tree/v1.5.0#source-rtsp)
+[See the go2rtc docs for more information](https://github.com/AlexxIT/go2rtc/tree/v1.6.0#source-rtsp)
 
 In the Unifi 2.0 update Unifi Protect Cameras had a change in audio sample rate which causes issues for ffmpeg. The input rate needs to be set for record and rtmp if used directly with unifi protect.
 

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -418,7 +418,7 @@ rtmp:
   enabled: False
 
 # Optional: Restream configuration
-# Uses https://github.com/AlexxIT/go2rtc (v1.5.0)
+# Uses https://github.com/AlexxIT/go2rtc (v1.6.0)
 go2rtc:
 
 # Optional: jsmpeg stream configuration for WebUI

--- a/docs/docs/configuration/live.md
+++ b/docs/docs/configuration/live.md
@@ -115,4 +115,4 @@ services:
 
 :::
 
-See [go2rtc WebRTC docs](https://github.com/AlexxIT/go2rtc/tree/v1.5.0#module-webrtc) for more information about this.
+See [go2rtc WebRTC docs](https://github.com/AlexxIT/go2rtc/tree/v1.6.0#module-webrtc) for more information about this.

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -7,7 +7,7 @@ title: Restream
 
 Frigate can restream your video feed as an RTSP feed for other applications such as Home Assistant to utilize it at `rtsp://<frigate_host>:8554/<camera_name>`. Port 8554 must be open. [This allows you to use a video feed for detection in Frigate and Home Assistant live view at the same time without having to make two separate connections to the camera](#reduce-connections-to-camera). The video feed is copied from the original video feed directly to avoid re-encoding. This feed does not include any annotation by Frigate.
 
-Frigate uses [go2rtc](https://github.com/AlexxIT/go2rtc/tree/v1.5.0) to provide its restream and MSE/WebRTC capabilities. The go2rtc config is hosted at the `go2rtc` in the config, see [go2rtc docs](https://github.com/AlexxIT/go2rtc/tree/v1.5.0#configuration) for more advanced configurations and features.
+Frigate uses [go2rtc](https://github.com/AlexxIT/go2rtc/tree/v1.6.0) to provide its restream and MSE/WebRTC capabilities. The go2rtc config is hosted at the `go2rtc` in the config, see [go2rtc docs](https://github.com/AlexxIT/go2rtc/tree/v1.6.0#configuration) for more advanced configurations and features.
 
 :::note
 
@@ -134,7 +134,7 @@ cameras:
 
 ## Advanced Restream Configurations
 
-The [exec](https://github.com/AlexxIT/go2rtc/tree/v1.5.0#source-exec) source in go2rtc can be used for custom ffmpeg commands. An example is below:
+The [exec](https://github.com/AlexxIT/go2rtc/tree/v1.6.0#source-exec) source in go2rtc can be used for custom ffmpeg commands. An example is below:
 
 NOTE: The output will need to be passed with two curly braces `{{output}}`
 

--- a/docs/docs/guides/configuring_go2rtc.md
+++ b/docs/docs/guides/configuring_go2rtc.md
@@ -10,7 +10,7 @@ Use of the bundled go2rtc is optional. You can still configure FFmpeg to connect
 
 # Setup a go2rtc stream
 
-First, you will want to configure go2rtc to connect to your camera stream by adding the stream you want to use for live view in your Frigate config file. If you set the stream name under go2rtc to match the name of your camera, it will automatically be mapped and you will get additional live view options for the camera. Avoid changing any other parts of your config at this step. Note that go2rtc supports [many different stream types](https://github.com/AlexxIT/go2rtc/tree/v1.5.0#module-streams), not just rtsp.
+First, you will want to configure go2rtc to connect to your camera stream by adding the stream you want to use for live view in your Frigate config file. If you set the stream name under go2rtc to match the name of your camera, it will automatically be mapped and you will get additional live view options for the camera. Avoid changing any other parts of your config at this step. Note that go2rtc supports [many different stream types](https://github.com/AlexxIT/go2rtc/tree/v1.6.0#module-streams), not just rtsp.
 
 ```yaml
 go2rtc:
@@ -23,7 +23,7 @@ The easiest live view to get working is MSE. After adding this to the config, re
 
 ### What if my video doesn't play?
 
-If you are unable to see your video feed, first check the go2rtc logs in the Frigate UI under Logs in the sidebar. If go2rtc is having difficulty connecting to your camera, you should see some error messages in the log. If you do not see any errors, then the video codec of the stream may not be supported in your browser. If your camera stream is set to H265, try switching to H264. You can see more information about [video codec compatibility](https://github.com/AlexxIT/go2rtc/tree/v1.5.0#codecs-madness) in the go2rtc documentation. If you are not able to switch your camera settings from H265 to H264 or your stream is a different format such as MJPEG, you can use go2rtc to re-encode the video using the [FFmpeg parameters](https://github.com/AlexxIT/go2rtc/tree/v1.5.0#source-ffmpeg). It supports rotating and resizing video feeds and hardware acceleration. Keep in mind that transcoding video from one format to another is a resource intensive task and you may be better off using the built-in jsmpeg view. Here is an example of a config that will re-encode the stream to H264 without hardware acceleration:
+If you are unable to see your video feed, first check the go2rtc logs in the Frigate UI under Logs in the sidebar. If go2rtc is having difficulty connecting to your camera, you should see some error messages in the log. If you do not see any errors, then the video codec of the stream may not be supported in your browser. If your camera stream is set to H265, try switching to H264. You can see more information about [video codec compatibility](https://github.com/AlexxIT/go2rtc/tree/v1.6.0#codecs-madness) in the go2rtc documentation. If you are not able to switch your camera settings from H265 to H264 or your stream is a different format such as MJPEG, you can use go2rtc to re-encode the video using the [FFmpeg parameters](https://github.com/AlexxIT/go2rtc/tree/v1.6.0#source-ffmpeg). It supports rotating and resizing video feeds and hardware acceleration. Keep in mind that transcoding video from one format to another is a resource intensive task and you may be better off using the built-in jsmpeg view. Here is an example of a config that will re-encode the stream to H264 without hardware acceleration:
 
 ```yaml
 go2rtc:


### PR DESCRIPTION
- Add support webrtc/tcp mode to video player
- Add support hls mode to video player
- Add support RTSP over WebSocket (ex. for Axis cameras) https://github.com/AlexxIT/go2rtc/issues/415
- Add Hass API source for WebRTC cameras
- Add Nest source for WebRTC cameras
- Add support filename query param for mp4 stream
- Add DVRIP discovery https://github.com/AlexxIT/go2rtc/pull/462 by @dbuezas
- Add TLS support for API https://github.com/AlexxIT/go2rtc/pull/352 by @skrashevich
- Add interactive OpenAPI to readme
- Add binary for old Raspberry 1 and Zero
- Add support templates for FFmpeg raw param https://github.com/AlexxIT/go2rtc/issues/487
- Add support FFmpeg drawtext param https://github.com/AlexxIT/go2rtc/issues/487
- Add support ALSA audio for Linux FFmpeg
- Add ESLinter and fix HTML/JS lint problems
- Improve HLS processing and replace MP4 stream mode to HLS mode
- Update prefer_tcp flag for FFmpeg RTSP
- Update codecs detection for DVIRIP stream https://github.com/AlexxIT/go2rtc/pull/460 https://github.com/AlexxIT/go2rtc/pull/461 by @dbuezas
- Update FFmpeg hardware detection for macOS https://github.com/AlexxIT/go2rtc/pull/413 by @skrashevich
- Update hardware.Dockerfile for multi-platform support https://github.com/AlexxIT/go2rtc/pull/414 by @skrashevich
- Update app exit code on config save https://github.com/AlexxIT/go2rtc/pull/274 by @skrashevich
- Update stream info for MP4/MSE/HLS
- Rewrite mDNS processing for HomeKit source
- Remove on the fly stream creation for security reason
- Fix AAC inside MP4 stream
- Fix MP4 with PCM on Android Telegram
- Fix video timestamp accuracy
- Fix OPUS transcoding quality
- Fix PCMA/PCMU audio for WebRTC
- Fix HTML video autoplay in some cases
- Fix origin setting for WebSocket server https://github.com/AlexxIT/go2rtc/pull/469 by @galindocode
- Fix extra blank player https://github.com/AlexxIT/go2rtc/pull/466, https://github.com/AlexxIT/go2rtc/issues/514 by @Vipas-ana
- Fix FFmpeg params in some cases https://github.com/AlexxIT/go2rtc/pull/510 by @horttorrell32
- Fix panic on empty RTSP medias https://github.com/AlexxIT/go2rtc/issues/481
- Fix panic on empty path in RTSP link https://github.com/AlexxIT/go2rtc/issues/474
- Fix panic with only audio for MP4/MSE https://github.com/AlexxIT/go2rtc/issues/404
- Fix panic on processing RTCP from HomeKit cameras https://github.com/AlexxIT/go2rtc/issues/287
- Fix panic after RTSP reconnect feature https://github.com/AlexxIT/go2rtc/issues/433
- Fix race on PCM for backchannel https://github.com/AlexxIT/go2rtc/issues/432
- Fix config tab showing byte string instead of text https://github.com/AlexxIT/go2rtc/issues/478, https://github.com/AlexxIT/go2rtc/pull/479 by @dbuezas