### PR TITLE
Fix: rename docker images and tags in Jetson configuration docs

### DIFF
--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -286,10 +286,10 @@ These instructions were originally based on the [Jellyfin documentation](https:/
 
 ## NVIDIA Jetson (Orin AGX, Orin NX, Orin Nano\*, Xavier AGX, Xavier NX, TX2, TX1, Nano)
 
-A separate set of docker images is available that is based on Jetpack/L4T. They comes with an `ffmpeg` build
+We provide docker images that are based on Jetpack/L4T. They come with an `ffmpeg` build
 with codecs that use the Jetson's dedicated media engine. If your Jetson host is running Jetpack 4.6, use the
-`frigate-tensorrt-jp4` image, or if your Jetson host is running Jetpack 5.0+, use the `frigate-tensorrt-jp5`
-image. Note that the Orin Nano has no video encoder, so frigate will use software encoding on this platform,
+`stable-tensorrt-jp4` tagged image, or if your Jetson host is running Jetpack 5.0+, use the `stable-tensorrt-jp5`
+tagged image. Note that the Orin Nano has no video encoder, so frigate will use software encoding on this platform,
 but the image will still allow hardware decoding and tensorrt object detection.
 
 You will need to use the image with the nvidia container runtime:
@@ -300,7 +300,7 @@ You will need to use the image with the nvidia container runtime:
 docker run -d \
   ...
   --runtime nvidia
-  ghcr.io/blakeblackshear/frigate-tensorrt-jp5
+  ghcr.io/blakeblackshear/frigate:stable-tensorrt-jp5
 ```
 
 ### Docker Compose - Jetson
@@ -310,7 +310,7 @@ version: '2.4'
 services:
   frigate:
     ...
-    image: ghcr.io/blakeblackshear/frigate-tensorrt-jp5
+    image: ghcr.io/blakeblackshear/frigate:stable-tensorrt-jp5
     runtime: nvidia   # Add this
 ```
 

--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -286,7 +286,7 @@ These instructions were originally based on the [Jellyfin documentation](https:/
 
 ## NVIDIA Jetson (Orin AGX, Orin NX, Orin Nano\*, Xavier AGX, Xavier NX, TX2, TX1, Nano)
 
-We provide docker images that are based on Jetpack/L4T. They come with an `ffmpeg` build
+A separate set of docker images is available that is based on Jetpack/L4T. They come with an `ffmpeg` build
 with codecs that use the Jetson's dedicated media engine. If your Jetson host is running Jetpack 4.6, use the
 `stable-tensorrt-jp4` tagged image, or if your Jetson host is running Jetpack 5.0+, use the `stable-tensorrt-jp5`
 tagged image. Note that the Orin Nano has no video encoder, so frigate will use software encoding on this platform,


### PR DESCRIPTION
The image names/tags for Jetson instructions were incorrect. I have updated the docs to point to the correct images and demonstrate the correct use of the tags.