### PR TITLE
IPv6 listen in nginx.conf

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -62,7 +62,7 @@ http {
     }
 
     server {
-        listen 5000;
+        listen [::]:5000 ipv6only=off;
 
         # vod settings
         vod_base_url '';


### PR DESCRIPTION
This is basically a duplicate of #3497 that has been approved but hasn't been merged for a long time and the author doesn't respond to comments.

This PR changes the listen directive in nginx.conf to listen on both IPv4 and IPv6.