### PR TITLE
Update FFmpeg for Rockchip image

### DIFF
--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -9,7 +9,7 @@ COPY docker/rockchip/requirements-wheels-rk.txt /requirements-wheels-rk.txt
 RUN sed -i "/https:\/\//d" /requirements-wheels.txt
 RUN pip3 wheel --wheel-dir=/rk-wheels -c /requirements-wheels.txt -r /requirements-wheels-rk.txt
 
-FROM deps AS rk-deps
+FROM deps AS rk-frigate
 ARG TARGETARCH
 
 RUN --mount=type=bind,from=rk-wheels,source=/rk-wheels,target=/deps/rk-wheels \ 
@@ -28,5 +28,5 @@ ADD https://github.com/MarcA711/rknn-models/releases/download/v1.5.2-rk3588/yolo
 
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffmpeg
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffprobe
-ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.0-1/ffmpeg /usr/lib/btbn-ffmpeg/bin/
-ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.0-1/ffprobe /usr/lib/btbn-ffmpeg/bin/
+ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-1/ffmpeg /usr/lib/btbn-ffmpeg/bin/
+ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-1/ffprobe /usr/lib/btbn-ffmpeg/bin/

--- a/docker/rockchip/rk.hcl
+++ b/docker/rockchip/rk.hcl
@@ -1,9 +1,3 @@
-target wget {
-  dockerfile = "docker/main/Dockerfile"
-  platforms = ["linux/arm64"]
-  target = "wget"
-}
-
 target wheels {
   dockerfile = "docker/main/Dockerfile"
   platforms = ["linux/arm64"]
@@ -25,7 +19,6 @@ target rootfs {
 target rk {
   dockerfile = "docker/rockchip/Dockerfile"
   contexts = {
-    wget = "target:wget",
     wheels = "target:wheels",
     deps = "target:deps",
     rootfs = "target:rootfs"

--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -42,11 +42,6 @@ class Rknn(DetectionApi):
     type_key = DETECTOR_KEY
 
     def __init__(self, config: RknnDetectorConfig):
-        # create symlink for Home Assistant add on
-        if not os.path.isfile("/proc/device-tree/compatible"):
-            if os.path.isfile("/device-tree/compatible"):
-                os.symlink("/device-tree/compatible", "/proc/device-tree/compatible")
-
         # find out SoC
         try:
             with open("/proc/device-tree/compatible") as file:

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -69,8 +69,8 @@ PRESETS_HW_ACCEL_DECODE = {
     FFMPEG_HWACCEL_NVIDIA: "-hwaccel cuda -hwaccel_output_format cuda",
     "preset-jetson-h264": "-c:v h264_nvmpi -resize {1}x{2}",
     "preset-jetson-h265": "-c:v hevc_nvmpi -resize {1}x{2}",
-    "preset-rk-h264": "-c:v h264_rkmpp_decoder",
-    "preset-rk-h265": "-c:v hevc_rkmpp_decoder",
+    "preset-rk-h264": "-hwaccel rkmpp -hwaccel_output_format drm_prime -afbc rga",
+    "preset-rk-h265": "-hwaccel rkmpp -hwaccel_output_format drm_prime -afbc rga",
 }
 PRESETS_HW_ACCEL_DECODE["preset-nvidia-h264"] = PRESETS_HW_ACCEL_DECODE[
     FFMPEG_HWACCEL_NVIDIA
@@ -91,8 +91,8 @@ PRESETS_HW_ACCEL_SCALE = {
     FFMPEG_HWACCEL_NVIDIA: "-r {0} -vf fps={0},scale_cuda=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
     "preset-jetson-h264": "-r {0}",  # scaled in decoder
     "preset-jetson-h265": "-r {0}",  # scaled in decoder
-    "preset-rk-h264": "-r {0} -vf fps={0},scale={1}:{2}",
-    "preset-rk-h265": "-r {0} -vf fps={0},scale={1}:{2}",
+    "preset-rk-h264": "-r {0} -vf scale_rkrga=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
+    "preset-rk-h265": "-r {0} -vf scale_rkrga=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
     "default": "-r {0} -vf fps={0},scale={1}:{2}",
 }
 PRESETS_HW_ACCEL_SCALE["preset-nvidia-h264"] = PRESETS_HW_ACCEL_SCALE[
@@ -111,8 +111,8 @@ PRESETS_HW_ACCEL_ENCODE_BIRDSEYE = {
     FFMPEG_HWACCEL_NVIDIA: "ffmpeg -hide_banner {0} -c:v h264_nvenc -g 50 -profile:v high -level:v auto -preset:v p2 -tune:v ll {1}",
     "preset-jetson-h264": "ffmpeg -hide_banner {0} -c:v h264_nvmpi -profile high {1}",
     "preset-jetson-h265": "ffmpeg -hide_banner {0} -c:v h264_nvmpi -profile high {1}",
-    "preset-rk-h264": "ffmpeg -hide_banner {0} -c:v h264_rkmpp_encoder -profile high {1}",
-    "preset-rk-h265": "ffmpeg -hide_banner {0} -c:v hevc_rkmpp_encoder -profile high {1}",
+    "preset-rk-h264": "ffmpeg -hide_banner {0} -c:v h264_rkmpp -profile:v high {1}",
+    "preset-rk-h265": "ffmpeg -hide_banner {0} -c:v hevc_rkmpp -profile:v high {1}",
     "default": "ffmpeg -hide_banner {0} -c:v libx264 -g 50 -profile:v high -level:v 4.1 -preset:v superfast -tune:v zerolatency {1}",
 }
 PRESETS_HW_ACCEL_ENCODE_BIRDSEYE[
@@ -132,8 +132,8 @@ PRESETS_HW_ACCEL_ENCODE_TIMELAPSE = {
     "preset-nvidia-h265": "ffmpeg -hide_banner -hwaccel cuda -hwaccel_output_format cuda -extra_hw_frames 8 {0} -c:v hevc_nvenc {1}",
     "preset-jetson-h264": "ffmpeg -hide_banner {0} -c:v h264_nvmpi -profile high {1}",
     "preset-jetson-h265": "ffmpeg -hide_banner {0} -c:v hevc_nvmpi -profile high {1}",
-    "preset-rk-h264": "ffmpeg -hide_banner {0} -c:v h264_rkmpp_encoder -profile high {1}",
-    "preset-rk-h265": "ffmpeg -hide_banner {0} -c:v hevc_rkmpp_encoder -profile high {1}",
+    "preset-rk-h264": "ffmpeg -hide_banner {0} -c:v h264_rkmpp -profile:v high {1}",
+    "preset-rk-h265": "ffmpeg -hide_banner {0} -c:v hevc_rkmpp -profile:v high {1}",
     "default": "ffmpeg -hide_banner {0} -c:v libx264 -preset:v ultrafast -tune:v zerolatency {1}",
 }
 PRESETS_HW_ACCEL_ENCODE_TIMELAPSE[


### PR DESCRIPTION
Changelog:
- remove some unnecessary lines in the build files
- update to FFmpeg (now [using the fork from](https://github.com/nyanmisaka/ffmpeg-rockchip) @nyanmisaka) and update presets; this introduces support for rescaling videos in hardware
- remove some lines in rknn.py that were intended to fix https://github.com/blakeblackshear/frigate-hass-addons/issues/145. However, it won't work this way (see further discussion).