### PR TITLE
Remove custom model example from basic coral docs

### DIFF
--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -42,8 +42,6 @@ detectors:
   coral:
     type: edgetpu
     device: usb
-    model:
-      path: "/custom_model.tflite"
 ```
 
 ### Multiple USB Corals


### PR DESCRIPTION
https://github.com/blakeblackshear/frigate/discussions/6898

Seems users are confused by or copy the default config without reading the docs, so I think it'll be easier to not show the custom model example and assume that users running custom models will read how to configure that.