### PR TITLE
Don't zero out motion during calibration

### DIFF
--- a/frigate/motion/__init__.py
+++ b/frigate/motion/__init__.py
@@ -20,3 +20,7 @@ class MotionDetector(ABC):
     @abstractmethod
     def detect(self, frame):
         pass
+
+    @abstractmethod
+    def is_calibrating(self):
+        pass

--- a/frigate/motion/frigate_motion.py
+++ b/frigate/motion/frigate_motion.py
@@ -38,6 +38,9 @@ class FrigateMotionDetector(MotionDetector):
         self.threshold = threshold
         self.contour_area = contour_area
 
+    def is_calibrating(self):
+        return False
+
     def detect(self, frame):
         motion_boxes = []
 

--- a/frigate/motion/improved_motion.py
+++ b/frigate/motion/improved_motion.py
@@ -49,6 +49,9 @@ class ImprovedMotionDetector(MotionDetector):
         self.contrast_values[:, 1:2] = 255
         self.contrast_values_index = 0
 
+    def is_calibrating(self):
+        return self.calibrating
+
     def detect(self, frame):
         motion_boxes = []
 
@@ -141,7 +144,6 @@ class ImprovedMotionDetector(MotionDetector):
 
         # if calibrating or the motion contours are > 80% of the image area (lightning, ir, ptz) recalibrate
         if self.calibrating or pct_motion > self.config.lightning_threshold:
-            motion_boxes = []
             self.calibrating = True
 
         if self.save_images:

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -1027,7 +1027,12 @@ class TestConfig(unittest.TestCase):
                                 "roles": ["detect"],
                             },
                         ]
-                    }
+                    },
+                    "detect": {
+                        "height": 720,
+                        "width": 1280,
+                        "fps": 5,
+                    },
                 }
             },
         }
@@ -1082,6 +1087,11 @@ class TestConfig(unittest.TestCase):
                             },
                         ]
                     },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
                     "snapshots": {
                         "height": 100,
                     },
@@ -1107,7 +1117,12 @@ class TestConfig(unittest.TestCase):
                                 "roles": ["detect"],
                             },
                         ]
-                    }
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
                 }
             },
         }
@@ -1131,6 +1146,11 @@ class TestConfig(unittest.TestCase):
                                 "roles": ["detect"],
                             },
                         ]
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
                     },
                     "snapshots": {
                         "height": 150,
@@ -1160,6 +1180,11 @@ class TestConfig(unittest.TestCase):
                             },
                         ]
                     },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
                 }
             },
         }
@@ -1181,7 +1206,12 @@ class TestConfig(unittest.TestCase):
                                 "roles": ["detect"],
                             },
                         ]
-                    }
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
                 }
             },
         }
@@ -1204,6 +1234,11 @@ class TestConfig(unittest.TestCase):
                                 "roles": ["detect", "rtmp"],
                             },
                         ]
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
                     },
                     "rtmp": {
                         "enabled": True,
@@ -1234,6 +1269,11 @@ class TestConfig(unittest.TestCase):
                             },
                         ]
                     },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
                 }
             },
         }
@@ -1257,6 +1297,11 @@ class TestConfig(unittest.TestCase):
                             },
                         ]
                     },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
                 }
             },
         }
@@ -1278,7 +1323,12 @@ class TestConfig(unittest.TestCase):
                                 "roles": ["detect"],
                             },
                         ]
-                    }
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
                 }
             },
         }
@@ -1301,6 +1351,11 @@ class TestConfig(unittest.TestCase):
                                 "roles": ["detect"],
                             },
                         ]
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
                     },
                     "live": {
                         "quality": 7,
@@ -1329,6 +1384,11 @@ class TestConfig(unittest.TestCase):
                             },
                         ]
                     },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
                 }
             },
         }
@@ -1350,7 +1410,12 @@ class TestConfig(unittest.TestCase):
                                 "roles": ["detect"],
                             },
                         ]
-                    }
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
                 }
             },
         }
@@ -1374,6 +1439,11 @@ class TestConfig(unittest.TestCase):
                                 "roles": ["detect"],
                             },
                         ]
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
                     },
                     "timestamp_style": {"position": "bl", "thickness": 4},
                 }
@@ -1400,6 +1470,11 @@ class TestConfig(unittest.TestCase):
                             },
                         ]
                     },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
                 }
             },
         }
@@ -1422,6 +1497,11 @@ class TestConfig(unittest.TestCase):
                                 "roles": ["detect"],
                             },
                         ]
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
                     },
                 }
             },
@@ -1450,6 +1530,11 @@ class TestConfig(unittest.TestCase):
                             },
                         ],
                     },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
                 }
             },
         }
@@ -1474,6 +1559,11 @@ class TestConfig(unittest.TestCase):
                                 "roles": ["detect"],
                             },
                         ]
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
                     },
                     "zones": {
                         "steps": {
@@ -1546,6 +1636,11 @@ class TestConfig(unittest.TestCase):
                             {"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}
                         ]
                     },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
                     "onvif": {"autotracking": {"movement_weights": "1.23, 2.34, 0.50"}},
                 }
             },
@@ -1568,6 +1663,11 @@ class TestConfig(unittest.TestCase):
                         "inputs": [
                             {"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}
                         ]
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
                     },
                     "onvif": {"autotracking": {"movement_weights": "1.234, 2.345a"}},
                 }


### PR DESCRIPTION
Zeroing out the motion boxes during calibration was causing users with "motion" mode for recordings to loose segments during ptz moves related to autotracking. This leaves the motion boxes so video will be retained, but won't use them for object detection.