### PR TITLE
[CHANGE] More resilient and slightly faster PTZ

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -490,7 +490,7 @@ class OnvifController:
         status_request = self.cams[camera_name]["status_request"]
         try:
             status = onvif.get_service("ptz").GetStatus(status_request)
-        except Exception as e:
+        except Exception:
             pass  # We're unsupported, that'll be reported in the next check.
 
         # there doesn't seem to be an onvif standard with this optional parameter

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -493,7 +493,7 @@ class OnvifController:
         try:
             status = onvif.get_service("ptz").GetStatus(status_request)
         except Exception as e:
-            pass # We're unsupported, that'll be reported in the next check.
+            pass  # We're unsupported, that'll be reported in the next check.
 
         # there doesn't seem to be an onvif standard with this optional parameter
         # some cameras can report MoveStatus with or without PanTilt or Zoom attributes

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -98,7 +98,7 @@ class OnvifController:
             ),
             None,
         )
-        
+
         # status request for autotracking and filling ptz-parameters
         status_request = ptz.create_type("GetStatus")
         status_request.ProfileToken = profile.token
@@ -107,9 +107,7 @@ class OnvifController:
             status = ptz.GetStatus(status_request)
             logger.debug(f"Onvif status config for {camera_name}: {status}")
         except Exception as e:
-            logger.warning(
-                f"Unable to get status from camera: {camera_name}: {e}"
-            )
+            logger.warning(f"Unable to get status from camera: {camera_name}: {e}")
             status = None
 
         # autoracking relative panning/tilting needs a relative zoom value set to 0

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -98,6 +98,19 @@ class OnvifController:
             ),
             None,
         )
+        
+        # status request for autotracking and filling ptz-parameters
+        status_request = ptz.create_type("GetStatus")
+        status_request.ProfileToken = profile.token
+        self.cams[camera_name]["status_request"] = status_request
+        try:
+            status = ptz.GetStatus(status_request)
+            logger.debug(f"Onvif status config for {camera_name}: {status}")
+        except Exception as e:
+            logger.warning(
+                f"Unable to get status from camera: {camera_name}: {e}"
+            )
+            status = None
 
         # autoracking relative panning/tilting needs a relative zoom value set to 0
         # if camera supports relative movement
@@ -122,9 +135,7 @@ class OnvifController:
         move_request = ptz.create_type("RelativeMove")
         move_request.ProfileToken = profile.token
         if move_request.Translation is None and fov_space_id is not None:
-            move_request.Translation = ptz.GetStatus(
-                {"ProfileToken": profile.token}
-            ).Position
+            move_request.Translation = status.Position
             move_request.Translation.PanTilt.space = ptz_config["Spaces"][
                 "RelativePanTiltTranslationSpace"
             ][fov_space_id]["URI"]
@@ -146,20 +157,13 @@ class OnvifController:
                 )
 
         if move_request.Speed is None:
-            move_request.Speed = ptz.GetStatus({"ProfileToken": profile.token}).Position
+            move_request.Speed = status.Position if status else None
         self.cams[camera_name]["relative_move_request"] = move_request
 
         # setup absolute moving request for autotracking zooming
         move_request = ptz.create_type("AbsoluteMove")
         move_request.ProfileToken = profile.token
         self.cams[camera_name]["absolute_move_request"] = move_request
-
-        # status request for autotracking
-        status_request = ptz.create_type("GetStatus")
-        status_request.ProfileToken = profile.token
-        self.cams[camera_name]["status_request"] = status_request
-        status = ptz.GetStatus(status_request)
-        logger.debug(f"Onvif status config for {camera_name}: {status}")
 
         # setup existing presets
         try:
@@ -486,7 +490,10 @@ class OnvifController:
 
         onvif: ONVIFCamera = self.cams[camera_name]["onvif"]
         status_request = self.cams[camera_name]["status_request"]
-        status = onvif.get_service("ptz").GetStatus(status_request)
+        try:
+            status = onvif.get_service("ptz").GetStatus(status_request)
+        except Exception as e:
+            pass # We're unsupported, that'll be reported in the next check.
 
         # there doesn't seem to be an onvif standard with this optional parameter
         # some cameras can report MoveStatus with or without PanTilt or Zoom attributes


### PR DESCRIPTION
While attempting to hack around TP-Links broken onvif implementation on the C210, I moved around some code. This potentially saves two calls to the camera, and over all makes it ever so slightly more resilient from partial Onvif implementations. So even though it didn't solve my problem, I figured this small change could be useful.

The C210 unfortunately suffers from broken Onvif all around, it simply freezes after a while, only responding with errors with roughly 30 seconds between each response. I'm guessing that it has to do with a timeout somewhere on a stream, as it works for rougly 2 minutes using ONVIF Device Manager on Windows before dropping out. Using Onvier on android gives the same, a couple of minutes of usable control, before all controls freeze for a while.

The Tapo app uses port 8800 with some TLS protocol. Because why would you take a perfectly good open standard when you can throw a shoddy closed alternative together yourself...

I might still be looking to see if they have an http api. I could imagine more cameras having one of those, and could see it being viable to have something like that exist next to Onvif for PTZ.