### PR TITLE
Include libraries and .rknn models for other Rockchip SoCs

### DIFF
--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -9,10 +9,11 @@ COPY docker/rockchip/requirements-wheels-rk.txt /requirements-wheels-rk.txt
 RUN sed -i "/https:\/\//d" /requirements-wheels.txt
 RUN pip3 wheel --wheel-dir=/rk-wheels -c /requirements-wheels.txt -r /requirements-wheels-rk.txt
 
-FROM wget as rk-libs
+FROM wget as rk-downloads
 RUN wget -qO librknnrt.so https://github.com/MarcA711/rknpu2/raw/master/runtime/RK3588/Linux/librknn_api/aarch64/librknnrt.so
 RUN wget -qO ffmpeg https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/latest/ffmpeg
 RUN wget -qO ffprobe https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/latest/ffprobe
+RUN wget -qO yolov8n-320x320.rknn https://github.com/MarcA711/rknn-models/releases/download/latest/yolov8n-320x320.rknn
 FROM deps AS rk-deps
 ARG TARGETARCH
 
@@ -21,12 +22,12 @@ RUN --mount=type=bind,from=rk-wheels,source=/rk-wheels,target=/deps/rk-wheels \
 
 WORKDIR /opt/frigate/
 COPY --from=rootfs / /
-COPY --from=rk-libs /rootfs/librknnrt.so /usr/lib/
-COPY docker/rockchip/yolov8n-320x320.rknn /models/
+COPY --from=rk-downloads /rootfs/librknnrt.so /usr/lib/
+COPY --from=rk-downloads /rootfs/yolov8n-320x320.rknn /models/
 
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffmpeg
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffprobe
-COPY --from=rk-libs /rootfs/ffmpeg /usr/lib/btbn-ffmpeg/bin/
-COPY --from=rk-libs /rootfs/ffprobe /usr/lib/btbn-ffmpeg/bin/
+COPY --from=rk-downloads /rootfs/ffmpeg /usr/lib/btbn-ffmpeg/bin/
+COPY --from=rk-downloads /rootfs/ffprobe /usr/lib/btbn-ffmpeg/bin/
 RUN chmod +x /usr/lib/btbn-ffmpeg/bin/ffmpeg
 RUN chmod +x /usr/lib/btbn-ffmpeg/bin/ffprobe

--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -9,18 +9,6 @@ COPY docker/rockchip/requirements-wheels-rk.txt /requirements-wheels-rk.txt
 RUN sed -i "/https:\/\//d" /requirements-wheels.txt
 RUN pip3 wheel --wheel-dir=/rk-wheels -c /requirements-wheels.txt -r /requirements-wheels-rk.txt
 
-FROM wget as rk-downloads
-RUN wget -qO ffmpeg https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/latest/ffmpeg
-RUN wget -qO ffprobe https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/latest/ffprobe
-
-RUN wget -qO librknnrt_rk356x.so https://github.com/MarcA711/rknpu2/releases/download/v1.5.2/librknnrt_rk356x.so
-RUN wget -qO librknnrt_rk3588.so https://github.com/MarcA711/rknpu2/releases/download/v1.5.2/librknnrt_rk3588.so
-
-RUN wget -qO yolov8n-320x320-rk3562.rknn https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3562/yolov8n-320x320-rk3562.rknn
-RUN wget -qO yolov8n-320x320-rk3566.rknn https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3566/yolov8n-320x320-rk3566.rknn
-RUN wget -qO yolov8n-320x320-rk3568.rknn https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3568/yolov8n-320x320-rk3568.rknn
-RUN wget -qO yolov8n-320x320-rk3588.rknn https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3588/yolov8n-320x320-rk3588.rknn
-
 FROM deps AS rk-deps
 ARG TARGETARCH
 
@@ -30,17 +18,15 @@ RUN --mount=type=bind,from=rk-wheels,source=/rk-wheels,target=/deps/rk-wheels \
 WORKDIR /opt/frigate/
 COPY --from=rootfs / /
 
-COPY --from=rk-downloads /rootfs/librknnrt_rk356x.so /usr/lib/
-COPY --from=rk-downloads /rootfs/librknnrt_rk3588.so /usr/lib/
+ADD https://github.com/MarcA711/rknpu2/releases/download/v1.5.2/librknnrt_rk356x.so /usr/lib/
+ADD https://github.com/MarcA711/rknpu2/releases/download/v1.5.2/librknnrt_rk3588.so /usr/lib/
 
