### PR TITLE
Fix black bar at bottom of previews

### DIFF
--- a/frigate/output/preview.py
+++ b/frigate/output/preview.py
@@ -131,7 +131,7 @@ class PreviewRecorder:
         self.start_time = 0
         self.last_output_time = 0
         self.output_frames = []
-        self.out_height = 160
+        self.out_height = 180
         self.out_width = (
             int((config.detect.width / config.detect.height) * self.out_height) // 4 * 4
         )


### PR DESCRIPTION
height of 160 caused black bar because aspect ratios did not fit into the frame with an even number of pixels