### PR TITLE
Fix permission error accessing /run/secrets

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -50,7 +50,7 @@ DEFAULT_TIME_FORMAT = "%m/%d/%Y %H:%M:%S"
 
 FRIGATE_ENV_VARS = {k: v for k, v in os.environ.items() if k.startswith("FRIGATE_")}
 # read docker secret files as env vars too
-if os.path.isdir("/run/secrets"):
+if os.path.isdir("/run/secrets") and os.access("/run/secrets", os.R_OK):
     for secret_file in os.listdir("/run/secrets"):
         if secret_file.startswith("FRIGATE_"):
             FRIGATE_ENV_VARS[secret_file] = Path(

--- a/frigate/plus.py
+++ b/frigate/plus.py
@@ -37,8 +37,10 @@ class PlusApi:
         self.key = None
         if PLUS_ENV_VAR in os.environ:
             self.key = os.environ.get(PLUS_ENV_VAR)
-        elif os.path.isdir("/run/secrets") and PLUS_ENV_VAR in os.listdir(
-            "/run/secrets"
+        elif (
+            os.path.isdir("/run/secrets")
+            and os.access("/run/secrets", os.R_OK)
+            and PLUS_ENV_VAR in os.listdir("/run/secrets")
         ):
             self.key = Path(os.path.join("/run/secrets", PLUS_ENV_VAR)).read_text()
         # check for the addon options file


### PR DESCRIPTION
Checks that the service has read access to the directory before trying to read it

I'm using NixOS and have a /run/secrets outside of Docker but it is only accessible by root and the `frigate` user my service is running as does not have access. `PermissionError: [Errno 13] Permission denied: '/run/secrets'` 

Version: 0.13.2