-COPY --from=rk-downloads /rootfs/yolov8n-320x320-rk3562.rknn /models/
-COPY --from=rk-downloads /rootfs/yolov8n-320x320-rk3566.rknn /models/
-COPY --from=rk-downloads /rootfs/yolov8n-320x320-rk3568.rknn /models/
-COPY --from=rk-downloads /rootfs/yolov8n-320x320-rk3588.rknn /models/
+ADD https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3562/yolov8n-320x320-rk3562.rknn /models/rknn/
+ADD https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3566/yolov8n-320x320-rk3566.rknn /models/rknn/
+ADD https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3568/yolov8n-320x320-rk3568.rknn /models/rknn/
+ADD https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3588/yolov8n-320x320-rk3588.rknn /models/rknn/
 
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffmpeg
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffprobe
-COPY --from=rk-downloads /rootfs/ffmpeg /usr/lib/btbn-ffmpeg/bin/
-COPY --from=rk-downloads /rootfs/ffprobe /usr/lib/btbn-ffmpeg/bin/
-RUN chmod +x /usr/lib/btbn-ffmpeg/bin/ffmpeg
-RUN chmod +x /usr/lib/btbn-ffmpeg/bin/ffprobe
+ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/latest/ffmpeg /usr/lib/btbn-ffmpeg/bin/
+ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/latest/ffprobe /usr/lib/btbn-ffmpeg/bin/

--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -10,10 +10,17 @@ RUN sed -i "/https:\/\//d" /requirements-wheels.txt
 RUN pip3 wheel --wheel-dir=/rk-wheels -c /requirements-wheels.txt -r /requirements-wheels-rk.txt
 
 FROM wget as rk-downloads
-RUN wget -qO librknnrt.so https://github.com/MarcA711/rknpu2/raw/master/runtime/RK3588/Linux/librknn_api/aarch64/librknnrt.so
 RUN wget -qO ffmpeg https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/latest/ffmpeg
 RUN wget -qO ffprobe https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/latest/ffprobe
-RUN wget -qO yolov8n-320x320.rknn https://github.com/MarcA711/rknn-models/releases/download/latest/yolov8n-320x320.rknn
+
+RUN wget -qO librknnrt_rk356x.so https://github.com/MarcA711/rknpu2/releases/download/v1.5.2/librknnrt_rk356x.so
+RUN wget -qO librknnrt_rk3588.so https://github.com/MarcA711/rknpu2/releases/download/v1.5.2/librknnrt_rk3588.so
+
+RUN wget -qO yolov8n-320x320-rk3562.rknn https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3562/yolov8n-320x320-rk3562.rknn
+RUN wget -qO yolov8n-320x320-rk3566.rknn https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3566/yolov8n-320x320-rk3566.rknn
+RUN wget -qO yolov8n-320x320-rk3568.rknn https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3568/yolov8n-320x320-rk3568.rknn
+RUN wget -qO yolov8n-320x320-rk3588.rknn https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3588/yolov8n-320x320-rk3588.rknn
+
 FROM deps AS rk-deps
 ARG TARGETARCH
 
@@ -22,8 +29,14 @@ RUN --mount=type=bind,from=rk-wheels,source=/rk-wheels,target=/deps/rk-wheels \
 
 WORKDIR /opt/frigate/
 COPY --from=rootfs / /
-COPY --from=rk-downloads /rootfs/librknnrt.so /usr/lib/
-COPY --from=rk-downloads /rootfs/yolov8n-320x320.rknn /models/
+
+COPY --from=rk-downloads /rootfs/librknnrt_rk356x.so /usr/lib/
+COPY --from=rk-downloads /rootfs/librknnrt_rk3588.so /usr/lib/
+
+COPY --from=rk-downloads /rootfs/yolov8n-320x320-rk3562.rknn /models/
+COPY --from=rk-downloads /rootfs/yolov8n-320x320-rk3566.rknn /models/
+COPY --from=rk-downloads /rootfs/yolov8n-320x320-rk3568.rknn /models/
+COPY --from=rk-downloads /rootfs/yolov8n-320x320-rk3588.rknn /models/
 
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffmpeg
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffprobe

