### PR TITLE
Update OpenVINO 2022.3.1

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -8,7 +8,7 @@ ARG SLIM_BASE=debian:11-slim
 
 FROM ${BASE_IMAGE} AS base
 
-FROM --platform=linux/amd64 debian:11 AS base_amd64
+FROM --platform=${BUILDPLATFORM} debian:11 AS base_host
 
 FROM ${SLIM_BASE} AS slim-base
 
@@ -46,7 +46,7 @@ RUN wget -qO go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/v1.6.2/
 #
 ####
 # Download and Convert OpenVino model
-FROM base_amd64 AS ov-converter
+FROM base_host AS ov-converter
 ARG DEBIAN_FRONTEND
 
 # Install OpenVino Runtime and Dev library

--- a/docker/main/requirements-ov.txt
+++ b/docker/main/requirements-ov.txt
@@ -1,3 +1,5 @@
 numpy == 1.23.*
-openvino == 2022.*
+# Openvino Library - Custom built with MYRIAD support
+openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.2.0/openvino-2022.2.0-000-cp39-cp39-manylinux_2_31_x86_64.whl; platform_machine == 'x86_64'
+openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.2.0/openvino-2022.2.0-000-cp39-cp39-linux_aarch64.whl; platform_machine == 'aarch64'
 openvino-dev[tensorflow2] == 2022.*

--- a/docker/main/requirements-ov.txt
+++ b/docker/main/requirements-ov.txt
@@ -1,5 +1,5 @@
-numpy == 1.23.*
+numpy
 # Openvino Library - Custom built with MYRIAD support
-openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.2.0/openvino-2022.2.0-000-cp39-cp39-manylinux_2_31_x86_64.whl; platform_machine == 'x86_64'
-openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.2.0/openvino-2022.2.0-000-cp39-cp39-linux_aarch64.whl; platform_machine == 'aarch64'
-openvino-dev[tensorflow2] == 2022.*
+openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.3.1/openvino-2022.3.1-1-cp39-cp39-manylinux_2_31_x86_64.whl; platform_machine == 'x86_64'
+openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.3.1/openvino-2022.3.1-1-cp39-cp39-linux_aarch64.whl; platform_machine == 'aarch64'
+openvino-dev[tensorflow2] @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.3.1/openvino_dev-2022.3.1-1-py3-none-any.whl

--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -3,7 +3,7 @@ Flask == 2.3.*
 imutils == 0.5.*
 matplotlib == 3.7.*
 mypy == 1.4.1
-numpy == 1.23.*
+numpy == 1.25.*
 onvif_zeep == 0.2.12
 opencv-python-headless == 4.7.0.*
 paho-mqtt == 1.6.*
@@ -24,5 +24,5 @@ norfair == 2.2.*
 setproctitle == 1.3.*
 ws4py == 0.5.*
 # Openvino Library - Custom built with MYRIAD support
-openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.2.0/openvino-2022.2.0-000-cp39-cp39-manylinux_2_31_x86_64.whl; platform_machine == 'x86_64'
-openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.2.0/openvino-2022.2.0-000-cp39-cp39-linux_aarch64.whl; platform_machine == 'aarch64'
+openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.3.1/openvino-2022.3.1-1-cp39-cp39-manylinux_2_31_x86_64.whl; platform_machine == 'x86_64'
+openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.3.1/openvino-2022.3.1-1-cp39-cp39-linux_aarch64.whl; platform_machine == 'aarch64'

--- a/docker/tensorrt/requirements-amd64.txt
+++ b/docker/tensorrt/requirements-amd64.txt
@@ -1,6 +1,6 @@
 # NVidia TensorRT Support (amd64 only)
 --extra-index-url 'https://pypi.nvidia.com'
-numpy < 1.24; platform_machine == 'x86_64'
+numpy <= 1.25; platform_machine == 'x86_64'
 tensorrt == 8.5.3.*; platform_machine == 'x86_64'
 cuda-python == 11.8; platform_machine == 'x86_64'
 cython == 0.29.*; platform_machine == 'x86_64'

--- a/docker/tensorrt/requirements-models-arm64.txt
+++ b/docker/tensorrt/requirements-models-arm64.txt
@@ -1,3 +1,3 @@
 onnx == 1.9.0; platform_machine == 'aarch64'
 protobuf == 3.20.3; platform_machine == 'aarch64'
-numpy == 1.23.*; platform_machine == 'aarch64'
+numpy == 1.25.*; platform_machine == 'aarch64'


### PR DESCRIPTION
This updates OpenVINO to 2022.3.1 LTS.  This is the LTS version and the last major version to support the NCS2 device.

The base OpenVINO model conversion stage of the build will now use the host architecture for generating the model.  This fixes building locally on arm64 platforms.