### PR TITLE
Fix recording segment management

### DIFF
--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -439,14 +439,14 @@ class RecordingMaintainer(threading.Thread):
                 except queue.Empty:
                     q_size = self.object_recordings_info_queue.qsize()
                     if q_size > camera_count:
-                        logger.warning(
-                            f"object_recordings_info loop queue not empty ({q_size}) - recording segments may be missing"
+                        logger.debug(
+                            f"object_recordings_info loop queue not empty ({q_size})."
                         )
                     break
 
             if stale_frame_count > 0:
-                logger.error(
-                    f"Found {stale_frame_count} old frames, segments from recordings may be missing"
+                logger.warning(
+                    f"Found {stale_frame_count} old frames, segments from recordings may be missing."
                 )
 
             # empty the audio recordings info queue if audio is enabled
@@ -474,8 +474,8 @@ class RecordingMaintainer(threading.Thread):
                     except queue.Empty:
                         q_size = self.audio_recordings_info_queue.qsize()
                         if q_size > camera_count:
-                            logger.warning(
-                                f"object_recordings_info loop audio queue not empty ({q_size}) - recording segments may be missing"
+                            logger.debug(
+                                f"object_recordings_info loop audio queue not empty ({q_size})."
                             )
                         break
 

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -406,6 +406,7 @@ class RecordingMaintainer(threading.Thread):
         return None
 
     def run(self) -> None:
+        camera_count = len(self.config.cameras.keys())
         # Check for new files every 5 seconds
         wait_time = 0.0
         while not self.stop_event.wait(wait_time):
@@ -421,7 +422,7 @@ class RecordingMaintainer(threading.Thread):
                         current_tracked_objects,
                         motion_boxes,
                         regions,
-                    ) = self.object_recordings_info_queue.get(True, timeout=0.1)
+                    ) = self.object_recordings_info_queue.get(True, timeout=0.01)
 
                     if frame_time < run_start - stale_frame_count_threshold:
                         stale_frame_count += 1
@@ -437,7 +438,7 @@ class RecordingMaintainer(threading.Thread):
                         )
                 except queue.Empty:
                     q_size = self.object_recordings_info_queue.qsize()
-                    if q_size > 5:
+                    if q_size > camera_count:
                         logger.warning(
                             f"object_recordings_info loop queue not empty ({q_size}) - recording segments may be missing"
                         )
@@ -458,7 +459,7 @@ class RecordingMaintainer(threading.Thread):
                             camera,
                             frame_time,
                             dBFS,
-                        ) = self.audio_recordings_info_queue.get(True, timeout=0.1)
+                        ) = self.audio_recordings_info_queue.get(True, timeout=0.01)
 
                         if frame_time < run_start - stale_frame_count_threshold:
                             stale_frame_count += 1
@@ -472,7 +473,7 @@ class RecordingMaintainer(threading.Thread):
                             )
                     except queue.Empty:
                         q_size = self.audio_recordings_info_queue.qsize()
-                        if q_size > 5:
+                        if q_size > camera_count:
                             logger.warning(
                                 f"object_recordings_info loop audio queue not empty ({q_size}) - recording segments may be missing"
                             )


### PR DESCRIPTION
fixes https://github.com/blakeblackshear/frigate/pull/8162 

With the blocking call in this queue and enough cameras with high enough detect fps (I have 7 cameras, some running at 8 detect fps with others running at 5). With a detect fps of 5 something will be put into the recordings info queue every 0.2 seconds, and with multiple cameras and a timeout of 0.1 there is an extremely high chance that frigate will essentially sit there for way too long reading from the recordings info queue because new info is constantly being put into the queue.