### PR TITLE
Ensure that birdseye error correction uses correct resolution

### DIFF
--- a/frigate/output.py
+++ b/frigate/output.py
@@ -63,8 +63,8 @@ def get_canvas_shape(width: int, height: int) -> tuple[int, int]:
     a_w, a_h = get_standard_aspect_ratio(width, height)
 
     if round(a_w / a_h, 2) != round(width / height, 2):
-        canvas_width = width
-        canvas_height = int((canvas_width / a_w) * a_h)
+        canvas_width = int(width // 4 * 4)
+        canvas_height = int((canvas_width / a_w * a_h) // 4 * 4)
         logger.warning(
             f"The birdseye resolution is a non-standard aspect ratio, forcing birdseye resolution to {canvas_width} x {canvas_height}"
         )


### PR DESCRIPTION
The birdseye error correction was causing corruption because it was not forcing the dimensions to be divisible by 4 which is required for the yuv pixel format