### PR TITLE
Catch case where detected object has a height of 0

### DIFF
--- a/frigate/video.py
+++ b/frigate/video.py
@@ -593,7 +593,7 @@ def detect(
         width = x_max - x_min
         height = y_max - y_min
         area = width * height
-        ratio = width / height
+        ratio = width / max(1, height)
         det = (
             d[0],
             d[1],


### PR DESCRIPTION
Saw an occasional crash on one of my cameras where the object was detected with a height of 0 leading to a division by zero exception. I think we can treat the ratio the same as if the width is the ratio in that case.