### PR TITLE
Fix inertia calculation check

### DIFF
--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -195,7 +195,7 @@ class TrackedObject:
                     self.zone_presence[name] = zone_score + 1
 
                     # an object is only considered present in a zone if it has a zone inertia of 3+
-                    if zone_score >= zone.inertia:
+                    if self.zone_presence[name] >= zone.inertia:
                         current_zones.append(name)
 
                         if name not in self.entered_zones:


### PR DESCRIPTION
Currently the inertia calculation for an object in a zone is based on the `zone_score` value, [which is taken](https://github.com/blakeblackshear/frigate/blob/dev/frigate/object_processing.py#L190) *before* the check if an object is in a zone is done.

This basically means that the required inertia is always off by one, and in cases where the very first frame has a true positive, the "new" MQTT event is fired without any zone information breaking automations expecting that information.

Fix by checking the zone score using the `zone_presence` value which is increased one line before this check.