### PR TITLE
Revert the switch to zstd docker layer compression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           set: |
             tensorrt.tags=${{ steps.setup.outputs.image-name }}-tensorrt
             *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-amd64
-            *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-amd64,mode=max,compression=zstd
+            *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-amd64,mode=max
   arm64_build:
     runs-on: ubuntu-latest
     name: ARM Build
@@ -78,7 +78,7 @@ jobs:
           set: |
             rpi.tags=${{ steps.setup.outputs.image-name }}-rpi
             *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-arm64
-            *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-arm64,mode=max,compression=zstd
+            *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-arm64,mode=max
   jetson_jp4_build:
     runs-on: ubuntu-latest
     name: Jetson Jetpack 4
@@ -103,8 +103,8 @@ jobs:
           files: docker/tensorrt/trt.hcl
           set: |
             tensorrt.tags=${{ steps.setup.outputs.image-name }}-tensorrt-jp4
-            *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-tensorrt-jp4
-            *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-tensorrt-jp4,mode=max,compression=zstd
+            *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-jp4
+            *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-jp4,mode=max
   jetson_jp5_build:
     runs-on: ubuntu-latest
     name: Jetson Jetpack 5
@@ -129,8 +129,8 @@ jobs:
           files: docker/tensorrt/trt.hcl
           set: |
             tensorrt.tags=${{ steps.setup.outputs.image-name }}-tensorrt-jp5
-            *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-tensorrt-jp5
-            *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-tensorrt-jp5,mode=max,compression=zstd
+            *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-jp5
+            *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-jp5,mode=max
   # The majority of users running arm64 are rpi users, so the rpi
   # build should be the primary arm64 image
   assemble_default_build:


### PR DESCRIPTION
Setting `cache-to=compression=zstd` causes the resulting user-pulled image to have zstd-compressed layers, which are not compatible with docker prior to 23.0. Ubuntu 20.04 still ships with docker 20.10, which yields `Error processing tar file` when pulling these images. It's best to minimize requirements of the host environment, and zstd (at its default compression level) was only making the images 1% smaller anyway.

Renaming the jetpack cache images is my way of clearing the cache of the prior zstd layers, and it clarifies the convention I used for the other cache images in which there is one cache per base image/job, not per target/step. We don't need to delete the non-jetson cache images because they haven't been rebuilt since zstd was enabled.