### PR TITLE
Fix checking first detected frame for true positive

### DIFF
--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -616,7 +616,6 @@ class CameraState:
         previous_ids = set(tracked_objects.keys())
         removed_ids = previous_ids.difference(current_ids)
         new_ids = current_ids.difference(previous_ids)
-        updated_ids = current_ids.intersection(previous_ids)
 
         for id in new_ids:
             new_obj = tracked_objects[id] = TrackedObject(
@@ -631,7 +630,7 @@ class CameraState:
             for c in self.callbacks["start"]:
                 c(self.name, new_obj, frame_time)
 
-        for id in updated_ids:
+        for id in current_ids:
             updated_obj = tracked_objects[id]
             thumb_update, significant_update, autotracker_update = updated_obj.update(
                 frame_time, current_detections[id]


### PR DESCRIPTION
When an object is first detected, the first frame is currently not used to check for true positive, nor zone presence etc. This is only done for updated objects.

Fix this by checking the new objects immediately after TrackedObject for them has been created.