### PR TITLE
Add info logging at startup if vacuuming database

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -271,6 +271,7 @@ class FrigateApp:
 
     def init_database(self) -> None:
         def vacuum_db(db: SqliteExtDatabase) -> None:
+            logger.info("Running database vacuum")
             db.execute_sql("VACUUM;")
 
             try:


### PR DESCRIPTION
I wasn't aware Frigate did this at startup, which I think is a bit debatable from a DB maintenance perspective. Per https://github.com/blakeblackshear/frigate/issues/9424 it would be helpful to have visibility when any periodic maintenance task is running during startup. I am continuing to try and debug slow restart issues separately; startup is next on my list.

I'm aware querying the .vacuum file is also an option, but logs are far easier (and historic).