### PR TITLE
Multiple detection queues (multiple model support)

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -431,6 +431,7 @@ class DetectConfig(FrigateBaseModel):
     annotation_offset: int = Field(
         default=0, title="Milliseconds to offset detect annotations by."
     )
+    queue: str = Field(default="default", title="Detection queue to use.")
 
 
 class FilterConfig(FrigateBaseModel):

--- a/frigate/detectors/detector_config.py
+++ b/frigate/detectors/detector_config.py
@@ -140,6 +140,7 @@ class ModelConfig(BaseModel):
 class BaseDetectorConfig(BaseModel):
     # the type field must be defined in all subclasses
     type: str = Field(default="cpu", title="Detector Type")
+    queue: str = Field(default="default", title="Detection queue")
     model: Optional[ModelConfig] = Field(
         default=None, title="Detector specific model configuration."
     )


### PR DESCRIPTION
This allows setting up multiple detection queues so you can assign cameras to specific detectors.

This adds a new field `queue` to the detector and camera detect configs and creates a queue for each one that's defined. If the camera doesn't have a matching detector queue it'll throw an error.

Partially solves #1301

This has a few benefits:

* multiple different models can now be used by creating a detector for each model and then assigning the camera to the detection queue. Some detectors such as edge TPUs can only support a single model so would need multiple physical chips. OpenVINO, CPU or TensorRT can have multiple detector processes on the same device.
* "high priority" cameras can be assigned dedicated object detection resources

Test plan:

```patch
 cameras:
   cam:
     ffmpeg:
       inputs:
       - path: http://10.0.0.107:8080
         roles:
         - detect
       input_args: -avoid_negative_ts make_zero -fflags nobuffer -flags low_delay -strict experimental -fflags +genpts+discardcorrupt -use_wallclock_as_timestamps 1 -c:v mjpeg
     detect:
       width: 640
       height: 480
+      queue: foo
    record:
      enabled: false
    audio:
      enabled: false
    birdseye:
      enabled: false

 detectors:
   cpu1:
     type: cpu
     num_threads: 3
+    queue: foo
```