### PR TITLE
Build CI images in parallel

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,8 +4,10 @@ inputs:
   GITHUB_TOKEN:
     required: true
 outputs:
-  lowercase-repo:
-    value: ${{ steps.lowercaseRepo.outputs.lowercase }}
+  image-name:
+    value: ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}
+  cache-name:
+    value: ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:cache
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,37 @@
+name: 'Setup'
+description: 'Set up QEMU and Buildx'
+inputs:
+  GITHUB_TOKEN:
+    required: true
+outputs:
+  lowercase-repo:
+    value: ${{ steps.lowercaseRepo.outputs.lowercase }}
+runs:
+  using: "composite"
+  steps:
+    - name: Remove unnecessary files
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+      shell: bash
+    - id: lowercaseRepo
+      uses: ASzc/change-string-case-action@v5
+      with:
+        string: ${{ github.repository }}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Log in to the Container registry
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.GITHUB_TOKEN }}
+    - name: Create version file
+      run: make version
+      shell: bash
+    - name: Create short sha
+      run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
           set: |
             tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt-jp4
             *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
   jetson_jp5_build:
     runs-on: ubuntu-latest
     name: Jetson Jetpack 5
@@ -129,6 +130,7 @@ jobs:
           set: |
             tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt-jp5
             *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
   # The majority of users running arm64 are rpi users, so the rpi
   # build should be the primary arm64 image
   assemble_default_build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           tags: |
             ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-amd64
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,compression=zstd
       - name: Build and push TensorRT (x86 GPU)
         uses: docker/bake-action@v3
         with:
@@ -69,7 +69,7 @@ jobs:
           tags: |
             ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-standard-arm64
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,compression=zstd
       - name: Build and push RPi build
         uses: docker/bake-action@v3
         with:
@@ -104,7 +104,7 @@ jobs:
           set: |
             tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt-jp4
             *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+            *.cache-to=type=gha,mode=max,compression=zstd
   jetson_jp5_build:
     runs-on: ubuntu-latest
     name: Jetson Jetpack 5
@@ -130,7 +130,7 @@ jobs:
           set: |
             tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt-jp5
             *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+            *.cache-to=type=gha,mode=max,compression=zstd
   # The majority of users running arm64 are rpi users, so the rpi
   # build should be the primary arm64 image
   assemble_default_build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,15 @@ jobs:
             ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Build and push TensorRT (x86 GPU)
+        uses: docker/bake-action@v3
+        with:
+          push: true
+          targets: tensorrt
+          files: docker/tensorrt/trt.hcl
+          set: |
+            tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt
+            *.cache-from=type=gha
       - name: Build and push arm64 standard build
         uses: docker/build-push-action@v4
         with:
@@ -60,15 +69,6 @@ jobs:
           files: docker/rpi/rpi.hcl
           set: |
             rpi.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-rpi
-            *.cache-from=type=gha
-      - name: Build and push TensorRT (x86 GPU)
-        uses: docker/bake-action@v3
-        with:
-          push: true
-          targets: tensorrt
-          files: docker/tensorrt/trt.hcl
-          set: |
-            tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt
             *.cache-from=type=gha
       - name: Build and push TensorRT (Jetson, Jetpack 4)
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ env:
   PYTHON_VERSION: 3.9
 
 jobs:
-  multi_arch_build:
+  amd64_build:
     runs-on: ubuntu-latest
-    name: Image Build
+    name: AMD64 Build
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -26,8 +26,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # The majority of users running arm64 are rpi users, so the rpi
-      # build should be the primary arm64 image
       - name: Build and push amd64 standard build
         uses: docker/build-push-action@v4
         with:
@@ -49,6 +47,17 @@ jobs:
           set: |
             tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt
             *.cache-from=type=gha
+  arm64_build:
+    runs-on: ubuntu-latest
+    name: ARM Build
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up QEMU and Buildx
+        id: setup
+        uses: ./.github/actions/setup
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push arm64 standard build
         uses: docker/build-push-action@v4
         with:
@@ -70,6 +79,17 @@ jobs:
           set: |
             rpi.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-rpi
             *.cache-from=type=gha
