### PR TITLE
Setting motion masks to zero to improve startup calibration

### DIFF
--- a/frigate/motion/improved_motion.py
+++ b/frigate/motion/improved_motion.py
@@ -96,7 +96,8 @@ class ImprovedMotionDetector(MotionDetector):
 
         # mask frame
         # this has to come after contrast improvement
-        resized_frame[self.mask] = [255]
+        # Setting masked pixels to zero, to match the average frame at startup
+        resized_frame[self.mask] = [0]
 
         resized_frame = gaussian_filter(resized_frame, sigma=1, radius=self.blur_radius)
 


### PR DESCRIPTION
Setting the motion masked areas to zero, rather than 255, will speed up calibration, as the average frame starts out at zero, currently the motion masked areas take the longest time to blend into the average of any region of the frame.

Here's a comparison of frames 1, 11, 21, 31, 41, 51 of startup, with each image column exported in various stages of processing via the [save_images flag in ImprovedMotionDetector](https://github.com/blakeblackshear/frigate/blob/dev/frigate/motion/improved_motion.py#L158)

![bird_box-frames-1to51](https://github.com/blakeblackshear/frigate/assets/2192223/55d77df7-7d7d-4e80-86f3-291f4801faf7)

Switching the motion masked areas to black, will mean they're immediately matched to the average frame and won't risk being considered motion after everything else. The blurred areas around the motion detection should also blend into the average frame faster than their surrounding areas anyway.

The current 255 motion mask doesn't present any issue after startup, so this is only a minor improvement, but this should improve things during system start at least.
