### PR TITLE
Recording scrubbing fixes

### DIFF
--- a/web/src/components/player/dynamic/DynamicVideoController.ts
+++ b/web/src/components/player/dynamic/DynamicVideoController.ts
@@ -9,7 +9,6 @@ export class DynamicVideoController {
   public camera = "";
   private playerController: HTMLVideoElement;
   private previewController: PreviewController;
-  private isScrubbing: boolean;
   private setFocusedItem: (timeline: Timeline) => void;
   private playerMode: PlayerMode = "playback";
 
@@ -24,7 +23,6 @@ export class DynamicVideoController {
     previewController: PreviewController,
     annotationOffset: number,
     defaultMode: PlayerMode,
-    isScrubbing: boolean,
     setFocusedItem: (timeline: Timeline) => void,
   ) {
     this.camera = camera;
@@ -32,7 +30,6 @@ export class DynamicVideoController {
     this.previewController = previewController;
     this.annotationOffset = annotationOffset;
     this.playerMode = defaultMode;
-    this.isScrubbing = isScrubbing;
     this.setFocusedItem = setFocusedItem;
   }
 
@@ -122,7 +119,7 @@ export class DynamicVideoController {
       this.previewController.setNewPreviewStartTime(time);
     }
 
-    if (scrubResult && this.playerMode != "scrubbing" && !this.isScrubbing) {
+    if (scrubResult && this.playerMode != "scrubbing") {
       this.playerMode = "scrubbing";
       this.playerController.pause();
     }

--- a/web/src/components/player/dynamic/DynamicVideoController.ts
+++ b/web/src/components/player/dynamic/DynamicVideoController.ts
@@ -9,7 +9,7 @@ export class DynamicVideoController {
   public camera = "";
   private playerController: HTMLVideoElement;
   private previewController: PreviewController;
-  private setScrubbing: (isScrubbing: boolean) => void;
+  private isScrubbing: boolean;
   private setFocusedItem: (timeline: Timeline) => void;
   private playerMode: PlayerMode = "playback";
 
@@ -24,7 +24,7 @@ export class DynamicVideoController {
     previewController: PreviewController,
     annotationOffset: number,
     defaultMode: PlayerMode,
-    setScrubbing: (isScrubbing: boolean) => void,
+    isScrubbing: boolean,
     setFocusedItem: (timeline: Timeline) => void,
   ) {
     this.camera = camera;
@@ -32,7 +32,7 @@ export class DynamicVideoController {
     this.previewController = previewController;
     this.annotationOffset = annotationOffset;
     this.playerMode = defaultMode;
-    this.setScrubbing = setScrubbing;
+    this.isScrubbing = isScrubbing;
     this.setFocusedItem = setFocusedItem;
   }
 
@@ -52,7 +52,6 @@ export class DynamicVideoController {
   seekToTimestamp(time: number, play: boolean = false) {
     if (this.playerMode != "playback") {
       this.playerMode = "playback";
-      this.setScrubbing(false);
     }
 
     if (
@@ -123,10 +122,9 @@ export class DynamicVideoController {
       this.previewController.setNewPreviewStartTime(time);
     }
 
-    if (scrubResult && this.playerMode != "scrubbing") {
+    if (scrubResult && this.playerMode != "scrubbing" && !this.isScrubbing) {
       this.playerMode = "scrubbing";
       this.playerController.pause();
-      this.setScrubbing(true);
     }
   }
 

--- a/web/src/components/player/dynamic/DynamicVideoController.ts
+++ b/web/src/components/player/dynamic/DynamicVideoController.ts
@@ -47,10 +47,6 @@ export class DynamicVideoController {
   }
 
   seekToTimestamp(time: number, play: boolean = false) {
-    if (this.playerMode != "playback") {
-      this.playerMode = "playback";
-    }
-
     if (
       this.recordings.length == 0 ||
       time < this.recordings[0].start_time ||
@@ -58,6 +54,10 @@ export class DynamicVideoController {
     ) {
       this.timeToStart = time;
       return;
+    }
+
+    if (this.playerMode != "playback") {
+      this.playerMode = "playback";
     }
 
     let seekSeconds = 0;

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -21,6 +21,7 @@ type DynamicVideoPlayerProps = {
   onControllerReady: (controller: DynamicVideoController) => void;
   onTimestampUpdate?: (timestamp: number) => void;
   onClipEnded?: () => void;
+  isScrubbing: boolean;
 };
 export default function DynamicVideoPlayer({
   className,
@@ -31,6 +32,7 @@ export default function DynamicVideoPlayer({
   onControllerReady,
   onTimestampUpdate,
   onClipEnded,
+  isScrubbing,
 }: DynamicVideoPlayerProps) {
   const apiHost = useApiHost();
   const { data: config } = useSWR<FrigateConfig>("config");
@@ -53,7 +55,6 @@ export default function DynamicVideoPlayer({
   const playerRef = useRef<HTMLVideoElement | null>(null);
   const [previewController, setPreviewController] =
     useState<PreviewController | null>(null);
-  const [isScrubbing, setIsScrubbing] = useState(false);
   const [focusedItem, setFocusedItem] = useState<Timeline | undefined>(
     undefined,
   );
@@ -68,7 +69,7 @@ export default function DynamicVideoPlayer({
       previewController,
       (config.cameras[camera]?.detect?.annotation_offset || 0) / 1000,
       "playback",
-      setIsScrubbing,
+      isScrubbing,
       setFocusedItem,
     );
     // we only want to fire once when players are ready

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -133,6 +133,10 @@ export default function DynamicVideoPlayer({
       return;
     }
 
+    if (playerRef.current) {
+      playerRef.current.autoplay = !isScrubbing;
+    }
+
     setSource(
       `${apiHost}vod/${camera}/start/${timeRange.start}/end/${timeRange.end}/master.m3u8`,
     );

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -68,8 +68,7 @@ export default function DynamicVideoPlayer({
       playerRef.current,
       previewController,
       (config.cameras[camera]?.detect?.annotation_offset || 0) / 1000,
-      "playback",
-      isScrubbing,
+      isScrubbing ? "scrubbing" : "playback",
       setFocusedItem,
     );
     // we only want to fire once when players are ready

--- a/web/src/views/events/RecordingView.tsx
+++ b/web/src/views/events/RecordingView.tsx
@@ -89,13 +89,16 @@ export function DesktopRecordingView({
   const [playerTime, setPlayerTime] = useState(startTime);
 
   const updateSelectedSegment = useCallback(
-    (currentTime: number) => {
+    (currentTime: number, updateStartTime: boolean) => {
       const index = timeRange.ranges.findIndex(
         (seg) => seg.start <= currentTime && seg.end >= currentTime,
       );
 
       if (index != -1) {
-        setPlaybackStart(currentTime);
+        if (updateStartTime) {
+          setPlaybackStart(currentTime);
+        }
+
         setSelectedRangeIdx(index);
       }
     },
@@ -108,7 +111,7 @@ export function DesktopRecordingView({
         currentTime > currentTimeRange.end + 60 ||
         currentTime < currentTimeRange.start - 60
       ) {
-        updateSelectedSegment(currentTime);
+        updateSelectedSegment(currentTime, false);
         return;
       }
 
@@ -128,38 +131,20 @@ export function DesktopRecordingView({
 
   useEffect(() => {
     if (!scrubbing) {
-      if (
-        currentTimeRange.start <= currentTime &&
-        currentTimeRange.end >= currentTime
-      ) {
-        mainControllerRef.current?.seekToTimestamp(currentTime, true);
-      } else {
-        updateSelectedSegment(currentTime);
-      }
-    }
-
-    // we only want to seek when user stops scrubbing
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scrubbing]);
-
-  useEffect(() => {
-    if (!scrubbing) {
       if (Math.abs(currentTime - playerTime) > 10) {
-        mainControllerRef.current?.pause();
-
         if (
           currentTimeRange.start <= currentTime &&
           currentTimeRange.end >= currentTime
         ) {
           mainControllerRef.current?.seekToTimestamp(currentTime, true);
         } else {
-          updateSelectedSegment(currentTime);
+          updateSelectedSegment(currentTime, true);
         }
       }
     }
     // we only want to seek when current time doesn't match the player update time
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentTime]);
+  }, [currentTime, scrubbing]);
 
   const onSelectCamera = useCallback(
     (newCam: string) => {

--- a/web/src/views/events/RecordingView.tsx
+++ b/web/src/views/events/RecordingView.tsx
@@ -234,6 +234,7 @@ export function DesktopRecordingView({
                 onControllerReady={(controller) => {
                   mainControllerRef.current = controller;
                 }}
+                isScrubbing={scrubbing}
               />
             </div>
             <div className="w-full flex justify-center gap-2 overflow-x-auto">
@@ -452,6 +453,7 @@ export function MobileRecordingView({
           }}
           onTimestampUpdate={setCurrentTime}
           onClipEnded={onClipEnded}
+          isScrubbing={scrubbing}
         />
       </div>
 


### PR DESCRIPTION
There was a race condition in the initialization of a new `DynamicVideoController` where scrubbing inside the controller would be initially false just for a split second even though the user had not released the handlebar on the timeline from scrubbing. This PR uses the `isScrubbing` that gets passed back from the handlebar as a single source of truth for scrubbing.

Also, scrubbing between hours without releasing the handlebar will still cause `onPlayerLoaded` to be called to load a new hour. Autoplay would kick in and would start playing the new hour in the background sometimes just for a second and `onTimeUpdate` would be called, setting a new seeking timestamp, even though the handlebar had never been released and seeking was still true. Because `seekToTimestamp` automatically sets the player mode to "playback", the video player would get sometimes get confused as to what the user actually wanted to seek to when releasing the handlebar. As a result, the handlebar would sometimes jump to near the beginning of the hour, even if released at a time much later in the hour. 