### PR TITLE
Suggest object masks for stationary false positives

### DIFF
--- a/docs/docs/guides/false_positives.md
+++ b/docs/docs/guides/false_positives.md
@@ -21,3 +21,5 @@ For object filters in your configuration, any single detection below `min_score`
 | 6     | 0.95          | 0.7, 0.85, 0.95, 0.90, 0.88, 0.95 | 0.89           | Yes             |
 
 In frame 2, the score is below the `min_score` value, so Frigate ignores it and it becomes a 0.0. The computed score is the median of the score history (padding to at least 3 values), and only when that computed score crosses the `threshold` is the object marked as a true positive. That happens in frame 4 in the example.
+
+If you're seeing false positives from stationary objects, please see Object Masks here: https://docs.frigate.video/configuration/masks/


### PR DESCRIPTION
Mention about false positives from stationary objects. Added because I just had this issue and the current page didn't really help me.