### PR TITLE
Revert TRT class id filtering

### DIFF
--- a/frigate/detectors/plugins/tensorrt.py
+++ b/frigate/detectors/plugins/tensorrt.py
@@ -293,16 +293,6 @@ class TensorRtDetector(DetectionApi):
         # raw_detections: Nx7 numpy arrays of
         #             [[x, y, w, h, box_confidence, class_id, class_prob],
 
-        # throw out any detections with negative class IDs
-        valid_detections = []
-        for r in raw_detections:
-            if r[5] >= 0:
-                valid_detections.append(r)
-            else:
-                logger.warning(f"Found TensorRT detection with invalid class id {r}")
-
-        raw_detections = valid_detections
-
         # Calculate score as box_confidence x class_prob
         raw_detections[:, 4] = raw_detections[:, 4] * raw_detections[:, 6]
         # Reorder elements by the score, best on top, remove class_prob


### PR DESCRIPTION
Based on https://github.com/blakeblackshear/frigate/issues/8329#issuecomment-1793735774 I think this should be reverted because it doesn't appear to be an intermittent issue but something else, and this fix did not work anyway