### PR TITLE
Better segment clicking

### DIFF
--- a/web/src/components/timeline/EventReviewTimeline.tsx
+++ b/web/src/components/timeline/EventReviewTimeline.tsx
@@ -97,6 +97,7 @@ export function EventReviewTimeline({
           minimapEndTime={minimapEndTime}
           severityType={severityType}
           contentRef={contentRef}
+          setHandlebarTime={setHandlebarTime}
         />
       );
     });

--- a/web/src/components/timeline/EventSegment.tsx
+++ b/web/src/components/timeline/EventSegment.tsx
@@ -29,6 +29,7 @@ type EventSegmentProps = {
   minimapEndTime?: number;
   severityType: ReviewSeverity;
   contentRef: RefObject<HTMLDivElement>;
+  setHandlebarTime?: React.Dispatch<React.SetStateAction<number>>;
 };
 
 export function EventSegment({
@@ -41,6 +42,7 @@ export function EventSegment({
   minimapEndTime,
   severityType,
   contentRef,
+  setHandlebarTime,
 }: EventSegmentProps) {
   const {
     getSeverity,
@@ -191,6 +193,10 @@ export function EventSegment({
           element.classList.remove("outline-4", "shadow-[0_0_6px_1px]");
           element.classList.add("outline-0", "shadow-none");
         }, 3000);
+      }
+
+      if (setHandlebarTime) {
+        setHandlebarTime(startTimestamp);
       }
     }
     // we know that these deps are correct

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -82,6 +82,19 @@ export function MotionSegment({
     return isMobile ? 30 : 50;
   }, []);
 
+  const segmentWidth = useMemo(() => {
+    return interpolateMotionAudioData(
+      getMotionSegmentValue(segmentTime + segmentDuration / 2),
+      maxSegmentWidth,
+    );
+  }, [
+    segmentTime,
+    segmentDuration,
+    maxSegmentWidth,
+    getMotionSegmentValue,
+    interpolateMotionAudioData,
+  ]);
+
   const alignedMinimapStartTime = useMemo(
     () => alignStartDateToTimeline(minimapStartTime ?? 0),
     [minimapStartTime, alignStartDateToTimeline],
@@ -154,13 +167,18 @@ export function MotionSegment({
   };
 
   const segmentClick = useCallback(() => {
-    if (startTimestamp && setHandlebarTime) {
+    if (startTimestamp && setHandlebarTime && segmentWidth > 1) {
       setHandlebarTime(startTimestamp);
     }
-  }, [startTimestamp, setHandlebarTime]);
+  }, [startTimestamp, setHandlebarTime, segmentWidth]);
 
   return (
-    <div key={segmentKey} className={segmentClasses}>
+    <div
+      key={segmentKey}
+      className={segmentClasses}
+      onClick={segmentClick}
+      onTouchStart={(event) => handleTouchStart(event, segmentClick)}
+    >
       <MinimapBounds
         isFirstSegmentInMinimap={isFirstSegmentInMinimap}
         isLastSegmentInMinimap={isLastSegmentInMinimap}
@@ -185,13 +203,8 @@ export function MotionSegment({
             <div
               key={`${segmentKey}_motion_data_1`}
               className={`h-[2px] rounded-full bg-motion_review`}
-              onClick={segmentClick}
-              onTouchStart={(event) => handleTouchStart(event, segmentClick)}
               style={{
-                width: interpolateMotionAudioData(
-                  getMotionSegmentValue(segmentTime + segmentDuration / 2),
-                  maxSegmentWidth,
-                ),
+                width: segmentWidth,
               }}
             ></div>
           </div>
@@ -202,13 +215,8 @@ export function MotionSegment({
             <div
               key={`${segmentKey}_motion_data_2`}
               className={`h-[2px] rounded-full bg-motion_review`}
-              onClick={segmentClick}
-              onTouchStart={(event) => handleTouchStart(event, segmentClick)}
               style={{
-                width: interpolateMotionAudioData(
-                  getMotionSegmentValue(segmentTime),
-                  maxSegmentWidth,
-                ),
+                width: segmentWidth,
               }}
             ></div>
           </div>

--- a/web/src/hooks/use-handle-dragging.ts
+++ b/web/src/hooks/use-handle-dragging.ts
@@ -130,6 +130,7 @@ function useDraggableHandler({
               scrollIntoView(thumb, {
                 block: "center",
                 behavior: "smooth",
+                scrollMode: "if-needed",
               });
             }
           }

--- a/web/src/hooks/use-motion-segment-utils.ts
+++ b/web/src/hooks/use-motion-segment-utils.ts
@@ -43,7 +43,7 @@ export const useMotionSegmentUtils = (
       const matchingEvent = motion_events.find((event) => {
         return (
           time >= getSegmentStart(event.start_time) &&
-          time < getSegmentEnd(event.start_time)
+          time <= getSegmentEnd(event.start_time)
         );
       });
 

--- a/web/src/pages/UIPlayground.tsx
+++ b/web/src/pages/UIPlayground.tsx
@@ -124,7 +124,7 @@ function UIPlayground() {
   const [mockEvents, setMockEvents] = useState<ReviewSegment[]>([]);
   const [mockMotionData, setMockMotionData] = useState<MotionData[]>([]);
   const [handlebarTime, setHandlebarTime] = useState(
-    Math.floor(Date.now() / 1000) - 15 * 60,
+    Math.round((Date.now() / 1000 - 15 * 60) / 60) * 60,
   );
 
   useMemo(() => {
@@ -285,7 +285,7 @@ function UIPlayground() {
               <MotionReviewTimeline
                 segmentDuration={zoomSettings.segmentDuration} // seconds per segment
                 timestampSpread={zoomSettings.timestampSpread} // minutes between each major timestamp
-                timelineStart={Math.floor(Date.now() / 1000)} // timestamp start of the timeline - the earlier time
+                timelineStart={Math.round(((Date.now() / 1000) * 60) / 60) * 60} // timestamp start of the timeline - the earlier time
                 timelineEnd={Math.floor(Date.now() / 1000) - 6 * 60 * 60} // end of timeline - the later time
                 showHandlebar // show / hide the handlebar
                 handlebarTime={handlebarTime} // set the time of the handlebar


### PR DESCRIPTION
- add ability to click on entire segment in motion review (rather than just the 2px line) only on segments with motion lines
- move handlebar when visible on motion review and recordings view timeline when segment is clicked
- only scroll handlebar on timeline if needed (allows for manual dragging on recordings view without constantly snapping back to center)
- playground updates to test handlebar pixel placement