### PR TITLE
Onvif presets: use getattr instead of get

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -176,7 +176,7 @@ class OnvifController:
 
         for preset in presets:
             self.cams[camera_name]["presets"][
-                preset.get("Name", f"preset {preset['token']}").lower()
+                getattr(preset, "Name", f"preset {preset['token']}").lower()
             ] = preset["token"]
 
         # get list of supported features


### PR DESCRIPTION
Fix a bug introduced by https://github.com/blakeblackshear/frigate/pull/8046

`PTZPreset has no attribute 'get'`. Should have used `getattr`.