### PR TITLE
Improve Recordings loading

### DIFF
--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -42,6 +42,7 @@ type HlsVideoPlayerProps = {
   onClipEnded?: () => void;
   onPlayerLoaded?: () => void;
   onTimeUpdate?: (time: number) => void;
+  onPlaying?: () => void;
 };
 export default function HlsVideoPlayer({
   className,
@@ -51,6 +52,7 @@ export default function HlsVideoPlayer({
   onClipEnded,
   onPlayerLoaded,
   onTimeUpdate,
+  onPlaying,
 }: HlsVideoPlayerProps) {
   // playback
 
@@ -183,6 +185,7 @@ export default function HlsVideoPlayer({
             setMobileCtrlTimeout(setTimeout(() => setControls(false), 4000));
           }
         }}
+        onPlaying={onPlaying}
         onPause={() => {
           setIsPlaying(false);
 

--- a/web/src/components/player/PreviewPlayer.tsx
+++ b/web/src/components/player/PreviewPlayer.tsx
@@ -271,8 +271,6 @@ class PreviewVideoController extends PreviewController {
       return;
     }
 
-    this.seekCheck = Date.now() / 1000;
-
     if (this.timeToSeek) {
       const diff =
         Math.round(this.timeToSeek) -

--- a/web/src/components/player/PreviewPlayer.tsx
+++ b/web/src/components/player/PreviewPlayer.tsx
@@ -271,27 +271,28 @@ class PreviewVideoController extends PreviewController {
       return;
     }
 
-    if (this.timeToSeek) {
-      if (
-        Math.round(this.previewRef.current.currentTime + this.preview.start) !=
-        Math.round(this.timeToSeek)
-      ) {
-        if (isAndroid) {
-          const currentTs =
-            this.previewRef.current.currentTime + this.preview.start;
-          const diff = this.timeToSeek - currentTs;
+    this.seekCheck = Date.now() / 1000;
 
+    if (this.timeToSeek) {
+      const diff =
+        Math.round(this.timeToSeek) -
+        Math.round(this.previewRef.current.currentTime + this.preview.start);
+
+      if (Math.abs(diff) > 1) {
+        let seekTime;
+        if (isAndroid) {
           if (diff < 30) {
-            this.previewRef.current.currentTime =
-              this.previewRef.current.currentTime + diff / 2;
+            seekTime = Math.round(
+              this.previewRef.current.currentTime + diff / 2,
+            );
           } else {
-            this.previewRef.current.currentTime =
-              this.timeToSeek - this.preview.start;
+            seekTime = Math.round(this.timeToSeek - this.preview.start);
           }
         } else {
-          this.previewRef.current.currentTime =
-            this.timeToSeek - this.preview.start;
+          seekTime = this.timeToSeek - this.preview.start;
         }
+
+        this.previewRef.current.currentTime = seekTime;
       } else {
         this.seeking = false;
         this.timeToSeek = undefined;

--- a/web/src/components/player/dynamic/DynamicVideoController.ts
+++ b/web/src/components/player/dynamic/DynamicVideoController.ts
@@ -81,12 +81,25 @@ export class DynamicVideoController {
       this.playerController.currentTime = seekSeconds;
 
       if (play) {
-        // use timeout to avoid race condition with other data loading
-        setTimeout(() => this.playerController.play()), 1;
+        this.waitAndPlay();
       } else {
         this.playerController.pause();
       }
     }
+  }
+
+  waitAndPlay() {
+    return new Promise((resolve) => {
+      const onSeekedHandler = () => {
+        this.playerController.removeEventListener("seeked", onSeekedHandler);
+        this.playerController.play();
+        resolve(undefined);
+      };
+
+      this.playerController.addEventListener("seeked", onSeekedHandler, {
+        once: true,
+      });
+    });
   }
 
   seekToTimelineItem(timeline: Timeline) {

--- a/web/src/components/player/dynamic/DynamicVideoController.ts
+++ b/web/src/components/player/dynamic/DynamicVideoController.ts
@@ -81,7 +81,8 @@ export class DynamicVideoController {
       this.playerController.currentTime = seekSeconds;
 
       if (play) {
-        this.playerController.play();
+        // use timeout to avoid race condition with other data loading
+        setTimeout(() => this.playerController.play()), 1;
       } else {
         this.playerController.pause();
       }

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -8,7 +8,6 @@ import { Preview } from "@/types/preview";
 import PreviewPlayer, { PreviewController } from "../PreviewPlayer";
 import { DynamicVideoController } from "./DynamicVideoController";
 import HlsVideoPlayer from "../HlsVideoPlayer";
-import { Skeleton } from "@/components/ui/skeleton";
 
 /**
  * Dynamically switches between video playback and scrubbing preview player.
@@ -98,6 +97,12 @@ export default function DynamicVideoPlayer({
 
   // start at correct time
 
+  useEffect(() => {
+    if (isScrubbing) {
+      setIsLoading(true);
+    }
+  }, [isScrubbing]);
+
   const onPlayerLoaded = useCallback(() => {
     if (!controller || !startTimestamp) {
       return;
@@ -112,13 +117,9 @@ export default function DynamicVideoPlayer({
         return;
       }
 
-      if (isLoading) {
-        setIsLoading(false);
-      }
-
       onTimestampUpdate(controller.getProgress(time));
     },
-    [controller, isLoading, onTimestampUpdate],
+    [controller, onTimestampUpdate],
   );
 
   // state of playback player
@@ -168,6 +169,7 @@ export default function DynamicVideoPlayer({
           onTimeUpdate={onTimeUpdate}
           onPlayerLoaded={onPlayerLoaded}
           onClipEnded={onClipEnded}
+          onPlaying={() => setIsLoading(false)}
         >
           {config && focusedItem && (
             <TimelineEventOverlay
@@ -177,9 +179,8 @@ export default function DynamicVideoPlayer({
           )}
         </HlsVideoPlayer>
       </div>
-      {isLoading && !isScrubbing && <Skeleton className="size-full" />}
       <PreviewPlayer
-        className={`${isScrubbing ? "visible" : "hidden"} ${className ?? ""}`}
+        className={`${isScrubbing || isLoading ? "visible" : "hidden"} ${className ?? ""}`}
         camera={camera}
         timeRange={timeRange}
         cameraPreviews={cameraPreviews}

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -177,7 +177,7 @@ export default function DynamicVideoPlayer({
           )}
         </HlsVideoPlayer>
       </div>
-      {isLoading && <Skeleton className="size-full" />}
+      {isLoading && !isScrubbing && <Skeleton className="size-full" />}
       <PreviewPlayer
         className={`${isScrubbing ? "visible" : "hidden"} ${className ?? ""}`}
         camera={camera}

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -8,6 +8,7 @@ import { Preview } from "@/types/preview";
 import PreviewPlayer, { PreviewController } from "../PreviewPlayer";
 import { DynamicVideoController } from "./DynamicVideoController";
 import HlsVideoPlayer from "../HlsVideoPlayer";
+import { Skeleton } from "@/components/ui/skeleton";
 
 /**
  * Dynamically switches between video playback and scrubbing preview player.
@@ -90,6 +91,7 @@ export default function DynamicVideoPlayer({
 
   // initial state
 
+  const [isLoading, setIsLoading] = useState(false);
   const [source, setSource] = useState(
     `${apiHost}vod/${camera}/start/${timeRange.start}/end/${timeRange.end}/master.m3u8`,
   );
@@ -110,9 +112,13 @@ export default function DynamicVideoPlayer({
         return;
       }
 
+      if (isLoading) {
+        setIsLoading(false);
+      }
+
       onTimestampUpdate(controller.getProgress(time));
     },
-    [controller, onTimestampUpdate],
+    [controller, isLoading, onTimestampUpdate],
   );
 
   // state of playback player
@@ -140,6 +146,7 @@ export default function DynamicVideoPlayer({
     setSource(
       `${apiHost}vod/${camera}/start/${timeRange.start}/end/${timeRange.end}/master.m3u8`,
     );
+    setIsLoading(true);
 
     controller.newPlayback({
       recordings: recordings ?? [],
@@ -151,7 +158,9 @@ export default function DynamicVideoPlayer({
 
   return (
     <div className={`relative ${className ?? ""} cursor-pointer`}>
-      <div className={`w-full relative ${isScrubbing ? "hidden" : "visible"}`}>
+      <div
+        className={`w-full relative ${isScrubbing || isLoading ? "hidden" : "visible"}`}
+      >
         <HlsVideoPlayer
           className={`  ${wideVideo ? "" : "aspect-video"}`}
           videoRef={playerRef}
@@ -168,6 +177,7 @@ export default function DynamicVideoPlayer({
           )}
         </HlsVideoPlayer>
       </div>
+      {isLoading && <Skeleton className="size-full" />}
       <PreviewPlayer
         className={`${isScrubbing ? "visible" : "hidden"} ${className ?? ""}`}
         camera={camera}

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -163,7 +163,7 @@ export default function DynamicVideoPlayer({
         className={`w-full relative ${isScrubbing || isLoading ? "hidden" : "visible"}`}
       >
         <HlsVideoPlayer
-          className={`  ${wideVideo ? "" : "aspect-video"}`}
+          className={`${wideVideo ? "" : "aspect-video"}`}
           videoRef={playerRef}
           currentSource={source}
           onTimeUpdate={onTimeUpdate}
@@ -184,6 +184,7 @@ export default function DynamicVideoPlayer({
         camera={camera}
         timeRange={timeRange}
         cameraPreviews={cameraPreviews}
+        startTime={startTimestamp}
         onControllerReady={(previewController) => {
           setPreviewController(previewController);
         }}

--- a/web/src/views/events/RecordingView.tsx
+++ b/web/src/views/events/RecordingView.tsx
@@ -301,6 +301,7 @@ export function MobileRecordingView({
   relevantPreviews,
   allCameras,
 }: MobileRecordingViewProps) {
+  const { data: config } = useSWR<FrigateConfig>("config");
   const navigate = useNavigate();
   const contentRef = useRef<HTMLDivElement | null>(null);
 
@@ -309,6 +310,21 @@ export function MobileRecordingView({
   const controllerRef = useRef<DynamicVideoController | undefined>(undefined);
   const [playbackCamera, setPlaybackCamera] = useState(startCamera);
   const [playbackStart, setPlaybackStart] = useState(startTime);
+
+  const grow = useMemo(() => {
+    if (!config) {
+      return "aspect-video";
+    }
+
+    const aspectRatio =
+      config.cameras[playbackCamera].detect.width /
+      config.cameras[playbackCamera].detect.height;
+    if (aspectRatio > 2) {
+      return "aspect-wide";
+    } else {
+      return "aspect-video";
+    }
+  }, [config, playbackCamera]);
 
   // timeline time
 
@@ -453,6 +469,7 @@ export function MobileRecordingView({
 
       <div>
         <DynamicVideoPlayer
+          className={`w-full ${grow}`}
           camera={playbackCamera}
           timeRange={currentTimeRange}
           cameraPreviews={relevantPreviews || []}


### PR DESCRIPTION
- use skeleton while new recording is loading
- clean up android and seekTime logic
- ensure that the mobile recording view does not cause layout shift