### PR TITLE
use useEffect for key listeners on camera control panel

### DIFF
--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -27,22 +27,22 @@ export default function CameraControlPanel({ camera = '' }) {
     setCurrentPreset('');
   };
 
-  const onSetMove = async (e, dir) => {
+  const onSetMove = useCallback(async (e, dir) => {
     e.stopPropagation();
     sendPtz(`MOVE_${dir}`);
     setCurrentPreset('');
-  };
+  }, [sendPtz, setCurrentPreset]);
 
-  const onSetZoom = async (e, dir) => {
+  const onSetZoom = useCallback(async (e, dir) => {
     e.stopPropagation();
     sendPtz(`ZOOM_${dir}`);
     setCurrentPreset('');
-  };
+  }, [sendPtz, setCurrentPreset]);
 
-  const onSetStop = async (e) => {
+  const onSetStop = useCallback(async (e) => {
     e.stopPropagation();
     sendPtz('STOP');
-  };
+  }, [sendPtz]);
 
   const keydownListener = useCallback((e) => {
     if (!ptz || !e) {

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useState } from 'preact/hooks';
+import { useEffect, useCallback, useState } from 'preact/hooks';
 import useSWR from 'swr';
 import { usePtzCommand } from '../api/ws';
 import ActivityIndicator from './ActivityIndicator';
@@ -44,12 +44,8 @@ export default function CameraControlPanel({ camera = '' }) {
     sendPtz('STOP');
   };
 
-  if (!ptz) {
-    return <ActivityIndicator />;
-  }
-
-  document.addEventListener('keydown', (e) => {
-    if (!e) {
+  const keydownListener = useCallback((e) => {
+    if (!ptz || !e) {
       return;
     }
 
@@ -83,9 +79,9 @@ export default function CameraControlPanel({ camera = '' }) {
         }
       }
     }
-  });
+  }, [ptz]);
 
-  document.addEventListener('keyup', (e) => {
+  const keyupListener = useCallback((e) => {
     if (!e || e.repeat) {
       return;
     }
@@ -101,7 +97,20 @@ export default function CameraControlPanel({ camera = '' }) {
       e.preventDefault();
       onSetStop(e);
     }
-  });
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('keydown', keydownListener);
+    document.addEventListener('keyup', keyupListener);
+    return () => {
+      document.removeEventListener('keydown', keydownListener);
+      document.removeEventListener('keyup', keyupListener);
+    };
+  }, [keydownListener, keyupListener, ptz]);
+
+  if (!ptz) {
+    return <ActivityIndicator />;
+  }
 
   return (
     <div data-testid="control-panel" className="p-4 text-center sm:flex justify-start">

--- a/web/src/components/CameraControlPanel.jsx
+++ b/web/src/components/CameraControlPanel.jsx
@@ -79,7 +79,7 @@ export default function CameraControlPanel({ camera = '' }) {
         }
       }
     }
-  }, [ptz]);
+  }, [onSetMove, onSetZoom, ptz]);
 
   const keyupListener = useCallback((e) => {
     if (!e || e.repeat) {
@@ -97,7 +97,7 @@ export default function CameraControlPanel({ camera = '' }) {
       e.preventDefault();
       onSetStop(e);
     }
-  }, []);
+  }, [onSetStop]);
 
   useEffect(() => {
     document.addEventListener('keydown', keydownListener);


### PR DESCRIPTION
The PTZ camera controls on birdseye and the individual camera components has a key listener that was triggering after the component was unmounted (when moving from birdseye to editing the config, for example).

I was able to reproduce the issue on both Safari and Firefox. Use the plus or minus keys to zoom in/out, then navigate to the config editor and type a dash.

This PR moves the keyup and keydown listeners into callbacks and implements useEffect.