### PR TITLE
Onvif: skip non-video profiles in setup

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -87,21 +87,24 @@ class OnvifController:
             )
             return False
 
+        ptz = onvif.create_ptz_service()
+
+        profile = None
         for key, onvif_profile in enumerate(profiles):
-            # skip non-H264 profiles
             if (
-                not onvif_profile.VideoEncoderConfiguration
-                or onvif_profile.VideoEncoderConfiguration.Encoding != "H264"
+                onvif_profile.VideoEncoderConfiguration
+                and onvif_profile.VideoEncoderConfiguration.Encoding == "H264"
             ):
-                continue
-            else:
-                # use the first H264 profile
                 profile = onvif_profile
                 break
 
-        ptz = onvif.create_ptz_service()
+        if profile is None:
+            logger.error(
+                f"No appropriate Onvif profiles found for camera: {camera_name}."
+            )
+            return False
 
-        # get the PTZ config for the first onvif profile
+        # get the PTZ config for the profile
         try:
             configs = profile.PTZConfiguration
             logger.debug(

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -87,8 +87,6 @@ class OnvifController:
             )
             return False
 
-        ptz = onvif.create_ptz_service()
-
         profile = None
         for key, onvif_profile in enumerate(profiles):
             if (
@@ -115,6 +113,8 @@ class OnvifController:
                 f"Invalid Onvif PTZ configuration for camera: {camera_name}: {e}"
             )
             return False
+
+        ptz = onvif.create_ptz_service()
 
         request = ptz.create_type("GetConfigurationOptions")
         request.ConfigurationToken = profile.PTZConfiguration.token

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -94,6 +94,7 @@ class OnvifController:
                 and onvif_profile.VideoEncoderConfiguration.Encoding == "H264"
             ):
                 profile = onvif_profile
+                logger.debug(f"Selected Onvif profile for {camera_name}: {profile}")
                 break
 
         if profile is None:


### PR DESCRIPTION
This PR:

- Looks for the first video onvif media profile to use for ptz controls (mimics the way the [HA onvif integration](https://github.com/home-assistant/core/blob/c61a2b46d4ac1d26bc56352fcdaef637f9814d61/homeassistant/components/onvif/device.py#L420) works)
- Adds some debug logging and exception handling