--- a/docker/rockchip/requirements-wheels-rk.txt
+++ b/docker/rockchip/requirements-wheels-rk.txt
@@ -1,2 +1,2 @@
 hide-warnings == 0.17
-rknn-toolkit-lite2 @ https://github.com/MarcA711/rknn-toolkit2/raw/master/rknn_toolkit_lite2/packages/rknn_toolkit_lite2-1.5.2-cp39-cp39-linux_aarch64.whl
+rknn-toolkit-lite2 @ https://github.com/MarcA711/rknn-toolkit2/releases/download/v1.5.2/rknn_toolkit_lite2-1.5.2-cp39-cp39-linux_aarch64.whl

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -316,12 +316,12 @@ detectors:                            # required
     type: rknn                        # required
     # core mask for npu
     core_mask: 0
-    # yolov8 model in rknn format to use; allowed calues: n, s, m, l, x
-    yolov8_rknn_model: n
 
 model:                                # required
-  # path to .rknn model file
-  path:
+  # name of yolov8 model or path to your own .rknn model file
+  # possible names of yolov8 models are: default-yolov8n,
+  # default-yolov8s, default-yolov8m, default-yolov8l, default-yolov8x"
+  path: default-yolov8n
   # width and height of detection frames
   width: 320
   height: 320
@@ -338,7 +338,6 @@ Explanation for rknn specific options:
   - `core_mask: 0b001` use only core0.
   - `core_mask: 0b011` use core0 and core1.
   - `core_mask: 0b110` use core1 and core2. **This does not** work, since core0 is disabled.
-- **yolov8_rknn_model** see section below.
 
 ### Choosing a model
 
@@ -363,23 +362,12 @@ $ cat /sys/kernel/debug/rknpu/load
 
 :::
 
