### PR TITLE
Rewrite websocket to use tracked state instead of context

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -46,6 +46,7 @@
         "react-hook-form": "^7.48.2",
         "react-icons": "^4.12.0",
         "react-router-dom": "^6.20.1",
+        "react-tracked": "^1.7.11",
         "react-transition-group": "^4.4.5",
         "react-use-websocket": "^4.5.0",
         "recoil": "^0.7.7",
@@ -6498,6 +6499,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/proxy-compare": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.4.0.tgz",
+      "integrity": "sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg=="
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -6725,6 +6731,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-tracked": {
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/react-tracked/-/react-tracked-1.7.11.tgz",
+      "integrity": "sha512-+XXv4dJH7NnLtSD/cPVL9omra4A3KRK91L33owevXZ81r7qF/a9DdCsVZa90jMGht/V1Ym9sasbmidsJykhULQ==",
+      "dependencies": {
+        "proxy-compare": "2.4.0",
+        "use-context-selector": "1.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": "*",
+        "react-native": "*",
+        "scheduler": ">=0.19.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
           "optional": true
         }
       }
@@ -7914,6 +7943,25 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-context-selector": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.4.1.tgz",
+      "integrity": "sha512-Io2ArvcRO+6MWIhkdfMFt+WKQX+Vb++W8DS2l03z/Vw/rz3BclKpM0ynr4LYGyU85Eke+Yx5oIhTY++QR0ZDoA==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": "*",
+        "react-native": "*",
+        "scheduler": ">=0.19.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
           "optional": true
         }
       }

--- a/web/package.json
+++ b/web/package.json
@@ -51,6 +51,7 @@
     "react-hook-form": "^7.48.2",
     "react-icons": "^4.12.0",
     "react-router-dom": "^6.20.1",
+    "react-tracked": "^1.7.11",
     "react-transition-group": "^4.4.5",
     "react-use-websocket": "^4.5.0",
     "recoil": "^0.7.7",

--- a/web/src/api/index.tsx
+++ b/web/src/api/index.tsx
@@ -1,9 +1,8 @@
 import { baseUrl } from "./baseUrl";
-import useSWR, { SWRConfig } from "swr";
+import { SWRConfig } from "swr";
 import { WsProvider } from "./ws";
 import axios from "axios";
 import { ReactNode } from "react";
-import { FrigateConfig } from "@/types/frigateConfig";
 
 axios.defaults.baseURL = `${baseUrl}api/`;
 
@@ -38,9 +37,7 @@ type WsWithConfigType = {
 };
 
 function WsWithConfig({ children }: WsWithConfigType) {
-  const { data } = useSWR<FrigateConfig>("config");
-
-  return data ? <WsProvider config={data}>{children}</WsProvider> : children;
+  return <WsProvider>{children}</WsProvider>;
 }
 
 export function useApiHost() {

--- a/web/src/components/dynamic/NewReviewData.tsx
+++ b/web/src/components/dynamic/NewReviewData.tsx
@@ -1,0 +1,67 @@
+import { useFrigateReviews } from "@/api/ws";
+import { ReviewSeverity } from "@/types/review";
+import { Button } from "../ui/button";
+import { LuRefreshCcw } from "react-icons/lu";
+import { MutableRefObject, useEffect, useState } from "react";
+
+type NewReviewDataProps = {
+  className: string;
+  contentRef: MutableRefObject<HTMLDivElement | null>;
+  severity: ReviewSeverity;
+  pullLatestData: () => void;
+};
+export default function NewReviewData({
+  className,
+  contentRef,
+  severity,
+  pullLatestData,
+}: NewReviewDataProps) {
+  const { payload: review } = useFrigateReviews();
+
+  const [reviewId, setReviewId] = useState("");
+  const [hasUpdate, setHasUpdate] = useState(false);
+
+  useEffect(() => {
+    if (!review) {
+      return;
+    }
+
+    if (review.type == "end" && review.review.severity == severity) {
+      setReviewId(review.review.id);
+    }
+  }, [review]);
+
+  useEffect(() => {
+    if (reviewId != "") {
+      setHasUpdate(true);
+    }
+  }, [reviewId]);
+
+  return (
+    <div className={className}>
+      <div className="flex justify-center items-center mr-[100px]">
+        <Button
+          className={`${
+            hasUpdate
+              ? "animate-in slide-in-from-top duration-500"
+              : "invisible"
+          }  text-center mt-5 mx-auto bg-gray-400 text-white`}
+          variant="secondary"
+          onClick={() => {
+            setHasUpdate(false);
+            pullLatestData();
+            if (contentRef.current) {
+              contentRef.current.scrollTo({
+                top: 0,
+                behavior: "smooth",
+              });
+            }
+          }}
+        >
+          <LuRefreshCcw className="w-4 h-4 mr-2" />
+          New Items To Review
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Events.tsx
+++ b/web/src/pages/Events.tsx
@@ -1,4 +1,3 @@
-import { useFrigateReviews } from "@/api/ws";
 import useApiFilter from "@/hooks/use-api-filter";
 import useOverlayState from "@/hooks/use-overlay-state";
 import { ReviewFilter, ReviewSegment, ReviewSeverity } from "@/types/review";
@@ -6,7 +5,7 @@ import DesktopEventView from "@/views/events/DesktopEventView";
 import DesktopRecordingView from "@/views/events/DesktopRecordingView";
 import MobileEventView from "@/views/events/MobileEventView";
 import axios from "axios";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { isMobile } from "react-device-detect";
 import useSWR from "swr";
 import useSWRInfinite from "swr/infinite";
@@ -102,7 +101,7 @@ export default function Events() {
   const reloadData = useCallback(() => {
     setSize(1);
     updateSegments();
-  }, [])
+  }, []);
 
   // preview videos
 
@@ -201,24 +200,6 @@ export default function Events() {
     };
   }, [selectedReviewId, reviewPages]);
 
