### PR TITLE
Adjust kalman filter used for norfair tracker

### DIFF
--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -3,7 +3,13 @@ import random
 import string
 
 import numpy as np
-from norfair import Detection, Drawable, Tracker, draw_boxes
+from norfair import (
+    Detection,
+    Drawable,
+    OptimizedKalmanFilterFactory,
+    Tracker,
+    draw_boxes,
+)
 from norfair.drawing.drawer import Drawer
 
 from frigate.config import CameraConfig
@@ -82,6 +88,7 @@ class NorfairTracker(ObjectTracker):
             distance_threshold=2.5,
             initialization_delay=self.detect_config.min_initialized,
             hit_counter_max=self.detect_config.max_disappeared,
+            filter_factory=OptimizedKalmanFilterFactory(R=3.4),
         )
         if self.ptz_autotracker_enabled.value:
             self.ptz_motion_estimator = PtzMotionEstimator(

--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -92,7 +92,7 @@ class NorfairTracker(ObjectTracker):
             # R is the multiplier for the sensor measurement noise matrix, default of 4.0
             # lowering R means that we trust the position of the bounding boxes more
             # testing shows that the prediction was being relied on a bit too much
-            # TODO: could use different kalman filter values along with 
+            # TODO: could use different kalman filter values along with
             #       the different tracker per object class
             filter_factory=OptimizedKalmanFilterFactory(R=3.4),
         )

--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -88,6 +88,12 @@ class NorfairTracker(ObjectTracker):
             distance_threshold=2.5,
             initialization_delay=self.detect_config.min_initialized,
             hit_counter_max=self.detect_config.max_disappeared,
+            # use default filter factory with custom values
+            # R is the multiplier for the sensor measurement noise matrix, default of 4.0
+            # lowering R means that we trust the position of the bounding boxes more
+            # testing shows that the prediction was being relied on a bit too much
+            # TODO: could use different kalman filter values along with 
+            #       the different tracker per object class
             filter_factory=OptimizedKalmanFilterFactory(R=3.4),
         )
         if self.ptz_autotracker_enabled.value:


### PR DESCRIPTION
After testing I believe that the default values for the kalman filter are not optimal for Frigate. 

**This is with the current values:**

![Screen Shot 2024-01-31 at 12 39 28 PM](https://github.com/blakeblackshear/frigate/assets/14866235/f5b7f467-d301-437c-9a22-f642483f1919) ![Screen Shot 2024-01-31 at 12 39 36 PM](https://github.com/blakeblackshear/frigate/assets/14866235/ae0650f5-503b-4486-ab2c-975bb6d324c2)

we can see that the estimate (green) is consistently behind the actual object

**with this PR:**

![Screen Shot 2024-01-31 at 12 41 17 PM](https://github.com/blakeblackshear/frigate/assets/14866235/16fdf9dc-2a4e-4a10-b701-13778042013a) ![Screen Shot 2024-01-31 at 12 41 23 PM](https://github.com/blakeblackshear/frigate/assets/14866235/75d6d711-b792-4d2f-adf5-4ecd5780789b)

we can see that the estimates are much more consistent with the actual detection.

I spent additional time testing this on other objects and it has performed well in tests