### PR TITLE
Add features to rknn detector

### DIFF
--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -9,10 +9,11 @@ COPY docker/rockchip/requirements-wheels-rk.txt /requirements-wheels-rk.txt
 RUN sed -i "/https:\/\//d" /requirements-wheels.txt
 RUN pip3 wheel --wheel-dir=/rk-wheels -c /requirements-wheels.txt -r /requirements-wheels-rk.txt
 
-FROM wget as rk-libs
+FROM wget as rk-downloads
 RUN wget -qO librknnrt.so https://github.com/MarcA711/rknpu2/raw/master/runtime/RK3588/Linux/librknn_api/aarch64/librknnrt.so
 RUN wget -qO ffmpeg https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/latest/ffmpeg
 RUN wget -qO ffprobe https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/latest/ffprobe
+RUN wget -qO yolov8n-320x320.rknn https://github.com/MarcA711/rknn-models/releases/download/latest/yolov8n-320x320.rknn
 FROM deps AS rk-deps
 ARG TARGETARCH
 
@@ -21,12 +22,12 @@ RUN --mount=type=bind,from=rk-wheels,source=/rk-wheels,target=/deps/rk-wheels \
 
 WORKDIR /opt/frigate/
 COPY --from=rootfs / /
-COPY --from=rk-libs /rootfs/librknnrt.so /usr/lib/
-COPY docker/rockchip/yolov8n-320x320.rknn /models/
+COPY --from=rk-downloads /rootfs/librknnrt.so /usr/lib/
+COPY --from=rk-downloads /rootfs/yolov8n-320x320.rknn /models/
 
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffmpeg
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffprobe
-COPY --from=rk-libs /rootfs/ffmpeg /usr/lib/btbn-ffmpeg/bin/
-COPY --from=rk-libs /rootfs/ffprobe /usr/lib/btbn-ffmpeg/bin/
+COPY --from=rk-downloads /rootfs/ffmpeg /usr/lib/btbn-ffmpeg/bin/
+COPY --from=rk-downloads /rootfs/ffprobe /usr/lib/btbn-ffmpeg/bin/
 RUN chmod +x /usr/lib/btbn-ffmpeg/bin/ffmpeg
 RUN chmod +x /usr/lib/btbn-ffmpeg/bin/ffprobe

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -316,12 +316,12 @@ detectors:                            # required
     type: rknn                        # required
     # core mask for npu
     core_mask: 0
-    # yolov8 model in rknn format to use; allowed calues: n, s, m, l, x
-    yolov8_rknn_model: n
 
 model:                                # required
-  # path to .rknn model file
-  path:
+  # name of yolov8 model or path to your own .rknn model file
+  # possible names of yolov8 models are: default-yolov8n,
+  # default-yolov8s, default-yolov8m, default-yolov8l, default-yolov8x"
+  path: default-yolov8n
   # width and height of detection frames
   width: 320
   height: 320
@@ -338,7 +338,6 @@ Explanation for rknn specific options:
   - `core_mask: 0b001` use only core0.
   - `core_mask: 0b011` use core0 and core1.
   - `core_mask: 0b110` use core1 and core2. **This does not** work, since core0 is disabled.
-- **yolov8_rknn_model** see section below.
 
 ### Choosing a model
 
@@ -363,23 +362,12 @@ $ cat /sys/kernel/debug/rknpu/load
 
 :::
 
