### PR TITLE
Fix path of device tree on HassOS add on

### DIFF
--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -42,7 +42,6 @@ class Rknn(DetectionApi):
     type_key = DETECTOR_KEY
 
     def __init__(self, config: RknnDetectorConfig):
-
         # create symlink for Home Assistant add on
         if not os.path.isfile("/proc/device-tree/compatible"):
             if os.path.isfile("/device-tree/compatible"):

--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -46,7 +46,7 @@ class Rknn(DetectionApi):
         # create symlink for Home Assistant add on
         if not os.path.isfile("/proc/device-tree/compatible"):
             if os.path.isfile("/device-tree/compatible"):
-                os.symlink("/proc/device-tree/compatible", "/device-tree/compatible")
+                os.symlink("/device-tree/compatible", "/proc/device-tree/compatible")
 
         # find out SoC
         try:

--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -42,6 +42,12 @@ class Rknn(DetectionApi):
     type_key = DETECTOR_KEY
 
     def __init__(self, config: RknnDetectorConfig):
+
+        # create symlink for Home Assistant add on
+        if not os.path.isfile("/proc/device-tree/compatible"):
+            if os.path.isfile("/device-tree/compatible"):
+                os.symlink("/proc/device-tree/compatible", "/device-tree/compatible")
+
         # find out SoC
         try:
             with open("/proc/device-tree/compatible") as file:


### PR DESCRIPTION
This PR tries to fix https://github.com/blakeblackshear/frigate-hass-addons/issues/145 (issue was mentioned before in https://github.com/blakeblackshear/frigate/pull/8382).

However, it is not yet known whether this solves the whole issue or is just a part of the solution. I don't have the possibility to test at the moment.