### PR TITLE
Add static FFmpeg with rockchip hardware acceleration to rk- image

### DIFF
--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -6,12 +6,13 @@ ARG DEBIAN_FRONTEND=noninteractive
 FROM wheels as rk-wheels
 COPY docker/main/requirements-wheels.txt /requirements-wheels.txt
 COPY docker/rockchip/requirements-wheels-rk.txt /requirements-wheels-rk.txt
-RUN sed -i "/https/d" /requirements-wheels.txt
+RUN sed -i "/https:\/\//d" /requirements-wheels.txt
 RUN pip3 wheel --wheel-dir=/rk-wheels -c /requirements-wheels.txt -r /requirements-wheels-rk.txt
 
 FROM wget as rk-libs
 RUN wget -qO librknnrt.so https://github.com/MarcA711/rknpu2/raw/master/runtime/RK3588/Linux/librknn_api/aarch64/librknnrt.so
-
+RUN wget -qO ffmpeg https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/latest/ffmpeg
+RUN wget -qO ffprobe https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/latest/ffprobe
 FROM deps AS rk-deps
 ARG TARGETARCH
 
@@ -22,3 +23,8 @@ WORKDIR /opt/frigate/
 COPY --from=rootfs / /
 COPY --from=rk-libs /rootfs/librknnrt.so /usr/lib/
 COPY docker/rockchip/yolov8n-320x320.rknn /models/
+
+RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffmpeg
+RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffprobe
+COPY --from=rk-libs /rootfs/ffmpeg /usr/lib/btbn-ffmpeg/bin/
+COPY --from=rk-libs /rootfs/ffprobe /usr/lib/btbn-ffmpeg/bin/

--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -28,3 +28,5 @@ RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffmpeg
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffprobe
 COPY --from=rk-libs /rootfs/ffmpeg /usr/lib/btbn-ffmpeg/bin/
 COPY --from=rk-libs /rootfs/ffprobe /usr/lib/btbn-ffmpeg/bin/
+RUN chmod +x /usr/lib/btbn-ffmpeg/bin/ffmpeg
+RUN chmod +x /usr/lib/btbn-ffmpeg/bin/ffprobe

--- a/docs/docs/configuration/ffmpeg_presets.md
+++ b/docs/docs/configuration/ffmpeg_presets.md
@@ -22,6 +22,8 @@ See [the hwaccel docs](/configuration/hardware_acceleration.md) for more info on
 | preset-nvidia-mjpeg   | Nvidia GPU with mjpeg stream   | Recommend restreaming mjpeg and using nvidia-h264     |
 | preset-jetson-h264    | Nvidia Jetson with h264 stream |                                                       |
 | preset-jetson-h265    | Nvidia Jetson with h265 stream |                                                       |
+| preset-rk-h264        | Nvidia Jetson with h264 stream | Use image with *-rk suffix and privileged mode        |
+| preset-rk-h265        | Nvidia Jetson with h265 stream | Use image with *-rk suffix and privileged mode        |
 
 ### Input Args Presets
 

--- a/docs/docs/configuration/ffmpeg_presets.md
+++ b/docs/docs/configuration/ffmpeg_presets.md
@@ -22,8 +22,8 @@ See [the hwaccel docs](/configuration/hardware_acceleration.md) for more info on
 | preset-nvidia-mjpeg   | Nvidia GPU with mjpeg stream   | Recommend restreaming mjpeg and using nvidia-h264     |
 | preset-jetson-h264    | Nvidia Jetson with h264 stream |                                                       |
 | preset-jetson-h265    | Nvidia Jetson with h265 stream |                                                       |
-| preset-rk-h264        | Nvidia Jetson with h264 stream | Use image with *-rk suffix and privileged mode        |
-| preset-rk-h265        | Nvidia Jetson with h265 stream | Use image with *-rk suffix and privileged mode        |
+| preset-rk-h264        | Rockchip MPP with h264 stream  | Use image with *-rk suffix and privileged mode        |
+| preset-rk-h265        | Rockchip MPP with h265 stream  | Use image with *-rk suffix and privileged mode        |
 
 ### Input Args Presets
 

