### PR TITLE
Ability to add, edit, and delete camera groups in the UI

### DIFF
--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -159,9 +159,9 @@ def config():
     config["plus"] = {"enabled": current_app.plus_api.is_active()}
 
     for detector, detector_config in config["detectors"].items():
-        detector_config["model"][
-            "labelmap"
-        ] = current_app.frigate_config.model.merged_labelmap
+        detector_config["model"]["labelmap"] = (
+            current_app.frigate_config.model.merged_labelmap
+        )
 
     return jsonify(config)
 

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -159,9 +159,9 @@ def config():
     config["plus"] = {"enabled": current_app.plus_api.is_active()}
 
     for detector, detector_config in config["detectors"].items():
-        detector_config["model"]["labelmap"] = (
-            current_app.frigate_config.model.merged_labelmap
-        )
+        detector_config["model"][
+            "labelmap"
+        ] = current_app.frigate_config.model.merged_labelmap
 
     return jsonify(config)
 
@@ -292,7 +292,7 @@ def config_set():
             f.close()
         # Validate the config schema
         try:
-            FrigateConfig.parse_raw(new_raw_config)
+            config_obj = FrigateConfig.parse_raw(new_raw_config)
         except Exception:
             with open(config_file, "w") as f:
                 f.write(old_raw_config)
@@ -312,6 +312,13 @@ def config_set():
         return make_response(
             jsonify({"success": False, "message": "Error updating config"}),
             500,
+        )
+
+    json = request.get_json(silent=True) or {}
+
+    if json.get("requires_restart", 1) == 0:
+        current_app.frigate_config = FrigateConfig.runtime_config(
+            config_obj, current_app.plus_api
         )
 
     return make_response(

--- a/frigate/util/builtin.py
+++ b/frigate/util/builtin.py
@@ -204,17 +204,22 @@ def update_yaml_from_url(file_path, url):
                 key_path.pop(i - 1)
             except ValueError:
                 pass
-        new_value = new_value_list[0]
-        update_yaml_file(file_path, key_path, new_value)
+
+        if len(new_value_list) > 1:
+            update_yaml_file(file_path, key_path, new_value_list)
+        else:
+            update_yaml_file(file_path, key_path, new_value_list[0])
 
 
 def update_yaml_file(file_path, key_path, new_value):
     yaml = YAML()
+    yaml.indent(mapping=2, sequence=4, offset=2)
     with open(file_path, "r") as f:
         data = yaml.load(f)
 
     data = update_yaml(data, key_path, new_value)
-
+    with open("/config/test.yaml", "w") as f:
+        yaml.dump(data, f)
     with open(file_path, "w") as f:
         yaml.dump(data, f)
 

--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -246,7 +246,7 @@ function NewGroupDialog({ open, setOpen, currentGroups }: NewGroupDialogProps) {
             </div>
           </div>
         ))}
-        <DropdownMenuSeparator />
+        {currentGroups.length > 0 && <DropdownMenuSeparator />}
         {editState == "none" && (
           <Button
             className="text-primary-foreground justify-start"

--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -226,6 +226,7 @@ function NewGroupDialog({ open, setOpen, currentGroups }: NewGroupDialogProps) {
             {group[0]}
             <div className="flex justify-center gap-1">
               <Button
+                className="bg-transparent"
                 size="icon"
                 onClick={() => {
                   setNewTitle(group[0]);
@@ -237,7 +238,7 @@ function NewGroupDialog({ open, setOpen, currentGroups }: NewGroupDialogProps) {
                 <LuPencil />
               </Button>
               <Button
-                className="text-destructive"
+                className="text-destructive bg-transparent"
                 size="icon"
                 onClick={() => onDeleteGroup(group[0])}
               >

--- a/web/src/components/filter/FilterCheckBox.tsx
+++ b/web/src/components/filter/FilterCheckBox.tsx
@@ -1,0 +1,32 @@
+import { LuCheck } from "react-icons/lu";
+import { Button } from "../ui/button";
+import { IconType } from "react-icons";
+
+type FilterCheckBoxProps = {
+  label: string;
+  CheckIcon?: IconType;
+  isChecked: boolean;
+  onCheckedChange: (isChecked: boolean) => void;
+};
+
+export default function FilterCheckBox({
+  label,
+  CheckIcon = LuCheck,
+  isChecked,
+  onCheckedChange,
+}: FilterCheckBoxProps) {
+  return (
+    <Button
+      className="capitalize flex justify-between items-center cursor-pointer w-full text-primary-foreground"
+      variant="ghost"
+      onClick={() => onCheckedChange(!isChecked)}
+    >
+      {isChecked ? (
+        <CheckIcon className="w-6 h-6" />
+      ) : (
+        <div className="w-6 h-6" />
+      )}
+      <div className="ml-1 w-full flex justify-start">{label}</div>
+    </Button>
+  );
+}

--- a/web/src/components/filter/ReviewFilterGroup.tsx
+++ b/web/src/components/filter/ReviewFilterGroup.tsx
@@ -1,4 +1,3 @@
-import { LuCheck } from "react-icons/lu";
 import { Button } from "../ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import useSWR from "swr";
@@ -16,11 +15,11 @@ import { ReviewFilter } from "@/types/review";
 import { getEndOfDayTimestamp } from "@/utils/dateUtil";
 import { useFormattedTimestamp } from "@/hooks/use-date-utils";
 import { FaCalendarAlt, FaFilter, FaVideo } from "react-icons/fa";
-import { IconType } from "react-icons";
 import { isMobile } from "react-device-detect";
 import { Drawer, DrawerContent, DrawerTrigger } from "../ui/drawer";
 import { Switch } from "../ui/switch";
 import { Label } from "../ui/label";
+import FilterCheckBox from "./FilterCheckBox";
 
 const ATTRIBUTES = ["amazon", "face", "fedex", "license_plate", "ups"];
 
@@ -477,34 +476,5 @@ function GeneralFilterButton({
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent side="left">{content}</PopoverContent>
     </Popover>
-  );
-}
-
-type FilterCheckBoxProps = {
-  label: string;
-  CheckIcon?: IconType;
-  isChecked: boolean;
-  onCheckedChange: (isChecked: boolean) => void;
-};
-
-function FilterCheckBox({
-  label,
-  CheckIcon = LuCheck,
-  isChecked,
-  onCheckedChange,
-}: FilterCheckBoxProps) {
-  return (
-    <Button
-      className="capitalize flex justify-between items-center cursor-pointer w-full text-primary-foreground"
-      variant="ghost"
-      onClick={() => onCheckedChange(!isChecked)}
-    >
-      {isChecked ? (
-        <CheckIcon className="w-6 h-6" />
-      ) : (
-        <div className="w-6 h-6" />
-      )}
-      <div className="ml-1 w-full flex justify-start">{label}</div>
-    </Button>
   );
 }

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -204,9 +204,11 @@ export interface CameraConfig {
   };
 }
 
+export const GROUP_ICONS = ["car", "cat", "dog", "leaf"] as const;
+
 export type CameraGroupConfig = {
   cameras: string[];
-  icon: string;
+  icon: (typeof GROUP_ICONS)[number];
   order: number;
 };
 


### PR DESCRIPTION
Frontend changes:
- adds + button on desktop so that camera groups can be edited
- camera group consists of a name, icon, and 2+ cameras
- when a user makes any changes to camera groups these changes are immediately reflected without frigate needing to restart
- fix bug where double clicking home button navigates to previous page

Backend changes:
- yaml updater now supports lists
- yaml updater now sets appropriate indentation when saving yaml file
- yaml update api accepts a json arg which can be used to update the config in place without restarting frigate