### PR TITLE
Add docker healthcheck

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.6
 
 # https://askubuntu.com/questions/972516/debian-frontend-environment-variable
 ARG DEBIAN_FRONTEND=noninteractive

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -257,5 +257,5 @@ FROM deps AS frigate
 WORKDIR /opt/frigate/
 COPY --from=rootfs / /
 
-HEALTHCHECK --start-period=90s --start-interval=5s --interval=15s --timeout=5s --retries=3 \
+HEALTHCHECK --start-period=120s --start-interval=5s --interval=15s --timeout=5s --retries=3 \
     CMD curl --fail --silent --show-error http://127.0.0.1:5000/api/version || exit 1

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -199,6 +199,9 @@ ENV S6_LOGGING_SCRIPT="T 1 n0 s10000000 T"
 ENTRYPOINT ["/init"]
 CMD []
 
+HEALTHCHECK --start-period=120s --start-interval=5s --interval=15s --timeout=5s --retries=3 \
+    CMD curl --fail --silent --show-error http://127.0.0.1:5000/api/version || exit 1
+
 # Frigate deps with Node.js and NPM for devcontainer
 FROM deps AS devcontainer
 
@@ -256,6 +259,3 @@ FROM deps AS frigate
 
 WORKDIR /opt/frigate/
 COPY --from=rootfs / /
-
-HEALTHCHECK --start-period=120s --start-interval=5s --interval=15s --timeout=5s --retries=3 \
-    CMD curl --fail --silent --show-error http://127.0.0.1:5000/api/version || exit 1

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -256,3 +256,6 @@ FROM deps AS frigate
 
 WORKDIR /opt/frigate/
 COPY --from=rootfs / /
+
+HEALTHCHECK --start-period=90s --start-interval=5s --interval=15s --timeout=5s --retries=3 \
+    CMD curl --fail --silent --show-error http://127.0.0.1:5000/api/version || exit 1

--- a/docker/tensorrt/Dockerfile.base
+++ b/docker/tensorrt/Dockerfile.base
@@ -24,3 +24,6 @@ COPY --from=trt-deps /usr/local/lib/libyolo_layer.so /usr/local/lib/libyolo_laye
 COPY --from=trt-deps /usr/local/src/tensorrt_demos /usr/local/src/tensorrt_demos
 COPY docker/tensorrt/detector/rootfs/ /
 ENV YOLO_MODELS="yolov7-320"
+
+HEALTHCHECK --start-period=600s --start-interval=5s --interval=15s --timeout=5s --retries=3 \
+    CMD curl --fail --silent --show-error http://127.0.0.1:5000/api/version || exit 1


### PR DESCRIPTION
This is inspired by addon-vscode, which implemented this not so long ago (https://github.com/hassio-addons/addon-vscode/blob/8149899349d5d5f0f9095b4fb47950d5ad58541e/vscode/Dockerfile#L133).

This will make the container be shown as `starting`, `healthy`, or `unhealthy` in `docker ps`. Example:

```console
❯ docker ps
CONTAINER ID   IMAGE                                                          COMMAND                  CREATED              STATUS                        PORTS                                                                                                                                                                     NAMES
e8ce50efee46   ghcr.io/hassio-addons/vscode/amd64:5.11.0                      "/init"                  About a minute ago   Up About a minute (healthy)                                                                                                                                                                             addon_a0d7b954_vscode
d665a841a9bf   local/amd64-addon-netdata:1.42.4-2                             "/run.sh"                2 days ago           Up 2 days (healthy)                                                                                                                                                                                     addon_local_netdata
```

This will also present a more helpful page from the hassio panel:

![chrome_SdoD1XbY2i](https://github.com/blakeblackshear/frigate/assets/29582865/189e23d5-05f3-455a-83d8-ad84630c31a7)

And finally, this will allow people using docker compose to automatically restart Frigate when unhealthy using [autoheal](https://github.com/willfarrell/docker-autoheal):

```diff
version: "3.9"
services:
  frigate:
    container_name: frigate
    privileged: true # this may not be necessary for all setups
    restart: unless-stopped
    image: ghcr.io/blakeblackshear/frigate:stable
    shm_size: "64mb" # update for your cameras based on calculation above
    devices:
      - /dev/bus/usb:/dev/bus/usb # passes the USB Coral, needs to be modified for other versions
      - /dev/apex_0:/dev/apex_0 # passes a PCIe Coral, follow driver instructions here https://coral.ai/docs/m2/get-started/#2a-on-linux
      - /dev/dri/renderD128 # for intel hwaccel, needs to be updated for your hardware
    volumes:
      - /etc/localtime:/etc/localtime:ro
      - /path/to/your/config.yml:/config/config.yml
      - /path/to/your/storage:/media/frigate
      - type: tmpfs # Optional: 1GB of memory, reduces SSD/SD Card wear
        target: /tmp/cache
        tmpfs:
          size: 1000000000
    ports:
      - "5000:5000"
      - "8554:8554" # RTSP feeds
      - "8555:8555/tcp" # WebRTC over tcp
      - "8555:8555/udp" # WebRTC over udp
    environment:
      FRIGATE_RTSP_PASSWORD: "password"
+   labels:
+     autoheal: "true"
+ autoheal:
+   restart: unless-stopped
+   depends_on:
+     frigate:
+       condition: service_healthy
+   image: willfarrell/autoheal
+   volumes:
+     - /var/run/docker.sock:/var/run/docker.sock
```