### PR TITLE
Fix mobile tooltips

### DIFF
--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -20,6 +20,7 @@ function Sidebar({
 }) {
   const sidebar = (
     <aside className="w-[52px] z-10 h-screen sticky top-0 overflow-y-auto scrollbar-hidden py-4 flex flex-col justify-between">
+      <span tabIndex={0} className="sr-only" />
       <div className="w-full flex flex-col gap-0 items-center">
         <Logo className="w-8 h-8 mb-6" />
         {navbarLinks.map((item) => (

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -78,10 +78,11 @@ function Live() {
       <div className="mt-4 md:grid md:grid-cols-2 xl:grid-cols-3 3xl:grid-cols-4 gap-4">
         {cameras.map((camera) => {
           let grow;
-          if (camera.detect.width / camera.detect.height > 2) {
-            grow = "aspect-wide md:col-span-2";
-          } else if (camera.detect.width / camera.detect.height < 1) {
-            grow = "aspect-tall md:aspect-auto md:row-span-2";
+          let aspectRatio = camera.detect.width / camera.detect.height;
+          if (aspectRatio > 2) {
+            grow = "md:col-span-2 aspect-wide";
+          } else if (aspectRatio < 1) {
+            grow = `md:row-span-2 aspect-[8/9] md:h-full`;
           } else {
             grow = "aspect-video";
           }


### PR DESCRIPTION
- Tooltips for the first sidebar icon was showing on mobile devices when the page loads. This is a known issue with shadcn/radix tooltips, but a simple fix is to include an element with a tab index of 0 to gain first focus.
- Add `h-full` to portrait cameras in the grid so that it takes up the full two rows.