### PR TITLE
Add documentation for TP-Link VIGI stream settings.

### DIFF
--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -150,3 +150,7 @@ ffmpeg:
     record: preset-record-ubiquiti
     rtmp: preset-rtmp-ubiquiti # recommend using go2rtc instead
 ```
+
+### TP-Link VIGI Cameras
+
+TP-Link VIGI cameras need some adjustments to the main stream settings on the camera itself to avoid issues. The stream needs to be configured as `H264` with `Smart Coding` set to `off`. Without these settings you may have problems when trying to watch recorded events. For example Firefox will stop playback after a few seconds and show the following error message: `The media playback was aborted due to a corruption problem or because the media used features your browser did not support.`.


### PR DESCRIPTION
This is not frigate-specific configuration, but especially the `Smart Coding` thing took me a while to figure out so I thought it best to include it in the docs anyway.