### PR TITLE
Improve desktop timeline view

### DIFF
--- a/web/src/components/card/TimelineItemCard.tsx
+++ b/web/src/components/card/TimelineItemCard.tsx
@@ -1,0 +1,32 @@
+import PreviewThumbnailPlayer from "../player/PreviewThumbnailPlayer";
+import { AspectRatio } from "../ui/aspect-ratio";
+import { Card, CardContent } from "../ui/card";
+
+type TimelineItemCardProps = {
+  timeline: Timeline;
+  relevantPreview: Preview | undefined;
+};
+export default function TimelineItemCard({
+  timeline,
+  relevantPreview,
+}: TimelineItemCardProps) {
+  return (
+    <Card className="bg-red-500">
+      <div className="flex justify-between h-24">
+        <div className="w-1/2">
+          <PreviewThumbnailPlayer
+            camera={timeline.camera}
+            relevantPreview={relevantPreview}
+            startTs={timeline.timestamp}
+            eventId={timeline.source_id}
+            isMobile={false}
+          />
+        </div>
+        <div>
+          <div>{timeline.camera}</div>
+          <div>{timeline.data.label}</div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/web/src/components/card/TimelineItemCard.tsx
+++ b/web/src/components/card/TimelineItemCard.tsx
@@ -20,7 +20,7 @@ export default function TimelineItemCard({
   const { data: config } = useSWR<FrigateConfig>("config");
 
   return (
-    <Card className="relative m-2 flex h-32 cursor-pointer" onClick={onSelect}>
+    <Card className="relative m-2 flex w-full h-32 cursor-pointer" onClick={onSelect}>
       <div className="w-1/2 p-2">
         {relevantPreview && (
           <VideoPlayer

--- a/web/src/components/card/TimelineItemCard.tsx
+++ b/web/src/components/card/TimelineItemCard.tsx
@@ -4,21 +4,51 @@ import Logo from "../Logo";
 import { formatUnixTimestampToDateTime } from "@/utils/dateUtil";
 import useSWR from "swr";
 import { FrigateConfig } from "@/types/frigateConfig";
+import VideoPlayer from "../player/VideoPlayer";
+import { Card } from "../ui/card";
 
 type TimelineItemCardProps = {
   timeline: Timeline;
   relevantPreview: Preview | undefined;
+  onSelect: () => void;
 };
 export default function TimelineItemCard({
   timeline,
   relevantPreview,
+  onSelect,
 }: TimelineItemCardProps) {
   const { data: config } = useSWR<FrigateConfig>("config");
 
   return (
-    <div className="relative m-2 flex h-24">
-      <div className="w-1/2 bg-black"></div>
-      <div className="px-1 w-1/2">
+    <Card className="relative m-2 flex h-32 cursor-pointer" onClick={onSelect}>
+      <div className="w-1/2 p-2">
+        {relevantPreview && (
+          <VideoPlayer
+            options={{
+              preload: "auto",
+              height: "114",
+              width: "202",
+              autoplay: true,
+              controls: false,
+              fluid: false,
+              muted: true,
+              loadingSpinner: false,
+              sources: [
+                {
+                  src: `${relevantPreview.src}`,
+                  type: "video/mp4",
+                },
+              ],
+            }}
+            seekOptions={{}}
+            onReady={(player) => {
+              player.pause(); // autoplay + pause is required for iOS
+              player.currentTime(timeline.timestamp - relevantPreview.start);
+            }}
+          />
+        )}
+      </div>
+      <div className="px-2 py-1 w-1/2">
         <div className="capitalize font-semibold text-sm">
           {getTimelineItemDescription(timeline)}
         </div>
@@ -31,7 +61,7 @@ export default function TimelineItemCard({
           })}
         </div>
         <Button
-          className="absolute bottom-0 right-0"
+          className="absolute bottom-1 right-1"
           size="sm"
           variant="secondary"
         >
@@ -41,6 +71,6 @@ export default function TimelineItemCard({
           +
         </Button>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/web/src/components/card/TimelineItemCard.tsx
+++ b/web/src/components/card/TimelineItemCard.tsx
@@ -1,6 +1,9 @@
-import PreviewThumbnailPlayer from "../player/PreviewThumbnailPlayer";
-import { AspectRatio } from "../ui/aspect-ratio";
-import { Card, CardContent } from "../ui/card";
+import { getTimelineItemDescription } from "@/utils/timelineUtil";
+import { Button } from "../ui/button";
+import Logo from "../Logo";
+import { formatUnixTimestampToDateTime } from "@/utils/dateUtil";
+import useSWR from "swr";
+import { FrigateConfig } from "@/types/frigateConfig";
 
 type TimelineItemCardProps = {
   timeline: Timeline;
@@ -10,23 +13,34 @@ export default function TimelineItemCard({
   timeline,
   relevantPreview,
 }: TimelineItemCardProps) {
+  const { data: config } = useSWR<FrigateConfig>("config");
+
   return (
-    <Card className="bg-red-500">
-      <div className="flex justify-between h-24">
-        <div className="w-1/2">
-          <PreviewThumbnailPlayer
-            camera={timeline.camera}
-            relevantPreview={relevantPreview}
-            startTs={timeline.timestamp}
-            eventId={timeline.source_id}
-            isMobile={false}
-          />
+    <div className="relative m-2 flex h-24">
+      <div className="w-1/2 bg-black"></div>
+      <div className="px-1 w-1/2">
+        <div className="capitalize font-semibold text-sm">
+          {getTimelineItemDescription(timeline)}
         </div>
-        <div>
-          <div>{timeline.camera}</div>
-          <div>{timeline.data.label}</div>
+        <div className="text-sm">
+          {formatUnixTimestampToDateTime(timeline.timestamp, {
+            strftime_fmt:
+              config?.ui.time_format == "24hour" ? "%H:%M:%S" : "%I:%M:%S %p",
+            time_style: "medium",
+            date_style: "medium",
+          })}
         </div>
+        <Button
+          className="absolute bottom-0 right-0"
+          size="sm"
+          variant="secondary"
+        >
+          <div className="w-8 h-8">
+            <Logo />
+          </div>
+          +
+        </Button>
       </div>
-    </Card>
+    </div>
   );
 }

--- a/web/src/components/player/PreviewThumbnailPlayer.tsx
+++ b/web/src/components/player/PreviewThumbnailPlayer.tsx
@@ -214,10 +214,11 @@ function PreviewContent({
   } else {
     return (
       <>
-        <div className={`${getPreviewWidth(camera, config)}`}>
+        <div className="w-full">
           <VideoPlayer
             options={{
               preload: "auto",
+              aspectRatio: "16:9",
               autoplay: true,
               controls: false,
               muted: true,
@@ -263,12 +264,12 @@ function isCurrentHour(timestamp: number) {
 function getPreviewWidth(camera: string, config: FrigateConfig) {
   const detect = config.cameras[camera].detect;
 
-  if (detect.width / detect.height < 1.0) {
-    return "w-[120px]";
+  if (detect.width / detect.height < 1) {
+    return "w-1/2";
   }
 
-  if (detect.width / detect.height < 1.4) {
-    return "w-[208px]";
+  if (detect.width / detect.height < 16 / 9) {
+    return "w-2/3";
   }
 
   return "w-full";

--- a/web/src/components/player/PreviewThumbnailPlayer.tsx
+++ b/web/src/components/player/PreviewThumbnailPlayer.tsx
@@ -186,8 +186,8 @@ function PreviewContent({
 
       const touchEnd = new Date().getTime();
 
-      // consider tap less than 500 ms
-      if (touchEnd - touchStart < 500) {
+      // consider tap less than 300 ms
+      if (touchEnd - touchStart < 300) {
         onClick();
       }
     });

--- a/web/src/components/scrubber/ActivityScrubber.tsx
+++ b/web/src/components/scrubber/ActivityScrubber.tsx
@@ -94,7 +94,7 @@ function ActivityScrubber({
     timeline: null,
   });
   const [currentTime, setCurrentTime] = useState(Date.now());
-  const [customTimes, setCustomTimes] = useState<
+  const [_, setCustomTimes] = useState<
     { id: IdType; time: DateType }[]
   >([]);
 

--- a/web/src/components/scrubber/ActivityScrubber.tsx
+++ b/web/src/components/scrubber/ActivityScrubber.tsx
@@ -76,7 +76,7 @@ const domEvents: TimelineEventsWithMissing[] = [
 type ActivityScrubberProps = {
   className?: string;
   items?: TimelineItem[];
-  timeBars?: { time: DateType; id?: IdType | undefined }[];
+  timeBars?: { time: DateType; id: IdType }[];
   groups?: TimelineGroup[];
   options?: TimelineOptions;
 } & TimelineEventsHandlers;
@@ -94,6 +94,9 @@ function ActivityScrubber({
     timeline: null,
   });
   const [currentTime, setCurrentTime] = useState(Date.now());
+  const [customTimes, setCustomTimes] = useState<
+    { id: IdType; time: DateType }[]
+  >([]);
 
   const defaultOptions: TimelineOptions = {
     width: "100%",
@@ -160,6 +163,41 @@ function ActivityScrubber({
       timelineInstance.destroy();
     };
   }, [containerRef]);
+
+  // need to keep custom times in sync
+  useEffect(() => {
+    if (!timelineRef.current.timeline || timeBars == undefined) {
+      return;
+    }
+
+    setCustomTimes((prevTimes) => {
+      if (prevTimes.length == 0 && timeBars.length == 0) {
+        return [];
+      }
+
+      prevTimes
+        .filter((x) => timeBars.find((y) => x.id == y.id) == undefined)
+        .forEach((time) => {
+          try {
+            timelineRef.current.timeline?.removeCustomTime(time.id);
+          } catch {}
+        });
+
+      timeBars.forEach((time) => {
+        try {
+          const existing = timelineRef.current.timeline?.getCustomTime(time.id);
+
+          if (existing != time.time) {
+            timelineRef.current.timeline?.setCustomTime(time.time, time.id);
+          }
+        } catch {
+          timelineRef.current.timeline?.addCustomTime(time.time, time.id);
+        }
+      });
+
+      return timeBars;
+    });
+  }, [timeBars, timelineRef]);
 
   return (
     <div className={className || ""}>

--- a/web/src/pages/History.tsx
+++ b/web/src/pages/History.tsx
@@ -25,6 +25,8 @@ import { IoMdArrowBack } from "react-icons/io";
 import useOverlayState from "@/hooks/use-overlay-state";
 import { useNavigate } from "react-router-dom";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
+import MobileTimelineView from "@/views/history/MobileTimelineView";
+import DesktopTimelineView from "@/views/history/DesktopTimelineView";
 
 const API_LIMIT = 200;
 
@@ -245,14 +247,7 @@ function TimelineViewer({
   if (isMobile) {
     return playback != undefined ? (
       <div className="w-screen absolute left-0 top-20 bottom-0 bg-background z-50">
-        {timelineData && (
-          <HistoryTimelineView
-            timelineData={timelineData}
-            allPreviews={allPreviews}
-            initialPlayback={playback}
-            isMobile={isMobile}
-          />
-        )}
+        {timelineData && <MobileTimelineView playback={playback} />}
       </div>
     ) : null;
   }
@@ -261,11 +256,10 @@ function TimelineViewer({
     <Dialog open={playback != undefined} onOpenChange={(_) => onClose()}>
       <DialogContent className="md:max-w-2xl lg:max-w-4xl xl:max-w-6xl 2xl:max-w-7xl 3xl:max-w-[1720px]">
         {timelineData && playback && (
-          <HistoryTimelineView
+          <DesktopTimelineView
             timelineData={timelineData}
             allPreviews={allPreviews}
             initialPlayback={playback}
-            isMobile={isMobile}
           />
         )}
       </DialogContent>

--- a/web/src/pages/History.tsx
+++ b/web/src/pages/History.tsx
@@ -19,7 +19,6 @@ import {
 import HistoryFilterPopover from "@/components/filter/HistoryFilterPopover";
 import useApiFilter from "@/hooks/use-api-filter";
 import HistoryCardView from "@/views/history/HistoryCardView";
-import HistoryTimelineView from "@/views/history/HistoryTimelineView";
 import { Button } from "@/components/ui/button";
 import { IoMdArrowBack } from "react-icons/io";
 import useOverlayState from "@/hooks/use-overlay-state";
@@ -78,10 +77,25 @@ function History() {
     setSize,
     isValidating,
   } = useSWRInfinite<HourlyTimeline>(getKey, timelineFetcher);
+
+  const previewTimes = useMemo(() => {
+    if (!timelinePages) {
+      return undefined;
+    }
+
+    const startDate = new Date();
+    startDate.setMinutes(0, 0, 0);
+
+    const endDate = new Date(timelinePages.at(-1)!!.end);
+    endDate.setHours(0, 0, 0, 0);
+    return {
+      start: startDate.getTime() / 1000,
+      end: endDate.getTime() / 1000,
+    };
+  }, [timelinePages]);
   const { data: allPreviews } = useSWR<Preview[]>(
-    timelinePages
-      ? `preview/all/start/${timelinePages?.at(0)
-          ?.start}/end/${timelinePages?.at(-1)?.end}`
+    previewTimes
+      ? `preview/all/start/${previewTimes.start}/end/${previewTimes.end}`
       : null,
     { revalidateOnFocus: false }
   );

--- a/web/src/pages/History.tsx
+++ b/web/src/pages/History.tsx
@@ -242,7 +242,7 @@ function TimelineViewer({ playback, isMobile, onClose }: TimelineViewerProps) {
 
   return (
     <Dialog open={playback != undefined} onOpenChange={(_) => onClose()}>
-      <DialogContent className="w-3/5 max-w-full">
+      <DialogContent className="w-screen 2xl:w-4/5 max-w-full">
         {playback && (
           <HistoryTimelineView playback={playback} isMobile={isMobile} />
         )}

--- a/web/src/pages/History.tsx
+++ b/web/src/pages/History.tsx
@@ -218,6 +218,7 @@ function History() {
       />
       <TimelineViewer
         timelineData={timelineCards}
+        allPreviews={allPreviews || []}
         playback={viewingPlayback ? playback : undefined}
         isMobile={isMobile}
         onClose={() => setPlaybackState(undefined)}
@@ -228,6 +229,7 @@ function History() {
 
 type TimelineViewerProps = {
   timelineData: CardsData | undefined;
+  allPreviews: Preview[];
   playback: TimelinePlayback | undefined;
   isMobile: boolean;
   onClose: () => void;
@@ -235,6 +237,7 @@ type TimelineViewerProps = {
 
 function TimelineViewer({
   timelineData,
+  allPreviews,
   playback,
   isMobile,
   onClose,
@@ -245,6 +248,7 @@ function TimelineViewer({
         {timelineData && (
           <HistoryTimelineView
             timelineData={timelineData}
+            allPreviews={allPreviews}
             initialPlayback={playback}
             isMobile={isMobile}
           />
@@ -259,6 +263,7 @@ function TimelineViewer({
         {timelineData && playback && (
           <HistoryTimelineView
             timelineData={timelineData}
+            allPreviews={allPreviews}
             initialPlayback={playback}
             isMobile={isMobile}
           />

--- a/web/src/pages/History.tsx
+++ b/web/src/pages/History.tsx
@@ -242,7 +242,7 @@ function TimelineViewer({ playback, isMobile, onClose }: TimelineViewerProps) {
 
   return (
     <Dialog open={playback != undefined} onOpenChange={(_) => onClose()}>
-      <DialogContent className="w-screen 2xl:w-4/5 max-w-full">
+      <DialogContent className="w-screen 2xl:w-2/3 max-w-full">
         {playback && (
           <HistoryTimelineView playback={playback} isMobile={isMobile} />
         )}

--- a/web/src/pages/History.tsx
+++ b/web/src/pages/History.tsx
@@ -104,9 +104,9 @@ function History() {
     return window.innerWidth < 768;
   }, [playback]);
 
-  const timelineCards: CardsData | never[] = useMemo(() => {
+  const timelineCards: CardsData = useMemo(() => {
     if (!timelinePages) {
-      return [];
+      return {};
     }
 
     return getHourlyTimelineData(
@@ -152,7 +152,7 @@ function History() {
     }
   }, [itemsToDelete, updateHistory]);
 
-  if (!config || !timelineCards || timelineCards.length == 0) {
+  if (!config || !timelineCards) {
     return <ActivityIndicator />;
   }
 
@@ -217,6 +217,7 @@ function History() {
         onItemSelected={(item) => setPlaybackState(item)}
       />
       <TimelineViewer
+        timelineData={timelineCards}
         playback={viewingPlayback ? playback : undefined}
         isMobile={isMobile}
         onClose={() => setPlaybackState(undefined)}
@@ -226,16 +227,28 @@ function History() {
 }
 
 type TimelineViewerProps = {
+  timelineData: CardsData | undefined;
   playback: TimelinePlayback | undefined;
   isMobile: boolean;
   onClose: () => void;
 };
 
-function TimelineViewer({ playback, isMobile, onClose }: TimelineViewerProps) {
+function TimelineViewer({
+  timelineData,
+  playback,
+  isMobile,
+  onClose,
+}: TimelineViewerProps) {
   if (isMobile) {
     return playback != undefined ? (
       <div className="w-screen absolute left-0 top-20 bottom-0 bg-background z-50">
-        <HistoryTimelineView playback={playback} isMobile={isMobile} />
+        {timelineData && (
+          <HistoryTimelineView
+            timelineData={timelineData}
+            initialPlayback={playback}
+            isMobile={isMobile}
+          />
+        )}
       </div>
     ) : null;
   }
@@ -243,8 +256,12 @@ function TimelineViewer({ playback, isMobile, onClose }: TimelineViewerProps) {
   return (
     <Dialog open={playback != undefined} onOpenChange={(_) => onClose()}>
       <DialogContent className="md:max-w-2xl lg:max-w-4xl xl:max-w-6xl 2xl:max-w-7xl 3xl:max-w-[1720px]">
-        {playback && (
-          <HistoryTimelineView playback={playback} isMobile={isMobile} />
+        {timelineData && playback && (
+          <HistoryTimelineView
+            timelineData={timelineData}
+            initialPlayback={playback}
+            isMobile={isMobile}
+          />
         )}
       </DialogContent>
     </Dialog>

--- a/web/src/pages/History.tsx
+++ b/web/src/pages/History.tsx
@@ -242,7 +242,7 @@ function TimelineViewer({ playback, isMobile, onClose }: TimelineViewerProps) {
 
   return (
     <Dialog open={playback != undefined} onOpenChange={(_) => onClose()}>
-      <DialogContent className="w-screen 2xl:w-2/3 max-w-full">
+      <DialogContent className="md:max-w-2xl lg:max-w-4xl xl:max-w-6xl 2xl:max-w-7xl 3xl:max-w-[1720px]">
         {playback && (
           <HistoryTimelineView playback={playback} isMobile={isMobile} />
         )}

--- a/web/src/types/history.ts
+++ b/web/src/types/history.ts
@@ -1,7 +1,7 @@
 type CardsData = {
-  [key: string]: {
-    [key: string]: {
-      [key: string]: Card;
+  [day: string]: {
+    [hour: string]: {
+      [groupKey: string]: Card;
     };
   };
 };
@@ -58,6 +58,7 @@ interface HistoryFilter extends FilterType {
 
 type TimelinePlayback = {
   camera: string;
+  range: { start: number; end: number };
   timelineItems: Timeline[];
   relevantPreview: Preview | undefined;
 };

--- a/web/src/utils/dateUtil.ts
+++ b/web/src/utils/dateUtil.ts
@@ -1,5 +1,5 @@
-import strftime from 'strftime';
-import { fromUnixTime, intervalToDuration, formatDuration } from 'date-fns';
+import strftime from "strftime";
+import { fromUnixTime, intervalToDuration, formatDuration } from "date-fns";
 export const longToDate = (long: number): Date => new Date(long * 1000);
 export const epochToLong = (date: number): number => date / 1000;
 export const dateToLong = (date: Date): number => epochToLong(date.getTime());
@@ -276,3 +276,12 @@ const getUTCOffset = (date: Date, timezone: string): number => {
 
   return (target.getTime() - utcDate.getTime()) / 60 / 1000;
 };
+
+export function getRangeForTimestamp(timestamp: number) {
+  const date = new Date(timestamp * 1000);
+  date.setMinutes(0, 0, 0);
+  const start = date.getTime() / 1000;
+  date.setHours(date.getHours() + 1);
+  const end = date.getTime() / 1000;
+  return { start, end };
+}

--- a/web/src/utils/historyUtil.ts
+++ b/web/src/utils/historyUtil.ts
@@ -156,9 +156,12 @@ export function getTimelineHoursForDay(
           return [];
         })
       : [];
+    const previewCheck = start + 30; // preview can start after the hour
     const relevantPreview = Object.values(allPreviews || []).find(
       (preview) =>
-        preview.camera == camera && preview.start < start && preview.end > start
+        preview.camera == camera &&
+        preview.start < previewCheck &&
+        preview.end > previewCheck
     );
     data.push({
       camera,

--- a/web/src/utils/historyUtil.ts
+++ b/web/src/utils/historyUtil.ts
@@ -105,6 +105,7 @@ export function getHourlyTimelineData(
 export function getTimelineHoursForDay(
   camera: string,
   cards: CardsData,
+  allPreviews: Preview[],
   timestamp: number
 ): TimelinePlayback[] {
   const now = new Date();
@@ -155,11 +156,15 @@ export function getTimelineHoursForDay(
           return [];
         })
       : [];
+    const relevantPreview = Object.values(allPreviews || []).find(
+      (preview) =>
+        preview.camera == camera && preview.start < start && preview.end > start
+    );
     data.push({
       camera,
       range: { start, end },
       timelineItems,
-      relevantPreview: undefined,
+      relevantPreview,
     });
     start = startDay.getTime() / 1000;
   }

--- a/web/src/utils/historyUtil.ts
+++ b/web/src/utils/historyUtil.ts
@@ -111,9 +111,19 @@ export function getTimelineHoursForDay(
   const now = new Date();
   const data: TimelinePlayback[] = [];
   const startDay = new Date(timestamp * 1000);
+  startDay.setHours(23, 59, 59, 999);
+  const dayEnd = startDay.getTime() / 1000;
   startDay.setHours(0, 0, 0, 0);
   let start = startDay.getTime() / 1000;
   let end = 0;
+
+  const relevantPreviews = allPreviews.filter((preview) => {
+    return (
+      preview.camera == camera &&
+      preview.start >= start &&
+      Math.floor(preview.end - 1) <= dayEnd
+    );
+  });
 
   const dayIdx = Object.keys(cards).find((day) => {
     if (parseInt(day) > start) {
@@ -156,12 +166,9 @@ export function getTimelineHoursForDay(
           return [];
         })
       : [];
-    const previewCheck = start + 30; // preview can start after the hour
-    const relevantPreview = Object.values(allPreviews || []).find(
+    const relevantPreview = relevantPreviews.find(
       (preview) =>
-        preview.camera == camera &&
-        preview.start < previewCheck &&
-        preview.end > previewCheck
+        Math.round(preview.start) >= start && Math.floor(preview.end) <= end
     );
     data.push({
       camera,

--- a/web/src/utils/historyUtil.ts
+++ b/web/src/utils/historyUtil.ts
@@ -101,3 +101,26 @@ export function getHourlyTimelineData(
 
   return cards;
 }
+
+export function getTimelineHoursForDay(timestamp: number) {
+  const now = new Date();
+  const data = [];
+  const startDay = new Date(timestamp * 1000);
+  startDay.setHours(0, 0, 0, 0);
+  let start = startDay.getTime() / 1000;
+  let end = 0;
+
+  for (let i = 0; i < 24; i++) {
+    startDay.setHours(startDay.getHours() + 1);
+
+    if (startDay > now) {
+      break;
+    }
+
+    end = startDay.getTime() / 1000;
+    data.push({ start, end });
+    start = startDay.getTime() / 1000;
+  }
+
+  return data.reverse();
+}

--- a/web/src/views/history/DesktopTimelineView.tsx
+++ b/web/src/views/history/DesktopTimelineView.tsx
@@ -56,7 +56,7 @@ export default function DesktopTimelineView({
 
   const timelineTime = useMemo(() => {
     if (!selectedPlayback || selectedPlayback.timelineItems.length == 0) {
-      return 0;
+      return selectedPlayback.range.start;
     }
 
     return selectedPlayback.timelineItems.at(0)!!.timestamp;
@@ -134,14 +134,6 @@ export default function DesktopTimelineView({
 
       const seekTimestamp = data.time.getTime() / 1000;
       const seekTime = seekTimestamp - selectedPlayback.relevantPreview.start;
-      console.log(
-        "seeking to " +
-          seekTime +
-          " comparing " +
-          new Date(seekTimestamp * 1000) +
-          " - " +
-          new Date(selectedPlayback.relevantPreview.start * 1000)
-      );
       setTimeToSeek(Math.round(seekTime));
     },
     [scrubbing, playerRef, selectedPlayback]
@@ -214,6 +206,12 @@ export default function DesktopTimelineView({
                 options={{
                   preload: "auto",
                   autoplay: true,
+                  sources: [
+                    {
+                      src: playbackUri,
+                      type: "application/vnd.apple.mpegurl",
+                    },
+                  ],
                 }}
                 seekOptions={{ forward: 10, backward: 5 }}
                 onReady={(player) => {

--- a/web/src/views/history/HistoryCardView.tsx
+++ b/web/src/views/history/HistoryCardView.tsx
@@ -2,7 +2,10 @@ import HistoryCard from "@/components/card/HistoryCard";
 import ActivityIndicator from "@/components/ui/activity-indicator";
 import Heading from "@/components/ui/heading";
 import { FrigateConfig } from "@/types/frigateConfig";
-import { formatUnixTimestampToDateTime } from "@/utils/dateUtil";
+import {
+  formatUnixTimestampToDateTime,
+  getRangeForTimestamp,
+} from "@/utils/dateUtil";
 import { useCallback, useRef } from "react";
 import useSWR from "swr";
 
@@ -117,6 +120,7 @@ export default function HistoryCardView({
                                 onClick={() => {
                                   onItemSelected({
                                     camera: timeline.camera,
+                                    range: getRangeForTimestamp(timeline.time),
                                     timelineItems: Object.values(
                                       timelineHour
                                     ).flatMap((card) =>

--- a/web/src/views/history/HistoryTimelineView.tsx
+++ b/web/src/views/history/HistoryTimelineView.tsx
@@ -259,47 +259,45 @@ function DesktopView({
     <div className="w-full">
       <div className="flex">
         <>
-          <div
-            className={`relative ${
-              hasRelevantPreview && scrubbing ? "hidden" : "visible"
-            }`}
-          >
-            <VideoPlayer
-              options={{
-                preload: "auto",
-                autoplay: true,
-                fluid: false,
-                height: "608",
-                width: "1080",
-                sources: [
-                  {
-                    src: playbackUri,
-                    type: "application/vnd.apple.mpegurl",
-                  },
-                ],
-              }}
-              seekOptions={{ forward: 10, backward: 5 }}
-              onReady={(player) => {
-                playerRef.current = player;
-                player.currentTime(timelineTime - playbackTimes.start);
-                player.on("playing", () => {
-                  onSelectItem(undefined);
-                });
-              }}
-              onDispose={() => {
-                playerRef.current = undefined;
-              }}
+          <div className="w-2/3 bg-black flex justify-center items-center">
+            <div
+              className={`w-full relative ${
+                hasRelevantPreview && scrubbing ? "hidden" : "visible"
+              }`}
             >
-              {config && focusedItem ? (
-                <TimelineEventOverlay
-                  timeline={focusedItem}
-                  cameraConfig={config.cameras[playback.camera]}
-                />
-              ) : undefined}
-            </VideoPlayer>
-          </div>
-          {hasRelevantPreview && (
-            <div className={`${scrubbing ? "visible" : "hidden"}`}>
+              <VideoPlayer
+                options={{
+                  preload: "auto",
+                  autoplay: true,
+                  sources: [
+                    {
+                      src: playbackUri,
+                      type: "application/vnd.apple.mpegurl",
+                    },
+                  ],
+                }}
+                seekOptions={{ forward: 10, backward: 5 }}
+                onReady={(player) => {
+                  playerRef.current = player;
+                  player.currentTime(timelineTime - playbackTimes.start);
+                  player.on("playing", () => {
+                    onSelectItem(undefined);
+                  });
+                }}
+                onDispose={() => {
+                  playerRef.current = undefined;
+                }}
+              >
+                {config && focusedItem ? (
+                  <TimelineEventOverlay
+                    timeline={focusedItem}
+                    cameraConfig={config.cameras[playback.camera]}
+                  />
+                ) : undefined}
+              </VideoPlayer>
+            </div>
+            {hasRelevantPreview && (
+            <div className={`w-full ${scrubbing ? "visible" : "hidden"}`}>
               <VideoPlayer
                 options={{
                   preload: "auto",
@@ -325,8 +323,9 @@ function DesktopView({
               />
             </div>
           )}
+          </div>
         </>
-        <div className="px-2 w-full h-[608px] overflow-auto">
+        <div className="px-2 h-[608px] overflow-auto">
           {playback.timelineItems.map((timeline) => {
             return (
               <TimelineItemCard

--- a/web/src/views/history/HistoryTimelineView.tsx
+++ b/web/src/views/history/HistoryTimelineView.tsx
@@ -20,6 +20,7 @@ import React, {
 } from "react";
 import useSWR from "swr";
 import Player from "video.js/dist/types/player";
+import TimelineItemCard from "@/components/card/TimelineItemCard";
 
 type HistoryTimelineViewProps = {
   playback: TimelinePlayback;
@@ -262,71 +263,86 @@ function DesktopView({
 }: DesktopViewProps) {
   return (
     <div className="w-full">
-      <>
-        <div
-          className={`relative ${
-            hasRelevantPreview && scrubbing ? "hidden" : "visible"
-          }`}
-        >
-          <VideoPlayer
-            options={{
-              preload: "auto",
-              autoplay: true,
-              sources: [
-                {
-                  src: playbackUri,
-                  type: "application/vnd.apple.mpegurl",
-                },
-              ],
-            }}
-            seekOptions={{ forward: 10, backward: 5 }}
-            onReady={(player) => {
-              playerRef.current = player;
-              player.currentTime(timelineTime - playbackTimes.start);
-              player.on("playing", () => {
-                setFocusedItem(undefined);
-              });
-            }}
-            onDispose={() => {
-              playerRef.current = undefined;
-            }}
+      <div className="flex">
+        <>
+          <div
+            className={`relative ${
+              hasRelevantPreview && scrubbing ? "hidden" : "visible"
+            }`}
           >
-            {config && focusedItem ? (
-              <TimelineEventOverlay
-                timeline={focusedItem}
-                cameraConfig={config.cameras[playback.camera]}
-              />
-            ) : undefined}
-          </VideoPlayer>
-        </div>
-        {hasRelevantPreview && (
-          <div className={`${scrubbing ? "visible" : "hidden"}`}>
             <VideoPlayer
               options={{
                 preload: "auto",
-                autoplay: false,
-                controls: false,
-                muted: true,
-                loadingSpinner: false,
+                autoplay: true,
+                fluid: false,
+                height: "320",
                 sources: [
                   {
-                    src: `${playback.relevantPreview?.src}`,
-                    type: "video/mp4",
+                    src: playbackUri,
+                    type: "application/vnd.apple.mpegurl",
                   },
                 ],
               }}
-              seekOptions={{}}
+              seekOptions={{ forward: 10, backward: 5 }}
               onReady={(player) => {
-                previewRef.current = player;
-                player.on("seeked", () => setSeeking(false));
+                playerRef.current = player;
+                player.currentTime(timelineTime - playbackTimes.start);
+                player.on("playing", () => {
+                  setFocusedItem(undefined);
+                });
               }}
               onDispose={() => {
-                previewRef.current = undefined;
+                playerRef.current = undefined;
               }}
-            />
+            >
+              {config && focusedItem ? (
+                <TimelineEventOverlay
+                  timeline={focusedItem}
+                  cameraConfig={config.cameras[playback.camera]}
+                />
+              ) : undefined}
+            </VideoPlayer>
           </div>
-        )}
-      </>
+          {hasRelevantPreview && (
+            <div className={`${scrubbing ? "visible" : "hidden"}`}>
+              <VideoPlayer
+                options={{
+                  preload: "auto",
+                  autoplay: false,
+                  controls: false,
+                  muted: true,
+                  loadingSpinner: false,
+                  sources: [
+                    {
+                      src: `${playback.relevantPreview?.src}`,
+                      type: "video/mp4",
+                    },
+                  ],
+                }}
+                seekOptions={{}}
+                onReady={(player) => {
+                  previewRef.current = player;
+                  player.on("seeked", () => setSeeking(false));
+                }}
+                onDispose={() => {
+                  previewRef.current = undefined;
+                }}
+              />
+            </div>
+          )}
+        </>
+        <div className="px-2 w-full h-80 overflow-auto">
+          {playback.timelineItems.map((timeline) => {
+            return (
+              <TimelineItemCard
+                key={timeline.timestamp}
+                timeline={timeline}
+                relevantPreview={playback.relevantPreview}
+              />
+            );
+          })}
+        </div>
+      </div>
       <div className="m-1">
         {playback != undefined && (
           <ActivityScrubber

--- a/web/src/views/history/HistoryTimelineView.tsx
+++ b/web/src/views/history/HistoryTimelineView.tsx
@@ -147,7 +147,15 @@ export default function HistoryTimelineView({
       }
 
       const seekTimestamp = data.time.getTime() / 1000;
-      const seekTime = seekTimestamp - selectedPlayback.relevantPreview!!.start;
+      const seekTime = seekTimestamp - selectedPlayback.relevantPreview.start;
+      console.log(
+        "seeking to " +
+          seekTime +
+          " comparing " +
+          new Date(seekTimestamp * 1000) +
+          " - " +
+          new Date(selectedPlayback.relevantPreview.start * 1000)
+      );
       setTimeToSeek(Math.round(seekTime));
     },
     [scrubbing, playerRef, selectedPlayback]

--- a/web/src/views/history/MobileTimelineView.tsx
+++ b/web/src/views/history/MobileTimelineView.tsx
@@ -1,0 +1,298 @@
+import { useApiHost } from "@/api";
+import TimelineEventOverlay from "@/components/overlay/TimelineDataOverlay";
+import VideoPlayer from "@/components/player/VideoPlayer";
+import ActivityScrubber, {
+  ScrubberItem,
+} from "@/components/scrubber/ActivityScrubber";
+import ActivityIndicator from "@/components/ui/activity-indicator";
+import { FrigateConfig } from "@/types/frigateConfig";
+import {
+  getTimelineDetectionIcon,
+  getTimelineIcon,
+} from "@/utils/timelineUtil";
+import { renderToStaticMarkup } from "react-dom/server";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import useSWR from "swr";
+import Player from "video.js/dist/types/player";
+
+type MobileTimelineViewProps = {
+  playback: TimelinePlayback;
+};
+
+export default function MobileTimelineView({
+  playback,
+}: MobileTimelineViewProps) {
+  const apiHost = useApiHost();
+  const { data: config } = useSWR<FrigateConfig>("config");
+  const timezone = useMemo(
+    () =>
+      config?.ui?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+    [config]
+  );
+
+  const playerRef = useRef<Player | undefined>(undefined);
+  const previewRef = useRef<Player | undefined>(undefined);
+
+  const [scrubbing, setScrubbing] = useState(false);
+  const [focusedItem, setFocusedItem] = useState<Timeline | undefined>(
+    undefined
+  );
+
+  const [seeking, setSeeking] = useState(false);
+  const [timeToSeek, setTimeToSeek] = useState<number | undefined>(undefined);
+
+  const annotationOffset = useMemo(() => {
+    if (!config) {
+      return 0;
+    }
+
+    return (
+      (config.cameras[playback.camera]?.detect?.annotation_offset || 0) / 1000
+    );
+  }, [config]);
+
+  const timelineTime = useMemo(() => {
+    if (!playback || playback.timelineItems.length == 0) {
+      return 0;
+    }
+
+    return playback.timelineItems.at(0)!!.timestamp;
+  }, [playback]);
+
+  const recordingParams = useMemo(() => {
+    return {
+      before: playback.range.end,
+      after: playback.range.start,
+    };
+  }, [playback]);
+  const { data: recordings } = useSWR<Recording[]>(
+    playback ? [`${playback.camera}/recordings`, recordingParams] : null,
+    { revalidateOnFocus: false }
+  );
+
+  const playbackUri = useMemo(() => {
+    if (!playback) {
+      return "";
+    }
+
+    const date = new Date(playback.range.start * 1000);
+    return `${apiHost}vod/${date.getFullYear()}-${
+      date.getMonth() + 1
+    }/${date.getDate()}/${date.getHours()}/${
+      playback.camera
+    }/${timezone.replaceAll("/", ",")}/master.m3u8`;
+  }, [playback]);
+
+  const onSelectItem = useCallback(
+    (timeline: Timeline | undefined) => {
+      if (timeline) {
+        setFocusedItem(timeline);
+        const selected = timeline.timestamp;
+        playerRef.current?.pause();
+
+        let seekSeconds = 0;
+        (recordings || []).every((segment) => {
+          // if the next segment is past the desired time, stop calculating
+          if (segment.start_time > selected) {
+            return false;
+          }
+
+          if (segment.end_time < selected) {
+            seekSeconds += segment.end_time - segment.start_time;
+            return true;
+          }
+
+          seekSeconds +=
+            segment.end_time -
+            segment.start_time -
+            (segment.end_time - selected);
+          return true;
+        });
+        playerRef.current?.currentTime(seekSeconds);
+      } else {
+        setFocusedItem(undefined);
+      }
+    },
+    [annotationOffset, recordings, playerRef]
+  );
+
+  const onScrubTime = useCallback(
+    (data: { time: Date }) => {
+      if (!playback.relevantPreview) {
+        return;
+      }
+
+      if (playerRef.current?.paused() == false) {
+        setScrubbing(true);
+        playerRef.current?.pause();
+      }
+
+      const seekTimestamp = data.time.getTime() / 1000;
+      const seekTime = seekTimestamp - playback.relevantPreview.start;
+      console.log(
+        "seeking to " +
+          seekTime +
+          " comparing " +
+          new Date(seekTimestamp * 1000) +
+          " - " +
+          new Date(playback.relevantPreview.start * 1000)
+      );
+      setTimeToSeek(Math.round(seekTime));
+    },
+    [scrubbing, playerRef, playback]
+  );
+
+  const onStopScrubbing = useCallback(
+    (data: { time: Date }) => {
+      const playbackTime = data.time.getTime() / 1000;
+      playerRef.current?.currentTime(playbackTime - playback.range.start);
+      setScrubbing(false);
+      playerRef.current?.play();
+    },
+    [playback, playerRef]
+  );
+
+  // handle seeking to next frame when seek is finished
+  useEffect(() => {
+    if (seeking) {
+      return;
+    }
+
+    if (timeToSeek && timeToSeek != previewRef.current?.currentTime()) {
+      setSeeking(true);
+      previewRef.current?.currentTime(timeToSeek);
+    }
+  }, [timeToSeek, seeking]);
+
+  if (!config || !recordings) {
+    return <ActivityIndicator />;
+  }
+
+  return (
+    <div className="w-full">
+      <>
+        <div
+          className={`relative ${
+            playback.relevantPreview && scrubbing ? "hidden" : "visible"
+          }`}
+        >
+          <VideoPlayer
+            options={{
+              preload: "auto",
+              autoplay: true,
+              sources: [
+                {
+                  src: playbackUri,
+                  type: "application/vnd.apple.mpegurl",
+                },
+              ],
+            }}
+            seekOptions={{ forward: 10, backward: 5 }}
+            onReady={(player) => {
+              playerRef.current = player;
+              player.currentTime(timelineTime - playback.range.start);
+              player.on("playing", () => {
+                onSelectItem(undefined);
+              });
+            }}
+            onDispose={() => {
+              playerRef.current = undefined;
+            }}
+          >
+            {config && focusedItem ? (
+              <TimelineEventOverlay
+                timeline={focusedItem}
+                cameraConfig={config.cameras[playback.camera]}
+              />
+            ) : undefined}
+          </VideoPlayer>
+        </div>
+        {playback.relevantPreview && (
+          <div className={`${scrubbing ? "visible" : "hidden"}`}>
+            <VideoPlayer
+              options={{
+                preload: "auto",
+                autoplay: false,
+                controls: false,
+                muted: true,
+                loadingSpinner: false,
+                sources: [
+                  {
+                    src: `${playback.relevantPreview?.src}`,
+                    type: "video/mp4",
+                  },
+                ],
+              }}
+              seekOptions={{}}
+              onReady={(player) => {
+                previewRef.current = player;
+                player.on("seeked", () => setSeeking(false));
+              }}
+              onDispose={() => {
+                previewRef.current = undefined;
+              }}
+            />
+          </div>
+        )}
+      </>
+      <div className="m-1">
+        {playback != undefined && (
+          <ActivityScrubber
+            items={timelineItemsToScrubber(playback.timelineItems)}
+            timeBars={
+              playback.relevantPreview
+                ? [{ time: new Date(timelineTime * 1000), id: "playback" }]
+                : []
+            }
+            options={{
+              start: new Date(
+                Math.max(playback.range.start, timelineTime - 300) * 1000
+              ),
+              end: new Date(
+                Math.min(playback.range.end, timelineTime + 300) * 1000
+              ),
+              snap: null,
+              min: new Date(playback.range.start * 1000),
+              max: new Date(playback.range.end * 1000),
+              timeAxis: { scale: "minute", step: 5 },
+            }}
+            timechangeHandler={onScrubTime}
+            timechangedHandler={onStopScrubbing}
+            selectHandler={(data) => {
+              if (data.items.length > 0) {
+                const selected = data.items[0];
+                onSelectItem(
+                  playback.timelineItems.find(
+                    (timeline) => timeline.timestamp == selected
+                  )
+                );
+              }
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function timelineItemsToScrubber(items: Timeline[]): ScrubberItem[] {
+  return items.map((item) => {
+    return {
+      id: item.timestamp,
+      content: getTimelineContentElement(item),
+      start: new Date(item.timestamp * 1000),
+      end: new Date(item.timestamp * 1000),
+      type: "box",
+    };
+  });
+}
+
+function getTimelineContentElement(item: Timeline): HTMLElement {
+  const output = document.createElement(`div-${item.timestamp}`);
+  output.innerHTML = renderToStaticMarkup(
+    <div className="flex items-center">
+      {getTimelineDetectionIcon(item)} : {getTimelineIcon(item)}
+    </div>
+  );
+  return output;
+}

--- a/web/src/views/history/MobileTimelineView.tsx
+++ b/web/src/views/history/MobileTimelineView.tsx
@@ -51,13 +51,11 @@ export default function MobileTimelineView({
     );
   }, [config]);
 
-  const timelineTime = useMemo(() => {
-    if (!playback || playback.timelineItems.length == 0) {
-      return 0;
-    }
-
-    return playback.timelineItems.at(0)!!.timestamp;
-  }, [playback]);
+  const [timelineTime, setTimelineTime] = useState(
+    playback.timelineItems.length > 0
+      ? playback.timelineItems[0].timestamp
+      : playback.range.start
+  );
 
   const recordingParams = useMemo(() => {
     return {
@@ -129,14 +127,7 @@ export default function MobileTimelineView({
 
       const seekTimestamp = data.time.getTime() / 1000;
       const seekTime = seekTimestamp - playback.relevantPreview.start;
-      console.log(
-        "seeking to " +
-          seekTime +
-          " comparing " +
-          new Date(seekTimestamp * 1000) +
-          " - " +
-          new Date(playback.relevantPreview.start * 1000)
-      );
+      setTimelineTime(seekTimestamp);
       setTimeToSeek(Math.round(seekTime));
     },
     [scrubbing, playerRef, playback]


### PR DESCRIPTION
Improvements:
- desktop view now shows timelines for the entire day of the selected item
- can double click to focus on particular timeline item to scrub or watch
- disable progress bar and use timeline as progress bar
- efficiency and other improvements