### PR TITLE
Lower min scores for person and car in plus docs

### DIFF
--- a/docs/docs/plus/index.md
+++ b/docs/docs/plus/index.md
@@ -70,10 +70,10 @@ objects:
     fedex:
       min_score: .75
     person:
-      min_score: .8
+      min_score: .65
       threshold: .85
     car:
-      min_score: .8
+      min_score: .65
       threshold: .85
 ```
 


### PR DESCRIPTION
In my experience 0.8 is a bit high and can cause negative effects due to some lower scoring true positives being thrown out. 