--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -341,3 +341,9 @@ ffmpeg:
 ffmpeg:
   hwaccel_args: preset-rk-h265
 ```
+
+:::note
+
+Make sure that your SoC supports hardware acceleration for your input stream. For example, if your camera streams with h265 encoding and a 4k resolution, your SoC must be able to de- and encode h265 with a 4k resolution or higher. If you are unsure whether your SoC meets the requirements, take a look at the datasheet.
+
+:::

--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -319,3 +319,25 @@ ffmpeg:
 If everything is working correctly, you should see a significant reduction in ffmpeg CPU load and power consumption.
 Verify that hardware decoding is working by running `jtop` (`sudo pip3 install -U jetson-stats`), which should show
 that NVDEC/NVDEC1 are in use.
+
+## Rockchip platform
+
+Hardware accelerated video de-/encoding is supported on all Rockchip SoCs.
+
+### Setup
+
+Use a frigate docker image with `-rk` suffix and enable privileged mode by adding the `--privileged` flag to your docker run command or `privileged: true` to your `docker-compose.yml` file.
+
+### Configuration
+
+Add one of the following ffmpeg presets to your `config.yaml` to enable hardware acceleration:
+
+```yaml
+# if you try to decode a h264 encoded stream
+ffmpeg:
+  hwaccel_args: preset-rk-h264
+
+# if you try to decode a h265 (hevc) encoded stream
+ffmpeg:
+  hwaccel_args: preset-rk-h265
+```

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -64,6 +64,8 @@ PRESETS_HW_ACCEL_DECODE = {
     "preset-nvidia-mjpeg": "-hwaccel cuda -hwaccel_output_format cuda",
     "preset-jetson-h264": "-c:v h264_nvmpi -resize {1}x{2}",
     "preset-jetson-h265": "-c:v hevc_nvmpi -resize {1}x{2}",
+    "preset-rk-h264": "-c:v h264_rkmpp_decoder",
+    "preset-rk-h265": "-c:v hevc_rkmpp_decoder",
 }
 
 PRESETS_HW_ACCEL_SCALE = {
@@ -75,6 +77,8 @@ PRESETS_HW_ACCEL_SCALE = {
     "preset-nvidia-h265": "-r {0} -vf fps={0},scale_cuda=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
     "preset-jetson-h264": "-r {0}",  # scaled in decoder
     "preset-jetson-h265": "-r {0}",  # scaled in decoder
+    "preset-rk-h264": "-r {0} -width {1} -height {2}",
+    "preset-rk-h265": "-r {0} -width {1} -height {2}",
     "default": "-r {0} -vf fps={0},scale={1}:{2}",
 }
 
@@ -87,6 +91,8 @@ PRESETS_HW_ACCEL_ENCODE_BIRDSEYE = {
     "preset-nvidia-h265": "ffmpeg -hide_banner {0} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {1}",
     "preset-jetson-h264": "ffmpeg -hide_banner {0} -c:v h264_nvmpi -profile high {1}",
     "preset-jetson-h265": "ffmpeg -hide_banner {0} -c:v h264_nvmpi -profile high {1}",
+    "preset-rk-h264": "ffmpeg -hide_banner {0} -c:v h264_rkmpp_encoder -profile high {1}",
+    "preset-rk-h265": "ffmpeg -hide_banner {0} -c:v hevc_rkmpp_encoder -profile high {1}",
     "default": "ffmpeg -hide_banner {0} -c:v libx264 -g 50 -profile:v high -level:v 4.1 -preset:v superfast -tune:v zerolatency {1}",
 }
 
@@ -99,6 +105,8 @@ PRESETS_HW_ACCEL_ENCODE_TIMELAPSE = {
     "preset-nvidia-h265": "ffmpeg -hide_banner -hwaccel cuda -hwaccel_output_format cuda -extra_hw_frames 8 {0} -c:v hevc_nvenc {1}",
     "preset-jetson-h264": "ffmpeg -hide_banner {0} -c:v h264_nvmpi -profile high {1}",
     "preset-jetson-h265": "ffmpeg -hide_banner {0} -c:v hevc_nvmpi -profile high {1}",
+    "preset-rk-h264": "ffmpeg -hide_banner {0} -c:v h264_rkmpp_encoder -profile high {1}",
+    "preset-rk-h265": "ffmpeg -hide_banner {0} -c:v hevc_rkmpp_encoder -profile high {1}",
     "default": "ffmpeg -hide_banner {0} -c:v libx264 -preset:v ultrafast -tune:v zerolatency {1}",
 }
 

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -77,8 +77,8 @@ PRESETS_HW_ACCEL_SCALE = {
     "preset-nvidia-h265": "-r {0} -vf fps={0},scale_cuda=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
     "preset-jetson-h264": "-r {0}",  # scaled in decoder
     "preset-jetson-h265": "-r {0}",  # scaled in decoder
-    "preset-rk-h264": "-r {0} -width {1} -height {2}",
-    "preset-rk-h265": "-r {0} -width {1} -height {2}",
+    "preset-rk-h264": "-r {0} -vf fps={0},scale={1}:{2}",
+    "preset-rk-h265": "-r {0} -vf fps={0},scale={1}:{2}",
     "default": "-r {0} -vf fps={0},scale={1}:{2}",
 }
 


### PR DESCRIPTION
Limitations:
- So far, I didn't test it very well.
- This FFmpeg build does not enable libvpx de-/encoding in software. However, you can decode vp8/9 and encode vp8 in hardware.
- I didn't add the FFmpeg presets so far.
- I haven't updated the docs so far.

I hope to add the hw accel presets this evening, so others can test this PR.