### PR TITLE
Update ESXi instructions

### DIFF
--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -204,6 +204,8 @@ It is recommended to run Frigate in LXC for maximum performance. See [this discu
 
 For details on running Frigate using ESXi, please see the instructions [here](https://williamlam.com/2023/05/frigate-nvr-with-coral-tpu-igpu-passthrough-using-esxi-on-intel-nuc.html).
 
+If you're running Frigate on a rack mounted server and want to passthough the Google Coral, [read this.](https://github.com/blakeblackshear/frigate/issues/305)
+
 ## Synology NAS on DSM 7
 
 These settings were tested on DSM 7.1.1-42962 Update 4


### PR DESCRIPTION
I spent 2 weeks trying to fix Frigate from crashing when visiting the webpage, and this [issue](https://github.com/blakeblackshear/frigate/issues/305) helped me fix it. I needed to install a USB PCIe card in my server to fix it from crashing. It was crashing because the USB passthrough on the integrated card kept breaking, causing it to try to use the Coral as the detector but couldn't find it. 

Updated docs to link to this issue if anyone else is having this problem. 

Anyways, thanks for creating Frigate, its awesome!