### PR TITLE
Add relative movement by clicking for supported ptzs

### DIFF
--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -315,6 +315,9 @@ class Dispatcher:
             if "preset" in payload.lower():
                 command = OnvifCommandEnum.preset
                 param = payload.lower()[payload.index("_") + 1 :]
+            elif "move_relative" in payload.lower():
+                command = OnvifCommandEnum.move_relative
+                param = payload.lower()[payload.index("_") + 1 :]
             else:
                 command = OnvifCommandEnum[payload.lower()]
                 param = ""

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -21,6 +21,7 @@ class OnvifCommandEnum(str, Enum):
     init = "init"
     move_down = "move_down"
     move_left = "move_left"
+    move_relative = "move_relative"
     move_right = "move_right"
     move_up = "move_up"
     preset = "preset"
@@ -536,6 +537,9 @@ class OnvifController:
             self._stop(camera_name)
         elif command == OnvifCommandEnum.preset:
             self._move_to_preset(camera_name, param)
+        elif command == OnvifCommandEnum.move_relative:
+            _, pan, tilt = param.split("_")
+            self._move_relative(camera_name, float(pan), float(tilt), 0, 1)
         elif (
             command == OnvifCommandEnum.zoom_in or command == OnvifCommandEnum.zoom_out
         ):


### PR DESCRIPTION
For PTZs that support relative movement, this PR enables "click to move" functionality. By enabling and clicking on a live camera image, the PTZ will move to center the image on the clicked point.