-- By default the rknn detector uses the yolov8**n** model (`yolov8_rknn_model: n`). This model comes with the image, so no further steps than those mentioned above are necessary.
-- If you want to use are more precise model, you can set `yolov8_rknn_model:` to `s`, `m`, `l` or `x`. But additional steps are required:
-    1. Mount the directory `/model/download/` to your system using one of the below methods. Of course, you can change to destination folder.
-      - If you start frigate with docker run, append this flag to your command: `-v /model/download:./data/rknn-models`
-      - If you use docker compose, append this to your `volumes` block: `/model/download:./data/rknn-models`
-    2. Download the rknn model.
-      - If your server has an internet connection, it will download the model.
-      - Otherwise, you can download the model from [this Github repository](https://github.com/MarcA711/rknn-models/releases/tag/latest) on another device and place it in the `rknn-models` folder that you mounted to your system.
-    3. Check the inference speeds in the frigate WebUI under System. If you use bigger models the inference speed will increase. If it gets too high, consider enabling more NPU cores using `core_mask` option.
-- Finally, you can also provide your own model. Note, that you will need to convert your model to the rknn format using `rknn-toolkit2` on a x86 machine. Afterwards, you can mount a directory to the image (docker run flag: `-v /model/custom:./data/my-rknn-models` or docker compose: add `/model/custom:./data/my-rknn-models` to the `volumes` block) and place your model file in that directory. Then you need to pass the path to your model using the `path` option of your `model` block like this:
+- By default the rknn detector uses the yolov8n model (`model: path: default-yolov8n`). This model comes with the image, so no further steps than those mentioned above are necessary.
+- If you want to use a more precise model, you can pass `default-yolov8s`, `default-yolov8m`, `default-yolov8l` or `default-yolov8x` as `model: path:` option.
+  - If the model does not exist, it will be automatically downloaded to `/config/model_cache/rknn`.
+  - If your server has no internet connection, you can download the model from [this Github repository](https://github.com/MarcA711/rknn-models/releases/tag/latest) using another device and place it in the `config/model_cache/rknn` on your system.
+- Finally, you can also provide your own model. Note that only yolov8 models are currently supported. Moreover, you will need to convert your model to the rknn format using `rknn-toolkit2` on a x86 machine. Afterwards, you can place your `.rknn` model file in the `config/model_cache/rknn` directory on your system. Then you need to pass the path to your model using the `path` option of your `model` block like this:
 ```yaml
 model:
-  path: /model/custom/my-rknn-model.rknn
+  path: /config/model_cache/rknn/my-rknn-model.rknn
 ```
-
-:::caution
-
-The `path` option of the `model` block will overwrite the `yolov8_rknn_model` option of the `detectors` block. So if you want to use one of the provided yolov8 models, make sure to not specify the `path` option.
-
-:::

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -295,9 +295,9 @@ To verify that the integration is working correctly, start Frigate and observe t
 ## Rockchip RKNN-Toolkit-Lite2
 
 This detector is only available if one of the following Rockchip SoCs is used:
-- RK3566/RK3568
 - RK3588/RK3588S
-- RV1103/RV1106
+- RK3568
+- RK3566
 - RK3562
 
 These SoCs come with a NPU that will highly speed up detection.

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -337,10 +337,11 @@ model:                                # required
 ```
 
 Explanation for rknn specific options:
-- **core mask** controls which cores of your NPU should be used. This option applies only to SoCs with a multicore NPU (at the time of writing this in only the RK3588/S). The easiest way is to pass the value as a binary number. To do so, use the prefix `0b` and write a `0` to disable a core and a `1` to enable a core, whereas the last digit coresponds to core0, the second last to core1, etc. Examples:
+- **core mask** controls which cores of your NPU should be used. This option applies only to SoCs with a multicore NPU (at the time of writing this in only the RK3588/S). The easiest way is to pass the value as a binary number. To do so, use the prefix `0b` and write a `0` to disable a core and a `1` to enable a core, whereas the last digit coresponds to core0, the second last to core1, etc. You also have to use the cores in ascending order (so you can't use core0 and core2; but you can use core0 and core1). Enabling more cores can reduce the inference speed, especially when using bigger models (see section below). Examples:
   - `core_mask: 0b000` or just `core_mask: 0` let the NPU decide which cores should be used. Default and recommended value.
-  - `core_mask: 0b001` use only core0
-  - `core_mask: 0b110` use core1 and core2
+  - `core_mask: 0b001` use only core0.
+  - `core_mask: 0b011` use core0 and core1.
+  - `core_mask: 0b110` use core1 and core2. **This does not** work, since core0 is disabled.
 - **yolov8_rknn_model** see section below.
 - **min_score** sets the minimal detection confidence. Should have the same value as min_score in the object block. See also [Reducing false positives](/guides/false_positives.md).
 - **nms_thresh** is the IoU threshold for Non-maximum Suppression (NMS). Enable "bounding boxes" in the debug viewer.
@@ -378,6 +379,7 @@ $ cat /sys/kernel/debug/rknpu/load
     2. Download the rknn model.
       - If your server has an internet connection, it will download the model.
       - Otherwise, you can download the model from [this Github repository](https://github.com/MarcA711/rknn-models/releases/tag/latest) on another device and place it in the `rknn-models` folder that you mounted to your system.
+    3. Check the inference speeds in the frigate WebUI under System. If you use bigger models the inference speed will increase. If it gets too high, consider enabling more NPU cores using `core_mask` option.
 - Finally, you can also provide your own model. Note, that you will need to convert your model to the rknn format using `rknn-toolkit2` on a x86 machine. Afterwards, you can mount a directory to the image (docker run flag: `-v /model/custom:./data/my-rknn-models` or docker compose: add `/model/custom:./data/my-rknn-models` to the `volumes` block) and place your model file in that directory. Then you need to pass the path to your model using the `path` option of your `model` block like this:
 ```yaml
 model:

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -319,8 +319,13 @@ detectors:                            # required
 
 model:                                # required
   # name of yolov8 model or path to your own .rknn model file
-  # possible names of yolov8 models are: default-yolov8n,
-  # default-yolov8s, default-yolov8m, default-yolov8l, default-yolov8x"
+  # possible values are:
+  # - default-yolov8n
+  # - default-yolov8s
+  # - default-yolov8m
+  # - default-yolov8l
+  # - default-yolov8x
+  # - /config/model_cache/rknn/your_custom_model.rknn
   path: default-yolov8n
   # width and height of detection frames
   width: 320
@@ -341,7 +346,7 @@ Explanation for rknn specific options:
 
 ### Choosing a model
 
-There are 5 yolov8 models that differ in size and therefore load the NPU more or less. In ascending order, with the top one being the smallest and least computationally intensive model:
+There are 5 default yolov8 models that differ in size and therefore load the NPU more or less. In ascending order, with the top one being the smallest and least computationally intensive model:
 
 | Model   | Size in mb |
 | ------- | ---------- |

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -379,7 +379,7 @@ model:
 
 :::tip
 
-When you have a multicore NPU, you can enable all cores to reduce inference times. You should consider activating all cores if you use a larger model like yolov8l. If your NPU has 3 cores (like rk3588/S SoCs), you can enable all 3 using:
+When you have a multicore NPU, you can enable all cores to reduce inference times. You should consider activating all cores if you use a larger model like yolov8l. If your NPU has 3 cores (like rk3588/S SoCs), you can enable all 3 cores using:
 
 ```yaml
 detectors:

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -304,7 +304,7 @@ These SoCs come with a NPU that will highly speed up detection.
 
 ### Setup
 
-RKNN support is provided using the `-rk` suffix for the docker image. Moreover, privileged mode must be enabled by adding the `--privileged` flag to your docker run command or `privileged: true` to your `docker-compose.yml` file.
+Use a frigate docker image with `-rk` suffix and enable privileged mode by adding the `--privileged` flag to your docker run command or `privileged: true` to your `docker-compose.yml` file.
 
 ### Configuration
 
@@ -376,3 +376,16 @@ $ cat /sys/kernel/debug/rknpu/load
 model:
   path: /config/model_cache/rknn/my-rknn-model.rknn
 ```
+
+:::tip
+
+When you have a multicore NPU, you can enable all cores to reduce inference times. You should consider activating all cores if you use a larger model like yolov8l. If your NPU has 3 cores (like rk3588/S SoCs), you can enable all 3 using:
+
+```yaml
+detectors:
+  rknn:
+    type: rknn
+    core_mask: 0b111
+```
+
+:::

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -318,10 +318,6 @@ detectors:                            # required
     core_mask: 0
     # yolov8 model in rknn format to use; allowed calues: n, s, m, l, x
     yolov8_rknn_model: n
-    # minimal confidence for detection
-    min_score: 0.5
-    # determines whether two overlapping boxes should be combined
-    nms_thresh: 0.45
 
 model:                                # required
   # path to .rknn model file
@@ -343,10 +339,6 @@ Explanation for rknn specific options:
   - `core_mask: 0b011` use core0 and core1.
   - `core_mask: 0b110` use core1 and core2. **This does not** work, since core0 is disabled.
 - **yolov8_rknn_model** see section below.
-- **min_score** sets the minimal detection confidence. Should have the same value as min_score in the object block. See also [Reducing false positives](/guides/false_positives.md).
-- **nms_thresh** is the IoU threshold for Non-maximum Suppression (NMS). Enable "bounding boxes" in the debug viewer.
-  - *Decrease* if two overlapping objects (for example one person in front of another) are detected as one object.
-  - *Increase* if there are multiple boxes around one object.
 
 ### Choosing a model
 

--- a/docs/docs/frigate/hardware.md
+++ b/docs/docs/frigate/hardware.md
@@ -103,7 +103,7 @@ Frigate supports SBCs with the following Rockchip SoCs:
 - RV1103/RV1106
 - RK3562
 
-Using the yolov8n model and an Orange Pi 5 Plus with RK3588 SoC inference speeds vary between 25-40 ms.
+Using the yolov8n model and an Orange Pi 5 Plus with RK3588 SoC inference speeds vary between 20 - 25 ms.
 
 ## What does Frigate use the CPU for and what does it use a detector for? (ELI5 Version)
 

--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -32,6 +32,7 @@ yolov8_suffix = {
     "default-yolov8x": "x",
 }
 
+
 class RknnDetectorConfig(BaseDetectorConfig):
     type: Literal[DETECTOR_KEY]
     core_mask: int = Field(default=0, ge=0, le=7, title="Core mask for NPU.")
@@ -44,7 +45,7 @@ class Rknn(DetectionApi):
         # find out SoC
         try:
             with open("/proc/device-tree/compatible") as file:
-                soc = file.read().split(",")[-1].strip('\x00')
+                soc = file.read().split(",")[-1].strip("\x00")
         except FileNotFoundError:
             logger.error("Make sure to run docker in privileged mode.")
             raise Exception("Make sure to run docker in privileged mode.")
@@ -60,12 +61,12 @@ class Rknn(DetectionApi):
                     soc, supported_socs
                 )
             )
