### PR TITLE
Remove deprecated RTMP port 1935 for v0.14

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
   "features": {
     "ghcr.io/devcontainers/features/common-utils:1": {}
   },
-  "forwardPorts": [5000, 5001, 5173, 1935, 8554, 8555],
+  "forwardPorts": [5000, 5001, 5173, 8554, 8555],
   "portsAttributes": {
     "5000": {
       "label": "NGINX",
@@ -22,10 +22,6 @@
     },
     "5173": {
       "label": "Vite Server",
-      "onAutoForward": "silent"
-    },
-    "1935": {
-      "label": "RTMP",
       "onAutoForward": "silent"
     },
     "8554": {

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -191,7 +191,6 @@ COPY --from=deps-rootfs / /
 RUN ldconfig
 
 EXPOSE 5000
-EXPOSE 1935
 EXPOSE 8554
 EXPOSE 8555/tcp 8555/udp
 

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -295,7 +295,6 @@ docker run \
   --network=bridge \
   --privileged \
   --workdir=/opt/frigate \
-  -p 1935:1935 \
   -p 5000:5000 \
   -p 8554:8554 \
   -p 8555:8555 \


### PR DESCRIPTION
RTMP clean up.
 
Identical as previous PR I had made for v0.13 except branch 0.14 already has 1935 removed from nginx config file `docker/main/rootfs/usr/local/nginx/conf/nginx.conf`.

For the Synology docs, I'll keep 1935 for 0.13 and prep another PR for 0.14 to remove it.