### PR TITLE
Motion review playback optimizations

### DIFF
--- a/web/src/components/timeline/EventSegment.tsx
+++ b/web/src/components/timeline/EventSegment.tsx
@@ -155,8 +155,8 @@ export function EventSegment({
 
   const severityColors: { [key: number]: string } = {
     1: reviewed
-      ? "from-severity_motion-dimmed/50 to-severity_motion/50"
-      : "from-severity_motion-dimmed to-severity_motion",
+      ? "from-severity_significant_motion-dimmed/50 to-severity_significant_motion/50"
+      : "from-severity_significant_motion-dimmed to-severity_significant_motion",
     2: reviewed
       ? "from-severity_detection-dimmed/50 to-severity_detection/50"
       : "from-severity_detection-dimmed to-severity_detection",

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -165,8 +165,8 @@ export function MotionSegment({
 
   const severityColors: { [key: number]: string } = {
     1: reviewed
-      ? "from-severity_motion-dimmed/50 to-severity_motion/50"
-      : "from-severity_motion-dimmed to-severity_motion",
+      ? "from-severity_significant_motion-dimmed/50 to-severity_significant_motion/50"
+      : "from-severity_significant_motion-dimmed to-severity_significant_motion",
     2: reviewed
       ? "from-severity_detection-dimmed/50 to-severity_detection/50"
       : "from-severity_detection-dimmed to-severity_detection",

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -253,7 +253,7 @@ export function MotionSegment({
 
           {!motionOnly &&
             severity.map((severityValue: number, index: number) => {
-              if (severityValue > 1) {
+              if (severityValue > 0) {
                 return (
                   <React.Fragment key={index}>
                     <div className="absolute right-0 h-2 z-10">

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -158,9 +158,9 @@ export function MotionSegment({
       : ""
   }`;
 
-  const animationClassesSecondHalf = `motion-segment ${secondHalfSegmentWidth > 1 ? "hidden" : ""}
+  const animationClassesSecondHalf = `motion-segment ${secondHalfSegmentWidth > 0 ? "hidden" : ""}
     zoom-in-[0.2] ${secondHalfSegmentWidth < 5 ? "duration-200" : "duration-1000"}`;
-  const animationClassesFirstHalf = `motion-segment ${firstHalfSegmentWidth > 1 ? "hidden" : ""}
+  const animationClassesFirstHalf = `motion-segment ${firstHalfSegmentWidth > 0 ? "hidden" : ""}
     zoom-in-[0.2] ${firstHalfSegmentWidth < 5 ? "duration-200" : "duration-1000"}`;
 
   const severityColors: { [key: number]: string } = {
@@ -183,14 +183,14 @@ export function MotionSegment({
 
   return (
     <>
-      {(((firstHalfSegmentWidth > 1 || secondHalfSegmentWidth > 1) &&
+      {(((firstHalfSegmentWidth > 0 || secondHalfSegmentWidth > 0) &&
         motionOnly &&
         severity[0] < 2) ||
         !motionOnly) && (
         <div
           key={segmentKey}
           data-segment-id={segmentKey}
-          className={`segment ${firstHalfSegmentWidth > 1 || secondHalfSegmentWidth > 1 ? "has-data" : ""} ${segmentClasses}`}
+          className={`segment ${firstHalfSegmentWidth > 0 || secondHalfSegmentWidth > 0 ? "has-data" : ""} ${segmentClasses}`}
           onClick={segmentClick}
           onTouchEnd={(event) => handleTouchStart(event, segmentClick)}
         >
@@ -228,9 +228,10 @@ export function MotionSegment({
               <div className="flex justify-center">
                 <div
                   key={`${segmentKey}_motion_data_1`}
+                  data-motion-value={secondHalfSegmentWidth}
                   className={`${isDesktop && animationClassesSecondHalf} h-[2px] rounded-full ${severity[0] != 0 ? "bg-motion_review-dimmed" : "bg-motion_review"}`}
                   style={{
-                    width: secondHalfSegmentWidth,
+                    width: secondHalfSegmentWidth || 1,
                   }}
                 ></div>
               </div>
@@ -240,9 +241,10 @@ export function MotionSegment({
               <div className="flex justify-center">
                 <div
                   key={`${segmentKey}_motion_data_2`}
+                  data-motion-value={firstHalfSegmentWidth}
                   className={`${isDesktop && animationClassesFirstHalf} h-[2px] rounded-full ${severity[0] != 0 ? "bg-motion_review-dimmed" : "bg-motion_review"}`}
                   style={{
-                    width: firstHalfSegmentWidth,
+                    width: firstHalfSegmentWidth || 1,
                   }}
                 ></div>
               </div>

--- a/web/src/components/timeline/SummarySegment.tsx
+++ b/web/src/components/timeline/SummarySegment.tsx
@@ -34,7 +34,9 @@ export function SummarySegment({
   const segmentKey = useMemo(() => segmentTime, [segmentTime]);
 
   const severityColors: { [key: number]: string } = {
-    1: reviewed ? "bg-severity_motion/50" : "bg-severity_motion",
+    1: reviewed
+      ? "bg-severity_significant_motion/50"
+      : "bg-severity_significant_motion",
     2: reviewed ? "bg-severity_detection/50" : "bg-severity_detection",
     3: reviewed ? "bg-severity_alert/50" : "bg-severity_alert",
   };

--- a/web/src/hooks/use-camera-activity.ts
+++ b/web/src/hooks/use-camera-activity.ts
@@ -4,8 +4,6 @@ import {
   useMotionActivity,
 } from "@/api/ws";
 import { CameraConfig } from "@/types/frigateConfig";
-import { MotionData, ReviewSegment } from "@/types/review";
-import { TimeRange } from "@/types/timeline";
 import { useEffect, useMemo, useState } from "react";
 
 type useCameraActivityReturn = {
@@ -67,58 +65,4 @@ export function useCameraActivity(
       ? audioRms >= camera.audio.min_volume
       : false,
   };
-}
-
-export function useCameraMotionTimestamps(
-  timeRange: TimeRange,
-  motionOnly: boolean,
-  events: ReviewSegment[],
-  motion: MotionData[],
-) {
-  const timestamps = useMemo(() => {
-    const seekableTimestamps = [];
-    let lastEventIdx = 0;
-    let lastMotionIdx = 0;
-
-    for (let i = timeRange.after; i <= timeRange.before; i += 0.5) {
-      if (!motionOnly) {
-        seekableTimestamps.push(i);
-      } else {
-        const relevantEventIdx = events.findIndex((seg, segIdx) => {
-          if (segIdx < lastEventIdx) {
-            return false;
-          }
-
-          return seg.start_time <= i && seg.end_time >= i;
-        });
-
-        if (relevantEventIdx != -1) {
-          lastEventIdx = relevantEventIdx;
-          continue;
-        }
-
-        const relevantMotionIdx = motion.findIndex((mot, motIdx) => {
-          if (motIdx < lastMotionIdx) {
-            return false;
-          }
-
-          return mot.start_time <= i && mot.start_time + 15 >= i;
-        });
-
-        if (relevantMotionIdx == -1 || motion[relevantMotionIdx].motion == 0) {
-          if (relevantMotionIdx != -1) {
-            lastMotionIdx = relevantMotionIdx;
-          }
-
-          continue;
-        }
-
-        seekableTimestamps.push(i);
-      }
-    }
-
-    return seekableTimestamps;
-  }, [timeRange, motionOnly, events, motion]);
-
-  return timestamps;
 }

--- a/web/src/hooks/use-draggable-element.ts
+++ b/web/src/hooks/use-draggable-element.ts
@@ -368,26 +368,9 @@ function useDraggableElement({
 
       const alignedSegmentTime = alignStartDateToTimeline(draggableElementTime);
 
-      let segmentElement = timelineRef.current.querySelector(
+      const segmentElement = timelineRef.current.querySelector(
         `[data-segment-id="${alignedSegmentTime}"]`,
       );
-
-      if (!segmentElement) {
-        // segment not found, maybe we collapsed over a collapsible segment
-        let searchTime = alignedSegmentTime;
-        while (searchTime >= timelineStartAligned - timelineDuration) {
-          // Decrement currentTime by segmentDuration
-          searchTime -= segmentDuration;
-          segmentElement = timelineRef.current.querySelector(
-            `[data-segment-id="${searchTime}"]`,
-          );
-
-          if (segmentElement) {
-            // segmentElement found
-            break;
-          }
-        }
-      }
 
       if (segmentElement) {
         const timelineRect = timelineRef.current.getBoundingClientRect();
@@ -421,6 +404,37 @@ function useDraggableElement({
     timelineCollapsed,
     segments,
   ]);
+
+  useEffect(() => {
+    if (timelineRef.current && draggableElementTime && timelineCollapsed) {
+      const alignedSegmentTime = alignStartDateToTimeline(draggableElementTime);
+
+      let segmentElement = timelineRef.current.querySelector(
+        `[data-segment-id="${alignedSegmentTime}"]`,
+      );
+
+      if (!segmentElement) {
+        // segment not found, maybe we collapsed over a collapsible segment
+        let searchTime = alignedSegmentTime;
+        while (searchTime >= timelineStartAligned - timelineDuration) {
+          searchTime -= segmentDuration;
+          segmentElement = timelineRef.current.querySelector(
+            `[data-segment-id="${searchTime}"]`,
+          );
+
+          if (segmentElement) {
+            // found, set time
+            if (setDraggableElementTime) {
+              setDraggableElementTime(searchTime);
+            }
+            break;
+          }
+        }
+      }
+    }
+    // we know that these deps are correct
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timelineCollapsed]);
 
   return { handleMouseDown, handleMouseUp, handleMouseMove };
 }

--- a/web/src/hooks/use-motion-segment-utils.ts
+++ b/web/src/hooks/use-motion-segment-utils.ts
@@ -33,7 +33,7 @@ export const useMotionSegmentUtils = (
 
   const interpolateMotionAudioData = useCallback(
     (value: number, newMax: number): number => {
-      return Math.ceil((Math.abs(value) / 100.0) * newMax) || 1;
+      return Math.ceil((Math.abs(value) / 100.0) * newMax) || 0;
     },
     [],
   );

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -830,11 +830,16 @@ function MotionReview({
       if (motionOnly) {
         return null;
       }
-      const segmentTime = alignStartDateToTimeline(currentTime);
+      const segmentStartTime = alignStartDateToTimeline(currentTime);
+      const segmentEndTime = segmentStartTime + segmentDuration;
       const matchingItem = reviewItems?.all.find(
         (item) =>
-          item.start_time >= segmentTime &&
-          item.end_time <= segmentTime + segmentDuration &&
+          ((item.start_time >= segmentStartTime &&
+            item.start_time < segmentEndTime) ||
+            (item.end_time > segmentStartTime &&
+              item.end_time <= segmentEndTime) ||
+            (item.start_time <= segmentStartTime &&
+              item.end_time >= segmentEndTime)) &&
           item.camera === cameraName,
       );
 

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -246,7 +246,7 @@ export default function EventView({
             value="significant_motion"
             aria-label="Select motion"
           >
-            <MdCircle className="size-2 md:mr-[10px] text-severity_motion" />
+            <MdCircle className="size-2 md:mr-[10px] text-severity_significant_motion" />
             <div className="hidden md:block">Motion</div>
           </ToggleGroupItem>
         </ToggleGroup>

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -87,9 +87,9 @@ module.exports = {
           DEFAULT: "hsl(var(--severity_detection))",
           dimmed: "hsl(var(--severity_detection_dimmed))",
         },
-        severity_motion: {
-          DEFAULT: "hsl(var(--severity_motion))",
-          dimmed: "hsl(var(--severity_motion_dimmed))",
+        severity_significant_motion: {
+          DEFAULT: "hsl(var(--severity_significant_motion))",
+          dimmed: "hsl(var(--severity_significant_motion_dimmed))",
         },
         motion_review: {
           DEFAULT: "hsl(var(--motion_review))",

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
   ],
   safelist: [
     {
-      pattern: /(outline|shadow)-severity_(alert|detection|motion)/,
+      pattern: /(outline|shadow)-severity_(alert|detection|significant_motion)/,
     },
   ],
   theme: {

--- a/web/themes/theme-default.css
+++ b/web/themes/theme-default.css
@@ -71,8 +71,8 @@
     --severity_detection: var(--orange-600);
     --severity_detection_dimmed: var(--orange-400);
 
-    --severity_motion: var(--yellow-400);
-    --severity_motion_dimmed: var(--yellow-200);
+    --severity_significant_motion: var(--yellow-400);
+    --severity_significant_motion_dimmed: var(--yellow-200);
 
     --motion_review: hsl(44, 94%, 50%);
     --motion_review: 44 94% 50%;


### PR DESCRIPTION
- Use a more efficient method for calculating the timestamps needed when playing back motion review
- Revamp motion segment logic to correctly show small-value motion segments
- Move draggable element segment search to its own useEffect to run only when switching to motion-only mode 
- Check for overlaps of events on motion review segments when outlining previews
- Rename motion color tailwind vars to `significant_motion` for consistency