### PR TITLE
Add missing frame_time argument to ObjectTracker.match_and_update()

### DIFF
--- a/frigate/track/__init__.py
+++ b/frigate/track/__init__.py
@@ -5,9 +5,9 @@ from frigate.config import DetectConfig
 
 class ObjectTracker(ABC):
     @abstractmethod
-    def __init__(self, config: DetectConfig):
+    def __init__(self, config: DetectConfig) -> None:
         pass
 
     @abstractmethod
-    def match_and_update(self, detections):
+    def match_and_update(self, frame_time: float, detections) -> None:
         pass


### PR DESCRIPTION
And some little type hints.

Was just digging through the object tracker and noticed the args of the abstract class don't match the implementations.

I wondered whether more of the definition (including two identical methods between the implementations) should be pulled up into the superclass too, but that's a question of architecture. I wasn't sure if both implementations are used anymore

Also, I wondered whether you might be open to me making some PRs defining some types and type hints for the detections and boxes and stuff? 