### PR TITLE
fix rknn.py

### DIFF
--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -6,7 +6,6 @@ import cv2.dnn
 import numpy as np
 from hide_warnings import hide_warnings
 from pydantic import Field
-from rknnlite.api import RKNNLite
 
 from frigate.detectors.detection_api import DetectionApi
 from frigate.detectors.detector_config import BaseDetectorConfig
@@ -36,6 +35,8 @@ class Rknn(DetectionApi):
         self.nms_thresh = config.nms_thresh
 
         self.model_path = config.model.path or "/models/yolov8n-320x320.rknn"
+
+        from rknnlite.api import RKNNLite
 
         self.rknn = RKNNLite(verbose=False)
         if self.rknn.load_rknn(self.model_path) != 0:


### PR DESCRIPTION
In the current `rknn.py` `RKNNlite` is imported at the beginning of the file. This seems to introduce problems with the logger, as it crashes with error `Unknown level: 'INFO'`. 

I moved the line down and import RKNNlite at the point it is actually used. This fixes the problem and is compatible with code formatting.