### PR TITLE
Ensure delayed segment info does not lead to lost segments

### DIFF
--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -265,10 +265,16 @@ class RecordingMaintainer(threading.Thread):
                     self.end_time_cache.pop(cache_path, None)
         # else retain days includes this segment
         else:
-            record_mode = self.config.cameras[camera].record.retain.mode
-            return await self.move_segment(
-                camera, start_time, end_time, duration, cache_path, record_mode
-            )
+            most_recently_processed_frame_time = self.object_recordings_info[camera][
+                -1
+            ][0]
+
+            # ensure delayed segment info does not lead to lost segments
+            if most_recently_processed_frame_time >= start_time:
+                record_mode = self.config.cameras[camera].record.retain.mode
+                return await self.move_segment(
+                    camera, start_time, end_time, duration, cache_path, record_mode
+                )
 
     def segment_stats(
         self, camera: str, start_time: datetime.datetime, end_time: datetime.datetime

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -265,9 +265,11 @@ class RecordingMaintainer(threading.Thread):
                     self.end_time_cache.pop(cache_path, None)
         # else retain days includes this segment
         else:
-            most_recently_processed_frame_time = self.object_recordings_info[camera][
-                -1
-            ][0]
+            # assume that empty means the relevant recording info has not been received yet
+            camera_info = self.object_recordings_info[camera]
+            most_recently_processed_frame_time = (
+                camera_info[-1][0] if len(camera_info) > 0 else 0
+            )
 
             # ensure delayed segment info does not lead to lost segments
             if most_recently_processed_frame_time >= end_time.timestamp():

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -270,7 +270,7 @@ class RecordingMaintainer(threading.Thread):
             ][0]
 
             # ensure delayed segment info does not lead to lost segments
-            if most_recently_processed_frame_time >= start_time.timestamp():
+            if most_recently_processed_frame_time >= end_time.timestamp():
                 record_mode = self.config.cameras[camera].record.retain.mode
                 return await self.move_segment(
                     camera, start_time, end_time, duration, cache_path, record_mode

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -270,7 +270,7 @@ class RecordingMaintainer(threading.Thread):
             ][0]
 
             # ensure delayed segment info does not lead to lost segments
-            if most_recently_processed_frame_time >= start_time:
+            if most_recently_processed_frame_time >= start_time.timestamp():
                 record_mode = self.config.cameras[camera].record.retain.mode
                 return await self.move_segment(
                     camera, start_time, end_time, duration, cache_path, record_mode

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -256,9 +256,10 @@ class RecordingMaintainer(threading.Thread):
             # if it ends more than the configured pre_capture for the camera
             else:
                 pre_capture = self.config.cameras[camera].record.events.pre_capture
-                most_recently_processed_frame_time = self.object_recordings_info[
-                    camera
-                ][-1][0]
+                camera_info = self.object_recordings_info[camera]
+                most_recently_processed_frame_time = (
+                    camera_info[-1][0] if len(camera_info) > 0 else 0
+                )
                 retain_cutoff = most_recently_processed_frame_time - pre_capture
                 if end_time.timestamp() < retain_cutoff:
                     Path(cache_path).unlink(missing_ok=True)

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -460,9 +460,7 @@ class RecordingMaintainer(threading.Thread):
                     break
 
             if stale_frame_count > 0:
-                logger.debug(
-                    f"Found {stale_frame_count} old frames, segments from recordings may be missing."
-                )
+                logger.debug(f"Found {stale_frame_count} old frames.")
 
             # empty the audio recordings info queue if audio is enabled
             if self.audio_recordings_info_queue:

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -451,7 +451,7 @@ class RecordingMaintainer(threading.Thread):
                     break
 
             if stale_frame_count > 0:
-                logger.warning(
+                logger.debug(
                     f"Found {stale_frame_count} old frames, segments from recordings may be missing."
                 )
 


### PR DESCRIPTION
Since https://github.com/blakeblackshear/frigate/pull/8162 was committed, I've seen this warning message often in my log:

```
[2023-10-25 06:55:23] frigate.record.maintainer      WARNING : Found 15 old frames, segments from recordings may be missing.
```

This warning was just symptomatic of a bug that caused missing segments because of delayed info.

This PR checks the most recently processed frame time for both recording segments and events and ensures that segments are retained when appropriate.