### PR TITLE
Add check for valid label index for object detection (#7149)

### DIFF
--- a/frigate/object_detection.py
+++ b/frigate/object_detection.py
@@ -59,6 +59,9 @@ class LocalObjectDetector(ObjectDetector):
         raw_detections = self.detect_raw(tensor_input)
 
         for d in raw_detections:
+            if int(d[0]) < 0 or int(d[0]) >= len(self.labels):
+                logger.warning(f"Raw Detect returned invalid label: {d}")
+                continue
             if d[1] < threshold:
                 break
             detections.append(


### PR DESCRIPTION
Issue #7149 appears to be getting invalid label indexes from the TensorRT object detection. Add a bounds check on the raw detections before indexing the label list and log a warning if an invalid index is found.