### PR TITLE
Add ability to customize order of output for edge tpu detector models

### DIFF
--- a/frigate/detectors/detector_config.py
+++ b/frigate/detectors/detector_config.py
@@ -51,6 +51,9 @@ class ModelConfig(BaseModel):
     model_type: ModelTypeEnum = Field(
         default=ModelTypeEnum.ssd, title="Object Detection Model Type"
     )
+    order: list[int] = Field(
+        default=[0,1,2,3], title="Order Output Tensors [0=boxes,1=scores,2=class_ids,3=count]"
+    )
     _merged_labelmap: Optional[Dict[int, str]] = PrivateAttr()
     _colormap: Dict[int, Tuple[int, int, int]] = PrivateAttr()
     _model_hash: str = PrivateAttr()

--- a/frigate/detectors/detector_config.py
+++ b/frigate/detectors/detector_config.py
@@ -51,8 +51,8 @@ class ModelConfig(BaseModel):
     model_type: ModelTypeEnum = Field(
         default=ModelTypeEnum.ssd, title="Object Detection Model Type"
     )
-    order: list[int] = Field(
-        default=[0,1,2,3], title="Order Output Tensors [0=boxes,1=scores,2=class_ids,3=count]"
+    tfl_detector_output_tensor_order: list[int] = Field(
+        default=[0,1,2,3], title="Order Output Tensors of TFL models [0=boxes,1=scores,2=class_ids,3=count]"
     )
     _merged_labelmap: Optional[Dict[int, str]] = PrivateAttr()
     _colormap: Dict[int, Tuple[int, int, int]] = PrivateAttr()

--- a/frigate/detectors/plugins/cpu_tfl.py
+++ b/frigate/detectors/plugins/cpu_tfl.py
@@ -37,15 +37,17 @@ class CpuTfl(DetectionApi):
         self.tensor_input_details = self.interpreter.get_input_details()
         self.tensor_output_details = self.interpreter.get_output_details()
 
+        self.tfl_detector_output_tensor_order = detector_config.model.tfl_detector_output_tensor_order
+
     def detect_raw(self, tensor_input):
         self.interpreter.set_tensor(self.tensor_input_details[0]["index"], tensor_input)
         self.interpreter.invoke()
 
-        boxes = self.interpreter.tensor(self.tensor_output_details[0]["index"])()[0]
-        class_ids = self.interpreter.tensor(self.tensor_output_details[1]["index"])()[0]
-        scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[0]
+        boxes = self.interpreter.tensor(self.tensor_output_details[self.tfl_detector_output_tensor_order[0]]["index"])()[0]
+        class_ids = self.interpreter.tensor(self.tensor_output_details[self.tfl_detector_output_tensor_order[1]]["index"])()[0]
+        scores = self.interpreter.tensor(self.tensor_output_details[self.tfl_detector_output_tensor_order[2]]["index"])()[0]
         count = int(
-            self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
+            self.interpreter.tensor(self.tensor_output_details[self.tfl_detector_output_tensor_order[3]]["index"])()[0]
         )
 
         detections = np.zeros((20, 6), np.float32)

--- a/frigate/detectors/plugins/edgetpu_tfl.py
+++ b/frigate/detectors/plugins/edgetpu_tfl.py
@@ -60,11 +60,11 @@ class EdgeTpuTfl(DetectionApi):
         self.interpreter.set_tensor(self.tensor_input_details[0]["index"], tensor_input)
         self.interpreter.invoke()
 
-        boxes = self.interpreter.tensor(self.tensor_output_details[0]["index"])()[0]
-        class_ids = self.interpreter.tensor(self.tensor_output_details[1]["index"])()[0]
-        scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[0]
+        boxes = self.interpreter.tensor(self.tensor_output_details[self.order[0]]["index"])()[0]
+        class_ids = self.interpreter.tensor(self.tensor_output_details[self.order[1]]["index"])()[0]
+        scores = self.interpreter.tensor(self.tensor_output_details[self.order[2]]["index"])()[0]
         count = int(
-            self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
+            self.interpreter.tensor(self.tensor_output_details[self.order[3]]["index"])()[0]
         )
 
         detections = np.zeros((20, 6), np.float32)

--- a/frigate/detectors/plugins/edgetpu_tfl.py
+++ b/frigate/detectors/plugins/edgetpu_tfl.py
@@ -44,7 +44,7 @@ class EdgeTpuTfl(DetectionApi):
                 model_path=detector_config.model.path,
                 experimental_delegates=[edge_tpu_delegate],
             )
-            self.order = detector_config.model.order
+            self.tfl_detector_output_tensor_order = detector_config.model.tfl_detector_output_tensor_order
         except ValueError:
             logger.error(
                 "No EdgeTPU was detected. If you do not have a Coral device yet, you must configure CPU detectors."
@@ -60,11 +60,11 @@ class EdgeTpuTfl(DetectionApi):
         self.interpreter.set_tensor(self.tensor_input_details[0]["index"], tensor_input)
         self.interpreter.invoke()
 
-        boxes = self.interpreter.tensor(self.tensor_output_details[self.order[0]]["index"])()[0]
-        class_ids = self.interpreter.tensor(self.tensor_output_details[self.order[1]]["index"])()[0]
-        scores = self.interpreter.tensor(self.tensor_output_details[self.order[2]]["index"])()[0]
+        boxes = self.interpreter.tensor(self.tensor_output_details[self.tfl_detector_output_tensor_order[0]]["index"])()[0]
+        class_ids = self.interpreter.tensor(self.tensor_output_details[self.tfl_detector_output_tensor_order[1]]["index"])()[0]
+        scores = self.interpreter.tensor(self.tensor_output_details[self.tfl_detector_output_tensor_order[2]]["index"])()[0]
         count = int(
-            self.interpreter.tensor(self.tensor_output_details[self.order[3]]["index"])()[0]
+            self.interpreter.tensor(self.tensor_output_details[self.tfl_detector_output_tensor_order[3]]["index"])()[0]
         )
 
         detections = np.zeros((20, 6), np.float32)

--- a/frigate/detectors/plugins/edgetpu_tfl.py
+++ b/frigate/detectors/plugins/edgetpu_tfl.py
@@ -44,6 +44,7 @@ class EdgeTpuTfl(DetectionApi):
                 model_path=detector_config.model.path,
                 experimental_delegates=[edge_tpu_delegate],
             )
+            self.order = detector_config.model.order
         except ValueError:
             logger.error(
                 "No EdgeTPU was detected. If you do not have a Coral device yet, you must configure CPU detectors."


### PR DESCRIPTION
Add order to config.model to allow the user the ability to specify the order of boxes, scores, class_ids, and count for their edge tpu detector output. The default value is the current setting.