### PR TITLE
Make all motion segments clickable

### DIFF
--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -179,19 +179,10 @@ export function MotionSegment({
   };
 
   const segmentClick = useCallback(() => {
-    if (
-      startTimestamp &&
-      setHandlebarTime &&
-      (firstHalfSegmentWidth > 1 || secondHalfSegmentWidth > 1)
-    ) {
-      setHandlebarTime(startTimestamp);
+    if (setHandlebarTime) {
+      setHandlebarTime(segmentTime);
     }
-  }, [
-    startTimestamp,
-    setHandlebarTime,
-    firstHalfSegmentWidth,
-    secondHalfSegmentWidth,
-  ]);
+  }, [segmentTime, setHandlebarTime]);
 
   return (
     <div

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -66,15 +66,6 @@ export function MotionSegment({
     [shouldShowRoundedCorners, segmentTime],
   );
 
-  const startTimestamp = useMemo(() => {
-    const eventStart = getMotionStart(segmentTime);
-    if (eventStart) {
-      return alignStartDateToTimeline(eventStart);
-    }
-    // we know that these deps are correct
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getMotionStart, segmentTime]);
-
   const timestamp = useMemo(() => new Date(segmentTime * 1000), [segmentTime]);
   const segmentKey = useMemo(() => segmentTime, [segmentTime]);
 

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -39,7 +39,7 @@ export function MotionSegment({
     shouldShowRoundedCorners,
   } = useEventSegmentUtils(segmentDuration, events, severityType);
 
-  const { getMotionSegmentValue, interpolateMotionAudioData, getMotionStart } =
+  const { getMotionSegmentValue, interpolateMotionAudioData } =
     useMotionSegmentUtils(segmentDuration, motion_events);
 
   const { alignStartDateToTimeline, alignEndDateToTimeline } = useEventUtils(


### PR DESCRIPTION
This PR makes every segment in the motion timeline clickable so that the handlebar moves to that position, regardless of whether or not the segment is displaying any motion bars.