### PR TITLE
Clean up selected data for recording

### DIFF
--- a/web/src/components/player/PreviewThumbnailPlayer.tsx
+++ b/web/src/components/player/PreviewThumbnailPlayer.tsx
@@ -26,7 +26,7 @@ type PreviewPlayerProps = {
   scrollLock?: boolean;
   onTimeUpdate?: React.Dispatch<React.SetStateAction<number | undefined>>;
   setReviewed: (review: ReviewSegment) => void;
-  onClick: (reviewId: string, ctrl: boolean) => void;
+  onClick: (review: ReviewSegment, ctrl: boolean) => void;
 };
 
 type Preview = {
@@ -55,7 +55,7 @@ export default function PreviewThumbnailPlayer({
   const handleOnClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (!ignoreClick) {
-        onClick(review.id, e.metaKey);
+        onClick(review, e.metaKey);
       }
     },
     [ignoreClick, review, onClick],
@@ -165,7 +165,7 @@ export default function PreviewThumbnailPlayer({
       onMouseLeave={isMobile ? undefined : () => setIsHovered(false)}
       onContextMenu={(e) => {
         e.preventDefault();
-        onClick(review.id, true);
+        onClick(review, true);
       }}
       onClick={handleOnClick}
       {...swipeHandlers}

--- a/web/src/hooks/use-overlay-state.tsx
+++ b/web/src/hooks/use-overlay-state.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { usePersistence } from "./use-persistence";
 
-export function useOverlayState<S extends string>(
+export function useOverlayState<S>(
   key: string,
   defaultValue: S | undefined = undefined,
 ): [S | undefined, (value: S, replace?: boolean) => void] {

--- a/web/src/types/record.ts
+++ b/web/src/types/record.ts
@@ -1,3 +1,5 @@
+import { ReviewSeverity } from "./review";
+
 export type Recording = {
   id: string;
   camera: string;
@@ -29,4 +31,10 @@ type RecordingSegmentActivity = {
   date: number;
   count: number;
   hasObjects: boolean;
+};
+
+export type RecordingStartingPoint = {
+  camera: string;
+  startTime: number;
+  severity: ReviewSeverity;
 };

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -36,6 +36,7 @@ import { Button } from "@/components/ui/button";
 import PreviewPlayer, {
   PreviewController,
 } from "@/components/player/PreviewPlayer";
+import { RecordingStartingPoint } from "@/types/record";
 
 type EventViewProps = {
   reviews?: ReviewSegment[];
@@ -48,7 +49,7 @@ type EventViewProps = {
   setSeverity: (severity: ReviewSeverity) => void;
   markItemAsReviewed: (review: ReviewSegment) => void;
   markAllItemsAsReviewed: (currentItems: ReviewSegment[]) => void;
-  onOpenReview: (reviewId: string) => void;
+  onOpenRecording: (recordingInfo: RecordingStartingPoint) => void;
   pullLatestData: () => void;
   updateFilter: (filter: ReviewFilter) => void;
 };
@@ -63,7 +64,7 @@ export default function EventView({
   setSeverity,
   markItemAsReviewed,
   markAllItemsAsReviewed,
-  onOpenReview,
+  onOpenRecording,
   pullLatestData,
   updateFilter,
 }: EventViewProps) {
@@ -145,9 +146,9 @@ export default function EventView({
 
   const [selectedReviews, setSelectedReviews] = useState<string[]>([]);
   const onSelectReview = useCallback(
-    (reviewId: string, ctrl: boolean) => {
+    (review: ReviewSegment, ctrl: boolean) => {
       if (selectedReviews.length > 0 || ctrl) {
-        const index = selectedReviews.indexOf(reviewId);
+        const index = selectedReviews.indexOf(review.id);
 
         if (index != -1) {
           if (selectedReviews.length == 1) {
@@ -161,14 +162,20 @@ export default function EventView({
           }
         } else {
           const copy = [...selectedReviews];
-          copy.push(reviewId);
+          copy.push(review.id);
           setSelectedReviews(copy);
         }
       } else {
-        onOpenReview(reviewId);
+        onOpenRecording({
+          camera: review.camera,
+          startTime: review.start_time,
+          severity: review.severity,
+        });
+
+        markItemAsReviewed(review);
       }
     },
-    [selectedReviews, setSelectedReviews, onOpenReview],
+    [selectedReviews, setSelectedReviews, onOpenRecording, markItemAsReviewed],
   );
 
   const exportReview = useCallback(
@@ -281,7 +288,7 @@ export default function EventView({
             timeRange={timeRange}
             startTime={startTime}
             filter={filter}
-            onSelectReview={onSelectReview}
+            onOpenRecording={onOpenRecording}
           />
         )}
       </div>
@@ -305,7 +312,7 @@ type DetectionReviewProps = {
   timeRange: { before: number; after: number };
   markItemAsReviewed: (review: ReviewSegment) => void;
   markAllItemsAsReviewed: (currentItems: ReviewSegment[]) => void;
-  onSelectReview: (id: string, ctrl: boolean) => void;
+  onSelectReview: (review: ReviewSegment, ctrl: boolean) => void;
   pullLatestData: () => void;
 };
 function DetectionReview({
@@ -538,7 +545,7 @@ type MotionReviewProps = {
   timeRange: { before: number; after: number };
   startTime?: number;
   filter?: ReviewFilter;
-  onSelectReview: (data: string, ctrl: boolean) => void;
+  onOpenRecording: (data: RecordingStartingPoint) => void;
 };
 function MotionReview({
   contentRef,
@@ -547,7 +554,7 @@ function MotionReview({
   timeRange,
   startTime,
   filter,
-  onSelectReview,
+  onOpenRecording,
 }: MotionReviewProps) {
   const segmentDuration = 30;
   const { data: config } = useSWR<FrigateConfig>("config");
@@ -674,7 +681,11 @@ function MotionReview({
                   videoPlayersRef.current[camera.name] = controller;
                 }}
                 onClick={() =>
-                  onSelectReview(`motion,${camera.name},${currentTime}`, false)
+                  onOpenRecording({
+                    camera: camera.name,
+                    startTime: currentTime,
+                    severity: "significant_motion",
+                  })
                 }
               />
             );


### PR DESCRIPTION
Currently the data to select motion recordings was a bit messy using serialized string and not conducive to future features. This updates overlay state so it can contain any object type. This way we can hold a state of a recording starting point and this information can be pulled using query args or other data in the future if we need to.