+  jetson_jp4_build:
+    runs-on: ubuntu-latest
+    name: Jetson Jetpack 4
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up QEMU and Buildx
+        id: setup
+        uses: ./.github/actions/setup
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push TensorRT (Jetson, Jetpack 4)
         env:
           ARCH: arm64
@@ -84,6 +104,17 @@ jobs:
           set: |
             tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt-jp4
             *.cache-from=type=gha
+  jetson_jp5_build:
+    runs-on: ubuntu-latest
+    name: Jetson Jetpack 5
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up QEMU and Buildx
+        id: setup
+        uses: ./.github/actions/setup
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push TensorRT (Jetson, Jetpack 5)
         env:
           ARCH: arm64
@@ -98,8 +129,28 @@ jobs:
           set: |
             tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt-jp5
             *.cache-from=type=gha
-      - name: Assemble and push default build
-        uses: int128/docker-manifest-create-action@v1
+  # The majority of users running arm64 are rpi users, so the rpi
+  # build should be the primary arm64 image
+  assemble_default_build:
+    runs-on: ubuntu-latest
+    name: Assemble and push default build
+    needs:
+      - amd64_build
+      - arm64_build
+    steps:
+      - id: lowercaseRepo
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ github.repository }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create short sha
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+      - uses: int128/docker-manifest-create-action@v1
         with:
           tags: ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}
           suffixes: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,31 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Image Build
     steps:
-      - name: Remove unnecessary files
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-      - id: lowercaseRepo
-        uses: ASzc/change-string-case-action@v5
-        with:
-          string: ${{ github.repository }}
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Log in to the Container registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+      - name: Set up QEMU and Buildx
+        id: setup
+        uses: ./.github/actions/setup
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create version file
-        run: make version
-      - name: Create short sha
-        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # The majority of users running arm64 are rpi users, so the rpi
       # build should be the primary arm64 image
       - name: Build and push amd64 standard build
@@ -55,7 +37,7 @@ jobs:
           platforms: linux/amd64
           target: frigate
           tags: |
-            ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-amd64
+            ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Build and push arm64 standard build
@@ -67,7 +49,7 @@ jobs:
           platforms: linux/arm64
           target: frigate
           tags: |
-            ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-standard-arm64
+            ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-standard-arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Build and push RPi build
@@ -77,7 +59,7 @@ jobs:
           targets: rpi
           files: docker/rpi/rpi.hcl
           set: |
-            rpi.tags=ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-rpi
+            rpi.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-rpi
             *.cache-from=type=gha
       - name: Build and push TensorRT (x86 GPU)
         uses: docker/bake-action@v3
@@ -86,7 +68,7 @@ jobs:
           targets: tensorrt
           files: docker/tensorrt/trt.hcl
           set: |
-            tensorrt.tags=ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt
+            tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt
             *.cache-from=type=gha
       - name: Build and push TensorRT (Jetson, Jetpack 4)
         env:
@@ -100,7 +82,7 @@ jobs:
           targets: tensorrt
           files: docker/tensorrt/trt.hcl
           set: |
-            tensorrt.tags=ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt-jp4
+            tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt-jp4
             *.cache-from=type=gha
       - name: Build and push TensorRT (Jetson, Jetpack 5)
         env:
@@ -114,12 +96,12 @@ jobs:
           targets: tensorrt
           files: docker/tensorrt/trt.hcl
           set: |
-            tensorrt.tags=ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt-jp5
+            tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt-jp5
             *.cache-from=type=gha
       - name: Assemble and push default build
         uses: int128/docker-manifest-create-action@v1
         with:
-          tags: ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}
+          tags: ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}
           suffixes: |
             -amd64
             -rpi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,9 @@ jobs:
           push: true
           platforms: linux/amd64
           target: frigate
-          tags: |
-            ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,compression=zstd
+          tags: ${{ steps.setup.outputs.image-name }}-amd64
+          cache-from: type=registry,ref=${{ steps.setup.outputs.cache-name }}-amd64
+          cache-to: type=registry,ref=${{ steps.setup.outputs.cache-name }}-amd64,mode=max,compression=zstd
       - name: Build and push TensorRT (x86 GPU)
         uses: docker/bake-action@v3
         with:
