### PR TITLE
Increase thumbnail resolution and quality

### DIFF
--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -295,7 +295,7 @@ class TrackedObject:
             ret, jpg = cv2.imencode(".jpg", np.zeros((175, 175, 3), np.uint8))
 
         jpg_bytes = self.get_jpg_bytes(
-            timestamp=False, bounding_box=False, crop=True, height=175
+            timestamp=False, bounding_box=False, crop=True, width=400, quality=90
         )
 
         if jpg_bytes:
@@ -326,7 +326,13 @@ class TrackedObject:
             return None
 
     def get_jpg_bytes(
-        self, timestamp=False, bounding_box=False, crop=False, height=None, quality=70
+        self,
+        timestamp=False,
+        bounding_box=False,
+        crop=False,
+        height=None,
+        width=None,
+        quality=70,
     ):
         if self.thumbnail_data is None:
             return None
@@ -389,8 +395,15 @@ class TrackedObject:
             )
             best_frame = best_frame[region[1] : region[3], region[0] : region[2]]
 
-        if height:
-            width = int(height * best_frame.shape[1] / best_frame.shape[0])
+        if width and height:
+            logger.warning(
+                "get_jpg_bytes() expects only width or height to be specified, not both"
+            )
+        if width or height:
+            if height:
+                width = int(height * best_frame.shape[1] / best_frame.shape[0])
+            elif width:
+                height = int(width * best_frame.shape[0] / best_frame.shape[1])
             best_frame = cv2.resize(
                 best_frame, dsize=(width, height), interpolation=cv2.INTER_AREA
             )


### PR DESCRIPTION
The fastest, most reliable and most user-friendly way to view a Frigate event on a phone is to long-press the HA notification to open the detection thumbnail. Frigate's thumbnails are cropped to include only the detection, which is great, and are also low-resolution, which is fine for the tiny notification thumbnail, but looks poor when opened.

I chose 400px as the new thumbnail width because it is close to the logical width of an iPhone and the physical width of an Apple Watch. I specified width rather than height because a phone in portrait mode will almost always constrain the thumbnail horizontally.

The guides I have seen for push notification image attachments recommend a width of 300-2000px and a size of 500KB. With this PR, the thumbnails now fall within this resolution range and remain under 40KB.

The following three images show:
- Before (h=175px, quality=70)
- After (w=400px, quality=90)
- Best possible (no scaling or encoding)

![image](https://github.com/blakeblackshear/frigate/assets/7854563/e3169f79-88b1-42ca-8b22-391c49b8b28f)

Are there other users of the thumbnails that require them to be 175px tall?