### PR TITLE
Increase initial hit count for norfair tracker

### DIFF
--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -107,7 +107,9 @@ class NorfairTracker(ObjectTracker):
         }
 
         # start object with a hit count of `fps` to avoid quick detection -> loss
-        next((o for o in self.tracker.tracked_objects if o.global_id == track_id)).hit_counter = self.camera_config.detect.fps
+        next(
+            (o for o in self.tracker.tracked_objects if o.global_id == track_id)
+        ).hit_counter = self.camera_config.detect.fps
 
     def deregister(self, id, track_id):
         del self.tracked_objects[id]

--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -106,6 +106,9 @@ class NorfairTracker(ObjectTracker):
             "ymax": self.detect_config.height,
         }
 
+        # start object with a hit count of `fps` to avoid quick detection -> loss
+        next((o for o in self.tracker.tracked_objects if o.global_id == track_id)).hit_counter = self.camera_config.detect.fps
+
     def deregister(self, id, track_id):
         del self.tracked_objects[id]
         del self.disappeared[id]


### PR DESCRIPTION
There are some cases where an object is quickly visible then hidden. Due to the inertia system if this happens after the object is first detected then it can lead to a burst of events. This initial hit count should alleviate some of these cases without affecting false positive inertia.