### PR TITLE
Set Compute Level for CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
           tags: ${{ steps.setup.outputs.image-name }}-amd64
           cache-from: type=registry,ref=${{ steps.setup.outputs.cache-name }}-amd64
       - name: Build and push TensorRT (x86 GPU)
+        env:
+          COMPUTE_LEVEL: "50 60 70 80 90"
         uses: docker/bake-action@v4
         with:
           push: true


### PR DESCRIPTION
Previous PR missed setting this arg for the CI builds.

I think this is the correct place to insert this value?