### PR TITLE
Adjust motion calibration to be more dynamic

### DIFF
--- a/frigate/motion/improved_motion.py
+++ b/frigate/motion/improved_motion.py
@@ -1,10 +1,13 @@
 import cv2
 import imutils
+import logging
 import numpy as np
 from scipy.ndimage import gaussian_filter
 
 from frigate.config import MotionConfig
 from frigate.motion import MotionDetector
+
+logger = logging.getLogger(__name__)
 
 
 class ImprovedMotionDetector(MotionDetector):
@@ -138,8 +141,8 @@ class ImprovedMotionDetector(MotionDetector):
             self.motion_frame_size[0] * self.motion_frame_size[1]
         )
 
-        # once the motion drops to less than 1% for the first time, assume its calibrated
-        if pct_motion < 0.01:
+        # once the motion is less than 5% and the number of contours is < 4, assume its calibrated
+        if pct_motion < 0.05 and len(motion_boxes) <= 4:
             self.calibrating = False
 
         # if calibrating or the motion contours are > 80% of the image area (lightning, ir, ptz) recalibrate

--- a/frigate/motion/improved_motion.py
+++ b/frigate/motion/improved_motion.py
@@ -1,6 +1,7 @@
+import logging
+
 import cv2
 import imutils
-import logging
 import numpy as np
 from scipy.ndimage import gaussian_filter
 


### PR DESCRIPTION
If a large lighting change occurs but there is motion from an actual object, the image will not be considered calibrated until that object stops moving or exits the frame. This change will mean that once the large motion has changed and there are a small number of contours - the image is calibrated