### PR TITLE
ci: AMD/ROCm builds for the rocm detector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,57 @@ jobs:
             tensorrt.tags=${{ steps.setup.outputs.image-name }}-tensorrt
             *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-amd64
             *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-amd64,mode=max
+      - name: AMD/ROCm general build
+        env:
+          AMDGPU: gfx
+          HSA_OVERRIDE: 0
+        uses: docker/bake-action@v3
+        with:
+          push: true
+          targets: rocm
+          files: docker/rocm/rocm.hcl
+          set: |
+            rocm.tags=${{ steps.setup.outputs.image-name }}-rocm
+            *.cache-from=type=gha
+      - name: AMD/ROCm gfx900
+        env:
+          AMDGPU: gfx900
+          HSA_OVERRIDE: 1
+          HSA_OVERRIDE_GFX_VERSION: 9.0.0
+        uses: docker/bake-action@v3
+        with:
+          push: true
+          targets: rocm
+          files: docker/rocm/rocm.hcl
+          set: |
+            rocm.tags=${{ steps.setup.outputs.image-name }}-rocm-gfx900
+            *.cache-from=type=gha
+      - name: AMD/ROCm gfx1030
+        env:
+          AMDGPU: gfx1030
+          HSA_OVERRIDE: 1
+          HSA_OVERRIDE_GFX_VERSION: 10.3.0
+        uses: docker/bake-action@v3
+        with:
+          push: true
+          targets: rocm
+          files: docker/rocm/rocm.hcl
+          set: |
+            rocm.tags=${{ steps.setup.outputs.image-name }}-rocm-gfx1030
+            *.cache-from=type=gha
+      - name: AMD/ROCm gfx1100
+        env:
+          AMDGPU: gfx1100
+          HSA_OVERRIDE: 1
+          HSA_OVERRIDE_GFX_VERSION: 11.0.0
+        uses: docker/bake-action@v3
+        with:
+          push: true
+          targets: rocm
+          files: docker/rocm/rocm.hcl
+          set: |
+            rocm.tags=${{ steps.setup.outputs.image-name }}-rocm-gfx1100
+            *.cache-from=type=gha
   arm64_build:
     runs-on: ubuntu-latest
     name: ARM Build


### PR DESCRIPTION
Github CI builds for the AMD/ROCm platform. Should create following builds:

- buildtag-rocm
- buildtag-rocm-gfx900
- buildtag-rocm-gfx1030
- buildtag-rocm-gfx1100

I have no experience with github continuous integration and copy-pasted existing and recommended lines. Have not tested it. Please review carefully. @NickM-27 