### PR TITLE
Reduce zones for timeline

### DIFF
--- a/frigate/timeline.py
+++ b/frigate/timeline.py
@@ -85,6 +85,7 @@ class TimelineProcessor(threading.Thread):
             if (
                 prev_event_data["current_zones"] != event_data["current_zones"]
                 and len(event_data["current_zones"]) > 0
+                and not event_data["stationary"]
             ):
                 timeline_entry[Timeline.class_type] = "entered_zone"
                 timeline_entry[Timeline.data]["zones"] = event_data["current_zones"]


### PR DESCRIPTION
When an object is stationary it can't be changing zones, sometimes when an object was stationary inside of a zone it would continuously have that zone added to the timeline. 