### PR TITLE
Fix switching camera group bug

### DIFF
--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -52,7 +52,10 @@ export function CameraGroupSelector({ className }: CameraGroupSelectorProps) {
 
   // groups
 
-  const [group, setGroup] = usePersistedOverlayState("cameraGroup", "default");
+  const [group, setGroup] = usePersistedOverlayState(
+    "cameraGroup",
+    "default" as string,
+  );
 
   const groups = useMemo(() => {
     if (!config) {

--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -52,7 +52,7 @@ export function CameraGroupSelector({ className }: CameraGroupSelectorProps) {
 
   // groups
 
-  const [group, setGroup] = usePersistedOverlayState("cameraGroup");
+  const [group, setGroup] = usePersistedOverlayState("cameraGroup", "default");
 
   const groups = useMemo(() => {
     if (!config) {

--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -78,24 +78,24 @@ export function CameraGroupSelector({ className }: CameraGroupSelectorProps) {
         currentGroups={groups}
       />
 
-      <Tooltip open={tooltip == "home"}>
+      <Tooltip open={tooltip == "default"}>
         <TooltipTrigger asChild>
           <Button
             className={
-              group == undefined
+              group == "default"
                 ? "text-selected bg-blue-900 focus:bg-blue-900 bg-opacity-60 focus:bg-opacity-60"
                 : "text-muted-foreground bg-secondary focus:text-muted-foreground focus:bg-secondary"
             }
             size="xs"
-            onClick={() => (group ? setGroup(undefined, true) : null)}
-            onMouseEnter={() => (isDesktop ? showTooltip("home") : null)}
+            onClick={() => (group ? setGroup("default", true) : null)}
+            onMouseEnter={() => (isDesktop ? showTooltip("default") : null)}
             onMouseLeave={() => (isDesktop ? showTooltip(undefined) : null)}
           >
             <MdHome className="size-4" />
           </Button>
         </TooltipTrigger>
         <TooltipContent className="capitalize" side="right">
-          Home
+          All Cameras
         </TooltipContent>
       </Tooltip>
       {groups.map(([name, config]) => {
@@ -109,7 +109,9 @@ export function CameraGroupSelector({ className }: CameraGroupSelectorProps) {
                     : "text-muted-foreground bg-secondary"
                 }
                 size="xs"
-                onClick={() => setGroup(name, group != undefined)}
+                onClick={() => {
+                  setGroup(name, group != "default");
+                }}
                 onMouseEnter={() => (isDesktop ? showTooltip(name) : null)}
                 onMouseLeave={() => (isDesktop ? showTooltip(undefined) : null)}
               >

--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -112,9 +112,7 @@ export function CameraGroupSelector({ className }: CameraGroupSelectorProps) {
                     : "text-muted-foreground bg-secondary"
                 }
                 size="xs"
-                onClick={() => {
-                  setGroup(name, group != "default");
-                }}
+                onClick={() => setGroup(name, group != "default")}
                 onMouseEnter={() => (isDesktop ? showTooltip(name) : null)}
                 onMouseLeave={() => (isDesktop ? showTooltip(undefined) : null)}
               >

--- a/web/src/hooks/use-overlay-state.tsx
+++ b/web/src/hooks/use-overlay-state.tsx
@@ -42,7 +42,7 @@ export function usePersistedOverlayState<S extends string>(
   const currentLocationState = location.state;
 
   const setOverlayStateValue = useCallback(
-    (value: S | undefined, replace?: boolean) => {
+    (value: S | undefined, replace: boolean = false) => {
       setPersistedValue(value);
       const newLocationState = { ...currentLocationState };
       newLocationState[key] = value;

--- a/web/src/hooks/use-overlay-state.tsx
+++ b/web/src/hooks/use-overlay-state.tsx
@@ -42,7 +42,7 @@ export function usePersistedOverlayState<S extends string>(
   const currentLocationState = location.state;
 
   const setOverlayStateValue = useCallback(
-    (value: S | undefined, replace: boolean = false) => {
+    (value: S | undefined, replace?: boolean) => {
       setPersistedValue(value);
       const newLocationState = { ...currentLocationState };
       newLocationState[key] = value;

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -11,7 +11,7 @@ function Live() {
   const { data: config } = useSWR<FrigateConfig>("config");
 
   const [selectedCameraName, setSelectedCameraName] = useOverlayState("camera");
-  const [cameraGroup] = usePersistedOverlayState("cameraGroup");
+  const [cameraGroup] = usePersistedOverlayState("cameraGroup", "default");
 
   const includesBirdseye = useMemo(() => {
     if (config && cameraGroup && cameraGroup != "default") {

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -11,7 +11,10 @@ function Live() {
   const { data: config } = useSWR<FrigateConfig>("config");
 
   const [selectedCameraName, setSelectedCameraName] = useOverlayState("camera");
-  const [cameraGroup] = usePersistedOverlayState("cameraGroup", "default");
+  const [cameraGroup] = usePersistedOverlayState(
+    "cameraGroup",
+    "default" as string,
+  );
 
   const includesBirdseye = useMemo(() => {
     if (config && cameraGroup && cameraGroup != "default") {

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -14,7 +14,7 @@ function Live() {
   const [cameraGroup] = usePersistedOverlayState("cameraGroup");
 
   const includesBirdseye = useMemo(() => {
-    if (config && cameraGroup) {
+    if (config && cameraGroup && cameraGroup != "default") {
       return config.camera_groups[cameraGroup].cameras.includes("birdseye");
     } else {
       return false;
@@ -26,7 +26,7 @@ function Live() {
       return [];
     }
 
-    if (cameraGroup) {
+    if (cameraGroup && cameraGroup != "default") {
       const group = config.camera_groups[cameraGroup];
       return Object.values(config.cameras)
         .filter((conf) => conf.enabled && group.cameras.includes(conf.name))


### PR DESCRIPTION
When switching camera groups and then navigating away from and back to the Live view, it was not possible to re-select the default group. This PR just gives the default group a name (`default`) so that everything works with the persisted overlay state hook.