### PR TITLE
Motion review changes

### DIFF
--- a/web/src/hooks/use-draggable-element.ts
+++ b/web/src/hooks/use-draggable-element.ts
@@ -235,7 +235,7 @@ function useDraggableElement({
         const elementEarliest = draggableElementEarliestTime
           ? timestampToPixels(draggableElementEarliestTime)
           : segmentHeight * (timelineDuration / segmentDuration) -
-            segmentHeight * 3;
+            segmentHeight * 3.5;
 
         // top of timeline - default 2 segments added for draggableElement visibility
         const elementLatest = draggableElementLatestTime

--- a/web/src/pages/UIPlayground.tsx
+++ b/web/src/pages/UIPlayground.tsx
@@ -77,10 +77,12 @@ function generateRandomMotionAudioData(): MotionData[] {
   ) {
     const motion = Math.floor(Math.random() * 101); // Random number between 0 and 100
     const audio = Math.random() * -100; // Random negative value between -100 and 0
+    const camera = "test_camera";
     data.push({
       start_time: startTimestamp,
       motion,
       audio,
+      camera,
     });
   }
 

--- a/web/src/types/review.ts
+++ b/web/src/types/review.ts
@@ -46,4 +46,5 @@ export type MotionData = {
   start_time: number;
   motion?: number;
   audio?: number;
+  camera: string;
 };


### PR DESCRIPTION
- Add `significant_motion` colored outlines around previews in motion only mode (depends on https://github.com/blakeblackshear/frigate/pull/10663)
- Make sure motion ranges are calculated after aligning to timeline start so that the wrong motion segment doesn't end up in the wrong segment
- Refactor next timestamp code back into a custom hook
- Adjust lower scroll limit of timeline slightly to prevent overscrolling