### PR TITLE
handle onvif connection failure in autotrack init

### DIFF
--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -238,6 +238,16 @@ class PtzAutoTracker:
         self.move_queues[camera] = queue.Queue()
         self.move_queue_locks[camera] = threading.Lock()
 
+        # handle onvif constructor failing due to no connection
+        if camera not in self.onvif.cams:
+            logger.warning(
+                f"onvif connection to {camera} failed. Disabling autotracking."
+            )
+            camera_config.onvif.autotracking.enabled = False
+            self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
+
+            return
+
         if not self.onvif.cams[camera]["init"]:
             if not self.onvif._init_onvif(camera):
                 logger.warning(f"Unable to initialize onvif for {camera}")

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -245,7 +245,6 @@ class PtzAutoTracker:
             )
             camera_config.onvif.autotracking.enabled = False
             self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
-
             return
 
         if not self.onvif.cams[camera]["init"]:
@@ -253,27 +252,24 @@ class PtzAutoTracker:
                 logger.warning(f"Unable to initialize onvif for {camera}")
                 camera_config.onvif.autotracking.enabled = False
                 self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
-
                 return
 
             if "pt-r-fov" not in self.onvif.cams[camera]["features"]:
-                camera_config.onvif.autotracking.enabled = False
-                self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
                 logger.warning(
                     f"Disabling autotracking for {camera}: FOV relative movement not supported"
                 )
-
+                camera_config.onvif.autotracking.enabled = False
+                self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
                 return
 
             movestatus_supported = self.onvif.get_service_capabilities(camera)
 
             if movestatus_supported is None or movestatus_supported.lower() != "true":
-                camera_config.onvif.autotracking.enabled = False
-                self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
                 logger.warning(
                     f"Disabling autotracking for {camera}: ONVIF MoveStatus not supported"
                 )
-
+                camera_config.onvif.autotracking.enabled = False
+                self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
                 return
 
         if self.onvif.cams[camera]["init"]:

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -241,7 +241,7 @@ class PtzAutoTracker:
         # handle onvif constructor failing due to no connection
         if camera not in self.onvif.cams:
             logger.warning(
-                f" Disabling autotracking for {camera}: onvif connection failed"
+                f"Disabling autotracking for {camera}: onvif connection failed"
             )
             camera_config.onvif.autotracking.enabled = False
             self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
@@ -249,7 +249,9 @@ class PtzAutoTracker:
 
         if not self.onvif.cams[camera]["init"]:
             if not self.onvif._init_onvif(camera):
-                logger.warning(f"Unable to initialize onvif for {camera}")
+                logger.warning(
+                    f"Disabling autotracking for {camera}: Unable to initialize onvif"
+                )
                 camera_config.onvif.autotracking.enabled = False
                 self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
                 return

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -241,7 +241,7 @@ class PtzAutoTracker:
         # handle onvif constructor failing due to no connection
         if camera not in self.onvif.cams:
             logger.warning(
-                f"onvif connection to {camera} failed. Disabling autotracking."
+                f" Disabling autotracking for {camera}: onvif connection failed"
             )
             camera_config.onvif.autotracking.enabled = False
             self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False


### PR DESCRIPTION
This PR more gracefully handles the case when an onvif connection fails and the user has autotracking enabled. (https://github.com/blakeblackshear/frigate/issues/8836)