### PR TITLE
Add detailed errors for unsupported label uploading to frigate+

### DIFF
--- a/frigate/http.py
+++ b/frigate/http.py
@@ -275,6 +275,13 @@ def send_to_plus(id):
                 box,
                 event.label,
             )
+        except ValueError:
+            message = "Error uploading annotation, unsupported label provided."
+            logger.error(message)
+            return make_response(
+                jsonify({"success": False, "message": message}),
+                400,
+            )
         except Exception as ex:
             logger.exception(ex)
             return make_response(
@@ -345,6 +352,13 @@ def false_positive(id):
             event.model_hash,
             event.model_type,
             event.detector_type,
+        )
+    except ValueError:
+        message = "Error uploading false positive, unsupported label provided."
+        logger.error(message)
+        return make_response(
+            jsonify({"success": False, "message": message}),
+            400,
         )
     except Exception as ex:
         logger.exception(ex)

--- a/frigate/plus.py
+++ b/frigate/plus.py
@@ -171,6 +171,17 @@ class PlusApi:
         )
 
         if not r.ok:
+            try:
+                error_response = r.json()
+                errors = error_response.get("errors", [])
+                for error in errors:
+                    if (
+                        error.get("param") == "label"
+                        and error.get("type") == "invalid_enum_value"
+                    ):
+                        raise ValueError(f"Unsupported label value provided: {label}")
+            except ValueError as e:
+                raise e
             raise Exception(r.text)
 
     def add_annotation(
@@ -193,6 +204,17 @@ class PlusApi:
         )
 
         if not r.ok:
+            try:
+                error_response = r.json()
+                errors = error_response.get("errors", [])
+                for error in errors:
+                    if (
+                        error.get("param") == "label"
+                        and error.get("type") == "invalid_enum_value"
+                    ):
+                        raise ValueError(f"Unsupported label value provided: {label}")
+            except ValueError as e:
+                raise e
             raise Exception(r.text)
 
     def get_model_download_url(


### PR DESCRIPTION
I ran into #8961 recently when I was getting started with Frigate+. Some of my uploads were initially getting stuck in this "Uploading..." state. I realized soon after that some of my labels weren't supported by Frigate+

Not sure if I should be targeting dev with this PR given that these are changes to "web-old". Also not sure if this issue has already been resolved in the new 0.14 UI!

Current upload error behaviour:
<img width="127" alt="image" src="https://github.com/blakeblackshear/frigate/assets/62088388/97e7cada-14c4-45eb-af68-379b883228dd">

Proposed unsupported label error:
<img width="221" alt="Screenshot 2024-02-10 at 12 16 29 AM" src="https://github.com/blakeblackshear/frigate/assets/62088388/3e96d662-dc22-42ed-acce-7b898b5b16fb">

Proposed generic upload error:
<img width="230" alt="Screenshot 2024-02-09 at 11 18 05 PM" src="https://github.com/blakeblackshear/frigate/assets/62088388/42d82009-3fe5-4159-a4e9-d62f3c1c2ac4">