### PR TITLE
Rework initialization delay

### DIFF
--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -77,7 +77,7 @@ class NorfairTracker(ObjectTracker):
         self.tracker = Tracker(
             distance_function=frigate_distance,
             distance_threshold=2.5,
-            initialization_delay=0,
+            initialization_delay=config.detect.fps / 2,
             hit_counter_max=self.max_disappeared,
         )
         if self.ptz_autotracker_enabled.value:
@@ -105,11 +105,6 @@ class NorfairTracker(ObjectTracker):
             "xmax": self.detect_config.width,
             "ymax": self.detect_config.height,
         }
-
-        # start object with a hit count of `fps` to avoid quick detection -> loss
-        next(
-            (o for o in self.tracker.tracked_objects if o.global_id == track_id)
-        ).hit_counter = self.camera_config.detect.fps
 
     def deregister(self, id, track_id):
         del self.tracked_objects[id]


### PR DESCRIPTION
I had a clip that I used for testing where multiple events would get created for me when I arrived home which caused 3 disjointed events with 100% reproducibility.

I tested this and it is working well, the only caveat is that it adds a ~ half second delay to an object event being created, but I don't believe that will be a problem