### PR TITLE
Add `ghcr.io/blakeblackshear/frigate:stable-tensorrt` example

### DIFF
--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -168,7 +168,7 @@ volumes:
 
 ## NVidia TensorRT Detector
 
-NVidia GPUs may be used for object detection using the TensorRT libraries. Due to the size of the additional libraries, this detector is only provided in images with the `-tensorrt` tag suffix. This detector is designed to work with Yolo models for object detection.
+NVidia GPUs may be used for object detection using the TensorRT libraries. Due to the size of the additional libraries, this detector is only provided in images with the `-tensorrt` tag suffix, e.g. `ghcr.io/blakeblackshear/frigate:stable-tensorrt`. This detector is designed to work with Yolo models for object detection.
 
 ### Minimum Hardware Support
 


### PR DESCRIPTION
Many people [1](https://github.com/blakeblackshear/frigate/issues/5810#issuecomment-1879918555) [2](https://github.com/blakeblackshear/frigate/issues/8228) [3](https://github.com/blakeblackshear/frigate/issues/7457) (and myself) skipped over the `-tensorrt` part, so perhaps this explicit example will help future users realize they need to use the right image.