### PR TITLE
Scrolling fixes and motion timeline changes

### DIFF
--- a/web/src/components/timeline/EventSegment.tsx
+++ b/web/src/components/timeline/EventSegment.tsx
@@ -17,6 +17,7 @@ import {
 import { HoverCardPortal } from "@radix-ui/react-hover-card";
 import scrollIntoView from "scroll-into-view-if-needed";
 import { MinimapBounds, Tick, Timestamp } from "./segment-metadata";
+import useTapUtils from "@/hooks/use-tap-utils";
 
 type EventSegmentProps = {
   events: ReviewSegment[];
@@ -87,6 +88,8 @@ export function EventSegment({
   }, [getEventStart, segmentTime]);
 
   const apiHost = useApiHost();
+
+  const { handleTouchStart } = useTapUtils();
 
   const eventThumbnail = useMemo(() => {
     return getEventThumbnail(segmentTime);
@@ -227,6 +230,9 @@ export function EventSegment({
                     key={`${segmentKey}_${index}_primary_data`}
                     className={`w-full h-2 bg-gradient-to-r ${roundBottomPrimary ? "rounded-bl-full rounded-br-full" : ""} ${roundTopPrimary ? "rounded-tl-full rounded-tr-full" : ""} ${severityColors[severityValue]}`}
                     onClick={segmentClick}
+                    onTouchStart={(event) =>
+                      handleTouchStart(event, segmentClick)
+                    }
                   ></div>
                 </HoverCardTrigger>
                 <HoverCardPortal>

--- a/web/src/components/timeline/MotionReviewTimeline.tsx
+++ b/web/src/components/timeline/MotionReviewTimeline.tsx
@@ -97,7 +97,7 @@ export function MotionReviewTimeline({
           showMinimap={showMinimap}
           minimapStartTime={minimapStartTime}
           minimapEndTime={minimapEndTime}
-          contentRef={contentRef}
+          setHandlebarTime={setHandlebarTime}
         />
       );
     });

--- a/web/src/components/timeline/ReviewTimeline.tsx
+++ b/web/src/components/timeline/ReviewTimeline.tsx
@@ -44,7 +44,7 @@ export function ReviewTimeline({
       onTouchMove={handleMouseMove}
       onMouseUp={handleMouseUp}
       onTouchEnd={handleMouseUp}
-      className={`relative h-full overflow-y-scroll no-scrollbar bg-secondary ${
+      className={`relative h-full overflow-y-auto no-scrollbar bg-secondary ${
         isDragging && showHandlebar ? "cursor-grabbing" : "cursor-auto"
       }`}
     >
@@ -64,7 +64,7 @@ export function ReviewTimeline({
             >
               <div
                 className={`bg-destructive rounded-full mx-auto ${
-                  segmentDuration < 60 ? "w-14 md:w-20" : "w-12 md:w-16"
+                  segmentDuration < 60 ? "w-12 md:w-20" : "w-12 md:w-16"
                 } h-5 flex items-center justify-center`}
               >
                 <div

--- a/web/src/hooks/use-handle-dragging.ts
+++ b/web/src/hooks/use-handle-dragging.ts
@@ -200,14 +200,12 @@ function useDraggableHandler({
           let newPosition = clientYPosition;
 
           if (draggingAtTopEdge) {
-            newPosition =
-              scrolled - (isMobile ? segmentHeight : segmentHeight * 2);
+            newPosition = scrolled - segmentHeight;
             timelineRef.current.scrollTop = newPosition;
           }
 
           if (draggingAtBottomEdge) {
-            newPosition =
-              scrolled + (isMobile ? segmentHeight : segmentHeight * 2);
+            newPosition = scrolled + segmentHeight;
             timelineRef.current.scrollTop = newPosition;
           }
         }

--- a/web/src/hooks/use-handle-dragging.ts
+++ b/web/src/hooks/use-handle-dragging.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { isDesktop, isMobile } from "react-device-detect";
 import scrollIntoView from "scroll-into-view-if-needed";
-import { isMobile } from "react-device-detect";
 
 type DragHandlerProps = {
   contentRef: React.RefObject<HTMLElement>;
@@ -34,15 +34,55 @@ function useDraggableHandler({
   isDragging,
   setIsDragging,
 }: DragHandlerProps) {
+  const [clientYPosition, setClientYPosition] = useState<number | null>(null);
+
+  const draggingAtTopEdge = useMemo(() => {
+    if (clientYPosition && timelineRef.current) {
+      return (
+        clientYPosition - timelineRef.current.offsetTop <
+          timelineRef.current.clientHeight * 0.03 && isDragging
+      );
+    }
+  }, [clientYPosition, timelineRef, isDragging]);
+
+  const draggingAtBottomEdge = useMemo(() => {
+    if (clientYPosition && timelineRef.current) {
+      return (
+        clientYPosition >
+          (timelineRef.current.clientHeight + timelineRef.current.offsetTop) *
+            0.97 && isDragging
+      );
+    }
+  }, [clientYPosition, timelineRef, isDragging]);
+
+  const getClientYPosition = useCallback(
+    (
+      e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
+    ) => {
+      let clientY;
+      if (isMobile && e.nativeEvent instanceof TouchEvent) {
+        clientY = e.nativeEvent.touches[0].clientY;
+      } else if (e.nativeEvent instanceof MouseEvent) {
+        clientY = e.nativeEvent.clientY;
+      }
+
+      if (clientY) {
+        setClientYPosition(clientY);
+      }
+    },
+    [setClientYPosition],
+  );
+
   const handleMouseDown = useCallback(
     (
       e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
     ) => {
       e.preventDefault();
       e.stopPropagation();
+      getClientYPosition(e);
       setIsDragging(true);
     },
-    [setIsDragging],
+    [setIsDragging, getClientYPosition],
   );
 
   const handleMouseUp = useCallback(
@@ -84,7 +124,7 @@ function useDraggableHandler({
             ).toLocaleTimeString([], {
               hour: "2-digit",
               minute: "2-digit",
-              ...(segmentDuration < 60 && { second: "2-digit" }),
+              ...(segmentDuration < 60 && isDesktop && { second: "2-digit" }),
             });
             if (scrollTimeline) {
               scrollIntoView(thumb, {
@@ -115,20 +155,24 @@ function useDraggableHandler({
         return;
       }
 
-      let clientY;
-      if (isMobile && e.nativeEvent instanceof TouchEvent) {
-        clientY = e.nativeEvent.touches[0].clientY;
-      } else if (e.nativeEvent instanceof MouseEvent) {
-        clientY = e.nativeEvent.clientY;
-      }
+      getClientYPosition(e);
+    },
 
-      e.preventDefault();
-      e.stopPropagation();
+    [contentRef, scrollTimeRef, timelineRef, getClientYPosition],
+  );
 
-      if (showHandlebar && isDragging && clientY) {
+  useEffect(() => {
+    let animationFrameId: number | null = null;
+
+    const handleScroll = () => {
+      if (
+        timelineRef.current &&
+        showHandlebar &&
+        isDragging &&
+        clientYPosition
+      ) {
         const {
           scrollHeight: timelineHeight,
-          clientHeight: visibleTimelineHeight,
           scrollTop: scrolled,
           offsetTop: timelineTop,
         } = timelineRef.current;
@@ -139,10 +183,11 @@ function useDraggableHandler({
         const parentScrollTop = getCumulativeScrollTop(timelineRef.current);
 
         const newHandlePosition = Math.min(
-          visibleTimelineHeight + parentScrollTop,
+          segmentHeight * (timelineDuration / segmentDuration) -
+            segmentHeight * 2,
           Math.max(
             segmentHeight + scrolled,
-            clientY - timelineTop + parentScrollTop,
+            clientYPosition - timelineTop + parentScrollTop,
           ),
         );
 
@@ -151,14 +196,26 @@ function useDraggableHandler({
           timelineStart - segmentIndex * segmentDuration,
         );
 
-        const scrollTimeline =
-          clientY < visibleTimelineHeight * 0.1 ||
-          clientY > visibleTimelineHeight * 0.9;
+        if (draggingAtTopEdge || draggingAtBottomEdge) {
+          let newPosition = clientYPosition;
+
+          if (draggingAtTopEdge) {
+            newPosition =
+              scrolled - (isMobile ? segmentHeight : segmentHeight * 2);
+            timelineRef.current.scrollTop = newPosition;
+          }
+
+          if (draggingAtBottomEdge) {
+            newPosition =
+              scrolled + (isMobile ? segmentHeight : segmentHeight * 2);
+            timelineRef.current.scrollTop = newPosition;
+          }
+        }
 
         updateHandlebarPosition(
           newHandlePosition - segmentHeight,
           segmentStartTime,
-          scrollTimeline,
+          false,
           false,
         );
 
@@ -168,22 +225,41 @@ function useDraggableHandler({
               (newHandlePosition / segmentHeight) * segmentDuration,
           );
         }
+
+        if (draggingAtTopEdge || draggingAtBottomEdge) {
+          animationFrameId = requestAnimationFrame(handleScroll);
+        }
       }
-    },
+    };
+
+    const startScroll = () => {
+      if (isDragging) {
+        handleScroll();
+      }
+    };
+
+    const stopScroll = () => {
+      if (animationFrameId !== null) {
+        cancelAnimationFrame(animationFrameId);
+      }
+    };
+
+    startScroll();
+
+    return stopScroll;
     // we know that these deps are correct
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      isDragging,
-      contentRef,
-      segmentDuration,
-      showHandlebar,
-      timelineDuration,
-      timelineStart,
-      updateHandlebarPosition,
-      alignStartDateToTimeline,
-      getCumulativeScrollTop,
-    ],
-  );
+  }, [
+    clientYPosition,
+    isDragging,
+    segmentDuration,
+    timelineStart,
+    timelineDuration,
+    timelineRef,
+    draggingAtTopEdge,
+    draggingAtBottomEdge,
+    showHandlebar,
+  ]);
 
   useEffect(() => {
     if (

--- a/web/src/hooks/use-motion-segment-utils.ts
+++ b/web/src/hooks/use-motion-segment-utils.ts
@@ -66,9 +66,25 @@ export const useMotionSegmentUtils = (
     [motion_events, getSegmentStart, getSegmentEnd],
   );
 
+  const getMotionStart = useCallback(
+    (time: number): number => {
+      const matchingEvent = motion_events.find((event) => {
+        return (
+          time >= getSegmentStart(event.start_time) &&
+          time < getSegmentEnd(event.start_time) &&
+          event.motion
+        );
+      });
+
+      return matchingEvent?.start_time ?? 0;
+    },
+    [motion_events, getSegmentStart, getSegmentEnd],
+  );
+
   return {
     getMotionSegmentValue,
     getAudioSegmentValue,
     interpolateMotionAudioData,
+    getMotionStart,
   };
 };

--- a/web/src/hooks/use-tap-utils.ts
+++ b/web/src/hooks/use-tap-utils.ts
@@ -1,0 +1,36 @@
+import { useCallback } from "react";
+
+interface TapUtils {
+  handleTouchStart: (
+    event: React.TouchEvent<Element>,
+    onClick: () => void,
+  ) => void;
+}
+
+const useTapUtils = (): TapUtils => {
+  const handleTouchStart = useCallback(
+    (event: React.TouchEvent<Element>, onClick: () => void) => {
+      event.preventDefault();
+
+      const element = event.target as Element;
+      const { clientX, clientY } = event.changedTouches[0];
+
+      // Determine if the touch is within the element's bounds
+      const rect = element.getBoundingClientRect();
+      if (
+        clientX >= rect.left &&
+        clientX <= rect.right &&
+        clientY >= rect.top &&
+        clientY <= rect.bottom
+      ) {
+        // Call the onClick handler
+        onClick();
+      }
+    },
+    [],
+  );
+
+  return { handleTouchStart };
+};
+
+export default useTapUtils;

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -658,38 +658,40 @@ function MotionReview({
 
   return (
     <>
-      <div
-        ref={contentRef}
-        className="w-full h-min m-2 grid sm:grid-cols-2 xl:grid-cols-3 3xl:grid-cols-4 gap-2 md:gap-4 overflow-auto no-scrollbar"
-      >
-        {reviewCameras.map((camera) => {
-          let grow;
-          const aspectRatio = camera.detect.width / camera.detect.height;
-          if (aspectRatio > 2) {
-            grow = "sm:col-span-2 aspect-wide";
-          } else if (aspectRatio < 1) {
-            grow = "md:row-span-2 md:h-full aspect-tall";
-          } else {
-            grow = "aspect-video";
-          }
-          return (
-            <DynamicVideoPlayer
-              key={camera.name}
-              className={`${grow}`}
-              camera={camera.name}
-              timeRange={timeRangeSegments.ranges[selectedRangeIdx]}
-              cameraPreviews={relevantPreviews || []}
-              previewOnly
-              onControllerReady={(controller) => {
-                videoPlayersRef.current[camera.name] = controller;
-                setPlayerReady(true);
-              }}
-              onClick={() =>
-                onSelectReview(`motion,${camera.name},${currentTime}`, false)
-              }
-            />
-          );
-        })}
+      <div className="flex flex-1 flex-wrap content-start gap-2 md:gap-4 overflow-y-auto no-scrollbar">
+        <div
+          ref={contentRef}
+          className="w-full m-2 grid sm:grid-cols-2 xl:grid-cols-3 3xl:grid-cols-4 gap-2 md:gap-4 overflow-auto no-scrollbar"
+        >
+          {reviewCameras.map((camera) => {
+            let grow;
+            const aspectRatio = camera.detect.width / camera.detect.height;
+            if (aspectRatio > 2) {
+              grow = "sm:col-span-2 aspect-wide";
+            } else if (aspectRatio < 1) {
+              grow = "md:row-span-2 md:h-full aspect-tall";
+            } else {
+              grow = "aspect-video";
+            }
+            return (
+              <DynamicVideoPlayer
+                key={camera.name}
+                className={`${grow}`}
+                camera={camera.name}
+                timeRange={timeRangeSegments.ranges[selectedRangeIdx]}
+                cameraPreviews={relevantPreviews || []}
+                previewOnly
+                onControllerReady={(controller) => {
+                  videoPlayersRef.current[camera.name] = controller;
+                  setPlayerReady(true);
+                }}
+                onClick={() =>
+                  onSelectReview(`motion,${camera.name},${currentTime}`, false)
+                }
+              />
+            );
+          })}
+        </div>
       </div>
       <div className="w-[55px] md:w-[100px] mt-2 overflow-y-auto no-scrollbar">
         <MotionReviewTimeline


### PR DESCRIPTION
- review timeline scroll behavior is much improved: drag the handlebar near the top or bottom and the timeline will scroll
- change motion review timeline show motion only (remove audio)
- clicking on segments on motion review timeline will move the handlebar 
- enabled tapping on event and motion review segments on mobile
- wrap motion review grid in flexbox so timeline remains expected width