### PR TITLE
Adding go2rtc presets for Rockchip hardware acceleration

### DIFF
--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -113,6 +113,20 @@ if int(os.environ["LIBAVFORMAT_VERSION_MAJOR"]) < 59:
             "rtsp"
         ] = "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"
 
+# add hardware acceleration presets for rockchip devices
+# will be removed, when frigate uses a go2rtc version that includes these presets
+if go2rtc_config.get("ffmpeg") is None:
+    go2rtc_config["ffmpeg"] = {
+        "h264/rk": "-c:v h264_rkmpp_encoder -g 50 -bf 0",
+        "h265/rk": "-c:v hevc_rkmpp_encoder -g 50 -bf 0"
+    }
+else:
+    if go2rtc_config["ffmpeg"].get("h264/rk") is None:
+        go2rtc_config["ffmpeg"]["h264/rk"] = "-c:v h264_rkmpp_encoder -g 50 -bf 0"
+
+    if go2rtc_config["ffmpeg"].get("h265/rk") is None:
+        go2rtc_config["ffmpeg"]["h265/rk"] = "-c:v hevc_rkmpp_encoder -g 50 -bf 0"
+
 for name in go2rtc_config.get("streams", {}):
     stream = go2rtc_config["streams"][name]
 

--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -114,7 +114,7 @@ if int(os.environ["LIBAVFORMAT_VERSION_MAJOR"]) < 59:
         ] = "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"
 
 # add hardware acceleration presets for rockchip devices
-# will be removed, when frigate uses a go2rtc version that includes these presets
+# may be removed if frigate uses a go2rtc version that includes these presets
 if go2rtc_config.get("ffmpeg") is None:
     go2rtc_config["ffmpeg"] = {
         "h264/rk": "-c:v h264_rkmpp_encoder -g 50 -bf 0",

--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -118,7 +118,7 @@ if int(os.environ["LIBAVFORMAT_VERSION_MAJOR"]) < 59:
 if go2rtc_config.get("ffmpeg") is None:
     go2rtc_config["ffmpeg"] = {
         "h264/rk": "-c:v h264_rkmpp_encoder -g 50 -bf 0",
-        "h265/rk": "-c:v hevc_rkmpp_encoder -g 50 -bf 0"
+        "h265/rk": "-c:v hevc_rkmpp_encoder -g 50 -bf 0",
     }
 else:
     if go2rtc_config["ffmpeg"].get("h264/rk") is None:

--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -354,3 +354,29 @@ ffmpeg:
 Make sure that your SoC supports hardware acceleration for your input stream. For example, if your camera streams with h265 encoding and a 4k resolution, your SoC must be able to de- and encode h265 with a 4k resolution or higher. If you are unsure whether your SoC meets the requirements, take a look at the datasheet.
 
 :::
+
+### go2rtc presets for hardware accelerated transcoding
+
+If your input stream is to be transcoded using hardware acceleration, there are these presets for go2rtc: `h264/rk` and `h265/rk`. You can use them this way:
+
+```
+go2rtc:
+  streams:
+    Cam_h264: ffmpeg:rtsp://username:password@192.168.1.123/av_stream/ch0#video=h264/rk
+    Cam_h265: ffmpeg:rtsp://username:password@192.168.1.123/av_stream/ch0#video=h265/rk
+```
+
+:::warning
+
+The go2rtc docs may suggest the following configuration:
+
+```
+go2rtc:
+  streams:
+    Cam_h264: ffmpeg:rtsp://username:password@192.168.1.123/av_stream/ch0#video=h264#hardware=rk
+    Cam_h265: ffmpeg:rtsp://username:password@192.168.1.123/av_stream/ch0#video=h265#hardware=rk
+```
+
+However, this does not currently work.
+
+:::


### PR DESCRIPTION
Works using this syntax:
```
go2rtc:
  streams:
    Cam:
      - ffmpeg:/config/Big_Buck_Bunny_1080_hevc.mp4#video=h264/rk
```

However, this does not work and uses software decoding instead:
```
go2rtc:
  streams:
    Cam:
      - ffmpeg:/config/Big_Buck_Bunny_1080_hevc.mp4#video=h264#hardware=rk
```
Is this normal behavior, because this preset was added using the config and not as a default preset?

And what about decoding? go2rtc calls FFmpeg this way:
`
ffmpeg -hide_banner -re -i /config/Big_Buck_Bunny_1080_hevc.mp4 -c:v libx264 -g 50 -profile:v high -level:v 4.1 -preset:v superfast -tune:v zerolatency -pix_fmt:v yuv420p -an -user_agent ffmpeg/go2rtc -rtsp_transport tcp -f rtsp {output}
`
So, no decoder is specified and and FFmpeg auto selects one. As far as I can see, this is the way it's done in go2rtc (selecting the encoder and not selecting decoder). Is this correct or should I also add decoding presets that can be passed using `#input=hevc/rk_dec`?
