### PR TITLE
Set max value for pre_capture

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -19,6 +19,7 @@ from frigate.const import (
     CACHE_DIR,
     CACHE_SEGMENT_FORMAT,
     DEFAULT_DB_PATH,
+    MAX_PRE_CAPTURE,
     REGEX_CAMERA_NAME,
     YAML_EXT,
 )
@@ -232,7 +233,9 @@ class RetainConfig(FrigateBaseModel):
 
 
 class EventsConfig(FrigateBaseModel):
-    pre_capture: int = Field(default=5, title="Seconds to retain before event starts.")
+    pre_capture: int = Field(
+        default=5, title="Seconds to retain before event starts.", le=MAX_PRE_CAPTURE
+    )
     post_capture: int = Field(default=5, title="Seconds to retain after event ends.")
     required_zones: List[str] = Field(
         default_factory=list,

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -51,7 +51,9 @@ DRIVER_INTEL_iHD = "iHD"
 # Record Values
 
 CACHE_SEGMENT_FORMAT = "%Y%m%d%H%M%S%z"
+MAX_PRE_CAPTURE = 60
 MAX_SEGMENT_DURATION = 600
+MAX_SEGMENTS_IN_CACHE = 6
 MAX_PLAYLIST_SECONDS = 7200  # support 2 hour segments for a single playlist to account for cameras with inconsistent segment times
 
 # Internal Comms Topics

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -23,6 +23,7 @@ from frigate.const import (
     CACHE_SEGMENT_FORMAT,
     INSERT_MANY_RECORDINGS,
     MAX_SEGMENT_DURATION,
+    MAX_SEGMENTS_IN_CACHE,
     RECORD_DIR,
 )
 from frigate.models import Event, Recordings
@@ -121,8 +122,8 @@ class RecordingMaintainer(threading.Thread):
                 }
             )
 
-        # delete all cached files past the most recent 5
-        keep_count = 5
+        # delete all cached files past the most recent MAX_SEGMENTS_IN_CACHE
+        keep_count = MAX_SEGMENTS_IN_CACHE
         for camera in grouped_recordings.keys():
             # sort based on start time
             grouped_recordings[camera] = sorted(


### PR DESCRIPTION
The frigate recording maintainer assumes that segments will be moved immediately, however in the event recording only scenario frigate will keep the segments up to `pre_capture` seconds before moving in case an event occurs that requires this segment.

That means that pre_capture > 60 seconds will be guaranteed to cause the recordings to be dropped. In this PR I have increased the keep_count to 6 so a round pre_capture of up to 60 can be used

closes #8654