### PR TITLE
API recordings snapsnot PNG fix

### DIFF
--- a/frigate/http.py
+++ b/frigate/http.py
@@ -1388,6 +1388,7 @@ def get_snapshot_from_recording(camera_name: str, frame_time: str):
             )
         )
         .where(Recordings.camera == camera_name)
+        .order_by(Recordings.start_time.desc())
     )
 
     try:

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -1389,6 +1389,7 @@ def get_snapshot_from_recording(camera_name: str, frame_time: str):
         )
         .where(Recordings.camera == camera_name)
         .order_by(Recordings.start_time.desc())
+        .limit(1)
     )
 
     try:


### PR DESCRIPTION
Query can have multiple results in case the frame time is on a recording segment boundary:

![image](https://github.com/blakeblackshear/frigate/assets/25168870/2c022b01-759d-433b-9ab7-4316f9029225)

In that case we should use the latest one.