### PR TITLE
fix restart from webui

### DIFF
--- a/web/src/AppBar.jsx
+++ b/web/src/AppBar.jsx
@@ -40,7 +40,7 @@ export default function AppBar() {
     setShowDialog(false);
     setShowDialogWait(true);
     sendRestart();
-  }, [setShowDialog]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [setShowDialog, sendRestart]);
 
   const handleDismissRestartDialog = useCallback(() => {
     setShowDialog(false);


### PR DESCRIPTION
This was probably broken since https://github.com/blakeblackshear/frigate/pull/8178 was introduced with `react-use-websocket`.