### PR TITLE
Disambiguate 12h export filename timestamp

### DIFF
--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -42,7 +42,7 @@ class RecordingExporter(threading.Thread):
 
     def get_datetime_from_timestamp(self, timestamp: int) -> str:
         """Convenience fun to get a simple date time from timestamp."""
-        return datetime.datetime.fromtimestamp(timestamp).strftime("%Y_%m_%d_%I:%M")
+        return datetime.datetime.fromtimestamp(timestamp).strftime("%Y_%m_%d_%I:%M%p")
 
     def run(self) -> None:
         logger.debug(

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -42,7 +42,7 @@ class RecordingExporter(threading.Thread):
 
     def get_datetime_from_timestamp(self, timestamp: int) -> str:
         """Convenience fun to get a simple date time from timestamp."""
-        return datetime.datetime.fromtimestamp(timestamp).strftime("%Y_%m_%d_%I:%M%p")
+        return datetime.datetime.fromtimestamp(timestamp).strftime("%Y_%m_%d_%H:%M")
 
     def run(self) -> None:
         logger.debug(


### PR DESCRIPTION
Timestamp in filename is currently ambiguous, leading to filenames like `mycamera_2023_07_27_10:00__2023_07_27_08:00.mp4`. We should either switch to 24-hour time or add AM/PM.