-  // review updates
-
-  const { payload: reviewUpdate } = useFrigateReviews();
-  const [hasUpdate, setHasUpdate] = useState(false);
-  useEffect(() => {
-    if (!reviewUpdate || hasUpdate) {
-      return;
-    }
-
-    if (
-      reviewUpdate.type == "end" &&
-      reviewUpdate.review.severity == severity
-    ) {
-      setHasUpdate(true);
-      return;
-    }
-  }, [reviewUpdate]);
-
   if (selectedData) {
     return (
       <DesktopRecordingView
@@ -236,9 +217,7 @@ export default function Events() {
           reachedEnd={isDone}
           isValidating={isValidating}
           severity={severity}
-          hasUpdate={hasUpdate}
           setSeverity={setSeverity}
-          setHasUpdate={setHasUpdate}
           loadNextPage={onLoadNextPage}
           markItemAsReviewed={markItemAsReviewed}
           pullLatestData={reloadData}
@@ -255,9 +234,7 @@ export default function Events() {
         isValidating={isValidating}
         filter={reviewFilter}
         severity={severity}
-        hasUpdate={hasUpdate}
         setSeverity={setSeverity}
-        setHasUpdate={setHasUpdate}
         loadNextPage={onLoadNextPage}
         markItemAsReviewed={markItemAsReviewed}
         onSelectReview={setSelectedReviewId}

--- a/web/src/views/events/DesktopEventView.tsx
+++ b/web/src/views/events/DesktopEventView.tsx
@@ -94,7 +94,7 @@ export default function DesktopEventView({
     }
 
     return contentRef.current.scrollHeight > contentRef.current.clientHeight;
-  }, [contentRef.current?.scrollHeight]);
+  }, [contentRef.current?.scrollHeight, severity]);
 
   // review interaction
 

--- a/web/src/views/events/DesktopEventView.tsx
+++ b/web/src/views/events/DesktopEventView.tsx
@@ -1,13 +1,13 @@
+import NewReviewData from "@/components/dynamic/NewReviewData";
 import ReviewFilterGroup from "@/components/filter/ReviewFilterGroup";
 import PreviewThumbnailPlayer from "@/components/player/PreviewThumbnailPlayer";
 import EventReviewTimeline from "@/components/timeline/EventReviewTimeline";
 import ActivityIndicator from "@/components/ui/activity-indicator";
-import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { ReviewFilter, ReviewSegment, ReviewSeverity } from "@/types/review";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { LuFolderCheck, LuRefreshCcw } from "react-icons/lu";
+import { LuFolderCheck } from "react-icons/lu";
 import { MdCircle } from "react-icons/md";
 import useSWR from "swr";
 
@@ -19,9 +19,7 @@ type DesktopEventViewProps = {
   isValidating: boolean;
   filter?: ReviewFilter;
   severity: ReviewSeverity;
-  hasUpdate: boolean;
   setSeverity: (severity: ReviewSeverity) => void;
-  setHasUpdate: (hasUpdated: boolean) => void;
   loadNextPage: () => void;
   markItemAsReviewed: (reviewId: string) => void;
   onSelectReview: (reviewId: string) => void;
@@ -36,9 +34,7 @@ export default function DesktopEventView({
   isValidating,
   filter,
   severity,
-  hasUpdate,
   setSeverity,
-  setHasUpdate,
   loadNextPage,
   markItemAsReviewed,
   onSelectReview,
@@ -235,33 +231,12 @@ export default function DesktopEventView({
           ref={contentRef}
           className="flex flex-1 flex-wrap content-start gap-2 overflow-y-auto no-scrollbar"
         >
-          {hasUpdate && (
-            <div className="absolute w-full z-30">
-              <div className="flex justify-center items-center mr-[100px]">
-                <Button
-                  className={`${
-                    hasUpdate
-                      ? "animate-in slide-in-from-top duration-500"
-                      : "invisible"
-                  }  text-center mt-5 mx-auto bg-gray-400 text-white`}
-                  variant="secondary"
-                  onClick={() => {
-                    setHasUpdate(false);
-                    pullLatestData();
-                    if (contentRef.current) {
-                      contentRef.current.scrollTo({
-                        top: 0,
-                        behavior: "smooth",
-                      });
-                    }
-                  }}
-                >
-                  <LuRefreshCcw className="w-4 h-4 mr-2" />
-                  New Items To Review
-                </Button>
-              </div>
-            </div>
-          )}
+          <NewReviewData
+            className="absolute w-full z-30"
+            contentRef={contentRef}
+            severity={severity}
+            pullLatestData={pullLatestData}
+          />
 
           {reachedEnd && currentItems == null && (
             <div className="w-full h-full flex flex-col justify-center items-center">

--- a/web/src/views/events/MobileEventView.tsx
+++ b/web/src/views/events/MobileEventView.tsx
@@ -1,11 +1,10 @@
+import NewReviewData from "@/components/dynamic/NewReviewData";
 import PreviewThumbnailPlayer from "@/components/player/PreviewThumbnailPlayer";
 import ActivityIndicator from "@/components/ui/activity-indicator";
-import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { ReviewSegment, ReviewSeverity } from "@/types/review";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { LuRefreshCcw } from "react-icons/lu";
 import { MdCircle } from "react-icons/md";
 import useSWR from "swr";
 
@@ -15,9 +14,7 @@ type MobileEventViewProps = {
   reachedEnd: boolean;
   isValidating: boolean;
   severity: ReviewSeverity;
-  hasUpdate: boolean;
   setSeverity: (severity: ReviewSeverity) => void;
-  setHasUpdate: (hasUpdated: boolean) => void;
   loadNextPage: () => void;
   markItemAsReviewed: (reviewId: string) => void;
   pullLatestData: () => void;
@@ -28,9 +25,7 @@ export default function MobileEventView({
   reachedEnd,
   isValidating,
   severity,
-  hasUpdate,
   setSeverity,
-  setHasUpdate,
   loadNextPage,
   markItemAsReviewed,
   pullLatestData,
@@ -209,33 +204,12 @@ export default function MobileEventView({
         </ToggleGroupItem>
       </ToggleGroup>
 
-      {hasUpdate && (
-        <div className="absolute w-full z-30">
-          <div className="flex justify-center items-center">
-            <Button
-              className={`${
-                hasUpdate
-                  ? "animate-in slide-in-from-top duration-500"
-                  : "invisible"
-              }  text-center mt-5 mx-auto bg-gray-400 text-white`}
-              variant="secondary"
-              onClick={() => {
-                setHasUpdate(false);
-                pullLatestData();
-                if (contentRef.current) {
-                  contentRef.current.scrollTo({
-                    top: 0,
-                    behavior: "smooth",
-                  });
-                }
-              }}
-            >
-              <LuRefreshCcw className="w-4 h-4 mr-2" />
-              New Items To Review
-            </Button>
-          </div>
-        </div>
-      )}
+      <NewReviewData
+        className="absolute w-full z-30"
+        contentRef={contentRef}
+        severity={severity}
+        pullLatestData={pullLatestData}
+      />
 
       <div
         ref={contentRef}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -12,24 +12,24 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',
+        target: 'http://192.168.50.106:5000',
         ws: true,
       },
       '/vod': {
-        target: 'http://localhost:5000'
+        target: 'http://192.168.50.106:5000'
       },
       '/clips': {
-        target: 'http://localhost:5000'
+        target: 'http://192.168.50.106:5000'
       },
       '/exports': {
-        target: 'http://localhost:5000'
+        target: 'http://192.168.50.106:5000'
       },
       '/ws': {
-        target: 'ws://localhost:5000',
+        target: 'ws://192.168.50.106:5000',
         ws: true,
       },
       '/live': {
-        target: 'ws://localhost:5000',
+        target: 'ws://192.168.50.106:5000',
         changeOrigin: true,
         ws: true,
       },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -12,24 +12,24 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://192.168.50.106:5000',
+        target: 'http://localhost:5000',
         ws: true,
       },
       '/vod': {
-        target: 'http://192.168.50.106:5000'
+        target: 'http://localhost:5000'
       },
       '/clips': {
-        target: 'http://192.168.50.106:5000'
+        target: 'http://localhost:5000'
       },
       '/exports': {
-        target: 'http://192.168.50.106:5000'
+        target: 'http://localhost:5000'
       },
       '/ws': {
-        target: 'ws://192.168.50.106:5000',
+        target: 'ws://localhost:5000',
         ws: true,
       },
       '/live': {
-        target: 'ws://192.168.50.106:5000',
+        target: 'ws://localhost:5000',
         changeOrigin: true,
         ws: true,
       },


### PR DESCRIPTION
React contexts force all children to rerender even if props did not change. This meant that with audio enabled the entire page rerendered multiple times per second causing extreme performance issues. 

React tracked allows us to only update children when the specific part of the state that they listen to updates