### PR TITLE
Use existing bounding box for region when object is stationary

### DIFF
--- a/frigate/video.py
+++ b/frigate/video.py
@@ -607,7 +607,12 @@ def process_frames(
 
             # get tracked object boxes that aren't stationary
             tracked_object_boxes = [
-                obj["estimate"]
+                (
+                    # use existing object box for stationary objects
+                    obj["estimate"]
+                    if obj["motionless_count"] < detect_config.stationary.threshold
+                    else obj["box"]
+                )
                 for obj in object_tracker.tracked_objects.values()
                 if obj["id"] not in stationary_object_ids
             ]


### PR DESCRIPTION
Stationary objects can have some changes in bounding box that lead to drastic changes in estimated bounding box. In the case of stationary objects, the previous bounding box should be used to get the region