### PR TITLE
Update linked proxmox install in docs

### DIFF
--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -202,7 +202,7 @@ To install make sure you have the [community app plugin here](https://forums.unr
 
 ## Proxmox
 
-It is recommended to run Frigate in LXC for maximum performance. See [this discussion](https://github.com/blakeblackshear/frigate/discussions/1111) for more information.
+It is recommended to run Frigate in LXC for maximum performance. See [this discussion](https://github.com/blakeblackshear/frigate/discussions/5773) for more information.
 
 ## ESXi
 


### PR DESCRIPTION
The currently linked guide points to 0.8.4 and users recently were confused about this. The updated guide points to ghcr stable tag so should be relevant for some time to come