### PR TITLE
Improve periodic sync reliability and make it optional

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -350,8 +350,8 @@ record:
   # Optional: Number of minutes to wait between cleanup runs (default: shown below)
   # This can be used to reduce the frequency of deleting recording segments from disk if you want to minimize i/o
   expire_interval: 60
-  # Optional: Sync recordings with disk on startup (default: shown below).
-  sync_on_startup: False
+  # Optional: Sync recordings with disk on startup and once a day (default: shown below).
+  sync_recordings: False
   # Optional: Retention settings for recording
   retain:
     # Optional: Number of days to retain recordings regardless of events (default: shown below)

--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -87,11 +87,11 @@ The export page in the Frigate WebUI allows for exporting real time clips with a
 
 ## Syncing Recordings With Disk
 
-In some cases the recordings files may be deleted but Frigate will not know this has happened. Sync on startup can be enabled which will tell Frigate to check the file system and delete any db entries for files which don't exist.
+In some cases the recordings files may be deleted but Frigate will not know this has happened. Recordings sync can be enabled which will tell Frigate to check the file system and delete any db entries for files which don't exist.
 
 ```yaml
 record:
-  sync_on_startup: True
+  sync_recordings: True
 ```
 
 :::warning

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -259,8 +259,8 @@ class RecordExportConfig(FrigateBaseModel):
 
 class RecordConfig(FrigateBaseModel):
     enabled: bool = Field(default=False, title="Enable record on all cameras.")
-    sync_on_startup: bool = Field(
-        default=False, title="Sync recordings with disk on startup."
+    sync_recordings: bool = Field(
+        default=False, title="Sync recordings with disk on startup and once a day."
     )
     expire_interval: int = Field(
         default=60,

--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -176,10 +176,9 @@ class RecordingCleanup(threading.Thread):
 
     def run(self) -> None:
         # on startup sync recordings with disk if enabled
-        if self.config.record.sync_on_startup:
+        if self.config.record.sync_recordings:
             sync_recordings(limited=False)
-
-        next_sync = get_tomorrow_at_time(3)
+            next_sync = get_tomorrow_at_time(3)
 
         # Expire tmp clips every minute, recordings and clean directories every hour.
         for counter in itertools.cycle(range(self.config.record.expire_interval)):
@@ -189,7 +188,11 @@ class RecordingCleanup(threading.Thread):
 
             self.clean_tmp_clips()
 
-            if datetime.datetime.now().astimezone(datetime.timezone.utc) > next_sync:
+            if (
+                self.config.record.sync_recordings
+                and datetime.datetime.now().astimezone(datetime.timezone.utc)
+                > next_sync
+            ):
                 sync_recordings(limited=True)
                 next_sync = get_tomorrow_at_time(3)
 

--- a/frigate/record/util.py
+++ b/frigate/record/util.py
@@ -101,7 +101,7 @@ def sync_recordings(limited: bool) -> None:
             return True
 
         logger.info(
-            f"Deleting {len(files_to_delete)} recordings files that are missing DB entries."
+            f"Deleting {len(files_to_delete)} recordings files with missing DB entries"
         )
 
         if float(len(files_to_delete)) / max(1, len(files_on_disk)) > 0.5:

--- a/frigate/record/util.py
+++ b/frigate/record/util.py
@@ -100,7 +100,9 @@ def sync_recordings(limited: bool) -> None:
         if len(files_to_delete) == 0:
             return True
 
-        logger.info(f"Deleting {len(files_to_delete)} recordings files that are missing DB entries.")
+        logger.info(
+            f"Deleting {len(files_to_delete)} recordings files that are missing DB entries."
+        )
 
         if float(len(files_to_delete)) / max(1, len(files_on_disk)) > 0.5:
             logger.debug(


### PR DESCRIPTION
This PR implements the following changes:
1. rename `sync_on_startup` -> `sync_recordings` so both startup and periodic syncing is optional (this is a breaking change for beta users)
2. log as info whenever files are being deleted due to sync, user should know when this is occurring instead of having to guess 
3. create a specific check timestamp that is on the hour, which removes the possibility that a time difference between the two timestamp calculations causes a file to be missing
4. don't use files_on_disk for DB check, just directly check if the file exists