### PR TITLE
Update Makefile "VERSION" to 0.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default_target: local
 
 COMMIT_HASH := $(shell git log -1 --pretty=format:"%h"|tail -1)
-VERSION = 0.13.0
+VERSION = 0.14.0
 IMAGE_REPO ?= ghcr.io/blakeblackshear/frigate
 GITHUB_REF_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
 CURRENT_UID := $(shell id -u)


### PR DESCRIPTION
Self-explanatory

This is logged on startup (as well as various other places) and for those of us experimenting useful to remember what we're looking at without needing to look up a git commit hash