### PR TITLE
Update live.md

### DIFF
--- a/docs/docs/configuration/live.md
+++ b/docs/docs/configuration/live.md
@@ -79,7 +79,7 @@ WebRTC works by creating a TCP or UDP connection on port `8555`. However, it req
         - stun:8555
   ```
 
-- For access through Tailscale, the Frigate system's Tailscale IP must be added as a WebRTC candidate. Tailscale IPs all start with `100.`, and are reserved within the `100.0.0.0/8` CIDR block.
+- For access through Tailscale, the Frigate system's Tailscale IP must be added as a WebRTC candidate. Tailscale IPs all start with `100.`, and are reserved within the `100.64.0.0/10` CIDR block.
 
 :::tip
 


### PR DESCRIPTION
Incorrectly stated tailscale used 100.0.0.0/8 CIDR block.

Correct CIDR block for tailscale in 100.64.0.0/10

RFC6598