### PR TITLE
Save recording segments with audio events

### DIFF
--- a/frigate/models.py
+++ b/frigate/models.py
@@ -66,7 +66,7 @@ class Recordings(Model):  # type: ignore[misc]
     duration = FloatField()
     motion = IntegerField(null=True)
     objects = IntegerField(null=True)
-    audio = IntegerField(null=True) # audio events in this recording
+    audio = BooleanField(default=False) # audio events in this recording
     segment_size = FloatField(default=0)  # this should be stored as MB
 
 

--- a/frigate/models.py
+++ b/frigate/models.py
@@ -66,7 +66,7 @@ class Recordings(Model):  # type: ignore[misc]
     duration = FloatField()
     motion = IntegerField(null=True)
     objects = IntegerField(null=True)
-    audio = BooleanField(default=False) # audio events in this recording
+    audio = BooleanField(default=False)  # audio events in this recording
     segment_size = FloatField(default=0)  # this should be stored as MB
 
 

--- a/frigate/models.py
+++ b/frigate/models.py
@@ -66,6 +66,7 @@ class Recordings(Model):  # type: ignore[misc]
     duration = FloatField()
     motion = IntegerField(null=True)
     objects = IntegerField(null=True)
+    audio = IntegerField(null=True) # audio events in this recording
     segment_size = FloatField(default=0)  # this should be stored as MB
 
 

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -342,7 +342,7 @@ class RecordingMaintainer(threading.Thread):
                     motion=motion_count,
                     # TODO: update this to store list of active objects at some point
                     objects=active_count,
-                    audio=1 if audio_event else 0,
+                    audio=audio_event,
                     segment_size=segment_size,
                 )
         except Exception as e:

--- a/migrations/018_add_recording_audio.py
+++ b/migrations/018_add_recording_audio.py
@@ -1,0 +1,39 @@
+"""Peewee migrations -- 018_add_recording_audio.py.
+
+Some examples (model - class or model name)::
+
+    > Model = migrator.orm['model_name']            # Return model in current state by name
+
+    > migrator.sql(sql)                             # Run custom SQL
+    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.create_model(Model)                  # Create a model (could be used as decorator)
+    > migrator.remove_model(model, cascade=True)    # Remove a model
+    > migrator.add_fields(model, **fields)          # Add fields to a model
+    > migrator.change_fields(model, **fields)       # Change fields
+    > migrator.remove_fields(model, *field_names, cascade=True)
+    > migrator.rename_field(model, old_field_name, new_field_name)
+    > migrator.rename_table(model, new_table_name)
+    > migrator.add_index(model, *col_names, unique=False)
+    > migrator.drop_index(model, *col_names)
+    > migrator.add_not_null(model, *field_names)
+    > migrator.drop_not_null(model, *field_names)
+    > migrator.add_default(model, field_name, default)
+
+"""
+
+import peewee as pw
+
+from frigate.models import Recordings
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.add_fields(
+        Recordings,
+        audio=pw.IntegerField(null=True),
+    )
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.remove_fields(Recordings, ["audio"])

--- a/migrations/018_add_recording_audio.py
+++ b/migrations/018_add_recording_audio.py
@@ -31,7 +31,7 @@ SQL = pw.SQL
 def migrate(migrator, database, fake=False, **kwargs):
     migrator.add_fields(
         Recordings,
-        audio=pw.IntegerField(null=True),
+        audio=pw.BooleanField(default=False),
     )
 
 


### PR DESCRIPTION
There are no zones to block when an audio event is saved, so audio events can be used to determine when recordings segments should be saved