### PR TITLE
Force birdseye to standard aspect ratio

### DIFF
--- a/frigate/output.py
+++ b/frigate/output.py
@@ -33,7 +33,7 @@ from frigate.util.image import (
 logger = logging.getLogger(__name__)
 
 
-def get_standard_aspect_ratio(width, height) -> tuple[int, int]:
+def get_standard_aspect_ratio(width: int, height: int) -> tuple[int, int]:
     """Ensure that only standard aspect ratios are used."""
     known_aspects = [
         (16, 9),
@@ -50,6 +50,19 @@ def get_standard_aspect_ratio(width, height) -> tuple[int, int]:
         key=lambda x: abs(x - (width / height)),
     )
     return known_aspects[known_aspects_ratios.index(closest)]
+
+def get_canvas_shape(width: int, height: int) -> tuple[int, int]:
+    """Get birdseye canvas shape."""
+    canvas_width = width
+    canvas_height = height
+    a_w, a_h = get_standard_aspect_ratio(width, height)
+
+    if round(a_w / a_h, 2) != round(width / height):
+        canvas_width = width
+        canvas_height = (canvas_width / a_w) * a_h
+        logger.warning(f"The birdseye resolution is a non-standard aspect ratio, forcing birdseye resolution to {canvas_width} x {canvas_height}")
+
+    return (canvas_width, canvas_height)
 
 
 class Canvas:
@@ -226,8 +239,7 @@ class BirdsEyeFrameManager:
         self.config = config
         self.mode = config.birdseye.mode
         self.frame_manager = frame_manager
-        width = config.birdseye.width
-        height = config.birdseye.height
+        width, height = get_canvas_shape(config.birdseye.width, config.birdseye.height)
         self.frame_shape = (height, width)
         self.yuv_shape = (height * 3 // 2, width)
         self.frame = np.ndarray(self.yuv_shape, dtype=np.uint8)

--- a/frigate/output.py
+++ b/frigate/output.py
@@ -51,6 +51,7 @@ def get_standard_aspect_ratio(width: int, height: int) -> tuple[int, int]:
     )
     return known_aspects[known_aspects_ratios.index(closest)]
 
+
 def get_canvas_shape(width: int, height: int) -> tuple[int, int]:
     """Get birdseye canvas shape."""
     canvas_width = width
@@ -60,7 +61,9 @@ def get_canvas_shape(width: int, height: int) -> tuple[int, int]:
     if round(a_w / a_h, 2) != round(width / height, 2):
         canvas_width = width
         canvas_height = (canvas_width / a_w) * a_h
-        logger.warning(f"The birdseye resolution is a non-standard aspect ratio, forcing birdseye resolution to {canvas_width} x {canvas_height}")
+        logger.warning(
+            f"The birdseye resolution is a non-standard aspect ratio, forcing birdseye resolution to {canvas_width} x {canvas_height}"
+        )
 
     return (canvas_width, canvas_height)
 

--- a/frigate/output.py
+++ b/frigate/output.py
@@ -57,7 +57,7 @@ def get_canvas_shape(width: int, height: int) -> tuple[int, int]:
     canvas_height = height
     a_w, a_h = get_standard_aspect_ratio(width, height)
 
-    if round(a_w / a_h, 2) != round(width / height):
+    if round(a_w / a_h, 2) != round(width / height, 2):
         canvas_width = width
         canvas_height = (canvas_width / a_w) * a_h
         logger.warning(f"The birdseye resolution is a non-standard aspect ratio, forcing birdseye resolution to {canvas_width} x {canvas_height}")

--- a/frigate/test/test_birdseye.py
+++ b/frigate/test/test_birdseye.py
@@ -43,5 +43,5 @@ class TestBirdseye(unittest.TestCase):
         width = 1280
         height = 840
         canvas_width, canvas_height = get_canvas_shape(width, height)
-        assert canvas_width == width # width will be the same
+        assert canvas_width == width  # width will be the same
         assert canvas_height != height

--- a/frigate/test/test_birdseye.py
+++ b/frigate/test/test_birdseye.py
@@ -1,0 +1,47 @@
+"""Test camera user and password cleanup."""
+
+import unittest
+
+from frigate.output import get_canvas_shape
+
+
+class TestBirdseye(unittest.TestCase):
+    def test_16x9(self):
+        """Test 16x9 aspect ratio works as expected for birdseye."""
+        width = 1280
+        height = 720
+        canvas_width, canvas_height = get_canvas_shape(width, height)
+        assert canvas_width == width
+        assert canvas_height == height
+
+    def test_4x3(self):
+        """Test 4x3 aspect ratio works as expected for birdseye."""
+        width = 1280
+        height = 960
+        canvas_width, canvas_height = get_canvas_shape(width, height)
+        assert canvas_width == width
+        assert canvas_height == height
+
+    def test_32x9(self):
+        """Test 32x9 aspect ratio works as expected for birdseye."""
+        width = 2560
+        height = 720
+        canvas_width, canvas_height = get_canvas_shape(width, height)
+        assert canvas_width == width
+        assert canvas_height == height
+
+    def test_9x16(self):
+        """Test 9x16 aspect ratio works as expected for birdseye."""
+        width = 720
+        height = 1280
+        canvas_width, canvas_height = get_canvas_shape(width, height)
+        assert canvas_width == width
+        assert canvas_height == height
+
+    def test_non_16x9(self):
+        """Test non 16x9 aspect ratio fails for birdseye."""
+        width = 1280
+        height = 840
+        canvas_width, canvas_height = get_canvas_shape(width, height)
+        assert canvas_width == width # width will be the same
+        assert canvas_height != height


### PR DESCRIPTION
When birdseye is a non-standard aspect ratio, it becomes very difficult to put standard aspect ratio cameras into it. This will ensure that birdseye is a standard aspect ratio and print a warning when it is not. 

I also added tests to ensure that things are working as expected

closes https://github.com/blakeblackshear/frigate/issues/7863