### PR TITLE
Update go2rtc to 1.7.1

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=tmpfs,target=/tmp --mount=type=tmpfs,target=/var/cache/apt \
 FROM scratch AS go2rtc
 ARG TARGETARCH
 WORKDIR /rootfs/usr/local/go2rtc/bin
-ADD --link --chmod=755 "https://github.com/AlexxIT/go2rtc/releases/download/v1.6.2/go2rtc_linux_${TARGETARCH}" go2rtc
+ADD --link --chmod=755 "https://github.com/AlexxIT/go2rtc/releases/download/v1.7.0/go2rtc_linux_${TARGETARCH}" go2rtc
 
 
 ####

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=tmpfs,target=/tmp --mount=type=tmpfs,target=/var/cache/apt \
 FROM scratch AS go2rtc
 ARG TARGETARCH
 WORKDIR /rootfs/usr/local/go2rtc/bin
-ADD --link --chmod=755 "https://github.com/AlexxIT/go2rtc/releases/download/v1.7.0/go2rtc_linux_${TARGETARCH}" go2rtc
+ADD --link --chmod=755 "https://github.com/AlexxIT/go2rtc/releases/download/v1.7.1/go2rtc_linux_${TARGETARCH}" go2rtc
 
 
 ####

--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -100,12 +100,21 @@ for name in go2rtc_config.get("streams", {}):
     stream = go2rtc_config["streams"][name]
 
     if isinstance(stream, str):
-        go2rtc_config["streams"][name] = go2rtc_config["streams"][name].format(
-            **FRIGATE_ENV_VARS
-        )
+        try:
+            go2rtc_config["streams"][name] = go2rtc_config["streams"][name].format(
+                **FRIGATE_ENV_VARS
+            )
+        except KeyError as e:
+            print("[ERROR] Invalid substitution found, see https://docs.frigate.video/configuration/restream#advanced-restream-configurations for more info.")
+            sys.exit(e)
+
     elif isinstance(stream, list):
         for i, stream in enumerate(stream):
-            go2rtc_config["streams"][name][i] = stream.format(**FRIGATE_ENV_VARS)
+            try:
+                go2rtc_config["streams"][name][i] = stream.format(**FRIGATE_ENV_VARS)
+            except KeyError as e:
+                print("[ERROR] Invalid substitution found, see https://docs.frigate.video/configuration/restream#advanced-restream-configurations for more info.")
+                sys.exit(e)
 
 # add birdseye restream stream if enabled
 if config.get("birdseye", {}).get("restream", False):

--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -105,7 +105,9 @@ for name in go2rtc_config.get("streams", {}):
                 **FRIGATE_ENV_VARS
             )
         except KeyError as e:
-            print("[ERROR] Invalid substitution found, see https://docs.frigate.video/configuration/restream#advanced-restream-configurations for more info.")
+            print(
+                "[ERROR] Invalid substitution found, see https://docs.frigate.video/configuration/restream#advanced-restream-configurations for more info."
+            )
             sys.exit(e)
 
     elif isinstance(stream, list):
@@ -113,7 +115,9 @@ for name in go2rtc_config.get("streams", {}):
             try:
                 go2rtc_config["streams"][name][i] = stream.format(**FRIGATE_ENV_VARS)
             except KeyError as e:
-                print("[ERROR] Invalid substitution found, see https://docs.frigate.video/configuration/restream#advanced-restream-configurations for more info.")
+                print(
+                    "[ERROR] Invalid substitution found, see https://docs.frigate.video/configuration/restream#advanced-restream-configurations for more info."
+                )
                 sys.exit(e)
 
 # add birdseye restream stream if enabled

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -120,7 +120,7 @@ NOTE: The folder that is mapped from the host needs to be the folder that contai
 
 ## Custom go2rtc version
 
-Frigate currently includes go2rtc v1.6.2, there may be certain cases where you want to run a different version of go2rtc.
+Frigate currently includes go2rtc v1.7.0, there may be certain cases where you want to run a different version of go2rtc.
 
 To do this:
 

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -120,7 +120,7 @@ NOTE: The folder that is mapped from the host needs to be the folder that contai
 
 ## Custom go2rtc version
 
-Frigate currently includes go2rtc v1.7.0, there may be certain cases where you want to run a different version of go2rtc.
+Frigate currently includes go2rtc v1.7.1, there may be certain cases where you want to run a different version of go2rtc.
 
 To do this:
 

