### PR TITLE
Add a section to dev guide on non-local development

### DIFF
--- a/docs/docs/development/contributing.md
+++ b/docs/docs/development/contributing.md
@@ -155,6 +155,12 @@ cd web && npm install
 cd web && npm run dev
 ```
 
+##### 3a. Run the development server against a non-local instance
+
+To run the development server against a non-local instance, you will need to
+replace the `localhost` values in `vite.config.ts` with the IP address of the
+non-local backend server.
+
 #### 4. Making changes
 
 The Web UI is built using [Vite](https://vitejs.dev/), [Preact](https://preactjs.com), and [Tailwind CSS](https://tailwindcss.com).


### PR DESCRIPTION
This adds a section with instructions on editing the source to run the Web UI against a non-local backend server.

There is an existing link that is broken that should be fixed by adding this section.

This resolves #10048