### PR TITLE
Fix long webrtc connections failing

### DIFF
--- a/web/src/components/WebRtcPlayer.jsx
+++ b/web/src/components/WebRtcPlayer.jsx
@@ -56,8 +56,8 @@ export default function WebRtcPlayer({ camera, width, height }) {
     }
   }
 
-  const connect = useCallback(async (ws) => {
-    const pc = await PeerConnection('video+audio');
+  const connect = useCallback(async (ws, aPc) => {
+    const pc = await aPc;
 
     ws.addEventListener('open', () => {
       pc.addEventListener('icecandidate', (ev) => {
@@ -82,21 +82,18 @@ export default function WebRtcPlayer({ camera, width, height }) {
         pc.setRemoteDescription({ type: 'answer', sdp: msg.value });
       }
     });
-
-    ws.addEventListener('close', () => {
-      pc.close();
-    })
-  }, [PeerConnection]);
+  }, []);
 
   useEffect(() => {
     const url = `${baseUrl.replace(/^http/, 'ws')}live/webrtc/api/ws?src=${camera}`;
     const ws = new WebSocket(url);
-    connect(ws);
+    const aPc = PeerConnection('video+audio');
+    connect(ws, aPc);
 
-    return () => {
-      ws.close();
+    return async () => {
+      (await aPc).close();
     }
-  }, [camera, connect]);
+  }, [camera, connect, PeerConnection]);
 
   return (
     <div>

--- a/web/src/components/WebRtcPlayer.jsx
+++ b/web/src/components/WebRtcPlayer.jsx
@@ -1,11 +1,8 @@
 import { h } from 'preact';
 import { baseUrl } from '../api/baseUrl';
 import { useCallback, useEffect } from 'preact/hooks';
-import { useMemo } from 'react';
 
 export default function WebRtcPlayer({ camera, width, height }) {
-  const url = `${baseUrl.replace(/^http/, 'ws')}live/webrtc/api/ws?src=${camera}`;
-  const ws = useMemo(() => new WebSocket(url), [url])
   const PeerConnection = useCallback(async (media) => {
     const pc = new RTCPeerConnection({
       iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
@@ -59,7 +56,7 @@ export default function WebRtcPlayer({ camera, width, height }) {
     }
   }
 
-  const connect = useCallback(async () => {
+  const connect = useCallback(async (ws) => {
     const pc = await PeerConnection('video+audio');
 
     ws.addEventListener('open', () => {
@@ -89,15 +86,17 @@ export default function WebRtcPlayer({ camera, width, height }) {
     ws.addEventListener('close', () => {
       pc.close();
     })
-  }, [PeerConnection, ws]);
+  }, [PeerConnection]);
 
   useEffect(() => {
-    connect();
+    const url = `${baseUrl.replace(/^http/, 'ws')}live/webrtc/api/ws?src=${camera}`;
+    const ws = new WebSocket(url);
+    connect(ws);
 
     return () => {
       ws.close();
     }
-  }, [connect, ws]);
+  }, [camera, connect]);
 
   return (
     <div>


### PR DESCRIPTION
My previous fix created a situation where the webrtc connection would be stopped before the user was done watching, this is because the original websocket connection used for setting up may close before the peer connection needs to close. Instead, we need to directly close the peerconnection on cleanup