### PR TITLE
update docs to clarify variable substitution in go2rtc

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -443,8 +443,6 @@ rtmp:
 # Uses https://github.com/AlexxIT/go2rtc (v1.8.3)
 go2rtc:
 
-
-
 # Optional: jsmpeg stream configuration for WebUI
 live:
   # Optional: Set the name of the stream that should be used for live view

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -47,6 +47,13 @@ onvif:
   password: "{FRIGATE_RTSP_PASSWORD}"
 ```
 
+```yaml
+go2rtc:
+  rtsp:
+    username: "{FRIGATE_GO2RTC_RTSP_USERNAME}"
+    password: "{FRIGATE_GO2RTC_RTSP_PASSWORD}"
+```
+
 ### Full configuration reference:
 
 :::caution
@@ -436,14 +443,7 @@ rtmp:
 # Uses https://github.com/AlexxIT/go2rtc (v1.8.3)
 go2rtc:
 
-  rtsp:
-    # username can be specified with an environment variables or docker secrets that must begin with 'FRIGATE_'.
-    #       e.g. user: '{FRIGATE_GO2RTC_RTSP_USERNAME}'
-    username: go2rtc_rtsp_username
-    # password can be specified with an environment variables or docker secrets that must begin with 'FRIGATE_'.
-    #       e.g. user: '{FRIGATE_GO2RTC_RTSP_PASSWORD}'
-    password: go2rtc_rtsp_password
-  stream: ...
+
 
 # Optional: jsmpeg stream configuration for WebUI
 live:

--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -436,6 +436,15 @@ rtmp:
 # Uses https://github.com/AlexxIT/go2rtc (v1.8.3)
 go2rtc:
 
+  rtsp:
+    # username can be specified with an environment variables or docker secrets that must begin with 'FRIGATE_'.
+    #       e.g. user: '{FRIGATE_GO2RTC_RTSP_USERNAME}'
+    username: go2rtc_rtsp_username
+    # password can be specified with an environment variables or docker secrets that must begin with 'FRIGATE_'.
+    #       e.g. user: '{FRIGATE_GO2RTC_RTSP_PASSWORD}'
+    password: go2rtc_rtsp_password
+  stream: ...
+
 # Optional: jsmpeg stream configuration for WebUI
 live:
   # Optional: Set the name of the stream that should be used for live view


### PR DESCRIPTION
I'm updated docs with the possibility of subtitution with FRIGATE_ variable for rtsp in go2rtc