--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -80,8 +80,8 @@ cameras:
     rtmp:
       enabled: False # <-- RTMP should be disabled if your stream is not H264
     detect:
-      width: # <- optional, by default Frigate tries to automatically detect resolution 
-      height: # <- optional, by default Frigate tries to automatically detect resolution 
+      width: # <- optional, by default Frigate tries to automatically detect resolution
+      height: # <- optional, by default Frigate tries to automatically detect resolution
 ```
 
 ### Blue Iris RTSP Cameras
@@ -117,11 +117,11 @@ cameras:
   reolink:
     ffmpeg:
       inputs:
-        - path: rtsp://127.0.0.1:8554/your_reolink_camera?video=copy&audio=aac
+        - path: rtsp://127.0.0.1:8554/your_reolink_camera
           input_args: preset-rtsp-restream
           roles:
             - record
-        - path: rtsp://127.0.0.1:8554/your_reolink_camera_sub?video=copy
+        - path: rtsp://127.0.0.1:8554/your_reolink_camera_sub
           input_args: preset-rtsp-restream
           roles:
             - detect
@@ -140,7 +140,7 @@ go2rtc:
       - rtspx://192.168.1.1:7441/abcdefghijk
 ```
 
-[See the go2rtc docs for more information](https://github.com/AlexxIT/go2rtc/tree/v1.6.2#source-rtsp)
+[See the go2rtc docs for more information](https://github.com/AlexxIT/go2rtc/tree/v1.7.1#source-rtsp)
 
 In the Unifi 2.0 update Unifi Protect Cameras had a change in audio sample rate which causes issues for ffmpeg. The input rate needs to be set for record and rtmp if used directly with unifi protect.
 

--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -108,13 +108,13 @@ According to [this discussion](https://github.com/blakeblackshear/frigate/issues
 ```yaml
 go2rtc:
   streams:
-    your_reolink_camera: 
+    your_reolink_camera:
       - "ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=username&password=password#video=copy#audio=copy#audio=opus"
-    your_reolink_camera_sub: 
+    your_reolink_camera_sub:
       - "ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user=username&password=password"
 
 cameras:
-  reolink:
+  your_reolink_camera:
     ffmpeg:
       inputs:
         - path: rtsp://127.0.0.1:8554/your_reolink_camera

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -425,7 +425,7 @@ rtmp:
   enabled: False
 
 # Optional: Restream configuration
-# Uses https://github.com/AlexxIT/go2rtc (v1.6.2)
+# Uses https://github.com/AlexxIT/go2rtc (v1.7.0)
 go2rtc:
 
 # Optional: jsmpeg stream configuration for WebUI

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -425,7 +425,7 @@ rtmp:
   enabled: False
 
 # Optional: Restream configuration
-# Uses https://github.com/AlexxIT/go2rtc (v1.7.0)
+# Uses https://github.com/AlexxIT/go2rtc (v1.7.1)
 go2rtc:
 
 # Optional: jsmpeg stream configuration for WebUI

--- a/docs/docs/configuration/live.md
+++ b/docs/docs/configuration/live.md
@@ -78,7 +78,7 @@ WebRTC works by creating a TCP or UDP connection on port `8555`. However, it req
         - 192.168.1.10:8555
         - stun:8555
   ```
-  
+
 - For access through Tailscale, the Frigate system's Tailscale IP must be added as a WebRTC candidate. Tailscale IPs all start with `100.`, and are reserved within the `100.0.0.0/8` CIDR block.
 
 :::tip
@@ -115,4 +115,4 @@ services:
 
 :::
 
-See [go2rtc WebRTC docs](https://github.com/AlexxIT/go2rtc/tree/v1.6.2#module-webrtc) for more information about this.
+See [go2rtc WebRTC docs](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#module-webrtc) for more information about this.

--- a/docs/docs/configuration/live.md
+++ b/docs/docs/configuration/live.md
@@ -115,4 +115,4 @@ services:
 
 :::
 
-See [go2rtc WebRTC docs](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#module-webrtc) for more information about this.
+See [go2rtc WebRTC docs](https://github.com/AlexxIT/go2rtc/tree/v1.7.1#module-webrtc) for more information about this.

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -53,31 +53,31 @@ One connection is made to the camera. One for the restream, `detect` and `record
 ```yaml
 go2rtc:
   streams:
-    rtsp_cam: # <- for RTSP streams
+    name_your_rtsp_cam: # <- for RTSP streams
       - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio
-      - "ffmpeg:rtsp_cam#audio=opus" # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
-    http_cam: # <- for other streams
+      - "ffmpeg:name_your_rtsp_cam#audio=opus" # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
+    name_your_http_cam: # <- for other streams
       - http://192.168.50.155/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=user&password=password # <- stream which supports video & aac audio
-      - "ffmpeg:http_cam#audio=opus" # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
+      - "ffmpeg:name_your_http_cam#audio=opus" # <- copy of the stream which transcodes audio to the missing codec (usually will be opus)
 
 cameras:
-  rtsp_cam:
+  name_your_rtsp_cam:
     ffmpeg:
       output_args:
         record: preset-record-generic-audio-copy
       inputs:
-        - path: rtsp://127.0.0.1:8554/rtsp_cam # <--- the name here must match the name of the camera in restream
+        - path: rtsp://127.0.0.1:8554/name_your_rtsp_cam # <--- the name here must match the name of the camera in restream
           input_args: preset-rtsp-restream
           roles:
             - record
             - detect
             - audio # <- only necessary if audio detection is enabled
-  http_cam:
+  name_your_http_cam:
     ffmpeg:
       output_args:
         record: preset-record-generic-audio-copy
       inputs:
-        - path: rtsp://127.0.0.1:8554/http_cam # <--- the name here must match the name of the camera in restream
+        - path: rtsp://127.0.0.1:8554/name_your_http_cam # <--- the name here must match the name of the camera in restream
           input_args: preset-rtsp-restream
           roles:
             - record
@@ -92,44 +92,44 @@ Two connections are made to the camera. One for the sub stream, one for the rest
 ```yaml
 go2rtc:
   streams:
-    rtsp_cam:
+    name_your_rtsp_cam:
       - rtsp://192.168.1.5:554/live0 # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - "ffmpeg:rtsp_cam#audio=opus" # <- copy of the stream which transcodes audio to opus
-    rtsp_cam_sub:
+      - "ffmpeg:name_your_rtsp_cam#audio=opus" # <- copy of the stream which transcodes audio to opus
+    name_your_rtsp_cam_sub:
       - rtsp://192.168.1.5:554/substream # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - "ffmpeg:rtsp_cam_sub#audio=opus" # <- copy of the stream which transcodes audio to opus
-    http_cam:
+      - "ffmpeg:name_your_rtsp_cam_sub#audio=opus" # <- copy of the stream which transcodes audio to opus
+    name_your_http_cam:
       - http://192.168.50.155/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=user&password=password # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - "ffmpeg:http_cam#audio=opus" # <- copy of the stream which transcodes audio to opus
-    http_cam_sub:
+      - "ffmpeg:name_your_http_cam#audio=opus" # <- copy of the stream which transcodes audio to opus
+    name_your_http_cam_sub:
       - http://192.168.50.155/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user=user&password=password # <- stream which supports video & aac audio. This is only supported for rtsp streams, http must use ffmpeg
-      - "ffmpeg:http_cam_sub#audio=opus" # <- copy of the stream which transcodes audio to opus
+      - "ffmpeg:name_your_http_cam_sub#audio=opus" # <- copy of the stream which transcodes audio to opus
 
 cameras:
-  rtsp_cam:
+  name_your_rtsp_cam:
     ffmpeg:
       output_args:
         record: preset-record-generic-audio-copy
       inputs:
-        - path: rtsp://127.0.0.1:8554/rtsp_cam # <--- the name here must match the name of the camera in restream
+        - path: rtsp://127.0.0.1:8554/name_your_rtsp_cam # <--- the name here must match the name of the camera in restream
           input_args: preset-rtsp-restream
           roles:
             - record
-        - path: rtsp://127.0.0.1:8554/rtsp_cam_sub # <--- the name here must match the name of the camera_sub in restream
+        - path: rtsp://127.0.0.1:8554/name_your_rtsp_cam_sub # <--- the name here must match the name of the camera_sub in restream
           input_args: preset-rtsp-restream
           roles:
             - audio # <- only necessary if audio detection is enabled
             - detect
-  http_cam:
+  name_your_http_cam:
     ffmpeg:
       output_args:
         record: preset-record-generic-audio-copy
       inputs:
-        - path: rtsp://127.0.0.1:8554/http_cam # <--- the name here must match the name of the camera in restream
+        - path: rtsp://127.0.0.1:8554/name_your_http_cam # <--- the name here must match the name of the camera in restream
           input_args: preset-rtsp-restream
           roles:
             - record
-        - path: rtsp://127.0.0.1:8554/http_cam_sub # <--- the name here must match the name of the camera_sub in restream
+        - path: rtsp://127.0.0.1:8554/name_your_http_cam_sub # <--- the name here must match the name of the camera_sub in restream
           input_args: preset-rtsp-restream
           roles:
             - audio # <- only necessary if audio detection is enabled

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -147,7 +147,7 @@ go2rtc:
   streams:
     your_camera: rtsp://192.168.1.5:554/live0
   homekit:
-    your_camera:  # same stream ID from streams list, default PIN - 195502224
+    your_camera:  # same stream ID from streams list, default PIN - 19550224
 ```
 
 For more information [see the go2rtc docs](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#module-homekit)

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -7,7 +7,7 @@ title: Restream
 
 Frigate can restream your video feed as an RTSP feed for other applications such as Home Assistant to utilize it at `rtsp://<frigate_host>:8554/<camera_name>`. Port 8554 must be open. [This allows you to use a video feed for detection in Frigate and Home Assistant live view at the same time without having to make two separate connections to the camera](#reduce-connections-to-camera). The video feed is copied from the original video feed directly to avoid re-encoding. This feed does not include any annotation by Frigate.
 
-Frigate uses [go2rtc](https://github.com/AlexxIT/go2rtc/tree/v1.6.2) to provide its restream and MSE/WebRTC capabilities. The go2rtc config is hosted at the `go2rtc` in the config, see [go2rtc docs](https://github.com/AlexxIT/go2rtc/tree/v1.6.2#configuration) for more advanced configurations and features.
+Frigate uses [go2rtc](https://github.com/AlexxIT/go2rtc/tree/v1.7.0) to provide its restream and MSE/WebRTC capabilities. The go2rtc config is hosted at the `go2rtc` in the config, see [go2rtc docs](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#configuration) for more advanced configurations and features.
 
 :::note
 
@@ -138,7 +138,7 @@ cameras:
 
 ## Advanced Restream Configurations
 
-The [exec](https://github.com/AlexxIT/go2rtc/tree/v1.6.2#source-exec) source in go2rtc can be used for custom ffmpeg commands. An example is below:
+The [exec](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#source-exec) source in go2rtc can be used for custom ffmpeg commands. An example is below:
 
 NOTE: The output will need to be passed with two curly braces `{{output}}`
 

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -136,6 +136,22 @@ cameras:
             - detect
 ```
 
+## HomeKit Restream
+
+Restreaming to HomeKit is supported but there are some requirements:
+- Frigate must be run in host mode, this means that this feature is not supported in the addon
+- Only h264 video / opus audio is supported
+
+```yaml
+go2rtc:
+  streams:
+    your_camera: rtsp://192.168.1.5:554/live0
+  homekit:
+    your_camera:  # same stream ID from streams list, default PIN - 195502224
+```
+
+For more information [see the go2rtc docs](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#module-homekit)
+
 ## Advanced Restream Configurations
 
 The [exec](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#source-exec) source in go2rtc can be used for custom ffmpeg commands. An example is below:

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -136,22 +136,6 @@ cameras:
             - detect
 ```
 
-## HomeKit Restream
-
-Restreaming to HomeKit is supported but there are some requirements:
-- Frigate must be run in host mode, this means that this feature is not supported in the addon
-- Only h264 video / opus audio is supported
-
-```yaml
-go2rtc:
-  streams:
-    your_camera: rtsp://192.168.1.5:554/live0
-  homekit:
-    your_camera:  # same stream ID from streams list, default PIN - 19550224
-```
-
-For more information [see the go2rtc docs](https://github.com/AlexxIT/go2rtc/tree/v1.7.1#module-homekit)
-
 ## Advanced Restream Configurations
 
 The [exec](https://github.com/AlexxIT/go2rtc/tree/v1.7.1#source-exec) source in go2rtc can be used for custom ffmpeg commands. An example is below:

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -7,7 +7,7 @@ title: Restream
 
 Frigate can restream your video feed as an RTSP feed for other applications such as Home Assistant to utilize it at `rtsp://<frigate_host>:8554/<camera_name>`. Port 8554 must be open. [This allows you to use a video feed for detection in Frigate and Home Assistant live view at the same time without having to make two separate connections to the camera](#reduce-connections-to-camera). The video feed is copied from the original video feed directly to avoid re-encoding. This feed does not include any annotation by Frigate.
 
-Frigate uses [go2rtc](https://github.com/AlexxIT/go2rtc/tree/v1.7.0) to provide its restream and MSE/WebRTC capabilities. The go2rtc config is hosted at the `go2rtc` in the config, see [go2rtc docs](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#configuration) for more advanced configurations and features.
+Frigate uses [go2rtc](https://github.com/AlexxIT/go2rtc/tree/v1.7.1) to provide its restream and MSE/WebRTC capabilities. The go2rtc config is hosted at the `go2rtc` in the config, see [go2rtc docs](https://github.com/AlexxIT/go2rtc/tree/v1.7.1#configuration) for more advanced configurations and features.
 
 :::note
 
@@ -150,11 +150,11 @@ go2rtc:
     your_camera:  # same stream ID from streams list, default PIN - 19550224
 ```
 
-For more information [see the go2rtc docs](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#module-homekit)
+For more information [see the go2rtc docs](https://github.com/AlexxIT/go2rtc/tree/v1.7.1#module-homekit)
 
 ## Advanced Restream Configurations
 
-The [exec](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#source-exec) source in go2rtc can be used for custom ffmpeg commands. An example is below:
+The [exec](https://github.com/AlexxIT/go2rtc/tree/v1.7.1#source-exec) source in go2rtc can be used for custom ffmpeg commands. An example is below:
 
 NOTE: The output will need to be passed with two curly braces `{{output}}`
 

--- a/docs/docs/guides/configuring_go2rtc.md
+++ b/docs/docs/guides/configuring_go2rtc.md
@@ -11,7 +11,7 @@ Use of the bundled go2rtc is optional. You can still configure FFmpeg to connect
 
 # Setup a go2rtc stream
 
-First, you will want to configure go2rtc to connect to your camera stream by adding the stream you want to use for live view in your Frigate config file. If you set the stream name under go2rtc to match the name of your camera, it will automatically be mapped and you will get additional live view options for the camera. Avoid changing any other parts of your config at this step. Note that go2rtc supports [many different stream types](https://github.com/AlexxIT/go2rtc/tree/v1.6.2#module-streams), not just rtsp.
+First, you will want to configure go2rtc to connect to your camera stream by adding the stream you want to use for live view in your Frigate config file. If you set the stream name under go2rtc to match the name of your camera, it will automatically be mapped and you will get additional live view options for the camera. Avoid changing any other parts of your config at this step. Note that go2rtc supports [many different stream types](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#module-streams), not just rtsp.
 
 ```yaml
 go2rtc:
@@ -24,7 +24,7 @@ The easiest live view to get working is MSE. After adding this to the config, re
 
 ### What if my video doesn't play?
 
-If you are unable to see your video feed, first check the go2rtc logs in the Frigate UI under Logs in the sidebar. If go2rtc is having difficulty connecting to your camera, you should see some error messages in the log. If you do not see any errors, then the video codec of the stream may not be supported in your browser. If your camera stream is set to H265, try switching to H264. You can see more information about [video codec compatibility](https://github.com/AlexxIT/go2rtc/tree/v1.6.2#codecs-madness) in the go2rtc documentation. If you are not able to switch your camera settings from H265 to H264 or your stream is a different format such as MJPEG, you can use go2rtc to re-encode the video using the [FFmpeg parameters](https://github.com/AlexxIT/go2rtc/tree/v1.6.2#source-ffmpeg). It supports rotating and resizing video feeds and hardware acceleration. Keep in mind that transcoding video from one format to another is a resource intensive task and you may be better off using the built-in jsmpeg view. Here is an example of a config that will re-encode the stream to H264 without hardware acceleration:
+If you are unable to see your video feed, first check the go2rtc logs in the Frigate UI under Logs in the sidebar. If go2rtc is having difficulty connecting to your camera, you should see some error messages in the log. If you do not see any errors, then the video codec of the stream may not be supported in your browser. If your camera stream is set to H265, try switching to H264. You can see more information about [video codec compatibility](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#codecs-madness) in the go2rtc documentation. If you are not able to switch your camera settings from H265 to H264 or your stream is a different format such as MJPEG, you can use go2rtc to re-encode the video using the [FFmpeg parameters](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#source-ffmpeg). It supports rotating and resizing video feeds and hardware acceleration. Keep in mind that transcoding video from one format to another is a resource intensive task and you may be better off using the built-in jsmpeg view. Here is an example of a config that will re-encode the stream to H264 without hardware acceleration:
 
 ```yaml
 go2rtc:

--- a/docs/docs/guides/configuring_go2rtc.md
+++ b/docs/docs/guides/configuring_go2rtc.md
@@ -11,7 +11,7 @@ Use of the bundled go2rtc is optional. You can still configure FFmpeg to connect
 
 # Setup a go2rtc stream
 
-First, you will want to configure go2rtc to connect to your camera stream by adding the stream you want to use for live view in your Frigate config file. If you set the stream name under go2rtc to match the name of your camera, it will automatically be mapped and you will get additional live view options for the camera. Avoid changing any other parts of your config at this step. Note that go2rtc supports [many different stream types](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#module-streams), not just rtsp.
+First, you will want to configure go2rtc to connect to your camera stream by adding the stream you want to use for live view in your Frigate config file. If you set the stream name under go2rtc to match the name of your camera, it will automatically be mapped and you will get additional live view options for the camera. Avoid changing any other parts of your config at this step. Note that go2rtc supports [many different stream types](https://github.com/AlexxIT/go2rtc/tree/v1.7.1#module-streams), not just rtsp.
 
 ```yaml
 go2rtc:
@@ -24,7 +24,7 @@ The easiest live view to get working is MSE. After adding this to the config, re
 
 ### What if my video doesn't play?
 
-If you are unable to see your video feed, first check the go2rtc logs in the Frigate UI under Logs in the sidebar. If go2rtc is having difficulty connecting to your camera, you should see some error messages in the log. If you do not see any errors, then the video codec of the stream may not be supported in your browser. If your camera stream is set to H265, try switching to H264. You can see more information about [video codec compatibility](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#codecs-madness) in the go2rtc documentation. If you are not able to switch your camera settings from H265 to H264 or your stream is a different format such as MJPEG, you can use go2rtc to re-encode the video using the [FFmpeg parameters](https://github.com/AlexxIT/go2rtc/tree/v1.7.0#source-ffmpeg). It supports rotating and resizing video feeds and hardware acceleration. Keep in mind that transcoding video from one format to another is a resource intensive task and you may be better off using the built-in jsmpeg view. Here is an example of a config that will re-encode the stream to H264 without hardware acceleration:
+If you are unable to see your video feed, first check the go2rtc logs in the Frigate UI under Logs in the sidebar. If go2rtc is having difficulty connecting to your camera, you should see some error messages in the log. If you do not see any errors, then the video codec of the stream may not be supported in your browser. If your camera stream is set to H265, try switching to H264. You can see more information about [video codec compatibility](https://github.com/AlexxIT/go2rtc/tree/v1.7.1#codecs-madness) in the go2rtc documentation. If you are not able to switch your camera settings from H265 to H264 or your stream is a different format such as MJPEG, you can use go2rtc to re-encode the video using the [FFmpeg parameters](https://github.com/AlexxIT/go2rtc/tree/v1.7.1#source-ffmpeg). It supports rotating and resizing video feeds and hardware acceleration. Keep in mind that transcoding video from one format to another is a resource intensive task and you may be better off using the built-in jsmpeg view. Here is an example of a config that will re-encode the stream to H264 without hardware acceleration:
 
 ```yaml
 go2rtc:

--- a/web/src/components/MsePlayer.js
+++ b/web/src/components/MsePlayer.js
@@ -217,6 +217,7 @@ class VideoRTC extends HTMLElement {
     this.video.controls = true;
     this.video.playsInline = true;
     this.video.preload = 'auto';
+    this.video.muted = true;
 
     this.video.style.display = 'block'; // fix bottom margin 4px
     this.video.style.width = '100%';


### PR DESCRIPTION
This is a major update with a lot of changes, likely needs more testing before merging.

In my initial testing of the dev version over the last week: with a total of 12 stream consumers and 6 stream producers, CPU usage went from 12% of one core to 8% of one core when moving to the dev version