### PR TITLE
Import escape function directly from markupsafe

### DIFF
--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -1,6 +1,7 @@
 click == 8.1.*
 Flask == 2.3.*
 imutils == 0.5.*
+markupsafe == 2.1.*
 matplotlib == 3.7.*
 mypy == 1.6.1
 numpy == 1.23.*

--- a/frigate/http.py
+++ b/frigate/http.py
@@ -24,11 +24,11 @@ from flask import (
     Flask,
     Response,
     current_app,
-    escape,
     jsonify,
     make_response,
     request,
 )
+from markupsafe import escape
 from peewee import DoesNotExist, fn, operator
 from playhouse.shortcuts import model_to_dict
 from playhouse.sqliteq import SqliteQueueDatabase


### PR DESCRIPTION
Adds a direct dependency on markupsafe, instead of relying on the implicit dependency via Flask.

This is in preparation of Flask 3.0 support, which will drop compat for importing escape indirectly.

> Importing escape and Markup from flask is deprecated. Import them directly from markupsafe instead. [#4996](https://github.com/pallets/flask/pull/4996)

https://flask.palletsprojects.com/en/3.0.x/changes/