### PR TITLE
Autodetect AMD GPUs for VAAPI GPU stats

### DIFF
--- a/frigate/stats.py
+++ b/frigate/stats.py
@@ -14,7 +14,7 @@ from requests.exceptions import RequestException
 
 from frigate.comms.dispatcher import Dispatcher
 from frigate.config import FrigateConfig
-from frigate.const import CACHE_DIR, CLIPS_DIR, DRIVER_AMD, DRIVER_ENV_VAR, RECORD_DIR
+from frigate.const import CACHE_DIR, CLIPS_DIR, RECORD_DIR
 from frigate.object_detection import ObjectDetectProcess
 from frigate.types import CameraMetricsTypes, StatsTrackingTypes
 from frigate.util.services import (
@@ -24,6 +24,7 @@ from frigate.util.services import (
     get_intel_gpu_stats,
     get_jetson_stats,
     get_nvidia_gpu_stats,
+    is_vaapi_amd_driver,
 )
 from frigate.version import VERSION
 
@@ -205,9 +206,7 @@ async def set_gpu_stats(
                 stats["intel-qsv"] = {"gpu": -1, "mem": -1}
                 hwaccel_errors.append(args)
         elif "vaapi" in args:
-            driver = os.environ.get(DRIVER_ENV_VAR)
-
-            if driver == DRIVER_AMD:
+            if is_vaapi_amd_driver():
                 if not config.telemetry.stats.amd_gpu_stats:
                     continue
 

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -202,10 +202,12 @@ def get_bandwidth_stats(config) -> dict[str, dict]:
 
 
 def is_vaapi_amd_driver() -> bool:
+    # Use the explicitly configured driver, if available
     driver = os.environ.get(DRIVER_ENV_VAR)
     if driver:
         return driver == DRIVER_AMD
 
+    # Otherwise, ask vainfo what is has autodetected
     p = vainfo_hwaccel()
 
     if p.returncode != 0:

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -214,10 +214,11 @@ def is_vaapi_amd_driver() -> bool:
         logger.error(f"Unable to poll vainfo: {p.stderr}")
         return False
     else:
-        output = p.stdout.decode('unicode_escape').split("\n")
+        output = p.stdout.decode("unicode_escape").split("\n")
 
         # VA Info will print out the friendly name of the driver
         return any("AMD Radeon Graphics" in line for line in output)
+
 
 def get_amd_gpu_stats() -> dict[str, str]:
     """Get stats using radeontop."""

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -15,7 +15,12 @@ import psutil
 import py3nvml.py3nvml as nvml
 import requests
 
-from frigate.const import DRIVER_AMD, DRIVER_ENV_VAR, FFMPEG_HWACCEL_NVIDIA, FFMPEG_HWACCEL_VAAPI
+from frigate.const import (
+    DRIVER_AMD,
+    DRIVER_ENV_VAR,
+    FFMPEG_HWACCEL_NVIDIA,
+    FFMPEG_HWACCEL_VAAPI,
+)
 from frigate.util.builtin import clean_camera_user_pass, escape_special_characters
 
 logger = logging.getLogger(__name__)
@@ -195,6 +200,7 @@ def get_bandwidth_stats(config) -> dict[str, dict]:
 
     return usages
 
+
 def is_vaapi_amd_driver() -> bool:
     driver = os.environ.get(DRIVER_ENV_VAR)
     if driver:
@@ -207,6 +213,7 @@ def is_vaapi_amd_driver() -> bool:
         return False
     else:
         output = p.stdout.decode('unicode_escape').split("\n")
+
         # VA Info will print out the friendly name of the driver
         return any("AMD Radeon Graphics" in line for line in output)
 


### PR DESCRIPTION
This simplifies the setup for AMD users and provides configuration portability across AMD & Intel NUCs. Prior to this PR, you can avoid specifying the vaapi driver name on some systems because its auto-detection will find the radeon driver, but the gpu stats logic assumes an intel GPU and gracefully fails. With this PR, an explicitly configured VAAPI driver is still honored as before, but if it is not set then we will try to auto-detect.

I don't have a full dev environment to test this change, but I tested this function by pasting it into a Python shell running in my frigate container.
