### PR TITLE
Reorganize stats

### DIFF
--- a/frigate/stats/emitter.py
+++ b/frigate/stats/emitter.py
@@ -1,0 +1,61 @@
+"""Emit stats to listeners."""
+
+import json
+import logging
+import threading
+import time
+from multiprocessing.synchronize import Event as MpEvent
+
+from frigate.comms.inter_process import InterProcessRequestor
+from frigate.config import FrigateConfig
+from frigate.stats.util import stats_snapshot
+from frigate.types import StatsTrackingTypes
+
+logger = logging.getLogger(__name__)
+
+
+class StatsEmitter(threading.Thread):
+    def __init__(
+        self,
+        config: FrigateConfig,
+        stats_tracking: StatsTrackingTypes,
+        stop_event: MpEvent,
+    ):
+        threading.Thread.__init__(self)
+        self.name = "frigate_stats_emitter"
+        self.config = config
+        self.stats_tracking = stats_tracking
+        self.stop_event = stop_event
+        self.hwaccel_errors: list[str] = []
+        self.stats_history: list[dict[str, any]] = []
+
+        # create communication for stats
+        self.requestor = InterProcessRequestor()
+
+    def get_latest_stats(self) -> dict[str, any]:
+        """Get latest stats."""
+        if len(self.stats_history) > 0:
+            return self.stats_history[-1]
+        else:
+            stats = stats_snapshot(
+                self.config, self.stats_tracking, self.hwaccel_errors
+            )
+            self.stats_history.append(stats)
+            return stats
+
+    def get_stats_history(self) -> list[dict[str, any]]:
+        """Get stats history."""
+        return self.stats_history
+
+    def run(self) -> None:
+        time.sleep(10)
+        while not self.stop_event.wait(self.config.mqtt.stats_interval):
+            logger.debug("Starting stats collection")
+            stats = stats_snapshot(
+                self.config, self.stats_tracking, self.hwaccel_errors
+            )
+            self.stats_history.append(stats)
+            self.stats_history = self.stats_history[-10:]
+            self.requestor.send_data("stats", json.dumps(stats))
+            logger.debug("Finished stats collection")
+        logger.info("Exiting stats emitter...")

--- a/frigate/test/test_http.py
+++ b/frigate/test/test_http.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock
 
 from peewee_migrate import Router
 from playhouse.shortcuts import model_to_dict
@@ -14,6 +14,7 @@ from frigate.config import FrigateConfig
 from frigate.http import create_app
 from frigate.models import Event, Recordings
 from frigate.plus import PlusApi
+from frigate.stats.emitter import StatsEmitter
 from frigate.test.const import TEST_DB, TEST_DB_CLEANUPS
 
 
@@ -119,8 +120,8 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
         id2 = "7890.random"
@@ -155,8 +156,8 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
 
@@ -176,8 +177,8 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
         bad_id = "654321.other"
@@ -196,8 +197,8 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
 
@@ -218,8 +219,8 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
 
@@ -244,8 +245,8 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            None,
             PlusApi(),
+            None,
         )
         morning_id = "123456.random"
         evening_id = "654321.random"
@@ -282,8 +283,8 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
         sub_label = "sub"
@@ -317,8 +318,8 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
         sub_label = "sub"
@@ -342,8 +343,8 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            None,
             PlusApi(),
+            None,
         )
 
         with app.test_client() as client:
@@ -359,8 +360,8 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            None,
             PlusApi(),
+            None,
         )
         id = "123456.random"
 
@@ -370,8 +371,9 @@ class TestHttp(unittest.TestCase):
             assert recording
             assert recording[0]["id"] == id
 
-    @patch("frigate.http.stats_snapshot")
-    def test_stats(self, mock_stats):
+    def test_stats(self):
+        stats = Mock(spec=StatsEmitter)
+        stats.get_latest_stats.return_value = self.test_stats
         app = create_app(
             FrigateConfig(**self.minimal_config).runtime_config(),
             self.db,
@@ -379,14 +381,13 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            None,
             PlusApi(),
+            stats,
         )
-        mock_stats.return_value = self.test_stats
 
         with app.test_client() as client:
-            stats = client.get("/stats").json
-            assert stats == self.test_stats
+            full_stats = client.get("/stats").json
+            assert full_stats == self.test_stats
 
 
 def _insert_mock_event(


### PR DESCRIPTION
This reorganizes the stats in to a class based approach. This allows us to have a cache of the last 10 stats entries which can be used as a short term history for graphs in the UI as well as ensure that the stats api can respond immediately with stats information. 