### PR TITLE
Use different consolidation requirement depending on label

### DIFF
--- a/frigate/const.py
+++ b/frigate/const.py
@@ -12,7 +12,7 @@ FRIGATE_LOCALHOST = "http://127.0.0.1:5000"
 PLUS_ENV_VAR = "PLUS_API_KEY"
 PLUS_API_HOST = "https://api.frigate.video"
 
-# Attributes
+# Attribute & Object Consts
 
 ATTRIBUTE_LABEL_MAP = {
     "person": ["face", "amazon"],
@@ -21,6 +21,11 @@ ATTRIBUTE_LABEL_MAP = {
 ALL_ATTRIBUTE_LABELS = [
     item for sublist in ATTRIBUTE_LABEL_MAP.values() for item in sublist
 ]
+LABEL_CONSOLIDATION_MAP = {
+    "car": 0.8,
+    "face": 0.5,
+}
+LABEL_CONSOLIDATION_DEFAULT = 0.9
 
 # Audio Consts
 


### PR DESCRIPTION
I believe the possible overlap will differ depending on the label. I have seen some partial car detections that are a little less than 90% overlapping but I don't think cars have the possibility to overlap the same way that for example people do. 