### PR TITLE
Clear plus id of submitted events

### DIFF
--- a/docs/docs/integrations/api.md
+++ b/docs/docs/integrations/api.md
@@ -201,6 +201,10 @@ Permanently deletes the event along with any clips/snapshots.
 
 Sets retain to true for the event id.
 
+### `DELETE /api/events/<id>/plus`
+
+Clears the submit flag of an event that was previously submitted to Frigate+. Useful when an event was submitted as a false positive while being a positive, or vice versa. Also make sure to delete the image in Frigate+ accordingly!
+
 ### `POST /api/events/<id>/plus`
 
 Submits the snapshot of the event to Frigate+ for labeling.

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -183,6 +183,23 @@ def set_retain(id):
     )
 
 
+@bp.route("/events/<id>/plus", methods=("DELETE",))
+def clear_plus(id):
+    try:
+        event = Event.get(Event.id == id)
+    except DoesNotExist:
+        return make_response(
+            jsonify({"success": False, "message": "Event " + id + " not found"}), 404
+        )
+
+    event.plus_id = None
+    event.save()
+
+    return make_response(
+        jsonify({"success": True, "message": "Event " + id + " plus_id cleared"}), 200
+    )
+
+
 @bp.route("/events/<id>/plus", methods=("POST",))
 def send_to_plus(id):
     if not current_app.plus_api.is_active():


### PR DESCRIPTION
Useful when the wrong button in the front-end is pressed.

@blakeblackshear 

Maybe we can add logic here to automatically clear the image on Frigate+ side as well?