-        
+
         if "rk356" in soc:
             os.rename("/usr/lib/librknnrt_rk356x.so", "/usr/lib/librknnrt.so")
         elif "rk3588" in soc:
             os.rename("/usr/lib/librknnrt_rk3588.so", "/usr/lib/librknnrt.so")
-        
+
         self.model_path = config.model.path or "default-yolov8n"
         self.core_mask = config.core_mask
         self.height = config.model.height
@@ -73,7 +74,9 @@ class Rknn(DetectionApi):
 
         if self.model_path in yolov8_suffix:
             if self.model_path == "default-yolov8n":
-                self.model_path = "/models/rknn/yolov8n-320x320-{soc}.rknn".format(soc=soc)
+                self.model_path = "/models/rknn/yolov8n-320x320-{soc}.rknn".format(
+                    soc=soc
+                )
             else:
                 model_suffix = yolov8_suffix[self.model_path]
                 self.model_path = (

--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 DETECTOR_KEY = "rknn"
 
+supported_socs = ["rk3562", "rk3566", "rk3568", "rk3588"]
+
 yolov8_rknn_models = {
     "default-yolov8n": "n",
     "default-yolov8s": "s",
@@ -40,6 +42,28 @@ class Rknn(DetectionApi):
     type_key = DETECTOR_KEY
 
     def __init__(self, config: RknnDetectorConfig):
+        # find out SoC
+        try:
+            with open("/proc/device-tree/compatible") as file:
+                device_string = file.read()
+                device_string_parts = device_string.split(",")
+                soc = device_string_parts[-1]
+        except FileNotFoundError:
+            logger.error("Make sure to run docker in privileged mode.")
+            raise Exception("Make sure to run docker in privileged mode.")
+
+        if soc not in supported_socs:
+            logger.error(
+                "Your SoC is not supported. Your SoC is: {}. Currently these SoCs are supported: {}.".format(
+                    soc, supported_socs
+                )
+            )
+            raise Exception(
+                "Your SoC is not supported. Your SoC is: {}. Currently these SoCs are supported: {}.".format(
+                    soc, supported_socs
+                )
+            )
+
         self.model_path = config.model.path or "default-yolov8n"
         self.core_mask = config.core_mask
         self.height = config.model.height
@@ -47,21 +71,23 @@ class Rknn(DetectionApi):
 
         if self.model_path in yolov8_rknn_models:
             if self.model_path == "default-yolov8n":
-                self.model_path = "/models/yolov8n-320x320.rknn"
+                self.model_path = "/models/yolov8n-320x320-{soc}.rknn".format(soc=soc)
             else:
                 model_suffix = yolov8_rknn_models[self.model_path]
                 self.model_path = (
-                    "/config/model_cache/rknn/yolov8{}-320x320.rknn".format(
-                        model_suffix
+                    "/config/model_cache/rknn/yolov8{suffix}-320x320-{soc}.rknn".format(
+                        suffix=model_suffix, soc=soc
                     )
                 )
 
                 os.makedirs("/config/model_cache/rknn", exist_ok=True)
                 if not os.path.isfile(self.model_path):
-                    logger.info("Downloading yolov8{} model.".format(model_suffix))
+                    logger.info(
+                        "Downloading yolov8{suffix} model.".format(suffix=model_suffix)
+                    )
                     urllib.request.urlretrieve(
-                        "https://github.com/MarcA711/rknn-models/releases/download/latest/yolov8{}-320x320.rknn".format(
-                            model_suffix
+                        "https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-{soc}/yolov8{suffix}-320x320-{soc}.rknn".format(
+                            soc=soc, suffix=model_suffix
                         ),
                         self.model_path,
                     )

--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -27,10 +27,8 @@ DETECTOR_KEY = "rknn"
 
 class RknnDetectorConfig(BaseDetectorConfig):
     type: Literal[DETECTOR_KEY]
-    yolov8_rknn_model: Literal['n', 's', 'm', 'l', 'x'] = 'n'
-    core_mask: int = Field(
-        default=0, ge=0, le=7, title="Core mask for NPU."
-    )
+    yolov8_rknn_model: Literal["n", "s", "m", "l", "x"] = "n"
+    core_mask: int = Field(default=0, ge=0, le=7, title="Core mask for NPU.")
     min_score: float = Field(
         default=0.5, ge=0, le=1, title="Minimal confidence for detection."
     )
@@ -43,37 +41,60 @@ class Rknn(DetectionApi):
     type_key = DETECTOR_KEY
 
     def __init__(self, config: RknnDetectorConfig):
-
         self.model_path = config.model.path or "/models/yolov8n-320x320.rknn"
 
         if config.model.path != None:
             self.model_path = config.model.path
         else:
-            if config.yolov8_rknn_model == 'n':
+            if config.yolov8_rknn_model == "n":
                 self.model_path = "/models/yolov8n-320x320.rknn"
             else:
                 # check if user mounted /models/download/
                 if not os.path.isdir("/models/download/"):
-                    logger.error("Make sure to mount the directory \"/models/download/\" to your system. Otherwise the file will be downloaded at every restart.")
-                    raise Exception("Make sure to mount the directory \"/models/download/\" to your system. Otherwise the file will be downloaded at every restart.")
+                    logger.error(
+                        'Make sure to mount the directory "/models/download/" to your system. Otherwise the file will be downloaded at every restart.'
+                    )
+                    raise Exception(
+                        'Make sure to mount the directory "/models/download/" to your system. Otherwise the file will be downloaded at every restart.'
+                    )
 
-
-                self.model_path = "/models/download/yolov8{}-320x320.rknn".format(config.yolov8_rknn_model)
+                self.model_path = "/models/download/yolov8{}-320x320.rknn".format(
+                    config.yolov8_rknn_model
+                )
                 if os.path.isfile(self.model_path) == False:
-                    logger.info("Downloading yolov8{} model.".format(config.yolov8_rknn_model))
-                    urllib.request.urlretrieve("https://github.com/MarcA711/rknn-models/releases/download/latest/yolov8{}-320x320.rknn".format(config.yolov8_rknn_model), self.model_path)
+                    logger.info(
+                        "Downloading yolov8{} model.".format(config.yolov8_rknn_model)
+                    )
+                    urllib.request.urlretrieve(
+                        "https://github.com/MarcA711/rknn-models/releases/download/latest/yolov8{}-320x320.rknn".format(
+                            config.yolov8_rknn_model
+                        ),
+                        self.model_path,
+                    )
 
             if (config.model.width != 320) or (config.model.height != 320):
-                logger.error("Make sure to set the model width and heigth to 320 in your config.yml.")
-                raise Exception("Make sure to set the model width and heigth to 320 in your config.yml.")
+                logger.error(
+                    "Make sure to set the model width and heigth to 320 in your config.yml."
+                )
+                raise Exception(
+                    "Make sure to set the model width and heigth to 320 in your config.yml."
+                )
 
-            if config.model.input_pixel_format != 'bgr':
-                logger.error("Make sure to set the model input_pixel_format to \"bgr\" in your config.yml.")
-                raise Exception("Make sure to set the model input_pixel_format to \"bgr\" in your config.yml.")
+            if config.model.input_pixel_format != "bgr":
+                logger.error(
+                    'Make sure to set the model input_pixel_format to "bgr" in your config.yml.'
+                )
+                raise Exception(
+                    'Make sure to set the model input_pixel_format to "bgr" in your config.yml.'
+                )
 
-            if config.model.input_tensor != 'nhwc':
-                logger.error("Make sure to set the model input_tensor to \"nhwc\" in your config.yml.")
-                raise Exception("Make sure to set the model input_tensor to \"nhwc\" in your config.yml.")
+            if config.model.input_tensor != "nhwc":
+                logger.error(
+                    'Make sure to set the model input_tensor to "nhwc" in your config.yml.'
+                )
+                raise Exception(
+                    'Make sure to set the model input_tensor to "nhwc" in your config.yml.'
+                )
 
         self.height = config.model.height
         self.width = config.model.width
@@ -87,7 +108,9 @@ class Rknn(DetectionApi):
         if self.rknn.load_rknn(self.model_path) != 0:
             logger.error("Error initializing rknn model.")
         if self.rknn.init_runtime(core_mask=self.core_mask) != 0:
-            logger.error("Error initializing rknn runtime. Do you run docker in privileged mode?")
+            logger.error(
+                "Error initializing rknn runtime. Do you run docker in privileged mode?"
+            )
 
     def __del__(self):
         self.rknn.release()


### PR DESCRIPTION
Before, only the rk3588/s specific libraries and models were included in the image. This PR adds support for the other SoCs listed in the docs.