### PR TITLE
Add optional cpu fallback support for detectors

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -57,6 +57,7 @@ detectors:
     # Detectors may require additional configuration.
     # Refer to the Detectors configuration page for more information.
     type: cpu
+    enable_cpu_fallback: false
 
 # Optional: Database configuration
 database:

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -1329,7 +1329,7 @@ class FrigateConfig(FrigateBaseModel):
         )
         detector_config.model.compute_model_hash()
 
-        if detector_config.type != "cpu":
+        if detector_config.enable_cpu_fallback and detector_config.type != "cpu":
             fallback_config = config.copy(deep=True)
             fallback_config.model = ModelConfig()
             detector_config.fallback_config = self.generate_detector_config(

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -1287,43 +1287,58 @@ class FrigateConfig(FrigateBaseModel):
         config.model.check_and_load_plus_model(plus_api)
 
         for key, detector in config.detectors.items():
-            detector_config: DetectorConfig = parse_obj_as(DetectorConfig, detector)
-            if detector_config.model is None:
-                detector_config.model = config.model
-            else:
-                model = detector_config.model
-                schema = ModelConfig.schema()["properties"]
-                if (
-                    model.width != schema["width"]["default"]
-                    or model.height != schema["height"]["default"]
-                    or model.labelmap_path is not None
-                    or model.labelmap is not {}
-                    or model.input_tensor != schema["input_tensor"]["default"]
-                    or model.input_pixel_format
-                    != schema["input_pixel_format"]["default"]
-                ):
-                    logger.warning(
-                        "Customizing more than a detector model path is unsupported."
-                    )
-            merged_model = deep_merge(
-                detector_config.model.dict(exclude_unset=True),
-                config.model.dict(exclude_unset=True),
+            config.detectors[key] = self.generate_detector_config(
+                config, detector, plus_api
             )
-
-            if "path" not in merged_model:
-                if detector_config.type == "cpu":
-                    merged_model["path"] = "/cpu_model.tflite"
-                elif detector_config.type == "edgetpu":
-                    merged_model["path"] = "/edgetpu_model.tflite"
-
-            detector_config.model = ModelConfig.parse_obj(merged_model)
-            detector_config.model.check_and_load_plus_model(
-                plus_api, detector_config.type
-            )
-            detector_config.model.compute_model_hash()
-            config.detectors[key] = detector_config
 
         return config
+
+    def generate_detector_config(self, config: FrigateConfig, detector, plus_api):
+        detector_config: DetectorConfig = parse_obj_as(DetectorConfig, detector)
+        if detector_config.model is None:
+            detector_config.model = config.model
+        else:
+            model = detector_config.model
+            schema = ModelConfig.schema()["properties"]
+            if (
+                model.width != schema["width"]["default"]
+                or model.height != schema["height"]["default"]
+                or model.labelmap_path is not None
+                or model.labelmap is not {}
+                or model.input_tensor != schema["input_tensor"]["default"]
+                or model.input_pixel_format
+                != schema["input_pixel_format"]["default"]
+            ):
+                logger.warning(
+                    "Customizing more than a detector model path is unsupported."
+                )
+        merged_model = deep_merge(
+            detector_config.model.dict(exclude_unset=True),
+            config.model.dict(exclude_unset=True),
+        )
+
+        if "path" not in merged_model:
+            if detector_config.type == "cpu":
+                merged_model["path"] = "/cpu_model.tflite"
+            elif detector_config.type == "edgetpu":
+                merged_model["path"] = "/edgetpu_model.tflite"
+
+        detector_config.model = ModelConfig.parse_obj(merged_model)
+        detector_config.model.check_and_load_plus_model(
+            plus_api, detector_config.type
+        )
+        detector_config.model.compute_model_hash()
+
+        if detector_config.type != "cpu":
+            fallback_config = config.copy(deep=True)
+            fallback_config.model = ModelConfig()
+            detector_config.fallback_config = self.generate_detector_config(
+                fallback_config,
+                parse_obj_as(DetectorConfig, DEFAULT_DETECTORS["cpu"]),
+                plus_api,
+            )
+
+        return detector_config
 
     @validator("cameras")
     def ensure_zones_and_cameras_have_different_names(cls, v: Dict[str, CameraConfig]):

--- a/frigate/detectors/detector_config.py
+++ b/frigate/detectors/detector_config.py
@@ -139,6 +139,9 @@ class ModelConfig(BaseModel):
 class BaseDetectorConfig(BaseModel):
     # the type field must be defined in all subclasses
     type: str = Field(default="cpu", title="Detector Type")
+    enable_cpu_fallback: bool = Field(
+        default=False, title="Fallback to CPU if startup fails"
+    )
     model: ModelConfig = Field(
         default=None, title="Detector specific model configuration."
     )

--- a/frigate/object_detection.py
+++ b/frigate/object_detection.py
@@ -103,11 +103,16 @@ def run_detector(
     try:
         object_detector = LocalObjectDetector(detector_config=detector_config)
     except Exception as ex:
-        logger.error(f"Got exception when initializing detector: {ex}, falling back to CPU detector")
-
-        object_detector = LocalObjectDetector(detector_config=detector_config.fallback_config)
-        using_fallback_detector.value = 1
-        
+        if detector_config.enable_cpu_fallback:
+            logger.error(
+                f"Got exception when initializing detector: {ex}, falling back to CPU detector"
+            )
+            object_detector = LocalObjectDetector(
+                detector_config=detector_config.fallback_config
+            )
+            using_fallback_detector.value = 1
+        else:
+            raise ex
 
     outputs = {}
     for name in out_events.keys():

--- a/frigate/stats.py
+++ b/frigate/stats.py
@@ -284,6 +284,7 @@ def stats_snapshot(
             # issue https://github.com/python/typeshed/issues/8799
             # from mypy 0.981 onwards
             "pid": pid,
+            "using_fallback_detector": bool(detector.using_fallback_detector.value),
         }
     stats["detection_fps"] = round(total_detection_fps, 2)
 

--- a/web/src/routes/System.jsx
+++ b/web/src/routes/System.jsx
@@ -232,7 +232,7 @@ export default function System() {
           <div data-testid="detectors" className="grid grid-cols-1 3xl:grid-cols-3 md:grid-cols-2 gap-4">
             {detectorNames.map((detector) => (
               <div key={detector} className="dark:bg-gray-800 shadow-md hover:shadow-lg rounded-lg transition-shadow">
-                <div className="text-lg flex justify-between p-4">{detector}</div>
+                <div className="text-lg flex justify-between p-4" style={{ color: detectors[detector]['using_fallback_detector'] ? "red" : null}}>{detector}{detectors[detector]['using_fallback_detector'] ? " - CPU FALLBACK MODE" : ""}</div>
                 <div className="p-2">
                   <Table className="w-full">
                     <Thead>


### PR DESCRIPTION
On detector initialization, if the detector fails (throws an exception) it will fallback to initializing a CPU detector (if enabled with `enable_cpu_fallback`). In the frigate UI under the "System" tab, the detector will show in red with the text `CPU FALLBACK MODE` appended to make the state clear.

To preserve current behavior and avoid cases where CPU resources aren't available to keep up, this is disabled by default.

This should handle most cases of issues in #2904, although it doesn't address things like auto-recovery or notifications.

Currently this would require manual restart of frigate/the container to re-enable accelerated detectors again - I was considering adding a timeout that would restart the process every 1 hour (configurable) to attempt to switch back to accelerated processing, but events could be lost or other unforeseen issues could crop up.