### PR TITLE
Update CAP_PERFMON instructions on hardware_acceleration.md

### DIFF
--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -62,11 +62,10 @@ ffmpeg:
 
 #### Configuring Intel GPU Stats in Docker
 
-Additional configuration is needed for the Docker container to be able to access the `intel_gpu_top` command for GPU stats. Three possible changes can be made:
+Additional configuration is needed for the Docker container to be able to access the `intel_gpu_top` command for GPU stats. Three are two options:
 
 1. Run the container as privileged.
-2. Adding the `CAP_PERFMON` capability.
-3. Setting the `perf_event_paranoid` low enough to allow access to the performance event system.
+2. Add the `CAP_PERFMON` capability (note: you might need to set the `perf_event_paranoid` low enough to allow access to the performance event system.)
 
 ##### Run as privileged
 
@@ -123,7 +122,7 @@ _Note: This setting must be changed for the entire system._
 
 For more information on the various values across different distributions, see https://askubuntu.com/questions/1400874/what-does-perf-paranoia-level-four-do.
 
-Depending on your OS and kernel configuration, you may need to change the `/proc/sys/kernel/perf_event_paranoid` kernel tunable. You can test the change by running `sudo sh -c 'echo 2 >/proc/sys/kernel/perf_event_paranoid'` which will persist until a reboot. Make it permanent by running `sudo sh -c 'echo kernel.perf_event_paranoid=1 >> /etc/sysctl.d/local.conf'`
+Depending on your OS and kernel configuration, you may need to change the `/proc/sys/kernel/perf_event_paranoid` kernel tunable. You can test the change by running `sudo sh -c 'echo 2 >/proc/sys/kernel/perf_event_paranoid'` which will persist until a reboot. Make it permanent by running `sudo sh -c 'echo kernel.perf_event_paranoid=2 >> /etc/sysctl.d/local.conf'`
 
 ### AMD/ATI GPUs (Radeon HD 2000 and newer GPUs) via libva-mesa-driver
 

--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -62,7 +62,7 @@ ffmpeg:
 
 #### Configuring Intel GPU Stats in Docker
 
-Additional configuration is needed for the Docker container to be able to access the `intel_gpu_top` command for GPU stats. Three are two options:
+Additional configuration is needed for the Docker container to be able to access the `intel_gpu_top` command for GPU stats. There are two options:
 
 1. Run the container as privileged.
 2. Add the `CAP_PERFMON` capability (note: you might need to set the `perf_event_paranoid` low enough to allow access to the performance event system.)


### PR DESCRIPTION
The current instructions on how to run `intel_gpu_top` in docker make it seem like there are 3 options, where there are actually only 2. The `perf_event_paranoid` instructions are needed in some distros to make `CAP_PERFMON` work.
Also changed the persistent instruction to 2. to make it consistent with the non-persistent instruction (and 2 seems to be sufficient).

(These are based on my testing with Debian Bookworm and current Testing - but even if it's not consistent with other distros, at the very least it needs to be clear that both `CAP_PERFMON` and `perf_event_paranoid` are needed to make this work in Debian)