### PR TITLE
Timeline minimap and scrolling changes

### DIFF
--- a/web/src/components/timeline/EventReviewTimeline.tsx
+++ b/web/src/components/timeline/EventReviewTimeline.tsx
@@ -79,9 +79,11 @@ export function EventReviewTimeline({
   );
 
   const { alignStartDateToTimeline, alignEndDateToTimeline } = useTimelineUtils(
-    segmentDuration,
-    timelineDuration,
-    selectedTimelineRef,
+    {
+      segmentDuration,
+      timelineDuration,
+      timelineRef: selectedTimelineRef,
+    },
   );
 
   const timelineStartAligned = useMemo(

--- a/web/src/components/timeline/EventReviewTimeline.tsx
+++ b/web/src/components/timeline/EventReviewTimeline.tsx
@@ -222,7 +222,7 @@ export function EventReviewTimeline({
   }, [isDragging, onHandlebarDraggingChange]);
 
   useEffect(() => {
-    if (contentRef.current && segments) {
+    if (contentRef.current && segments && !showMinimap) {
       observer.current = new IntersectionObserver(
         (entries) => {
           entries.forEach((entry) => {
@@ -260,7 +260,7 @@ export function EventReviewTimeline({
     return () => {
       observer.current?.disconnect();
     };
-  }, [contentRef, segments]);
+  }, [contentRef, segments, showMinimap]);
 
   useEffect(() => {
     if (

--- a/web/src/components/timeline/EventReviewTimeline.tsx
+++ b/web/src/components/timeline/EventReviewTimeline.tsx
@@ -74,8 +74,11 @@ export function EventReviewTimeline({
     [timelineEnd, timelineStart],
   );
 
-  const { alignStartDateToTimeline, alignEndDateToTimeline } =
-    useTimelineUtils(segmentDuration);
+  const { alignStartDateToTimeline, alignEndDateToTimeline } = useTimelineUtils(
+    segmentDuration,
+    timelineDuration,
+    timelineRef || internalTimelineRef,
+  );
 
   const timelineStartAligned = useMemo(
     () => alignStartDateToTimeline(timelineStart),

--- a/web/src/components/timeline/EventSegment.tsx
+++ b/web/src/components/timeline/EventSegment.tsx
@@ -53,8 +53,10 @@ export function EventSegment({
     getEventThumbnail,
   } = useEventSegmentUtils(segmentDuration, events, severityType);
 
-  const { alignStartDateToTimeline, alignEndDateToTimeline } =
-    useTimelineUtils(segmentDuration);
+  const { alignStartDateToTimeline, alignEndDateToTimeline } = useTimelineUtils(
+    segmentDuration,
+    0,
+  );
 
   const severity = useMemo(
     () => getSeverity(segmentTime, displaySeverityType),

--- a/web/src/components/timeline/EventSegment.tsx
+++ b/web/src/components/timeline/EventSegment.tsx
@@ -54,8 +54,7 @@ export function EventSegment({
   } = useEventSegmentUtils(segmentDuration, events, severityType);
 
   const { alignStartDateToTimeline, alignEndDateToTimeline } = useTimelineUtils(
-    segmentDuration,
-    0,
+    { segmentDuration },
   );
 
   const severity = useMemo(

--- a/web/src/components/timeline/EventSegment.tsx
+++ b/web/src/components/timeline/EventSegment.tsx
@@ -201,6 +201,7 @@ export function EventSegment({
   return (
     <div
       key={segmentKey}
+      data-segment-id={segmentKey}
       className={segmentClasses}
       onClick={segmentClick}
       onTouchEnd={(event) => handleTouchStart(event, segmentClick)}

--- a/web/src/components/timeline/MotionReviewTimeline.tsx
+++ b/web/src/components/timeline/MotionReviewTimeline.tsx
@@ -77,8 +77,10 @@ export function MotionReviewTimeline({
   );
 
   const { alignStartDateToTimeline, alignEndDateToTimeline } = useTimelineUtils(
-    segmentDuration,
-    timelineDuration,
+    {
+      segmentDuration,
+      timelineDuration,
+    },
   );
 
   const timelineStartAligned = useMemo(

--- a/web/src/components/timeline/MotionReviewTimeline.tsx
+++ b/web/src/components/timeline/MotionReviewTimeline.tsx
@@ -76,8 +76,10 @@ export function MotionReviewTimeline({
     [timelineEnd, timelineStart, segmentDuration],
   );
 
-  const { alignStartDateToTimeline, alignEndDateToTimeline } =
-    useTimelineUtils(segmentDuration);
+  const { alignStartDateToTimeline, alignEndDateToTimeline } = useTimelineUtils(
+    segmentDuration,
+    timelineDuration,
+  );
 
   const timelineStartAligned = useMemo(
     () => alignStartDateToTimeline(timelineStart) + 2 * segmentDuration,

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -43,8 +43,7 @@ export function MotionSegment({
     useMotionSegmentUtils(segmentDuration, motion_events);
 
   const { alignStartDateToTimeline, alignEndDateToTimeline } = useTimelineUtils(
-    segmentDuration,
-    0,
+    { segmentDuration },
   );
 
   const { handleTouchStart } = useTapUtils();

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -42,8 +42,10 @@ export function MotionSegment({
   const { getMotionSegmentValue, interpolateMotionAudioData } =
     useMotionSegmentUtils(segmentDuration, motion_events);
 
-  const { alignStartDateToTimeline, alignEndDateToTimeline } =
-    useTimelineUtils(segmentDuration);
+  const { alignStartDateToTimeline, alignEndDateToTimeline } = useTimelineUtils(
+    segmentDuration,
+    0,
+  );
 
   const { handleTouchStart } = useTapUtils();
 

--- a/web/src/components/timeline/SummaryTimeline.tsx
+++ b/web/src/components/timeline/SummaryTimeline.tsx
@@ -39,16 +39,20 @@ export function SummaryTimeline({
 
   const observer = useRef<ResizeObserver | null>(null);
 
-  const { alignStartDateToTimeline } = useTimelineUtils(segmentDuration);
+  const reviewTimelineDuration = useMemo(
+    () => timelineStart - timelineEnd + 4 * segmentDuration,
+    [timelineEnd, timelineStart, segmentDuration],
+  );
+
+  const { alignStartDateToTimeline } = useTimelineUtils(
+    segmentDuration,
+    reviewTimelineDuration,
+    reviewTimelineRef,
+  );
 
   const timelineStartAligned = useMemo(
     () => alignStartDateToTimeline(timelineStart) + 2 * segmentDuration,
     [timelineStart, alignStartDateToTimeline, segmentDuration],
-  );
-
-  const reviewTimelineDuration = useMemo(
-    () => timelineStart - timelineEnd + 4 * segmentDuration,
-    [timelineEnd, timelineStart, segmentDuration],
   );
 
   // Generate segments for the timeline

--- a/web/src/components/timeline/SummaryTimeline.tsx
+++ b/web/src/components/timeline/SummaryTimeline.tsx
@@ -44,11 +44,11 @@ export function SummaryTimeline({
     [timelineEnd, timelineStart, segmentDuration],
   );
 
-  const { alignStartDateToTimeline } = useTimelineUtils(
+  const { alignStartDateToTimeline } = useTimelineUtils({
     segmentDuration,
-    reviewTimelineDuration,
-    reviewTimelineRef,
-  );
+    timelineDuration: reviewTimelineDuration,
+    timelineRef: reviewTimelineRef,
+  });
 
   const timelineStartAligned = useMemo(
     () => alignStartDateToTimeline(timelineStart) + 2 * segmentDuration,

--- a/web/src/hooks/use-draggable-element.ts
+++ b/web/src/hooks/use-draggable-element.ts
@@ -40,8 +40,11 @@ function useDraggableElement({
 }: DraggableElementProps) {
   const [clientYPosition, setClientYPosition] = useState<number | null>(null);
   const [initialClickAdjustment, setInitialClickAdjustment] = useState(0);
-  const { alignStartDateToTimeline, getCumulativeScrollTop } =
-    useTimelineUtils(segmentDuration);
+  const { alignStartDateToTimeline, getCumulativeScrollTop } = useTimelineUtils(
+    timelineDuration,
+    segmentDuration,
+    timelineRef,
+  );
 
   const draggingAtTopEdge = useMemo(() => {
     if (clientYPosition && timelineRef.current) {

--- a/web/src/hooks/use-draggable-element.ts
+++ b/web/src/hooks/use-draggable-element.ts
@@ -41,9 +41,11 @@ function useDraggableElement({
   const [clientYPosition, setClientYPosition] = useState<number | null>(null);
   const [initialClickAdjustment, setInitialClickAdjustment] = useState(0);
   const { alignStartDateToTimeline, getCumulativeScrollTop } = useTimelineUtils(
-    segmentDuration,
-    timelineDuration,
-    timelineRef,
+    {
+      segmentDuration: segmentDuration,
+      timelineDuration: timelineDuration,
+      timelineRef,
+    },
   );
 
   const draggingAtTopEdge = useMemo(() => {

--- a/web/src/hooks/use-draggable-element.ts
+++ b/web/src/hooks/use-draggable-element.ts
@@ -41,8 +41,8 @@ function useDraggableElement({
   const [clientYPosition, setClientYPosition] = useState<number | null>(null);
   const [initialClickAdjustment, setInitialClickAdjustment] = useState(0);
   const { alignStartDateToTimeline, getCumulativeScrollTop } = useTimelineUtils(
-    timelineDuration,
     segmentDuration,
+    timelineDuration,
     timelineRef,
   );
 

--- a/web/src/hooks/use-timeline-utils.ts
+++ b/web/src/hooks/use-timeline-utils.ts
@@ -1,6 +1,10 @@
 import { useCallback } from "react";
 
-export const useTimelineUtils = (segmentDuration: number) => {
+export const useTimelineUtils = (
+  segmentDuration: number,
+  timelineDuration: number,
+  timelineRef?: React.RefObject<HTMLElement>,
+) => {
   const alignEndDateToTimeline = useCallback(
     (time: number): number => {
       const remainder = time % segmentDuration;
@@ -28,9 +32,27 @@ export const useTimelineUtils = (segmentDuration: number) => {
     return scrollTop;
   }, []);
 
+  const getVisibleTimelineDuration = useCallback(() => {
+    if (timelineRef?.current) {
+      const {
+        scrollHeight: timelineHeight,
+        clientHeight: visibleTimelineHeight,
+      } = timelineRef.current;
+
+      const segmentHeight =
+        timelineHeight / (timelineDuration / segmentDuration);
+
+      const visibleTime =
+        (visibleTimelineHeight / segmentHeight) * segmentDuration;
+
+      return visibleTime;
+    }
+  }, [segmentDuration, timelineDuration, timelineRef]);
+
   return {
     alignEndDateToTimeline,
     alignStartDateToTimeline,
     getCumulativeScrollTop,
+    getVisibleTimelineDuration,
   };
 };

--- a/web/src/hooks/use-timeline-utils.ts
+++ b/web/src/hooks/use-timeline-utils.ts
@@ -1,10 +1,16 @@
 import { useCallback } from "react";
 
-export const useTimelineUtils = (
-  segmentDuration: number,
-  timelineDuration: number,
-  timelineRef?: React.RefObject<HTMLElement>,
-) => {
+export type TimelineUtilsProps = {
+  segmentDuration: number;
+  timelineDuration?: number;
+  timelineRef?: React.RefObject<HTMLElement>;
+};
+
+export function useTimelineUtils({
+  segmentDuration,
+  timelineDuration,
+  timelineRef,
+}: TimelineUtilsProps) {
   const alignEndDateToTimeline = useCallback(
     (time: number): number => {
       const remainder = time % segmentDuration;
@@ -33,7 +39,7 @@ export const useTimelineUtils = (
   }, []);
 
   const getVisibleTimelineDuration = useCallback(() => {
-    if (timelineRef?.current) {
+    if (timelineRef?.current && timelineDuration) {
       const {
         scrollHeight: timelineHeight,
         clientHeight: visibleTimelineHeight,
@@ -55,4 +61,4 @@ export const useTimelineUtils = (
     getCumulativeScrollTop,
     getVisibleTimelineDuration,
   };
-};
+}

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -508,7 +508,7 @@ function DetectionReview({
                   data-segment-start={
                     alignStartDateToTimeline(value.start_time) - segmentDuration
                   }
-                  className={`outline outline-offset-1 rounded-lg shadow-none transition-all my-1 md:my-0 ${selected ? `outline-4 shadow-[0_0_6px_1px] outline-severity_${value.severity} shadow-severity_${value.severity}` : "outline-0 duration-500"}`}
+                  className={`review-item outline outline-offset-1 rounded-lg shadow-none transition-all my-1 md:my-0 ${selected ? `outline-4 shadow-[0_0_6px_1px] outline-severity_${value.severity} shadow-severity_${value.severity}` : "outline-0 duration-500"}`}
                 >
                   <div className="aspect-video rounded-lg overflow-hidden">
                     <PreviewThumbnailPlayer

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -384,11 +384,8 @@ function DetectionReview({
     [timeRange],
   );
 
-  const { alignStartDateToTimeline } = useTimelineUtils(
-    segmentDuration,
-    timelineDuration,
-    reviewTimelineRef,
-  );
+  const { alignStartDateToTimeline, getVisibleTimelineDuration } =
+    useTimelineUtils(segmentDuration, timelineDuration, reviewTimelineRef);
 
   const scrollLock = useScrollLockout(contentRef);
 
@@ -457,10 +454,21 @@ function DetectionReview({
       return false;
     }
 
-    return contentRef.current.scrollHeight > contentRef.current.clientHeight;
+    // don't show minimap if the view is not scrollable
+    if (contentRef.current.scrollHeight < contentRef.current.clientHeight) {
+      return false;
+    }
+
+    const visibleTime = getVisibleTimelineDuration();
+    const minimapTime = minimapBounds.end - minimapBounds.start;
+    if (visibleTime && minimapTime >= visibleTime * 0.75) {
+      return false;
+    }
+
+    return true;
     // we know that these deps are correct
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [contentRef.current?.scrollHeight, severity]);
+  }, [contentRef.current?.scrollHeight, minimapBounds]);
 
   return (
     <>

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -470,6 +470,11 @@ function DetectionReview({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contentRef.current?.scrollHeight, minimapBounds]);
 
+  const visibleTimestamps = useMemo(
+    () => minimap.map((str) => parseFloat(str)),
+    [minimap],
+  );
+
   return (
     <>
       <div
@@ -559,6 +564,7 @@ function DetectionReview({
             minimapEndTime={minimapBounds.end}
             showHandlebar={previewTime != undefined}
             handlebarTime={previewTime}
+            visibleTimestamps={visibleTimestamps}
             events={reviewItems?.all ?? []}
             severityType={severity}
             contentRef={contentRef}

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -379,7 +379,16 @@ function DetectionReview({
 
   // timeline interaction
 
-  const { alignStartDateToTimeline } = useTimelineUtils(segmentDuration);
+  const timelineDuration = useMemo(
+    () => timeRange.before - timeRange.after,
+    [timeRange],
+  );
+
+  const { alignStartDateToTimeline } = useTimelineUtils(
+    segmentDuration,
+    timelineDuration,
+    reviewTimelineRef,
+  );
 
   const scrollLock = useScrollLockout(contentRef);
 

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -385,7 +385,11 @@ function DetectionReview({
   );
 
   const { alignStartDateToTimeline, getVisibleTimelineDuration } =
-    useTimelineUtils(segmentDuration, timelineDuration, reviewTimelineRef);
+    useTimelineUtils({
+      segmentDuration,
+      timelineDuration,
+      timelineRef: reviewTimelineRef,
+    });
 
   const scrollLock = useScrollLockout(contentRef);
 


### PR DESCRIPTION
- Add hook function to get visible timeline duration
- Only show minimap if visible review items fit within visible timeline
- More intelligently scroll timeline when minimap is hidden - don't scroll again after hovering preview unless preview area is scrolled by the user