### PR TITLE
Ability to configure loitering time in a zone

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -488,6 +488,8 @@ cameras:
         coordinates: 545,1077,747,939,788,805
         # Optional: Number of consecutive frames required for object to be considered present in the zone (default: shown below).
         inertia: 3
+        # Optional: Number of seconds that an object must loiter to be considered in the zone (default: shown below)
+        loitering_time: 0
         # Optional: List of objects that can trigger this zone (default: all tracked objects)
         objects:
           - person

--- a/docs/docs/configuration/zones.md
+++ b/docs/docs/configuration/zones.md
@@ -62,12 +62,12 @@ Only car objects can trigger the `front_yard_street` zone and only person can tr
 
 ### Zone Loitering
 
-Sometimes objects are expected to be passing through a zone, but there an object loitering in an area is unexpected. Zones can be configured to have a minimum loitering time before the object will be considered in the zone.
+Sometimes objects are expected to be passing through a zone, but an object loitering in an area is unexpected. Zones can be configured to have a minimum loitering time before the object will be considered in the zone.
 
 ```yaml
 camera:
   zones:
-    front_yard:
+    sidewalk:
       loitering_time: 4 # unit is in seconds
       objects:
         - person

--- a/docs/docs/configuration/zones.md
+++ b/docs/docs/configuration/zones.md
@@ -60,6 +60,19 @@ camera:
 
 Only car objects can trigger the `front_yard_street` zone and only person can trigger the `entire_yard`. You will get events for person objects that enter anywhere in the yard, and events for cars only if they enter the street.
 
+### Zone Loitering
+
+Sometimes objects are expected to be passing through a zone, but there an object loitering in an area is unexpected. Zones can be configured to have a minimum loitering time before the object will be considered in the zone.
+
+```yaml
+camera:
+  zones:
+    front_yard:
+      loitering_time: 4 # unit is in seconds
+      objects:
+        - person
+```
+
 ### Zone Inertia
 
 Sometimes an objects bounding box may be slightly incorrect and the bottom center of the bounding box is inside the zone while the object is not actually in the zone. Zone inertia helps guard against this by requiring an object's bounding box to be within the zone for multiple consecutive frames. This value can be configured:

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -518,7 +518,7 @@ class ZoneConfig(BaseModel):
     loitering_time: int = Field(
         default=0,
         ge=0,
-        title="Number of seconds that an object must loiter to be considered in the zone."
+        title="Number of seconds that an object must loiter to be considered in the zone.",
     )
     objects: List[str] = Field(
         default_factory=list,

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -515,6 +515,11 @@ class ZoneConfig(BaseModel):
         title="Number of consecutive frames required for object to be considered present in the zone.",
         gt=0,
     )
+    loitering_time: int = Field(
+        default=0,
+        ge=0,
+        title="Number of seconds that an object must loiter to be considered in the zone."
+    )
     objects: List[str] = Field(
         default_factory=list,
         title="List of objects that can trigger the zone.",

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -535,9 +535,7 @@ class CameraState:
                     ):
                         max_target_box = self.ptz_autotracker_thread.ptz_autotracker.tracked_object_metrics[
                             self.name
-                        ][
-                            "max_target_box"
-                        ]
+                        ]["max_target_box"]
                         side_length = max_target_box * (
                             max(
                                 self.camera_config.detect.width,


### PR DESCRIPTION
This PR adds a config, docs, and functionality to make a zone only consider an object when that object has loitered in that zone for a configurable amount of time. By default objects are considered part of the zone immediately after the inertia has been passed.

closes https://github.com/blakeblackshear/frigate/issues/2397