### PR TITLE
UI tweaks

### DIFF
--- a/web/src/components/camera/CameraImage.tsx
+++ b/web/src/components/camera/CameraImage.tsx
@@ -37,7 +37,9 @@ export default function CameraImage({
 
   return (
     <div
-      className={`relative w-full h-full flex justify-center ${className}`}
+      className={`relative w-full h-full flex justify-center ${
+        className || ""
+      }`}
       ref={containerRef}
     >
       {enabled ? (

--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -111,7 +111,7 @@ export default function LivePlayer({
   } else if (liveMode == "jsmpeg") {
     player = (
       <JSMpegPlayer
-        className="w-full flex justify-center"
+        className="w-full flex justify-center rounded-2xl overflow-hidden"
         camera={cameraConfig.name}
         width={cameraConfig.detect.width}
         height={cameraConfig.detect.height}


### PR DESCRIPTION
- ensure jsmpeg player's canvas element is rounded and clipped
- prevent "undefined" from appearing as a class name when no classes are passed