### PR TITLE
Add yolov8 support to tensorrt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,16 +12,17 @@ services:
     build:
       context: .
       dockerfile: docker/main/Dockerfile
-      # Use target devcontainer-trt for TensorRT dev
       target: devcontainer
-    ## Uncomment this block for nvidia gpu support
+    # Run this command to build the devcontainer with tensorrt support, then uncomment the image and deploy blocks and comment the build block above
+    # ARCH=amd64 docker buildx bake --load --file=docker/tensorrt/trt.hcl --set tensorrt.tags=frigate:devcontainer-trt devcontainer-trt
+    # image: frigate:devcontainer-trt
     # deploy:
-    #       resources:
-    #           reservations:
-    #               devices:
-    #                   - driver: nvidia
-    #                     count: 1
-    #                     capabilities: [gpu]
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: 1
+    #           capabilities: [gpu]
     environment:
       YOLO_MODELS: yolov7-320
     devices:

--- a/docker/tensorrt/trt.hcl
+++ b/docker/tensorrt/trt.hcl
@@ -95,4 +95,5 @@ target "devcontainer-trt" {
   }
   platforms = ["linux/amd64"]
   target = "devcontainer-trt"
+  tags = ["frigate:devcontainer-trt"]
 }

--- a/frigate/detectors/plugins/tensorrt.py
+++ b/frigate/detectors/plugins/tensorrt.py
@@ -300,7 +300,9 @@ class TensorRtDetector(DetectionApi):
             for o in trt_outputs:
                 detections.append(
                     yolov8_postprocess(
-                        self.input_shape[0], o.reshape(self.output_shape[0])
+                        self.input_shape[0],
+                        o.reshape(self.output_shape[0]),
+                        score_threshold=self.conf_th,
                     ),
                 )
             detections = np.concatenate(detections)

--- a/frigate/detectors/plugins/tensorrt.py
+++ b/frigate/detectors/plugins/tensorrt.py
@@ -106,8 +106,8 @@ class TensorRtDetector(DetectionApi):
         for i in range(self.engine.num_bindings):
             name = self.engine.get_tensor_name(i)
             shape = (
-                tuple(self.engine.get_binding_shape(name)),
-                trt.nptype(self.engine.get_binding_dtype(name)),
+                tuple(self.engine.get_tensor_shape(name)),
+                trt.nptype(self.engine.get_tensor_dtype(name)),
             )
             if self.engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT:
                 input_shape = shape

--- a/frigate/detectors/util.py
+++ b/frigate/detectors/util.py
@@ -73,12 +73,8 @@ def yolov8_postprocess(
         boxes = np.stack((cx - w / 2, cy - h / 2, w, h), axis=1)
         indexes = cv2.dnn.NMSBoxes(boxes, confidences, score_threshold, nms_threshold)
         detections = detections[indexes]
-        # if still too many, trim the rest by confidence
-        if detections.shape[0] > box_count:
-            detections = detections[
-                np.argpartition(detections[:, 1], -box_count)[-box_count:]
-            ]
-        detections = detections.copy()
     # sort detections by confidence
     detections = detections[detections[:, 1].argsort()[::-1]]
+    # trim to box_count
+    detections = detections[:box_count]
     return np.resize(detections, (box_count, 6))

--- a/frigate/detectors/util.py
+++ b/frigate/detectors/util.py
@@ -79,5 +79,6 @@ def yolov8_postprocess(
                 np.argpartition(detections[:, 1], -box_count)[-box_count:]
             ]
         detections = detections.copy()
-    detections.resize((box_count, 6))
-    return detections
+    # sort detections by confidence
+    detections = detections[detections[:, 1].argsort()[::-1]]
+    return np.resize(detections, (box_count, 6))


### PR DESCRIPTION
This adds support for yolov8 models generated by the yolo export cli. Models will need to be generated manually by the user before it can be used.

```
yolo export model=yolov8s.pt format=engine imgsz='(640,640)' half
```