### PR TITLE
Refactor Exports To Better Handle Recording Configs

### DIFF
--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -76,7 +76,7 @@ class RecordingExporter(threading.Thread):
             page_size = 1000
             num_pages = (export_recordings.count() + page_size - 1) // page_size
 
-            for page in range(num_pages):
+            for page in range(1, num_pages + 1):
                 playlist = export_recordings.paginate(page, page_size)
                 playlist_lines.append(
                     f"file 'http://127.0.0.1:5000/vod/{self.camera}/start/{float(playlist[0].start_time)}/end/{float(playlist[-1].end_time)}/index.m3u8'"

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -66,7 +66,10 @@ class RecordingExporter(threading.Thread):
                 .where(
                     Recordings.start_time.between(self.start_time, self.end_time)
                     | Recordings.end_time.between(self.start_time, self.end_time)
-                    | ((self.start_time > Recordings.start_time) & (self.end_time < Recordings.end_time))
+                    | (
+                        (self.start_time > Recordings.start_time)
+                        & (self.end_time < Recordings.end_time)
+                    )
                 )
                 .where(Recordings.camera == self.camera)
                 .order_by(Recordings.start_time.asc())

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -77,9 +77,9 @@ class RecordingExporter(threading.Thread):
             num_pages = (export_recordings.count() + page_size - 1) // page_size
 
             for page in range(num_pages):
-                page = export_recordings.paginate(page, page_size)
+                playlist = export_recordings.paginate(page, page_size)
                 playlist_lines.append(
-                    f"file 'http://127.0.0.1:5000/vod/{self.camera}/start/{float(page[0].start_time)}/end/{float(page[-1].end_time)}/index.m3u8'"
+                    f"file 'http://127.0.0.1:5000/vod/{self.camera}/start/{float(playlist[0].start_time)}/end/{float(playlist[-1].end_time)}/index.m3u8'"
                 )
 
             ffmpeg_input = "-y -protocol_whitelist pipe,file,http,tcp -f concat -safe 0 -i /dev/stdin"

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -79,7 +79,7 @@ class RecordingExporter(threading.Thread):
             for page in range(num_pages):
                 page = export_recordings.paginate(page, page_size)
                 playlist_lines.append(
-                    f"file 'http://127.0.0.1:5000/vod/{self.camera}/start/{page[0].start_time}/end/{page[-1].end_time}/index.m3u8'"
+                    f"file 'http://127.0.0.1:5000/vod/{self.camera}/start/{float(page[0].start_time)}/end/{float(page[-1].end_time)}/index.m3u8'"
                 )
 
             ffmpeg_input = "-y -protocol_whitelist pipe,file,http,tcp -f concat -safe 0 -i /dev/stdin"

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -13,6 +13,7 @@ from frigate.ffmpeg_presets import (
     EncodeTypeEnum,
     parse_preset_hardware_acceleration_encode,
 )
+from frigate.models import Recordings
 
 logger = logging.getLogger(__name__)
 
@@ -58,13 +59,28 @@ class RecordingExporter(threading.Thread):
             )
         else:
             playlist_lines = []
-            playlist_start = self.start_time
 
-            while playlist_start < self.end_time:
-                playlist_lines.append(
-                    f"file 'http://127.0.0.1:5000/vod/{self.camera}/start/{playlist_start}/end/{min(playlist_start + MAX_PLAYLIST_SECONDS, self.end_time)}/index.m3u8'"
+            # get full set of recordings
+            export_recordings = (
+                Recordings.select()
+                .where(
+                    Recordings.start_time.between(self.start_time, self.end_time)
+                    | Recordings.end_time.between(self.start_time, self.end_time)
+                    | ((self.start > Recordings.start_time) & (self.end_time < Recordings.end_time))
                 )
-                playlist_start += MAX_PLAYLIST_SECONDS
+                .where(Recordings.camera == self.camera)
+                .order_by(Recordings.start_time.asc())
+            )
+
+            # Use pagination to process records in chunks
+            page_size = 1000
+            num_pages = (export_recordings.count() + page_size - 1) // page_size
+
+            for page in range(num_pages):
+                page = export_recordings.paginate(page, page_size)
+                playlist_lines.append(
+                    f"file 'http://127.0.0.1:5000/vod/{self.camera}/start/{page[0].start_time}/end/{page[-1].end_time}/index.m3u8'"
+                )
 
             ffmpeg_input = "-y -protocol_whitelist pipe,file,http,tcp -f concat -safe 0 -i /dev/stdin"
 

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -66,7 +66,7 @@ class RecordingExporter(threading.Thread):
                 .where(
                     Recordings.start_time.between(self.start_time, self.end_time)
                     | Recordings.end_time.between(self.start_time, self.end_time)
-                    | ((self.start > Recordings.start_time) & (self.end_time < Recordings.end_time))
+                    | ((self.start_time > Recordings.start_time) & (self.end_time < Recordings.end_time))
                 )
                 .where(Recordings.camera == self.camera)
                 .order_by(Recordings.start_time.asc())


### PR DESCRIPTION
The current implementation works well with 24/7 mode `all` but has issues due to the handling of trying to pull recordings 2 hours at a time, it could lead to gaps (and inefficient requests) causing errors.

This new approach queries the DB directly and handles at 1000 segments for each request to ensure that requests are more efficient.