### PR TITLE
Fix divide by zero in normalized motion data

### DIFF
--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -400,7 +400,7 @@ def motion_activity():
             (part["motion"] - part["motion"].min())
             / (part["motion"].max() - part["motion"].min())
             * 100
-        )
+        ).fillna(0.0)
 
     # change types for output
     df.index = df.index.astype(int) // (10**9)


### PR DESCRIPTION
Normalization of all zeros in motion data would result in NaN values for chunks with equal minimum and maximum values, and these NaN values would propagate to the final normalized pandas data frame. This would then result in an invalid json object being passed out of the function (it would be a string) and would break the frontend which is looking for an array.

The fix is just to add a second transformation of NaN any values to zeros before returning.