### PR TITLE
Add special casing for android preview scrubbing

### DIFF
--- a/web/src/views/events/RecordingView.tsx
+++ b/web/src/views/events/RecordingView.tsx
@@ -134,7 +134,7 @@ export function DesktopRecordingView({
   const { data: motionData } = useSWR<MotionData[]>(
     severity == "significant_motion"
       ? [
-          "review/activity",
+          "review/activity/motion",
           {
             before: timeRange.end,
             after: timeRange.start,
@@ -351,7 +351,7 @@ export function MobileRecordingView({
   const { data: motionData } = useSWR<MotionData[]>(
     severity == "significant_motion"
       ? [
-          "review/activity",
+          "review/activity/motion",
           {
             before: timeRange.end,
             after: timeRange.start,


### PR DESCRIPTION
Android decoder seems to be not as fast as iPhone or desktop, so to improve the experience it is best to average the current and new time to ensure that more frames are shown as you scrub