### PR TITLE
Remove rtmp

### DIFF
--- a/docker/main/build_nginx.sh
+++ b/docker/main/build_nginx.sh
@@ -5,7 +5,6 @@ set -euxo pipefail
 NGINX_VERSION="1.25.3"
 VOD_MODULE_VERSION="1.31"
 SECURE_TOKEN_MODULE_VERSION="1.5"
-RTMP_MODULE_VERSION="1.2.2"
 
 cp /etc/apt/sources.list /etc/apt/sources.list.d/sources-src.list
 sed -i 's|deb http|deb-src http|g' /etc/apt/sources.list.d/sources-src.list
@@ -49,10 +48,6 @@ mkdir /tmp/nginx-secure-token-module
 wget https://github.com/kaltura/nginx-secure-token-module/archive/refs/tags/${SECURE_TOKEN_MODULE_VERSION}.tar.gz
 tar -zxf ${SECURE_TOKEN_MODULE_VERSION}.tar.gz -C /tmp/nginx-secure-token-module --strip-components=1
 rm ${SECURE_TOKEN_MODULE_VERSION}.tar.gz
-mkdir /tmp/nginx-rtmp-module
-wget -nv https://github.com/arut/nginx-rtmp-module/archive/refs/tags/v${RTMP_MODULE_VERSION}.tar.gz
-tar -zxf v${RTMP_MODULE_VERSION}.tar.gz -C /tmp/nginx-rtmp-module --strip-components=1
-rm v${RTMP_MODULE_VERSION}.tar.gz
 
 cd /tmp/nginx
 
@@ -63,7 +58,6 @@ cd /tmp/nginx
     --with-threads \
     --add-module=../nginx-vod-module \
     --add-module=../nginx-secure-token-module \
-    --add-module=../nginx-rtmp-module \
     --with-cc-opt="-O3 -Wno-error=implicit-fallthrough"
 
 make CC="ccache gcc" -j$(nproc) && make install

--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -275,18 +275,3 @@ http {
         }
     }
 }
-
-rtmp {
-    server {
-        listen 1935;
-        chunk_size 4096;
-        allow publish 127.0.0.1;
-        deny publish all;
-        allow play all;
-        application live {
-            live on;
-            record off;
-            meta copy;
-        }
-    }
-}

--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -69,16 +69,12 @@ cameras:
     ffmpeg:
       output_args:
         record: -f segment -segment_time 10 -segment_format mp4 -reset_timestamps 1 -strftime 1 -c:v copy -tag:v hvc1 -bsf:v hevc_mp4toannexb -c:a aac
-        rtmp: -c:v copy -c:a aac -f flv
 
       inputs:
         - path: rtsp://user:password@camera-ip:554/H264/ch1/main/av_stream # <----- Update for your camera
           roles:
             - detect
             - record
-            - rtmp
-    rtmp:
-      enabled: False # <-- RTMP should be disabled if your stream is not H264
     detect:
       width: # <- optional, by default Frigate tries to automatically detect resolution
       height: # <- optional, by default Frigate tries to automatically detect resolution
