### PR TITLE
Set supported ptz features in init to not fail when camera has an error

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -54,6 +54,7 @@ class OnvifController:
                         ),
                         "init": False,
                         "active": False,
+                        "features": [],
                         "presets": {},
                     }
                 except ONVIFError as e:


### PR DESCRIPTION
Will help cases like https://github.com/blakeblackshear/frigate/issues/7218 where camera has an error in ptz implementation, the webUI will continue to work in this case