@@ -45,8 +44,7 @@ jobs:
           targets: tensorrt
           files: docker/tensorrt/trt.hcl
           set: |
-            tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt
-            *.cache-from=type=gha
+            tensorrt.tags=${{ steps.setup.outputs.image-name }}-tensorrt
   arm64_build:
     runs-on: ubuntu-latest
     name: ARM Build
@@ -67,9 +65,9 @@ jobs:
           platforms: linux/arm64
           target: frigate
           tags: |
-            ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-standard-arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,compression=zstd
+            ${{ steps.setup.outputs.image-name }}-standard-arm64
+          cache-from: type=registry,ref=${{ steps.setup.outputs.cache-name }}-standard-arm64
+          cache-to: type=registry,ref=${{ steps.setup.outputs.cache-name }}-standard-arm64,mode=max,compression=zstd
       - name: Build and push RPi build
         uses: docker/bake-action@v3
         with:
@@ -77,8 +75,7 @@ jobs:
           targets: rpi
           files: docker/rpi/rpi.hcl
           set: |
-            rpi.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-rpi
-            *.cache-from=type=gha
+            rpi.tags=${{ steps.setup.outputs.image-name }}-rpi
   jetson_jp4_build:
     runs-on: ubuntu-latest
     name: Jetson Jetpack 4
@@ -102,9 +99,9 @@ jobs:
           targets: tensorrt
           files: docker/tensorrt/trt.hcl
           set: |
-            tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt-jp4
-            *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max,compression=zstd
+            tensorrt.tags=${{ steps.setup.outputs.image-name }}-tensorrt-jp4
+            *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-tensorrt-jp4
+            *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-tensorrt-jp4,mode=max,compression=zstd
   jetson_jp5_build:
     runs-on: ubuntu-latest
     name: Jetson Jetpack 5
@@ -128,9 +125,9 @@ jobs:
           targets: tensorrt
           files: docker/tensorrt/trt.hcl
           set: |
-            tensorrt.tags=ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}-tensorrt-jp5
-            *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max,compression=zstd
+            tensorrt.tags=${{ steps.setup.outputs.image-name }}-tensorrt-jp5
+            *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-tensorrt-jp5
+            *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-tensorrt-jp5,mode=max,compression=zstd
   # The majority of users running arm64 are rpi users, so the rpi
   # build should be the primary arm64 image
   assemble_default_build:
@@ -154,7 +151,7 @@ jobs:
         run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
       - uses: int128/docker-manifest-create-action@v1
         with:
-          tags: ghcr.io/${{ steps.setup.outputs.lowercase-repo }}:${{ github.ref_name }}-${{ env.SHORT_SHA }}
+          tags: ${{ steps.setup.outputs.image-name }}
           suffixes: |
             -amd64
             -rpi

--- a/.github/workflows/maintain_cache.yml
+++ b/.github/workflows/maintain_cache.yml
@@ -12,29 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Image Build
     steps:
-      - name: Remove unnecessary files
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-      - id: lowercaseRepo
-        uses: ASzc/change-string-case-action@v5
-        with:
-          string: ${{ github.repository }}
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Log in to the Container registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+      - name: Set up QEMU and Buildx
+        uses: ./.github/actions/setup
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create version file
-        run: make version
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
With the Jetson images added to the CI job, it now takes so long that it times out. This PR refactors the CI workflow to build the images in four independent jobs, which each run simultaneously on their own runner:

1. `frigate-amd64` and `frigate-tensorrt`
2. `frigate-standard-arm64` and `frigate-rpi`
3. `frigate-tensorrt-jp4`
4. `frigate-tensorrt-jp5`

It also enables caching for the jetpack builds, which take 2.5 hours without it.

Review by commit.

WIP because the required cache currently exceeds the 10GB gha limit. I'm trying to understand how multi-image multi-platform builds are cached, whether caching intermediate layers is important, what makes sense for gha `scope`, whether we should cache to a `registry` instead of `gha`, how the docker cache mount interacts with the gha cache, and if there are simple ways to make the cached images smaller. That'll take a while though, so we will should merge the uncontroversial parts of this PR before getting it all perfect.