### PR TITLE
show version in UI for dev production builds

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -56,6 +56,7 @@ import {
 } from "./ui/sheet";
 import ActivityIndicator from "./ui/activity-indicator";
 import { useRestart } from "@/api/ws";
+import { ENV } from "@/env";
 
 type HeaderProps = {
   onToggleNavbar: () => void;
@@ -111,6 +112,11 @@ function Header({ onToggleNavbar }: HeaderProps) {
             </div>
             <Heading as="h1">Frigate</Heading>
           </div>
+          {ENV == "production" && (
+            <div className="text-red-500 text-sm items-center text-right">
+              0.14 unstable
+            </div>
+          )}
         </Link>
       </div>
       <div className="flex flex-shrink-0 md:gap-2">


### PR DESCRIPTION
Some users have mistakenly pulled the dev builds and presumed it is 0.13. This PR just shows red "0.14 unstable" text in the header for users who pull and run a production build. We can remove this later.