@@ -156,13 +152,12 @@ go2rtc:
 
 [See the go2rtc docs for more information](https://github.com/AlexxIT/go2rtc/tree/v1.8.4#source-rtsp)
 
-In the Unifi 2.0 update Unifi Protect Cameras had a change in audio sample rate which causes issues for ffmpeg. The input rate needs to be set for record and rtmp if used directly with unifi protect.
+In the Unifi 2.0 update Unifi Protect Cameras had a change in audio sample rate which causes issues for ffmpeg. The input rate needs to be set for record if used directly with unifi protect.
 
 ```yaml
 ffmpeg:
   output_args:
     record: preset-record-ubiquiti
-    rtmp: preset-rtmp-ubiquiti # recommend using go2rtc instead
 ```
 
 ### TP-Link VIGI Cameras

--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -16,7 +16,6 @@ Each role can only be assigned to one input per camera. The options for roles ar
 | `detect` | Main feed for object detection. [docs](object_detectors.md)                              |
 | `record` | Saves segments of the video feed based on configuration settings. [docs](record.md)      |
 | `audio`  | Feed for audio based detection. [docs](audio_detectors.md)                               |
-| `rtmp`   | Deprecated: Broadcast as an RTMP feed for other services to consume. [docs](restream.md) |
 
 ```yaml
 mqtt:
@@ -29,7 +28,6 @@ cameras:
         - path: rtsp://viewer:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2
           roles:
             - detect
-            - rtmp # <- deprecated, recommend using restream instead
         - path: rtsp://viewer:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/live
           roles:
             - record

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -206,8 +206,6 @@ ffmpeg:
     detect: -threads 2 -f rawvideo -pix_fmt yuv420p
     # Optional: output args for record streams (default: shown below)
     record: preset-record-generic
-    # Optional: output args for rtmp streams (default: shown below)
-    rtmp: preset-rtmp-generic
   # Optional: Time in seconds to wait before ffmpeg retries connecting to the camera. (default: shown below)
   # If set too low, frigate will retry a connection to the camera's stream too frequently, using up the limited streams some cameras can allow at once
   # If set too high, then if a ffmpeg crash or camera stream timeout occurs, you could potentially lose up to a maximum of retry_interval second(s) of footage
@@ -430,13 +428,6 @@ snapshots:
   # Optional: quality of the encoded jpeg, 0-100 (default: shown below)
   quality: 70
 
-# Optional: RTMP configuration
-# NOTE: RTMP is deprecated in favor of restream
-# NOTE: Can be overridden at the camera level
-rtmp:
-  # Optional: Enable the RTMP stream (default: False)
-  enabled: False
-
 # Optional: Restream configuration
 # Uses https://github.com/AlexxIT/go2rtc (v1.8.3)
 go2rtc:
@@ -493,14 +484,13 @@ cameras:
         # Required: the path to the stream
         # NOTE: path may include environment variables or docker secrets, which must begin with 'FRIGATE_' and be referenced in {}
         - path: rtsp://viewer:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2
-          # Required: list of roles for this stream. valid values are: audio,detect,record,rtmp
-          # NOTICE: In addition to assigning the audio, record, and rtmp roles,
+          # Required: list of roles for this stream. valid values are: audio,detect,record
+          # NOTICE: In addition to assigning the audio and record roles,
           # they must also be enabled in the camera config.
           roles:
             - audio
             - detect
             - record
-            - rtmp
           # Optional: stream specific global args (default: inherit)
           # global_args:
           # Optional: stream specific hwaccel args (default: inherit)

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -38,10 +38,6 @@ go2rtc:
 
 **NOTE:** This does not apply to localhost requests, there is no need to provide credentials when using the restream as a source for frigate cameras.
 
-## RTMP (Deprecated)
-
-In previous Frigate versions RTMP was used for re-streaming. RTMP has disadvantages however including being incompatible with H.265, high bitrates, and certain audio codecs. RTMP is deprecated and it is recommended to move to the new restream role.
-
 ## Reduce Connections To Camera
 
 Some cameras only support one active connection or you may just want to have a single connection open to the camera. The RTSP restream allows this to be possible.

--- a/docs/docs/guides/configuring_go2rtc.md
+++ b/docs/docs/guides/configuring_go2rtc.md
@@ -9,7 +9,7 @@ Use of the bundled go2rtc is optional. You can still configure FFmpeg to connect
 
 - WebRTC or MSE for live viewing with higher resolutions and frame rates than the jsmpeg stream which is limited to the detect stream
 - Live stream support for cameras in Home Assistant Integration
-- RTSP (instead of RTMP) relay for use with other consumers to reduce the number of connections to your camera streams
+- RTSP relay for use with other consumers to reduce the number of connections to your camera streams
 
 # Setup a go2rtc stream
 

--- a/docs/docs/integrations/home-assistant.md
+++ b/docs/docs/integrations/home-assistant.md
@@ -124,10 +124,6 @@ https://HA_URL/api/frigate/notifications/<event-id>/clip.mp4
 
 <a name="streams"></a>
 
-## RTMP stream
-
-RTMP is deprecated and it is recommended to switch to use RTSP restreams.
-
 ## RTSP stream
 
 In order for the live streams to function they need to be accessible on the RTSP

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -446,28 +446,3 @@ def parse_preset_output_record(arg: Any) -> list[str]:
         return None
 
     return PRESETS_RECORD_OUTPUT.get(arg, None)
-
-
-PRESETS_RTMP_OUTPUT = {
-    "preset-rtmp-generic": ["-c", "copy", "-f", "flv"],
-    "preset-rtmp-mjpeg": ["-c:v", "libx264", "-an", "-f", "flv"],
-    "preset-rtmp-jpeg": ["-c:v", "libx264", "-an", "-f", "flv"],
-    "preset-rtmp-ubiquiti": [
-        "-c:v",
-        "copy",
-        "-f",
-        "flv",
-        "-ar",
-        "44100",
-        "-c:a",
-        "aac",
-    ],
-}
-
-
-def parse_preset_output_rtmp(arg: Any) -> list[str]:
-    """Return the correct preset if in preset format otherwise return None."""
-    if not isinstance(arg, str):
-        return None
-
-    return PRESETS_RTMP_OUTPUT.get(arg, None)

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -930,6 +930,7 @@ class TestConfig(unittest.TestCase):
                         "width": 1920,
                         "fps": 5,
                     },
+                    "audio": {"enabled": True},
                 }
             },
         }

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -653,7 +653,7 @@ class TestConfig(unittest.TestCase):
                         "inputs": [
                             {
                                 "path": "rtsp://10.0.0.1:554/video",
-                                "roles": ["detect", "rtmp"],
+                                "roles": ["detect"],
                             },
                             {"path": "rtsp://10.0.0.1:554/record", "roles": ["record"]},
                         ]
@@ -930,7 +930,6 @@ class TestConfig(unittest.TestCase):
                         "width": 1920,
                         "fps": 5,
                     },
-                    "rtmp": {"enabled": True},
                 }
             },
         }
@@ -1167,122 +1166,6 @@ class TestConfig(unittest.TestCase):
         assert runtime_config.cameras["back"].snapshots.height == 150
         assert runtime_config.cameras["back"].snapshots.enabled
 
-    def test_global_rtmp_disabled(self):
-        config = {
-            "mqtt": {"host": "mqtt"},
-            "cameras": {
-                "back": {
-                    "ffmpeg": {
-                        "inputs": [
-                            {
-                                "path": "rtsp://10.0.0.1:554/video",
-                                "roles": ["detect"],
-                            },
-                        ]
-                    },
-                    "detect": {
-                        "height": 1080,
-                        "width": 1920,
-                        "fps": 5,
-                    },
-                }
-            },
-        }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.dict(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        assert not runtime_config.cameras["back"].rtmp.enabled
-
-    def test_default_not_rtmp(self):
-        config = {
-            "mqtt": {"host": "mqtt"},
-            "cameras": {
-                "back": {
-                    "ffmpeg": {
-                        "inputs": [
-                            {
-                                "path": "rtsp://10.0.0.1:554/video",
-                                "roles": ["detect"],
-                            },
-                        ]
-                    },
-                    "detect": {
-                        "height": 1080,
-                        "width": 1920,
-                        "fps": 5,
-                    },
-                }
-            },
-        }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.dict(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        assert not runtime_config.cameras["back"].rtmp.enabled
-
-    def test_global_rtmp_merge(self):
-        config = {
-            "mqtt": {"host": "mqtt"},
-            "rtmp": {"enabled": False},
-            "cameras": {
-                "back": {
-                    "ffmpeg": {
-                        "inputs": [
-                            {
-                                "path": "rtsp://10.0.0.1:554/video",
-                                "roles": ["detect", "rtmp"],
-                            },
-                        ]
-                    },
-                    "detect": {
-                        "height": 1080,
-                        "width": 1920,
-                        "fps": 5,
-                    },
-                    "rtmp": {
-                        "enabled": True,
-                    },
-                }
-            },
-        }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.dict(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].rtmp.enabled
-
-    def test_global_rtmp_default(self):
-        config = {
-            "mqtt": {"host": "mqtt"},
-            "cameras": {
-                "back": {
-                    "ffmpeg": {
-                        "inputs": [
-                            {
-                                "path": "rtsp://10.0.0.1:554/video",
-                                "roles": ["detect"],
-                            },
-                            {
-                                "path": "rtsp://10.0.0.1:554/video2",
-                                "roles": ["record"],
-                            },
-                        ]
-                    },
-                    "detect": {
-                        "height": 1080,
-                        "width": 1920,
-                        "fps": 5,
-                    },
-                }
-            },
-        }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.dict(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        assert not runtime_config.cameras["back"].rtmp.enabled
-
     def test_global_jsmpeg(self):
         config = {
             "mqtt": {"host": "mqtt"},
@@ -1428,7 +1311,6 @@ class TestConfig(unittest.TestCase):
     def test_global_timestamp_style_merge(self):
         config = {
             "mqtt": {"host": "mqtt"},
-            "rtmp": {"enabled": False},
             "timestamp_style": {"position": "br", "thickness": 2},
             "cameras": {
                 "back": {

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -14,13 +14,12 @@ class TestFfmpegPresets(unittest.TestCase):
                         "inputs": [
                             {
                                 "path": "rtsp://10.0.0.1:554/video",
-                                "roles": ["detect", "rtmp"],
+                                "roles": ["detect"],
                             }
                         ],
                         "output_args": {
                             "detect": "-f rawvideo -pix_fmt yuv420p",
                             "record": "-f segment -segment_time 10 -segment_format mp4 -reset_timestamps 1 -strftime 1 -c copy -an",
-                            "rtmp": "-c copy -f flv",
                         },
                     },
                     "detect": {
@@ -29,9 +28,6 @@ class TestFfmpegPresets(unittest.TestCase):
                         "fps": 5,
                     },
                     "record": {
-                        "enabled": True,
-                    },
-                    "rtmp": {
                         "enabled": True,
                     },
                     "name": "back",
@@ -150,29 +146,6 @@ class TestFfmpegPresets(unittest.TestCase):
     def test_ffmpeg_output_record_not_preset(self):
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
             "record"
-        ] = "-some output"
-        frigate_config = FrigateConfig(**self.default_ffmpeg)
-        frigate_config.cameras["back"].create_ffmpeg_cmds()
-        assert "-some output" in (
-            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
-        )
-
-    def test_ffmpeg_output_rtmp_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
-            "rtmp"
-        ] = "preset-rtmp-jpeg"
-        frigate_config = FrigateConfig(**self.default_ffmpeg)
-        frigate_config.cameras["back"].create_ffmpeg_cmds()
-        assert "preset-rtmp-jpeg" not in (
-            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
-        )
-        assert "-c:v libx264" in (
-            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
-        )
-
-    def test_ffmpeg_output_rtmp_not_preset(self):
-        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"][
-            "rtmp"
         ] = "-some output"
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         frigate_config.cameras["back"].create_ffmpeg_cmds()

--- a/process_clip.py
+++ b/process_clip.py
@@ -262,7 +262,6 @@ def process(path, label, output, debug_path):
                         }
                     ]
                 },
-                "rtmp": {"enabled": False},
                 "record": {"enabled": False},
             }
         },


### PR DESCRIPTION
This removes the previously deprecated rtmp restream. Not only is go2rtc rtsp restream fully featured for the HA integration and other use cases, but go2rtc also supports http-flv, hls, and rtmp restreaming for any needs that rtsp won't work for.