### PR TITLE
Update Jetson ffmpeg patch for Jetpack 5.1.2 compatibility

### DIFF
--- a/docker/tensorrt/build_jetson_ffmpeg.sh
+++ b/docker/tensorrt/build_jetson_ffmpeg.sh
@@ -23,8 +23,8 @@ else
 fi
 tar xaf jetson_multimedia_api.tbz2 -C / && rm jetson_multimedia_api.tbz2
 
-wget -q https://github.com/madsciencetist/jetson-ffmpeg/archive/refs/heads/master.zip
-unzip master.zip && rm master.zip && cd jetson-ffmpeg-master
+wget -q https://github.com/AndBobsYourUncle/jetson-ffmpeg/archive/9c17b09.zip -O jetson-ffmpeg.zip
+unzip jetson-ffmpeg.zip && rm jetson-ffmpeg.zip && mv jetson-ffmpeg-* jetson-ffmpeg && cd jetson-ffmpeg
 LD_LIBRARY_PATH=$(pwd)/stubs:$LD_LIBRARY_PATH   # tegra multimedia libs aren't available in image, so use stubs for ffmpeg build
 mkdir build
 cd build
@@ -42,7 +42,7 @@ cd ../ && rm -rf nv-codec-headers-master
 # Build ffmpeg with nvmpi patch
 wget -q https://ffmpeg.org/releases/ffmpeg-6.0.tar.xz
 tar xaf ffmpeg-*.tar.xz && rm ffmpeg-*.tar.xz && cd ffmpeg-*
-patch -p1 < ../jetson-ffmpeg-master/ffmpeg_patches/ffmpeg6.0_nvmpi.patch
+patch -p1 < ../jetson-ffmpeg/ffmpeg_patches/ffmpeg6.0_nvmpi.patch
 export PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig
 # enable Jetson codecs but disable dGPU codecs
 ./configure --cc='ccache gcc' --cxx='ccache g++' \


### PR DESCRIPTION
This PR updates the script that builds the custom ffmpeg version for Jetson devices to use an updated commit that intelligently does not link the `nvbuf_utils` library if it detects the presence of the NvUtils API.

This allows Frigate to run on a Jetson device running Jetpack 5.1.2 and newer that lacks the `nvbuf_utils` shared library.

The commit sha that is referenced is from a fork of the original repo used from @madsciencetist, with a change to the `CMakeLists.txt` file so that it leaves out the linked library.

It can always be switched back to point to @madsciencetist's repository later if this PR is merged in, but it might be a good idea to make the ffmpeg build script here in Frigate use a sha instead of master so that Docker caches are busted when new changes are required.

Here is the PR against jetson-ffmpeg:
https://github.com/madsciencetist/jetson-ffmpeg/pull/3

I have built this locally, and ran it successfully on my Nvidia Jetson AGX Orin device, running Jetpack 5.1.2. Detections were working, and it appeared that everything was using GPU resources, verified by running jtop.