### PR TITLE
Add endpoint to restart Frigate

### DIFF
--- a/docs/docs/integrations/api.md
+++ b/docs/docs/integrations/api.md
@@ -366,7 +366,6 @@ Recording retention config still applies to manual events, if frigate is configu
 
 End a specific manual event without a predetermined length.
 
-
 ### `POST /api/restart`
 
 Restarts Frigate process.

--- a/docs/docs/integrations/api.md
+++ b/docs/docs/integrations/api.md
@@ -365,3 +365,8 @@ Recording retention config still applies to manual events, if frigate is configu
 ### `PUT /api/events/<event_id>/end`
 
 End a specific manual event without a predetermined length.
+
+
+### `POST /api/restart`
+
+Restarts Frigate process.

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -2103,3 +2103,30 @@ def logs(service: str):
             jsonify({"success": False, "message": "Could not find log file"}),
             500,
         )
+
+
+@bp.route("/restart", methods=["POST"])
+def restart():
+    try:
+        restart_frigate()
+    except Exception as e:
+        logging.error(f"Error restarting Frigate: {e}")
+        return make_response(
+            jsonify(
+                {
+                    "success": False,
+                    "message": "Unable to restart Frigate.",
+                }
+            ),
+            500,
+        )
+
+    return make_response(
+        jsonify(
+            {
+                "success": True,
+                "message": "Restarting (this can take up to one minute)...",
+            }
+        ),
+        200,
+    )


### PR DESCRIPTION
This PR:

- Adds a new endpoint `/api/restart` to restarts Frigate.

The only means of restarting Frigate remotely is to issue a restart topic on the server's websocket. It's
convenient to also expose this capability via HTTP endpoint. I'm a Home Assistant user and use Frigate frequently to recast my RTSP feeds. I find that I have to restart occasionally to get the feeds back up. Adding this capability would help me automate restarting Frigate. 

Open to any suggestions for a way to restart Frigate restfully if there is a better path. 

