### PR TITLE
MQTT: Birdseye enabled/disabled and mode change support

### DIFF
--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -220,3 +220,29 @@ Topic to turn the PTZ autotracker for a camera on and off. Expected values are `
 ### `frigate/<camera_name>/ptz_autotracker/state`
 
 Topic with current state of the PTZ autotracker for a camera. Published values are `ON` and `OFF`.
+
+### `frigate/<camera_name>/birdseye/set`
+
+Topic to turn Birdseye for a camera on and off. Expected values are `ON` and `OFF`. Birdseye mode
+must be enabled in the configuration.
+
+### `frigate/<camera_name>/birdseye/state`
+
+Topic with current state of Birdseye for a camera. Published values are `ON` and `OFF`.
+
+### `frigate/<camera_name>/birdseye_mode`
+
+Topic to set Birdseye mode for a camera. Birdseye offers different modes to customize under which circumstances the camera is shown.
+
+_Note: Changing the value from `CONTINUOUS` -> `MOTION | OBJECTS` will take up to 30 seconds for
+the camera to be removed from the view._
+
+| Command      | Description                                                       |
+| ------------ | ----------------------------------------------------------------- |
+| `CONTINUOUS` | Always included included                                          |
+| `MOTION`     | Show when detected motion within the last 30 seconds are included |
+| `OBJECTS`    | Shown if an active object tracked within the last 30 seconds      |
+
+### `frigate/<camera_name>/birdseye_mode/state`
+
+Topic with current state of the Birdseye mode for a camera. Published values are `CONTINUOUS`, `MOTION`, `OBJECTS`.

--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -239,7 +239,7 @@ the camera to be removed from the view._
 
 | Command      | Description                                                       |
 | ------------ | ----------------------------------------------------------------- |
-| `CONTINUOUS` | Always included included                                          |
+| `CONTINUOUS` | Always included                                                   |
 | `MOTION`     | Show when detected motion within the last 30 seconds are included |
 | `OBJECTS`    | Shown if an active object tracked within the last 30 seconds      |
 

--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -230,7 +230,7 @@ must be enabled in the configuration.
 
 Topic with current state of Birdseye for a camera. Published values are `ON` and `OFF`.
 
-### `frigate/<camera_name>/birdseye_mode`
+### `frigate/<camera_name>/birdseye_mode/set`
 
 Topic to set Birdseye mode for a camera. Birdseye offers different modes to customize under which circumstances the camera is shown.
 

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -20,7 +20,7 @@ from frigate.comms.dispatcher import Communicator, Dispatcher
 from frigate.comms.inter_process import InterProcessCommunicator
 from frigate.comms.mqtt import MqttClient
 from frigate.comms.ws import WebSocketClient
-from frigate.config import FrigateConfig
+from frigate.config import BirdseyeModeEnum, FrigateConfig
 from frigate.const import (
     CACHE_DIR,
     CLIPS_DIR,
@@ -168,6 +168,20 @@ class FrigateApp:
                 "process": None,
                 "audio_rms": mp.Value("d", 0.0),  # type: ignore[typeddict-item]
                 "audio_dBFS": mp.Value("d", 0.0),  # type: ignore[typeddict-item]
+                "birdseye_enabled": mp.Value(  # type: ignore[typeddict-item]
+                    # issue https://github.com/python/typeshed/issues/8799
+                    # from mypy 0.981 onwards
+                    "i",
+                    self.config.cameras[camera_name].birdseye.enabled,
+                ),
+                "birdseye_mode": mp.Value(  # type: ignore[typeddict-item]
+                    # issue https://github.com/python/typeshed/issues/8799
+                    # from mypy 0.981 onwards
+                    "i",
+                    BirdseyeModeEnum.get_index(
+                        self.config.cameras[camera_name].birdseye.mode.value
+                    ),
+                ),
             }
             self.ptz_metrics[camera_name] = {
                 "ptz_autotracker_enabled": mp.Value(  # type: ignore[typeddict-item]
@@ -454,6 +468,7 @@ class FrigateApp:
             args=(
                 self.config,
                 self.video_output_queue,
+                self.camera_metrics,
             ),
         )
         output_processor.daemon = True

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Callable
 
-from frigate.config import FrigateConfig
+from frigate.config import BirdseyeModeEnum, FrigateConfig
 from frigate.const import INSERT_MANY_RECORDINGS, REQUEST_REGION_GRID
 from frigate.models import Recordings
 from frigate.ptz.onvif import OnvifCommandEnum, OnvifController
@@ -63,6 +63,7 @@ class Dispatcher:
             "motion_threshold": self._on_motion_threshold_command,
             "recordings": self._on_recordings_command,
             "snapshots": self._on_snapshots_command,
+            "birdseye": self._on_birdseye_command,
         }
 
         for comm in self.comms:
@@ -96,6 +97,14 @@ class Dispatcher:
             self.camera_metrics[camera]["region_grid_queue"].put(
                 get_camera_regions_grid(camera, self.config.cameras[camera].detect)
             )
+        elif topic.endswith("birdseye_mode"):
+            try:
+                # example /cam_name/birdseye payload=CONTINUOUS|MOTION|OBJECTS
+                camera_name = topic.split("/")[-2]
+                self._on_birdseye_mode_command(camera_name, payload)
+            except IndexError:
+                logger.error(f"Received invalid birdseye_mode command: {topic}")
+                return
         else:
             self.publish(topic, payload, retain=False)
 
@@ -296,3 +305,45 @@ class Dispatcher:
             logger.info(f"Setting ptz command to {command} for {camera_name}")
         except KeyError as k:
             logger.error(f"Invalid PTZ command {payload}: {k}")
+
+    def _on_birdseye_command(self, camera_name: str, payload: str) -> None:
+        """Callback for birdseye topic."""
+        birdseye_settings = self.config.cameras[camera_name].birdseye
+
+        if payload == "ON":
+            if not self.camera_metrics[camera_name]["birdseye_enabled"].value:
+                logger.info(f"Turning on birdseye for {camera_name}")
+                self.camera_metrics[camera_name]["birdseye_enabled"].value = True
+                birdseye_settings.enabled = True
+
+        elif payload == "OFF":
+            if self.camera_metrics[camera_name]["birdseye_enabled"].value:
+                logger.info(f"Turning off birdseye for {camera_name}")
+                self.camera_metrics[camera_name]["birdseye_enabled"].value = False
+                birdseye_settings.enabled = False
+
+        self.publish(f"{camera_name}/birdseye/state", payload, retain=True)
+
+    def _on_birdseye_mode_command(self, camera_name: str, payload: str) -> None:
+        """Callback for birdseye mode topic."""
+
+        if payload not in ["CONTINUOUS", "MOTION", "OBJECTS"]:
+            logger.info(f"Invalid birdseye_mode command: {payload}")
+            return
+
+        birdseye_config = self.config.cameras[camera_name].birdseye
+        if not birdseye_config.enabled:
+            logger.info(f"Birdseye mode not enabled for {camera_name}")
+            return
+
+        new_birdseye_mode = BirdseyeModeEnum(payload.lower())
+        # birdseye_config.mode = BirdseyeModeEnum.continuous
+        # self.config.cameras[camera_name].birdseye.enabled = False
+        logger.info(f"Setting birdseye mode for {camera_name} to {new_birdseye_mode}")
+
+        # update the metric (need the mode converted to an int)
+        self.camera_metrics[camera_name][
+            "birdseye_mode"
+        ].value = BirdseyeModeEnum.get_index(new_birdseye_mode)
+
+        self.publish(f"{camera_name}/birdseye_mode/state", payload, retain=True)

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -64,6 +64,7 @@ class Dispatcher:
             "recordings": self._on_recordings_command,
             "snapshots": self._on_snapshots_command,
             "birdseye": self._on_birdseye_command,
+            "birdseye_mode": self._on_birdseye_mode_command,
         }
 
         for comm in self.comms:
@@ -97,14 +98,6 @@ class Dispatcher:
             self.camera_metrics[camera]["region_grid_queue"].put(
                 get_camera_regions_grid(camera, self.config.cameras[camera].detect)
             )
-        elif topic.endswith("birdseye_mode"):
-            try:
-                # example /cam_name/birdseye payload=CONTINUOUS|MOTION|OBJECTS
-                camera_name = topic.split("/")[-2]
-                self._on_birdseye_mode_command(camera_name, payload)
-            except IndexError:
-                logger.error(f"Received invalid birdseye_mode command: {topic}")
-                return
         else:
             self.publish(topic, payload, retain=False)
 

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -330,8 +330,6 @@ class Dispatcher:
             return
 
         new_birdseye_mode = BirdseyeModeEnum(payload.lower())
-        # birdseye_config.mode = BirdseyeModeEnum.continuous
-        # self.config.cameras[camera_name].birdseye.enabled = False
         logger.info(f"Setting birdseye mode for {camera_name} to {new_birdseye_mode}")
 
         # update the metric (need the mode converted to an int)

--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -89,6 +89,18 @@ class MqttClient(Communicator):  # type: ignore[misc]
                 "OFF",
                 retain=False,
             )
+            self.publish(
+                f"{camera_name}/birdseye/state",
+                "ON" if camera.birdseye.enabled else "OFF",
+                retain=True,
+            )
+            self.publish(
+                f"{camera_name}/birdseye_mode/state",
+                camera.birdseye.mode.value.upper()
+                if camera.birdseye.enabled
+                else "OFF",
+                retain=True,
+            )
 
         self.publish("available", "online", retain=True)
 
@@ -160,6 +172,7 @@ class MqttClient(Communicator):  # type: ignore[misc]
             "ptz_autotracker",
             "motion_threshold",
             "motion_contour_area",
+            "birdseye",
         ]
 
         for name in self.config.cameras.keys():
@@ -180,6 +193,12 @@ class MqttClient(Communicator):  # type: ignore[misc]
             if self.config.cameras[name].onvif.host:
                 self.client.message_callback_add(
                     f"{self.mqtt_config.topic_prefix}/{name}/ptz",
+                    self.on_mqtt_command,
+                )
+
+            if self.config.cameras[name].birdseye.enabled:
+                self.client.message_callback_add(
+                    f"{self.mqtt_config.topic_prefix}/{name}/birdseye_mode",
                     self.on_mqtt_command,
                 )
 

--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -173,6 +173,7 @@ class MqttClient(Communicator):  # type: ignore[misc]
             "motion_threshold",
             "motion_contour_area",
             "birdseye",
+            "birdseye_mode",
         ]
 
         for name in self.config.cameras.keys():
@@ -193,12 +194,6 @@ class MqttClient(Communicator):  # type: ignore[misc]
             if self.config.cameras[name].onvif.host:
                 self.client.message_callback_add(
                     f"{self.mqtt_config.topic_prefix}/{name}/ptz",
-                    self.on_mqtt_command,
-                )
-
-            if self.config.cameras[name].birdseye.enabled:
-                self.client.message_callback_add(
-                    f"{self.mqtt_config.topic_prefix}/{name}/birdseye_mode",
                     self.on_mqtt_command,
                 )
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -501,6 +501,14 @@ class BirdseyeModeEnum(str, Enum):
     motion = "motion"
     continuous = "continuous"
 
+    @classmethod
+    def get_index(cls, type):
+        return list(cls).index(type)
+
+    @classmethod
+    def get(cls, index):
+        return list(cls)[index]
+
 
 class BirdseyeConfig(FrigateBaseModel):
     enabled: bool = Field(default=True, title="Enable birdseye view.")

--- a/frigate/output.py
+++ b/frigate/output.py
@@ -24,6 +24,7 @@ from ws4py.websocket import WebSocket
 
 from frigate.config import BirdseyeModeEnum, FrigateConfig
 from frigate.const import BASE_DIR, BIRDSEYE_PIPE
+from frigate.types import CameraMetricsTypes
 from frigate.util.image import (
     SharedMemoryFrameManager,
     copy_yuv_to_position,
@@ -238,6 +239,7 @@ class BirdsEyeFrameManager:
         config: FrigateConfig,
         frame_manager: SharedMemoryFrameManager,
         stop_event: mp.Event,
+        camera_metrics: dict[str, CameraMetricsTypes],
     ):
         self.config = config
         self.mode = config.birdseye.mode
@@ -248,6 +250,7 @@ class BirdsEyeFrameManager:
         self.frame = np.ndarray(self.yuv_shape, dtype=np.uint8)
         self.canvas = Canvas(width, height)
         self.stop_event = stop_event
+        self.camera_metrics = camera_metrics
 
         # initialize the frame as black and with the Frigate logo
         self.blank_frame = np.zeros(self.yuv_shape, np.uint8)
@@ -579,9 +582,29 @@ class BirdsEyeFrameManager:
         if not camera_config.enabled:
             return False
 
+        # get our metrics (sync'd across processes)
+        # which allows us to control it via mqtt (or any other dispatcher)
+        camera_metrics = self.camera_metrics[camera]
+
+        # disabling birdseye is a little tricky
+        if not camera_metrics["birdseye_enabled"].value:
+            # if we've rendered a frame (we have a value for last_active_frame)
+            # then we need to set it to zero
+            if self.cameras[camera]["last_active_frame"] > 0:
+                self.cameras[camera]["last_active_frame"] = 0
+
+            return False
+
+        # default the mode to the camera config at load time
+        # if we have a metric (which we always should as it is set onload)
+        # then use that value
+        birdseye_mode = camera_config.mode
+        if camera_metrics["birdseye_mode"]:
+            birdseye_mode = BirdseyeModeEnum.get(camera_metrics["birdseye_mode"].value)
+
         # update the last active frame for the camera
         self.cameras[camera]["current_frame"] = frame_time
-        if self.camera_active(camera_config.mode, object_count, motion_count):
+        if self.camera_active(birdseye_mode, object_count, motion_count):
             self.cameras[camera]["last_active_frame"] = frame_time
 
         now = datetime.datetime.now().timestamp()
@@ -605,7 +628,11 @@ class BirdsEyeFrameManager:
         return False
 
 
-def output_frames(config: FrigateConfig, video_output_queue):
+def output_frames(
+    config: FrigateConfig,
+    video_output_queue,
+    camera_metrics: dict[str, CameraMetricsTypes],
+):
     threading.current_thread().name = "output"
     setproctitle("frigate.output")
 
@@ -661,7 +688,10 @@ def output_frames(config: FrigateConfig, video_output_queue):
             config.birdseye.restream,
         )
         broadcasters["birdseye"] = BroadcastThread(
-            "birdseye", converters["birdseye"], websocket_server, stop_event
+            "birdseye",
+            converters["birdseye"],
+            websocket_server,
+            stop_event,
         )
 
     websocket_thread.start()
@@ -669,7 +699,9 @@ def output_frames(config: FrigateConfig, video_output_queue):
     for t in broadcasters.values():
         t.start()
 
-    birdseye_manager = BirdsEyeFrameManager(config, frame_manager, stop_event)
+    birdseye_manager = BirdsEyeFrameManager(
+        config, frame_manager, stop_event, camera_metrics
+    )
 
     if config.birdseye.restream:
         birdseye_buffer = frame_manager.create(

--- a/frigate/output.py
+++ b/frigate/output.py
@@ -595,12 +595,8 @@ class BirdsEyeFrameManager:
 
             return False
 
-        # default the mode to the camera config at load time
-        # if we have a metric (which we always should as it is set onload)
-        # then use that value
-        birdseye_mode = camera_config.mode
-        if camera_metrics["birdseye_mode"]:
-            birdseye_mode = BirdseyeModeEnum.get(camera_metrics["birdseye_mode"].value)
+        # get the birdseye mode state from camera metrics
+        birdseye_mode = BirdseyeModeEnum.get(camera_metrics["birdseye_mode"].value)
 
         # update the last active frame for the camera
         self.cameras[camera]["current_frame"] = frame_time

--- a/frigate/types.py
+++ b/frigate/types.py
@@ -25,6 +25,8 @@ class CameraMetricsTypes(TypedDict):
     skipped_fps: Synchronized
     audio_rms: Synchronized
     audio_dBFS: Synchronized
+    birdseye_enabled: Synchronized
+    birdseye_mode: Synchronized
 
 
 class PTZMetricsTypes(TypedDict):


### PR DESCRIPTION
Added two new MQTT topics for adjusting the enabled/disabled state per camera as well as the mode.

This is in draft as there are a few things I'm not a big fan of. This is most likely due to my lack of python experience.

1. `BirdseyeModeEnum` is a string and camera metrics are using multiprocessing ctypes to sync data between processes. I hacked in an integer based index for support. You probably have a better idea of how this should be done. 
1. When testing this out I noticed that disabling birdseye for a previously enabled camera that has had a `last_active_frame` wouldn't get cleared. So there is some logic to zero out the last active frame which works... But is this how it should be done? https://github.com/blakeblackshear/frigate/compare/dev...sberryman:frigate:sberryman/mqtt-birdseye-mode?expand=1#diff-032726a7034bcbf31b308cd4452c695b71839494197d463764e5389604af23efR590-R596
1. Topics: Does this match the standard you are using right now? I tried to copy it but could have made a few mistakes.

This is a solution for issue #3244 