### PR TITLE
Don't save segments < 3 seconds in duration

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -16,6 +16,7 @@ from frigate.const import (
     AUDIO_MIN_CONFIDENCE,
     CACHE_DIR,
     DEFAULT_DB_PATH,
+    MIN_SEGMENT_DURATION,
     REGEX_CAMERA_NAME,
     YAML_EXT,
 )
@@ -931,9 +932,10 @@ def verify_recording_segments_setup_with_reasonable_time(
             f"Camera {camera_config.name} has no segment_time in recording output args, segment args are required for record."
         )
 
-    if int(record_args[seg_arg_index + 1]) > 60:
+    config_duration = int(record_args[seg_arg_index + 1])
+    if config_duration < MIN_SEGMENT_DURATION or config_duration > 60:
         raise ValueError(
-            f"Camera {camera_config.name} has invalid segment_time output arg, segment_time must be 60 or less."
+            f"Camera {camera_config.name} has invalid segment_time output arg, segment_time must be {MIN_SEGMENT_DURATION} <= x <= 60."
         )
 
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -934,7 +934,10 @@ def verify_recording_segments_setup_with_reasonable_time(
         )
 
     config_duration = int(record_args[seg_arg_index + 1])
-    if config_duration < MIN_SEGMENT_DURATION or config_duration > MAX_SEGMENT_CONFIG_DURATION:
+    if (
+        config_duration < MIN_SEGMENT_DURATION
+        or config_duration > MAX_SEGMENT_CONFIG_DURATION
+    ):
         raise ValueError(
             f"Camera {camera_config.name} has invalid segment_time output arg, segment_time must be {MIN_SEGMENT_DURATION} <= x <= 60."
         )

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -939,7 +939,7 @@ def verify_recording_segments_setup_with_reasonable_time(
         or config_duration > MAX_SEGMENT_CONFIG_DURATION
     ):
         raise ValueError(
-            f"Camera {camera_config.name} has invalid segment_time output arg, segment_time must be {MIN_SEGMENT_DURATION} <= x <= 60."
+            f"Camera {camera_config.name} has invalid segment_time output arg, segment_time must be {MIN_SEGMENT_DURATION} <= x <= {MAX_SEGMENT_CONFIG_DURATION}."
         )
 
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -16,6 +16,7 @@ from frigate.const import (
     AUDIO_MIN_CONFIDENCE,
     CACHE_DIR,
     DEFAULT_DB_PATH,
+    MAX_SEGMENT_CONFIG_DURATION,
     MIN_SEGMENT_DURATION,
     REGEX_CAMERA_NAME,
     YAML_EXT,
@@ -933,7 +934,7 @@ def verify_recording_segments_setup_with_reasonable_time(
         )
 
     config_duration = int(record_args[seg_arg_index + 1])
-    if config_duration < MIN_SEGMENT_DURATION or config_duration > 60:
+    if config_duration < MIN_SEGMENT_DURATION or config_duration > MAX_SEGMENT_CONFIG_DURATION:
         raise ValueError(
             f"Camera {camera_config.name} has invalid segment_time output arg, segment_time must be {MIN_SEGMENT_DURATION} <= x <= 60."
         )

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -45,6 +45,7 @@ DRIVER_INTEL_iHD = "iHD"
 
 # Record Values
 
+MIN_SEGMENT_DURATION = 3
 MAX_SEGMENT_DURATION = 600
 MAX_PLAYLIST_SECONDS = 7200  # support 2 hour segments for a single playlist to account for cameras with inconsistent segment times
 

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -47,6 +47,7 @@ DRIVER_INTEL_iHD = "iHD"
 
 MIN_SEGMENT_DURATION = 3
 MAX_SEGMENT_DURATION = 600
+MAX_SEGMENT_CONFIG_DURATION = 60
 MAX_PLAYLIST_SECONDS = 7200  # support 2 hour segments for a single playlist to account for cameras with inconsistent segment times
 
 # Internal Comms Topics

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -22,6 +22,7 @@ from frigate.const import (
     CACHE_DIR,
     INSERT_MANY_RECORDINGS,
     MAX_SEGMENT_DURATION,
+    MIN_SEGMENT_DURATION,
     RECORD_DIR,
 )
 from frigate.models import Event, Recordings
@@ -199,7 +200,7 @@ class RecordingMaintainer(threading.Thread):
                 duration = -1
 
             # ensure duration is within expected length
-            if 0 < duration < MAX_SEGMENT_DURATION:
+            if MIN_SEGMENT_DURATION < duration < MAX_SEGMENT_DURATION:
                 end_time = start_time + datetime.timedelta(seconds=duration)
                 self.end_time_cache[cache_path] = (end_time, duration)
             else:


### PR DESCRIPTION
This ensures users don't configure a segment duration < 3 seconds. It also ensures that if a camera starts creating segments that are < 3 seconds in duration despite being configured for > 3 seconds in duration that the segment is considered corrupt.

The reason for this is because a camera that is sending bad timestamps can cause segments to be created that are much lower than the configured length. If these segments are too short it will be difficult for the recordings maintainer to move them before enough are created and this will cause the "unable to keep up with segments" warning. This warning would be a red herring insinuating that the error is related to storage or the maintainer when it is actually a problem with the camera.