### PR TITLE
Fix overflowing review timeline on mobile

### DIFF
--- a/web/src/components/timeline/EventReviewTimeline.tsx
+++ b/web/src/components/timeline/EventReviewTimeline.tsx
@@ -184,7 +184,7 @@ export function EventReviewTimeline({
             >
               <div
                 className={`bg-destructive rounded-full mx-auto ${
-                  segmentDuration < 60 ? "w-14 md:w-20" : "w-12 md:w-16"
+                  segmentDuration < 60 ? "w-16 md:w-20" : "w-12 md:w-16"
                 } h-5 flex items-center justify-center`}
               >
                 <div

--- a/web/src/views/events/RecordingView.tsx
+++ b/web/src/views/events/RecordingView.tsx
@@ -81,7 +81,7 @@ export default function RecordingView({
   }, [scrubbing]);
 
   return (
-    <div ref={contentRef} className="relative w-full h-full">
+    <div ref={contentRef} className="flex flex-col relative w-full h-full">
       <Button
         className="md:absolute md:top-0 md:left-0 rounded-lg"
         onClick={() => navigate(-1)}
@@ -110,7 +110,7 @@ export default function RecordingView({
         />
       </div>
 
-      <div className="md:absolute md:w-[100px] md:inset-y-0 md:right-0">
+      <div className="flex-grow overflow-hidden md:absolute md:w-[100px] md:inset-y-0 md:right-0">
         <EventReviewTimeline
           segmentDuration={30}
           timestampSpread={15}


### PR DESCRIPTION
The review timeline on the full recordings view was overflowing and obscuring the video and back button.