### PR TITLE
Revert numpy upgrade

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
 # Community-supported boards
 /docker/tensorrt/ @madsciencetist @NateMeyer
+/docker/tensorrt/*arm64* @madsciencetist
+/docker/tensorrt/*jetson* @madsciencetist

--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -3,7 +3,7 @@ Flask == 2.3.*
 imutils == 0.5.*
 matplotlib == 3.7.*
 mypy == 1.4.1
-numpy == 1.25.*
+numpy == 1.23.*
 onvif_zeep == 0.2.12
 opencv-python-headless == 4.7.0.*
 paho-mqtt == 1.6.*

--- a/docker/tensorrt/requirements-models-arm64.txt
+++ b/docker/tensorrt/requirements-models-arm64.txt
@@ -1,3 +1,3 @@
-onnx == 1.9.0; platform_machine == 'aarch64'
+onnx == 1.14.0; platform_machine == 'aarch64'
 protobuf == 3.20.3; platform_machine == 'aarch64'
 numpy == 1.23.*; platform_machine == 'aarch64'  # required by python-tensorrt 8.2.1 (Jetpack 4.6)

--- a/docker/tensorrt/requirements-models-arm64.txt
+++ b/docker/tensorrt/requirements-models-arm64.txt
@@ -1,3 +1,3 @@
 onnx == 1.9.0; platform_machine == 'aarch64'
 protobuf == 3.20.3; platform_machine == 'aarch64'
-numpy == 1.25.*; platform_machine == 'aarch64'
+numpy == 1.23.*; platform_machine == 'aarch64'  # required by python-tensorrt 8.2.1 (Jetpack 4.6)


### PR DESCRIPTION
#7319 upgraded numpy from 1.23 to 1.25, which is incompatible with the TensorRT 8.2.1 used in the Jetpack 4.6 build. This reverts that change to fix Jetpack 4.6 detection.