### PR TITLE
Included caution about Snapcraft docker issues.

### DIFF
--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -46,6 +46,7 @@ services:
           size: 1000000000
     ...
 ```
+
 :::caution
 
 Users of the Snapcraft build of Docker cannot use storage locations outside your $HOME folder. 

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -46,6 +46,11 @@ services:
           size: 1000000000
     ...
 ```
+:::caution
+
+Users of the Snapcraft build of Docker cannot use storage locations outside your $HOME folder. 
+
+:::
 
 ### Calculating required shm-size
 


### PR DESCRIPTION
I have created a caution about the use of Snapcraft docker and how it affects storage locations. 

If you use the Snapcraft build of Docker, you cannot use storage locations outside of your $HOME directory. This is something that I struggled with for months before figuring it out. (Refer to issue #8592)