### PR TITLE
Use zoom space id in Onvif RelativeMove setup

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -151,7 +151,10 @@ class OnvifController:
 
         # autoracking relative panning/tilting needs a relative zoom value set to 0
         # if camera supports relative movement
-        if self.config.cameras[camera_name].onvif.autotracking.zooming:
+        if (
+            self.config.cameras[camera_name].onvif.autotracking.zooming
+            != ZoomingModeEnum.disabled
+        ):
             zoom_space_id = next(
                 (
                     i
@@ -182,12 +185,12 @@ class OnvifController:
         try:
             if (
                 self.config.cameras[camera_name].onvif.autotracking.zooming
-                == ZoomingModeEnum.relative
+                != ZoomingModeEnum.disabled
             ):
                 if zoom_space_id is not None:
                     move_request.Translation.Zoom.space = ptz_config["Spaces"][
                         "RelativeZoomTranslationSpace"
-                    ][0]["URI"]
+                    ][zoom_space_id]["URI"]
         except Exception:
             if (
                 self.config.cameras[camera_name].onvif.autotracking.zooming

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -191,17 +191,15 @@ class OnvifController:
                     move_request.Translation.Zoom.space = ptz_config["Spaces"][
                         "RelativeZoomTranslationSpace"
                     ][zoom_space_id]["URI"]
+            else:
+                move_request.Translation.Zoom = []
         except Exception:
-            if (
-                self.config.cameras[camera_name].onvif.autotracking.zooming
-                == ZoomingModeEnum.relative
-            ):
-                self.config.cameras[
-                    camera_name
-                ].onvif.autotracking.zooming = ZoomingModeEnum.disabled
-                logger.warning(
-                    f"Disabling autotracking zooming for {camera_name}: Relative zoom not supported"
-                )
+            self.config.cameras[
+                camera_name
+            ].onvif.autotracking.zooming = ZoomingModeEnum.disabled
+            logger.warning(
+                f"Disabling autotracking zooming for {camera_name}: Relative zoom not supported"
+            )
 
         if move_request.Speed is None:
             move_request.Speed = configs.DefaultPTZSpeed if configs else None
@@ -390,7 +388,11 @@ class OnvifController:
         move_request.Translation.PanTilt.x = pan
         move_request.Translation.PanTilt.y = tilt
 
-        if "zoom-r" in self.cams[camera_name]["features"]:
+        if (
+            "zoom-r" in self.cams[camera_name]["features"]
+            and self.config.cameras[camera_name].onvif.autotracking.zooming
+            == ZoomingModeEnum.relative
+        ):
             move_request.Speed = {
                 "PanTilt": {
                     "x": speed,
@@ -406,7 +408,11 @@ class OnvifController:
         move_request.Translation.PanTilt.x = 0
         move_request.Translation.PanTilt.y = 0
 
-        if "zoom-r" in self.cams[camera_name]["features"]:
+        if (
+            "zoom-r" in self.cams[camera_name]["features"]
+            and self.config.cameras[camera_name].onvif.autotracking.zooming
+            == ZoomingModeEnum.relative
+        ):
             move_request.Translation.Zoom.x = 0
 
         self.cams[camera_name]["active"] = False


### PR DESCRIPTION
This PR fixes a small bug (found in https://github.com/blakeblackshear/frigate/discussions/9855) that may prevent some users from using autotracking when their camera actually supports it. Regardless of the autotracking zooming mode set (absolute or relative), a relative zoom onvif space is required to be set in the RelativeMove request.