-- By default the rknn detector uses the yolov8**n** model (`yolov8_rknn_model: n`). This model comes with the image, so no further steps than those mentioned above are necessary.
-- If you want to use are more precise model, you can set `yolov8_rknn_model:` to `s`, `m`, `l` or `x`. But additional steps are required:
-    1. Mount the directory `/model/download/` to your system using one of the below methods. Of course, you can change to destination folder.
-      - If you start frigate with docker run, append this flag to your command: `-v /model/download:./data/rknn-models`
-      - If you use docker compose, append this to your `volumes` block: `/model/download:./data/rknn-models`
-    2. Download the rknn model.
-      - If your server has an internet connection, it will download the model.
-      - Otherwise, you can download the model from [this Github repository](https://github.com/MarcA711/rknn-models/releases/tag/latest) on another device and place it in the `rknn-models` folder that you mounted to your system.
-    3. Check the inference speeds in the frigate WebUI under System. If you use bigger models the inference speed will increase. If it gets too high, consider enabling more NPU cores using `core_mask` option.
-- Finally, you can also provide your own model. Note, that you will need to convert your model to the rknn format using `rknn-toolkit2` on a x86 machine. Afterwards, you can mount a directory to the image (docker run flag: `-v /model/custom:./data/my-rknn-models` or docker compose: add `/model/custom:./data/my-rknn-models` to the `volumes` block) and place your model file in that directory. Then you need to pass the path to your model using the `path` option of your `model` block like this:
+- By default the rknn detector uses the yolov8n model (`model: path: default-yolov8n`). This model comes with the image, so no further steps than those mentioned above are necessary.
+- If you want to use a more precise model, you can pass `default-yolov8s`, `default-yolov8m`, `default-yolov8l` or `default-yolov8x` as `model: path:` option.
+  - If the model does not exist, it will be automatically downloaded to `/config/model_cache/rknn`.
+  - If your server has no internet connection, you can download the model from [this Github repository](https://github.com/MarcA711/rknn-models/releases/tag/latest) using another device and place it in the `config/model_cache/rknn` on your system.
+- Finally, you can also provide your own model. Note that only yolov8 models are currently supported. Moreover, you will need to convert your model to the rknn format using `rknn-toolkit2` on a x86 machine. Afterwards, you can place your `.rknn` model file in the `config/model_cache/rknn` directory on your system. Then you need to pass the path to your model using the `path` option of your `model` block like this:
 ```yaml
 model:
-  path: /model/custom/my-rknn-model.rknn
+  path: /config/model_cache/rknn/my-rknn-model.rknn
 ```
-
-:::caution
-
-The `path` option of the `model` block will overwrite the `yolov8_rknn_model` option of the `detectors` block. So if you want to use one of the provided yolov8 models, make sure to not specify the `path` option.
-
-:::

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -337,10 +337,11 @@ model:                                # required
 ```
 
 Explanation for rknn specific options:
-- **core mask** controls which cores of your NPU should be used. This option applies only to SoCs with a multicore NPU (at the time of writing this in only the RK3588/S). The easiest way is to pass the value as a binary number. To do so, use the prefix `0b` and write a `0` to disable a core and a `1` to enable a core, whereas the last digit coresponds to core0, the second last to core1, etc. Examples:
+- **core mask** controls which cores of your NPU should be used. This option applies only to SoCs with a multicore NPU (at the time of writing this in only the RK3588/S). The easiest way is to pass the value as a binary number. To do so, use the prefix `0b` and write a `0` to disable a core and a `1` to enable a core, whereas the last digit coresponds to core0, the second last to core1, etc. You also have to use the cores in ascending order (so you can't use core0 and core2; but you can use core0 and core1). Enabling more cores can reduce the inference speed, especially when using bigger models (see section below). Examples:
   - `core_mask: 0b000` or just `core_mask: 0` let the NPU decide which cores should be used. Default and recommended value.
-  - `core_mask: 0b001` use only core0
-  - `core_mask: 0b110` use core1 and core2
+  - `core_mask: 0b001` use only core0.
+  - `core_mask: 0b011` use core0 and core1.
+  - `core_mask: 0b110` use core1 and core2. **This does not** work, since core0 is disabled.
 - **yolov8_rknn_model** see section below.
 - **min_score** sets the minimal detection confidence. Should have the same value as min_score in the object block. See also [Reducing false positives](/guides/false_positives.md).
 - **nms_thresh** is the IoU threshold for Non-maximum Suppression (NMS). Enable "bounding boxes" in the debug viewer.
@@ -378,6 +379,7 @@ $ cat /sys/kernel/debug/rknpu/load
     2. Download the rknn model.
       - If your server has an internet connection, it will download the model.
       - Otherwise, you can download the model from [this Github repository](https://github.com/MarcA711/rknn-models/releases/tag/latest) on another device and place it in the `rknn-models` folder that you mounted to your system.
+    3. Check the inference speeds in the frigate WebUI under System. If you use bigger models the inference speed will increase. If it gets too high, consider enabling more NPU cores using `core_mask` option.
 - Finally, you can also provide your own model. Note, that you will need to convert your model to the rknn format using `rknn-toolkit2` on a x86 machine. Afterwards, you can mount a directory to the image (docker run flag: `-v /model/custom:./data/my-rknn-models` or docker compose: add `/model/custom:./data/my-rknn-models` to the `volumes` block) and place your model file in that directory. Then you need to pass the path to your model using the `path` option of your `model` block like this:
 ```yaml
 model:

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -319,8 +319,13 @@ detectors:                            # required
 
 model:                                # required
   # name of yolov8 model or path to your own .rknn model file
-  # possible names of yolov8 models are: default-yolov8n,
-  # default-yolov8s, default-yolov8m, default-yolov8l, default-yolov8x"
+  # possible values are:
+  # - default-yolov8n
+  # - default-yolov8s
+  # - default-yolov8m
+  # - default-yolov8l
+  # - default-yolov8x
+  # - /config/model_cache/rknn/your_custom_model.rknn
   path: default-yolov8n
   # width and height of detection frames
   width: 320
@@ -341,7 +346,7 @@ Explanation for rknn specific options:
 
 ### Choosing a model
 
-There are 5 yolov8 models that differ in size and therefore load the NPU more or less. In ascending order, with the top one being the smallest and least computationally intensive model:
+There are 5 default yolov8 models that differ in size and therefore load the NPU more or less. In ascending order, with the top one being the smallest and least computationally intensive model:
 
 | Model   | Size in mb |
 | ------- | ---------- |

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -318,10 +318,6 @@ detectors:                            # required
     core_mask: 0
     # yolov8 model in rknn format to use; allowed calues: n, s, m, l, x
     yolov8_rknn_model: n
-    # minimal confidence for detection
-    min_score: 0.5
-    # determines whether two overlapping boxes should be combined
-    nms_thresh: 0.45
 
 model:                                # required
   # path to .rknn model file
@@ -343,10 +339,6 @@ Explanation for rknn specific options:
   - `core_mask: 0b011` use core0 and core1.
   - `core_mask: 0b110` use core1 and core2. **This does not** work, since core0 is disabled.
 - **yolov8_rknn_model** see section below.
-- **min_score** sets the minimal detection confidence. Should have the same value as min_score in the object block. See also [Reducing false positives](/guides/false_positives.md).
-- **nms_thresh** is the IoU threshold for Non-maximum Suppression (NMS). Enable "bounding boxes" in the debug viewer.
-  - *Decrease* if two overlapping objects (for example one person in front of another) are detected as one object.
-  - *Increase* if there are multiple boxes around one object.
 
 ### Choosing a model
 

--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -27,10 +27,8 @@ DETECTOR_KEY = "rknn"
 
 class RknnDetectorConfig(BaseDetectorConfig):
     type: Literal[DETECTOR_KEY]
-    yolov8_rknn_model: Literal['n', 's', 'm', 'l', 'x'] = 'n'
-    core_mask: int = Field(
-        default=0, ge=0, le=7, title="Core mask for NPU."
-    )
+    yolov8_rknn_model: Literal["n", "s", "m", "l", "x"] = "n"
+    core_mask: int = Field(default=0, ge=0, le=7, title="Core mask for NPU.")
     min_score: float = Field(
         default=0.5, ge=0, le=1, title="Minimal confidence for detection."
     )
@@ -43,37 +41,60 @@ class Rknn(DetectionApi):
     type_key = DETECTOR_KEY
 
     def __init__(self, config: RknnDetectorConfig):
-
         self.model_path = config.model.path or "/models/yolov8n-320x320.rknn"
 
         if config.model.path != None:
             self.model_path = config.model.path
         else:
-            if config.yolov8_rknn_model == 'n':
+            if config.yolov8_rknn_model == "n":
                 self.model_path = "/models/yolov8n-320x320.rknn"
             else:
                 # check if user mounted /models/download/
                 if not os.path.isdir("/models/download/"):
-                    logger.error("Make sure to mount the directory \"/models/download/\" to your system. Otherwise the file will be downloaded at every restart.")
-                    raise Exception("Make sure to mount the directory \"/models/download/\" to your system. Otherwise the file will be downloaded at every restart.")
+                    logger.error(
+                        'Make sure to mount the directory "/models/download/" to your system. Otherwise the file will be downloaded at every restart.'
+                    )
+                    raise Exception(
+                        'Make sure to mount the directory "/models/download/" to your system. Otherwise the file will be downloaded at every restart.'
+                    )
 
-
-                self.model_path = "/models/download/yolov8{}-320x320.rknn".format(config.yolov8_rknn_model)
+                self.model_path = "/models/download/yolov8{}-320x320.rknn".format(
+                    config.yolov8_rknn_model
+                )
                 if os.path.isfile(self.model_path) == False:
-                    logger.info("Downloading yolov8{} model.".format(config.yolov8_rknn_model))
-                    urllib.request.urlretrieve("https://github.com/MarcA711/rknn-models/releases/download/latest/yolov8{}-320x320.rknn".format(config.yolov8_rknn_model), self.model_path)
+                    logger.info(
+                        "Downloading yolov8{} model.".format(config.yolov8_rknn_model)
+                    )
+                    urllib.request.urlretrieve(
+                        "https://github.com/MarcA711/rknn-models/releases/download/latest/yolov8{}-320x320.rknn".format(
+                            config.yolov8_rknn_model
+                        ),
+                        self.model_path,
+                    )
 
             if (config.model.width != 320) or (config.model.height != 320):
-                logger.error("Make sure to set the model width and heigth to 320 in your config.yml.")
-                raise Exception("Make sure to set the model width and heigth to 320 in your config.yml.")
+                logger.error(
+                    "Make sure to set the model width and heigth to 320 in your config.yml."
+                )
+                raise Exception(
+                    "Make sure to set the model width and heigth to 320 in your config.yml."
+                )
 
-            if config.model.input_pixel_format != 'bgr':
-                logger.error("Make sure to set the model input_pixel_format to \"bgr\" in your config.yml.")
-                raise Exception("Make sure to set the model input_pixel_format to \"bgr\" in your config.yml.")
+            if config.model.input_pixel_format != "bgr":
+                logger.error(
+                    'Make sure to set the model input_pixel_format to "bgr" in your config.yml.'
+                )
+                raise Exception(
+                    'Make sure to set the model input_pixel_format to "bgr" in your config.yml.'
+                )
 
-            if config.model.input_tensor != 'nhwc':
-                logger.error("Make sure to set the model input_tensor to \"nhwc\" in your config.yml.")
-                raise Exception("Make sure to set the model input_tensor to \"nhwc\" in your config.yml.")
+            if config.model.input_tensor != "nhwc":
+                logger.error(
+                    'Make sure to set the model input_tensor to "nhwc" in your config.yml.'
+                )
+                raise Exception(
+                    'Make sure to set the model input_tensor to "nhwc" in your config.yml.'
+                )
 
         self.height = config.model.height
         self.width = config.model.width
@@ -87,7 +108,9 @@ class Rknn(DetectionApi):
         if self.rknn.load_rknn(self.model_path) != 0:
             logger.error("Error initializing rknn model.")
         if self.rknn.init_runtime(core_mask=self.core_mask) != 0:
-            logger.error("Error initializing rknn runtime. Do you run docker in privileged mode?")
+            logger.error(
+                "Error initializing rknn runtime. Do you run docker in privileged mode?"
+            )
 
     def __del__(self):
         self.rknn.release()


### PR DESCRIPTION
Added features:
- Add checks to make sure that the user sets the correct options in his config (for example `input_pixel_format: bgr` instead of rgb)
- Let the user choose the yolov8 model: 
  - yolov8n is still included in the image, but now it is downloaded during the image build process and not added to the frigate repository and copied over.
  - The user can choose another model (yolov8{s,m,l,x}); for this the user needs to mount a directory to his system and the model will be downloaded to that directory if it does not exist.
  - The user can also use a custom model that he provides using the `model: path:` option; this overwrites the provided yolov8 models
- adds the ability to set the core mask of the npu
- adds options for postprocessing, but I have some questions here @NickM-27 :
  - min_score: the minimum score for a possible detection to be considered a detection; this option is basically the same as `object: min_score:`. It would be better, if I could access this option directly, but I don't know how.
  - nms_thresh: IoU threshold used in nms algorithm; this basically controls whether two detection boxes that overlap are actually one object or not. This option also fits better in the `objects` block of the config, rather than the `detectors` block. However, it would be confusing for other users to add an option that only some detectors actually use. So, if this option gets added to the object block, it should be implemented in all other detectors. However, then we should also add all parameters used in postprocessing of other models. Therefore, I think it is best to keep it in the rknn detector block for now. But in the future, we could maybe implement a common `postprocessing.py` file that all detectors can use to do their postprocessing and that exposes the most important parameters to the config.
- Updated docs explaining the new configuration options.