### PR TITLE
[rknn detector] Add rk3588s to supported SOCs

### DIFF
--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 DETECTOR_KEY = "rknn"
 
-supported_socs = ["rk3562", "rk3566", "rk3568", "rk3588"]
+supported_socs = ["rk3562", "rk3566", "rk3568", "rk3588", "rk3588s"]
 
 yolov8_suffix = {
     "default-yolov8n": "n",


### PR DESCRIPTION
It's the same as rk3588, but running the latest linux kernel SOC Orange Pi 5