### PR TITLE
Add `--validate-config` option for CI config validation

### DIFF
--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -131,7 +131,7 @@ To do this:
 
 ## Validating your config.yaml file updates
 
-When frigate starts up, it checks whether your config file is valid, and if it is not, the process exits. To minimize interruptions when updating your config, you have two options -- you can either leverage the config update API endpoint, or you can validate on the command line using the frigate docker container.
+When frigate starts up, it checks whether your config file is valid, and if it is not, the process exits. To minimize interruptions when updating your config, you have three options -- you can edit the config via the WebUI which has built in validation, use the config API, or you can validate on the command line using the frigate docker container.
 
 ### Via API
 

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -128,3 +128,34 @@ To do this:
 2. Rename the build to `go2rtc`.
 3. Give `go2rtc` execute permission.
 4. Restart Frigate and the custom version will be used, you can verify by checking go2rtc logs.
+
+## Validating your config.yaml file updates
+
+When frigate starts up, it checks whether your config file is valid, and if it is not, the process exits. To minimize interruptions when updating your config, you have two options -- you can either leverage the config update API endpoint, or you can validate on the command line using the frigate docker container.
+
+### Via API
+
+Frigate can accept a new configuration file as JSON at the `/config/save` endpoint. When updating the config this way, Frigate will validate the config before saving it, and return a `400` if the config is not valid.
+
+```bash
+curl -X POST http://frigate_host:5000/config/save -d @config.json
+```
+
+if you'd like you can use your yaml config directly by using [`yq`](https://github.com/mikefarah/yq) to convert it to json:
+
+```bash
+yq r -j config.yml | curl -X POST http://frigate_host:5000/config/save -d @-
+```
+
+### Via Command Line
+
+You can also validate your config at the command line by using the docker container itself. In CI/CD, you leverage the return code to determine if your config is valid, Frigate will return `1` if the config is invalid, or `0` if it's valid.
+
+```bash
+docker run                                \
+  -v $(pwd)/config.yml:/config/config.yml \
+  --entrypoint python3                    \
+  ghcr.io/blakeblackshear/frigate:stable  \
+  -u -m frigate                           \
+  --validate_config
+```

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -574,7 +574,7 @@ class FrigateApp:
     def start(self) -> None:
         parser = argparse.ArgumentParser(
             prog="Frigate",
-            description="Frigate is a realtime object detection package that runs on Nvidia Jetson hardware."
+            description="An NVR with realtime local object detection for IP cameras.",
         )
         parser.add_argument("--validate-config", action="store_true")
         args = parser.parse_args()

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -622,9 +622,6 @@ class FrigateApp:
             print(e)
             self.log_process.terminate()
             sys.exit(1)
-
-
-
         self.start_detectors()
         self.start_video_output_processor()
         self.start_ptz_autotracker()

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -1,3 +1,4 @@
+import argparse
 import datetime
 import logging
 import multiprocessing as mp
@@ -571,6 +572,13 @@ class FrigateApp:
             )
 
     def start(self) -> None:
+        parser = argparse.ArgumentParser(
+            prog="Frigate",
+            description="Frigate is a realtime object detection package that runs on Nvidia Jetson hardware."
+        )
+        parser.add_argument("--validate-config", action="store_true")
+        args = parser.parse_args()
+
         self.init_logger()
         logger.info(f"Starting Frigate ({VERSION})")
         try:
@@ -608,6 +616,13 @@ class FrigateApp:
             print(e)
             self.log_process.terminate()
             sys.exit(1)
+
+        if args.validate_config:
+            print("*************************************************************")
+            print("*** Your config file is valid.                            ***")
+            print("*************************************************************")
+            sys.exit(0)
+
         self.start_detectors()
         self.start_video_output_processor()
         self.start_ptz_autotracker()

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -602,6 +602,12 @@ class FrigateApp:
                 print("*************************************************************")
                 self.log_process.terminate()
                 sys.exit(1)
+            if args.validate_config:
+                print("*************************************************************")
+                print("*** Your config file is valid.                            ***")
+                print("*************************************************************")
+                self.log_process.terminate()
+                sys.exit(0)
             self.set_environment_vars()
             self.set_log_levels()
             self.init_queues()
@@ -617,11 +623,7 @@ class FrigateApp:
             self.log_process.terminate()
             sys.exit(1)
 
-        if args.validate_config:
-            print("*************************************************************")
-            print("*** Your config file is valid.                            ***")
-            print("*************************************************************")
-            sys.exit(0)
+
 
         self.start_detectors()
         self.start_video_output_processor()


### PR DESCRIPTION
RFC PR here for #8221 - This PR add an option to do a lightweight config check by passing `--validate-config` to frigate. This option is useful especially in CI, where I'd like to validate my frigate config before re-deploying the app.

It looks like most config is parsed directly in `app.py` via envvars, so I placed the flag for config validation there as well, as a flag given the flag triggers an early exit. Other options:
- flag in `__main__.py`, in which case I'll need to untange the config validation from `start()`
- use an envvar over flags.

lmk what you think.