### PR TITLE
Fix recording events intermittently missing

### DIFF
--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -410,7 +410,8 @@ class RecordingMaintainer(threading.Thread):
         wait_time = 0.0
         while not self.stop_event.wait(wait_time):
             run_start = datetime.datetime.now().timestamp()
-
+            stale_frame_count = 0
+            stale_frame_count_threshold = 10
             # empty the object recordings info queue
             while True:
                 try:
@@ -422,6 +423,9 @@ class RecordingMaintainer(threading.Thread):
                         regions,
                     ) = self.object_recordings_info_queue.get(True, timeout=0.1)
 
+                    if frame_time < run_start - stale_frame_count_threshold:
+                        stale_frame_count += 1
+
                     if self.process_info[camera]["record_enabled"].value:
                         self.object_recordings_info[camera].append(
                             (
@@ -432,10 +436,22 @@ class RecordingMaintainer(threading.Thread):
                             )
                         )
                 except queue.Empty:
+                    q_size = self.object_recordings_info_queue.qsize()
+                    if q_size > 5:
+                        logger.warning(
+                            f"object_recordings_info loop queue not empty ({q_size}) - recording segments may be missing"
+                        )
                     break
+
+            if stale_frame_count > 0:
+                logger.error(
+                    f"Found {stale_frame_count} old frames, segments from recordings may be missing"
+                )
 
             # empty the audio recordings info queue if audio is enabled
             if self.audio_recordings_info_queue:
+                stale_frame_count = 0
+
                 while True:
                     try:
                         (
@@ -443,6 +459,9 @@ class RecordingMaintainer(threading.Thread):
                             frame_time,
                             dBFS,
                         ) = self.audio_recordings_info_queue.get(True, timeout=0.1)
+
+                        if frame_time < run_start - stale_frame_count_threshold:
+                            stale_frame_count += 1
 
                         if self.process_info[camera]["record_enabled"].value:
                             self.audio_recordings_info[camera].append(
@@ -452,7 +471,17 @@ class RecordingMaintainer(threading.Thread):
                                 )
                             )
                     except queue.Empty:
+                        q_size = self.audio_recordings_info_queue.qsize()
+                        if q_size > 5:
+                            logger.warning(
+                                f"object_recordings_info loop audio queue not empty ({q_size}) - recording segments may be missing"
+                            )
                         break
+
+                if stale_frame_count > 0:
+                    logger.error(
+                        f"Found {stale_frame_count} old audio frames, segments from recordings may be missing"
+                    )
 
             try:
                 asyncio.run(self.move_files())

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -420,7 +420,7 @@ class RecordingMaintainer(threading.Thread):
                         current_tracked_objects,
                         motion_boxes,
                         regions,
-                    ) = self.object_recordings_info_queue.get(False)
+                    ) = self.object_recordings_info_queue.get(True, timeout=0.1)
 
                     if self.process_info[camera]["record_enabled"].value:
                         self.object_recordings_info[camera].append(
@@ -442,7 +442,7 @@ class RecordingMaintainer(threading.Thread):
                             camera,
                             frame_time,
                             dBFS,
-                        ) = self.audio_recordings_info_queue.get(False)
+                        ) = self.audio_recordings_info_queue.get(True, timeout=0.1)
 
                         if self.process_info[camera]["record_enabled"].value:
                             self.audio_recordings_info[camera].append(


### PR DESCRIPTION
I've run into several cases where recordings are missing for events failing with the common error:

```The media could not be loaded, either because the server or network failed or because the format is not supported.```

recording config is set as:
```
record:
  enabled: True
  expire_interval: 5
  retain:
    days: 7
    mode: motion
  events:
    retain:
      default: 14
      mode: active_objects
```

In most cases, these were due to the `object_recordings_info` queue backing up and not being processed before the recording segments were deleted. There appears to be a bug in the multiprocessing python library where in some cases a non-blocking `get()` can trigger a `queue.Empty` when the queue isn't actually empty yet. A similar long-standing issue appears here: https://bugs.python.org/issue43136

This change resolves the issue by:
- changing the queue `get()` to a blocking call with a short timeout - this ensures the queue is emptied fully before the loop ends
- adding extra errors/warnings when it is likely the loop is falling behind and may be prematurely deleting segments

This likely may also help resource constrained instances, as the bug appears to be triggered more frequently in those situations.