### PR TITLE
Remove Deprecated RTMP(1935) port

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
   "features": {
     "ghcr.io/devcontainers/features/common-utils:1": {}
   },
-  "forwardPorts": [5000, 5001, 5173, 1935, 8554, 8555],
+  "forwardPorts": [5000, 5001, 5173, 8554, 8555],
   "portsAttributes": {
     "5000": {
       "label": "NGINX",
@@ -22,10 +22,6 @@
     },
     "5173": {
       "label": "Vite Server",
-      "onAutoForward": "silent"
-    },
-    "1935": {
-      "label": "RTMP",
       "onAutoForward": "silent"
     },
     "8554": {

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -191,7 +191,6 @@ COPY --from=deps-rootfs / /
 RUN ldconfig
 
 EXPOSE 5000
-EXPOSE 1935
 EXPOSE 8554
 EXPOSE 8555/tcp 8555/udp
 

--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -275,18 +275,3 @@ http {
         }
     }
 }
-
-rtmp {
-    server {
-        listen 1935;
-        chunk_size 4096;
-        allow publish 127.0.0.1;
-        deny publish all;
-        allow play all;
-        application live {
-            live on;
-            record off;
-            meta copy;
-        }
-    }
-}

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -295,7 +295,6 @@ docker run \
   --network=bridge \
   --privileged \
   --workdir=/opt/frigate \
-  -p 1935:1935 \
   -p 5000:5000 \
   -p 8554:8554 \
   -p 8555:8555 \


### PR DESCRIPTION
While on Synology docs ~~for 0.13~~ , I figured this wasn't needed anymore.

I think this is good, if not let me know.