### PR TITLE
make go2rtc always rebuild config at startup

### DIFF
--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
@@ -45,15 +45,20 @@ function get_ip_and_port_from_supervisor() {
 
 export LIBAVFORMAT_VERSION_MAJOR=$(ffmpeg -version | grep -Po 'libavformat\W+\K\d+')
 
+if [[ -f "/dev/shm/go2rtc.yaml" ]]; then
+    echo "[INFO] Removing stale config from last run..."
+    rm /dev/shm/go2rtc.yaml
+
 if [[ ! -f "/dev/shm/go2rtc.yaml" ]]; then
-    echo "[INFO] Preparing go2rtc config..."
+    echo "[INFO] Preparing new go2rtc config..."
+    python3 /usr/local/go2rtc/create_config.py
 
     if [[ -n "${SUPERVISOR_TOKEN:-}" ]]; then
         # Running as a Home Assistant add-on, infer the IP address and port
         get_ip_and_port_from_supervisor
     fi
-
-    python3 /usr/local/go2rtc/create_config.py
+else
+    echo "[WARNING] Unable to remove existing go2rtc config. Changes made to your frigate config file may not be recognized. Please remove the /dev/shm/go2rtc.yaml from your docker host manually."
 fi
 
 readonly config_path="/config"

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
@@ -55,9 +55,8 @@ if [[ ! -f "/dev/shm/go2rtc.yaml" ]]; then
     if [[ -n "${SUPERVISOR_TOKEN:-}" ]]; then
         # Running as a Home Assistant add-on, infer the IP address and port
         get_ip_and_port_from_supervisor
-        
+        fi
     python3 /usr/local/go2rtc/create_config.py
-    fi
 else
     echo "[WARNING] Unable to remove existing go2rtc config. Changes made to your frigate config file may not be recognized. Please remove the /dev/shm/go2rtc.yaml from your docker host manually."
 fi

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
@@ -51,11 +51,12 @@ if [[ -f "/dev/shm/go2rtc.yaml" ]]; then
 
 if [[ ! -f "/dev/shm/go2rtc.yaml" ]]; then
     echo "[INFO] Preparing new go2rtc config..."
-    python3 /usr/local/go2rtc/create_config.py
 
     if [[ -n "${SUPERVISOR_TOKEN:-}" ]]; then
         # Running as a Home Assistant add-on, infer the IP address and port
         get_ip_and_port_from_supervisor
+        
+    python3 /usr/local/go2rtc/create_config.py
     fi
 else
     echo "[WARNING] Unable to remove existing go2rtc config. Changes made to your frigate config file may not be recognized. Please remove the /dev/shm/go2rtc.yaml from your docker host manually."

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
@@ -55,7 +55,8 @@ if [[ ! -f "/dev/shm/go2rtc.yaml" ]]; then
     if [[ -n "${SUPERVISOR_TOKEN:-}" ]]; then
         # Running as a Home Assistant add-on, infer the IP address and port
         get_ip_and_port_from_supervisor
-        fi
+    fi
+
     python3 /usr/local/go2rtc/create_config.py
 else
     echo "[WARNING] Unable to remove existing go2rtc config. Changes made to your frigate config file may not be recognized. Please remove the /dev/shm/go2rtc.yaml from your docker host manually."


### PR DESCRIPTION
/dev/shm can be left mounted (in fact im pretty sure it's always left mounted) on the docker host after shutting down the frigate container. If we only check that the file doesn't exist, stale data gets re-read every startup  This will make troubleshooting a nightmare for the average user.

I had given up troubleshooting go2rtc several times because of this.