### PR TITLE
Revert numpy upgrade cont.

### DIFF
--- a/docker/tensorrt/requirements-amd64.txt
+++ b/docker/tensorrt/requirements-amd64.txt
@@ -1,6 +1,6 @@
 # NVidia TensorRT Support (amd64 only)
 --extra-index-url 'https://pypi.nvidia.com'
-numpy <= 1.25; platform_machine == 'x86_64'
+numpy < 1.24; platform_machine == 'x86_64'
 tensorrt == 8.5.3.*; platform_machine == 'x86_64'
 cuda-python == 11.8; platform_machine == 'x86_64'
 cython == 0.29.*; platform_machine == 'x86_64'


### PR DESCRIPTION
#7319 upgraded numpy from 1.23 to 1.25, which is incompatible with the TensorRT Frigate uses. #7341 downgraded numpy back to 1.23 in the main Dockerfile and arm64 TensorRT Dockerfile, but had left the amd64 TensorRT Dockerfile as `numpy <= 1.25`. This resulted in version 1.25 in the final image, which is not compatible with the amd64 python-tensorrt either. This PR brings the numpy versioning completely back to where it was before #7319