### PR TITLE
Use drawer instead of dropdown menu for mobile settings

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,7 +25,7 @@ function App() {
     <Providers>
       <BrowserRouter>
         <Wrapper>
-          <div className="size-full pt-2 overflow-hidden">
+          <div className="size-full overflow-hidden">
             {isDesktop && <Sidebar />}
             {isDesktop && <Statusbar />}
             {isMobile && <Bottombar />}

--- a/web/src/components/navigation/Bottombar.tsx
+++ b/web/src/components/navigation/Bottombar.tsx
@@ -1,6 +1,5 @@
 import { navbarLinks } from "@/pages/site-navigation";
 import NavItem from "./NavItem";
-import SettingsNavItems from "../settings/SettingsNavItems";
 import { IoIosWarning } from "react-icons/io";
 import { Drawer, DrawerContent, DrawerTrigger } from "../ui/drawer";
 import useSWR from "swr";
@@ -8,6 +7,8 @@ import { FrigateStats } from "@/types/stats";
 import { useFrigateStats } from "@/api/ws";
 import { useMemo } from "react";
 import useStats from "@/hooks/use-stats";
+import GeneralSettings from "../settings/GeneralSettings";
+import AccountSettings from "../settings/AccountSettings";
 
 function Bottombar() {
   return (
@@ -23,7 +24,8 @@ function Bottombar() {
           dev={item.dev}
         />
       ))}
-      <SettingsNavItems className="flex flex-shrink-0 justify-between gap-4" />
+      <GeneralSettings />
+      <AccountSettings />
       <StatusAlertNav />
     </div>
   );

--- a/web/src/components/navigation/Sidebar.tsx
+++ b/web/src/components/navigation/Sidebar.tsx
@@ -1,6 +1,5 @@
 import Logo from "../Logo";
 import { navbarLinks } from "@/pages/site-navigation";
-import SettingsNavItems from "../settings/SettingsNavItems";
 import NavItem from "./NavItem";
 import { CameraGroupSelector } from "../filter/CameraGroupSelector";
 import { useLocation } from "react-router-dom";

--- a/web/src/components/navigation/Sidebar.tsx
+++ b/web/src/components/navigation/Sidebar.tsx
@@ -4,6 +4,8 @@ import SettingsNavItems from "../settings/SettingsNavItems";
 import NavItem from "./NavItem";
 import { CameraGroupSelector } from "../filter/CameraGroupSelector";
 import { useLocation } from "react-router-dom";
+import GeneralSettings from "../settings/GeneralSettings";
+import AccountSettings from "../settings/AccountSettings";
 
 function Sidebar() {
   const location = useLocation();
@@ -31,7 +33,10 @@ function Sidebar() {
           );
         })}
       </div>
-      <SettingsNavItems className="hidden md:flex flex-col items-center mb-8" />
+      <div className="flex flex-col items-center mb-8">
+        <GeneralSettings />
+        <AccountSettings />
+      </div>
     </aside>
   );
 }

--- a/web/src/components/settings/AccountSettings.tsx
+++ b/web/src/components/settings/AccountSettings.tsx
@@ -1,0 +1,22 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { VscAccount } from "react-icons/vsc";
+import { Button } from "../ui/button";
+
+export default function AccountSettings() {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button size="icon" variant="ghost">
+          <VscAccount />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="right">
+        <p>Account</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web/src/components/settings/GeneralSettings.tsx
+++ b/web/src/components/settings/GeneralSettings.tsx
@@ -59,9 +59,13 @@ import {
 import ActivityIndicator from "../indicators/activity-indicator";
 import { isDesktop } from "react-device-detect";
 import { Drawer, DrawerContent, DrawerTrigger } from "../ui/drawer";
-import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
-import { PopoverPortal } from "@radix-ui/react-popover";
-import { DialogClose } from "../ui/dialog";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogPortal,
+  DialogTrigger,
+} from "../ui/dialog";
 
 type GeneralSettings = {
   className?: string;
@@ -102,10 +106,10 @@ export default function GeneralSettings({ className }: GeneralSettings) {
   const Trigger = isDesktop ? DropdownMenuTrigger : DrawerTrigger;
   const Content = isDesktop ? DropdownMenuContent : DrawerContent;
   const MenuItem = isDesktop ? DropdownMenuItem : DialogClose;
-  const SubItem = isDesktop ? DropdownMenuSub : Popover;
-  const SubItemTrigger = isDesktop ? DropdownMenuSubTrigger : PopoverTrigger;
-  const SubItemContent = isDesktop ? DropdownMenuSubContent : PopoverContent;
-  const Portal = isDesktop ? DropdownMenuPortal : PopoverPortal;
+  const SubItem = isDesktop ? DropdownMenuSub : Dialog;
+  const SubItemTrigger = isDesktop ? DropdownMenuSubTrigger : DialogTrigger;
+  const SubItemContent = isDesktop ? DropdownMenuSubContent : DialogContent;
+  const Portal = isDesktop ? DropdownMenuPortal : DialogPortal;
 
   return (
     <>
@@ -216,7 +220,9 @@ export default function GeneralSettings({ className }: GeneralSettings) {
                     <span>Dark Mode</span>
                   </SubItemTrigger>
                   <Portal>
-                    <SubItemContent>
+                    <SubItemContent
+                      className={isDesktop ? "" : "w-[92%] rounded-2xl"}
+                    >
                       <MenuItem
                         className={
                           isDesktop
@@ -283,7 +289,9 @@ export default function GeneralSettings({ className }: GeneralSettings) {
                     <span>Theme</span>
                   </SubItemTrigger>
                   <Portal>
-                    <SubItemContent>
+                    <SubItemContent
+                      className={isDesktop ? "" : "w-[92%] rounded-2xl"}
+                    >
                       {colorSchemes.map((scheme) => (
                         <MenuItem
                           key={scheme}

--- a/web/src/components/settings/GeneralSettings.tsx
+++ b/web/src/components/settings/GeneralSettings.tsx
@@ -57,7 +57,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import ActivityIndicator from "../indicators/activity-indicator";
-import { isDesktop } from "react-device-detect";
+import { isDesktop, isMobile } from "react-device-detect";
 import { Drawer, DrawerContent, DrawerTrigger } from "../ui/drawer";
 import {
   Dialog,
@@ -220,6 +220,7 @@ export default function GeneralSettings({ className }: GeneralSettings) {
                     <span>Dark Mode</span>
                   </SubItemTrigger>
                   <Portal>
+                    {isMobile && <div tabIndex={0} />}
                     <SubItemContent
                       className={isDesktop ? "" : "w-[92%] rounded-2xl"}
                     >
@@ -292,6 +293,7 @@ export default function GeneralSettings({ className }: GeneralSettings) {
                     <SubItemContent
                       className={isDesktop ? "" : "w-[92%] rounded-2xl"}
                     >
+                      {isMobile && <div tabIndex={0} />}
                       {colorSchemes.map((scheme) => (
                         <MenuItem
                           key={scheme}

--- a/web/src/components/settings/GeneralSettings.tsx
+++ b/web/src/components/settings/GeneralSettings.tsx
@@ -57,7 +57,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import ActivityIndicator from "../indicators/activity-indicator";
-import { isDesktop, isMobile } from "react-device-detect";
+import { isDesktop } from "react-device-detect";
 import { Drawer, DrawerContent, DrawerTrigger } from "../ui/drawer";
 import {
   Dialog,
@@ -220,7 +220,7 @@ export default function GeneralSettings({ className }: GeneralSettings) {
                     <span>Dark Mode</span>
                   </SubItemTrigger>
                   <Portal>
-                    {isMobile && <div tabIndex={0} />}
+                    <span tabIndex={0} className="sr-only" />
                     <SubItemContent
                       className={isDesktop ? "" : "w-[92%] rounded-2xl"}
                     >
@@ -293,7 +293,7 @@ export default function GeneralSettings({ className }: GeneralSettings) {
                     <SubItemContent
                       className={isDesktop ? "" : "w-[92%] rounded-2xl"}
                     >
-                      {isMobile && <div tabIndex={0} />}
+                      <span tabIndex={0} className="sr-only" />
                       {colorSchemes.map((scheme) => (
                         <MenuItem
                           key={scheme}

--- a/web/src/components/settings/GeneralSettings.tsx
+++ b/web/src/components/settings/GeneralSettings.tsx
@@ -27,7 +27,6 @@ import {
 import { Button } from "../ui/button";
 import { Link } from "react-router-dom";
 import { CgDarkMode } from "react-icons/cg";
-import { VscAccount } from "react-icons/vsc";
 import {
   colorSchemes,
   friendlyColorSchemeName,
@@ -59,10 +58,10 @@ import {
 } from "@/components/ui/tooltip";
 import ActivityIndicator from "../indicators/activity-indicator";
 
-type SettingsNavItemsProps = {
+type GeneralSettings = {
   className?: string;
 };
-export default function SettingsNavItems({ className }: SettingsNavItemsProps) {
+export default function GeneralSettings({ className }: GeneralSettings) {
   const { theme, colorScheme, setTheme, setColorScheme } = useTheme();
   const [restartDialogOpen, setRestartDialogOpen] = useState(false);
   const [restartingSheetOpen, setRestartingSheetOpen] = useState(false);
@@ -243,16 +242,6 @@ export default function SettingsNavItems({ className }: SettingsNavItemsProps) {
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button size="icon" variant="ghost">
-              <VscAccount />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="right">
-            <p>Account</p>
-          </TooltipContent>
-        </Tooltip>
       </div>
       {restartDialogOpen && (
         <AlertDialog

--- a/web/src/components/settings/GeneralSettings.tsx
+++ b/web/src/components/settings/GeneralSettings.tsx
@@ -125,192 +125,230 @@ export default function GeneralSettings({ className }: GeneralSettings) {
               </Tooltip>
             </a>
           </Trigger>
-          <Content className={isDesktop ? "w-72 mr-5" : "max-h-[75dvh]"}>
-            <DropdownMenuLabel>System</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuGroup className={isDesktop ? "" : "flex flex-col"}>
-              <Link to="/storage">
-                <MenuItem
-                  className={
-                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
-                  }
-                >
-                  <LuHardDrive className="mr-2 size-4" />
-                  <span>Storage</span>
-                </MenuItem>
-              </Link>
-              <Link to="/system">
-                <MenuItem
-                  className={
-                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
-                  }
-                >
-                  <LuActivity className="mr-2 size-4" />
-                  <span>System metrics</span>
-                </MenuItem>
-              </Link>
-              <Link to="/logs">
-                <MenuItem
-                  className={
-                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
-                  }
-                >
-                  <LuList className="mr-2 size-4" />
-                  <span>System logs</span>
-                </MenuItem>
-              </Link>
-            </DropdownMenuGroup>
-            <DropdownMenuLabel className="mt-3">
-              Configuration
-            </DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuGroup>
-              <Link to="/settings">
-                <MenuItem
-                  className={
-                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
-                  }
-                >
-                  <LuSettings className="mr-2 size-4" />
-                  <span>Settings</span>
-                </MenuItem>
-              </Link>
-              <Link to="/config">
-                <MenuItem
-                  className={
-                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
-                  }
-                >
-                  <LuPenSquare className="mr-2 size-4" />
-                  <span>Configuration editor</span>
-                </MenuItem>
-              </Link>
-              <DropdownMenuLabel className="mt-3">Appearance</DropdownMenuLabel>
+          <Content
+            className={
+              isDesktop ? "w-72 mr-5" : "max-h-[75dvh] p-2 overflow-hidden"
+            }
+          >
+            <div className="w-full flex-col overflow-y-auto overflow-x-hidden">
+              <DropdownMenuLabel>System</DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <SubItem>
-                <SubItemTrigger
-                  className={
-                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
-                  }
-                >
-                  <LuSunMoon className="mr-2 size-4" />
-                  <span>Dark Mode</span>
-                </SubItemTrigger>
-                <Portal>
-                  <SubItemContent>
-                    <MenuItem
-                      className={
-                        isDesktop ? "cursor-pointer" : "p-2 flex items-center"
-                      }
-                      onClick={() => setTheme("light")}
-                    >
-                      {theme === "light" ? (
-                        <>
-                          <LuSun className="mr-2 size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-                          Light
-                        </>
-                      ) : (
-                        <span className="mr-2 ml-6">Light</span>
-                      )}
-                    </MenuItem>
-                    <MenuItem
-                      className={
-                        isDesktop ? "cursor-pointer" : "p-2 flex items-center"
-                      }
-                      onClick={() => setTheme("dark")}
-                    >
-                      {theme === "dark" ? (
-                        <>
-                          <LuMoon className="mr-2 size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-                          Dark
-                        </>
-                      ) : (
-                        <span className="mr-2 ml-6">Dark</span>
-                      )}
-                    </MenuItem>
-                    <MenuItem
-                      className={
-                        isDesktop ? "cursor-pointer" : "p-2 flex items-center"
-                      }
-                      onClick={() => setTheme("system")}
-                    >
-                      {theme === "system" ? (
-                        <>
-                          <CgDarkMode className="mr-2 size-4 scale-100 transition-all" />
-                          System
-                        </>
-                      ) : (
-                        <span className="mr-2 ml-6">System</span>
-                      )}
-                    </MenuItem>
-                  </SubItemContent>
-                </Portal>
-              </SubItem>
-              <SubItem>
-                <SubItemTrigger
-                  className={
-                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
-                  }
-                >
-                  <LuSunMoon className="mr-2 size-4" />
-                  <span>Theme</span>
-                </SubItemTrigger>
-                <Portal>
-                  <SubItemContent>
-                    {colorSchemes.map((scheme) => (
+              <DropdownMenuGroup className={isDesktop ? "" : "flex flex-col"}>
+                <Link to="/storage">
+                  <MenuItem
+                    className={
+                      isDesktop
+                        ? "cursor-pointer"
+                        : "p-2 flex items-center text-sm"
+                    }
+                  >
+                    <LuHardDrive className="mr-2 size-4" />
+                    <span>Storage</span>
+                  </MenuItem>
+                </Link>
+                <Link to="/system">
+                  <MenuItem
+                    className={
+                      isDesktop
+                        ? "cursor-pointer"
+                        : "p-2 flex items-center text-sm"
+                    }
+                  >
+                    <LuActivity className="mr-2 size-4" />
+                    <span>System metrics</span>
+                  </MenuItem>
+                </Link>
+                <Link to="/logs">
+                  <MenuItem
+                    className={
+                      isDesktop
+                        ? "cursor-pointer"
+                        : "p-2 flex items-center text-sm"
+                    }
+                  >
+                    <LuList className="mr-2 size-4" />
+                    <span>System logs</span>
+                  </MenuItem>
+                </Link>
+              </DropdownMenuGroup>
+              <DropdownMenuLabel className={isDesktop ? "mt-3" : "mt-1"}>
+                Configuration
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuGroup>
+                <Link to="/settings">
+                  <MenuItem
+                    className={
+                      isDesktop
+                        ? "cursor-pointer"
+                        : "p-2 flex items-center text-sm"
+                    }
+                  >
+                    <LuSettings className="mr-2 size-4" />
+                    <span>Settings</span>
+                  </MenuItem>
+                </Link>
+                <Link to="/config">
+                  <MenuItem
+                    className={
+                      isDesktop
+                        ? "cursor-pointer"
+                        : "p-2 flex items-center text-sm"
+                    }
+                  >
+                    <LuPenSquare className="mr-2 size-4" />
+                    <span>Configuration editor</span>
+                  </MenuItem>
+                </Link>
+                <DropdownMenuLabel className={isDesktop ? "mt-3" : "mt-1"}>
+                  Appearance
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <SubItem>
+                  <SubItemTrigger
+                    className={
+                      isDesktop
+                        ? "cursor-pointer"
+                        : "p-2 flex items-center text-sm"
+                    }
+                  >
+                    <LuSunMoon className="mr-2 size-4" />
+                    <span>Dark Mode</span>
+                  </SubItemTrigger>
+                  <Portal>
+                    <SubItemContent>
                       <MenuItem
-                        key={scheme}
                         className={
-                          isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                          isDesktop
+                            ? "cursor-pointer"
+                            : "p-2 flex items-center text-sm"
                         }
-                        onClick={() => setColorScheme(scheme)}
+                        onClick={() => setTheme("light")}
                       >
-                        {scheme === colorScheme ? (
+                        {theme === "light" ? (
                           <>
-                            <IoColorPalette className="mr-2 size-4 rotate-0 scale-100 transition-all" />
-                            {friendlyColorSchemeName(scheme)}
+                            <LuSun className="mr-2 size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+                            Light
                           </>
                         ) : (
-                          <span className="mr-2 ml-6">
-                            {friendlyColorSchemeName(scheme)}
-                          </span>
+                          <span className="mr-2 ml-6">Light</span>
                         )}
                       </MenuItem>
-                    ))}
-                  </SubItemContent>
-                </Portal>
-              </SubItem>
-            </DropdownMenuGroup>
-            <DropdownMenuLabel className="mt-3">Help</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <a href="https://docs.frigate.video">
+                      <MenuItem
+                        className={
+                          isDesktop
+                            ? "cursor-pointer"
+                            : "p-2 flex items-center text-sm"
+                        }
+                        onClick={() => setTheme("dark")}
+                      >
+                        {theme === "dark" ? (
+                          <>
+                            <LuMoon className="mr-2 size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+                            Dark
+                          </>
+                        ) : (
+                          <span className="mr-2 ml-6">Dark</span>
+                        )}
+                      </MenuItem>
+                      <MenuItem
+                        className={
+                          isDesktop
+                            ? "cursor-pointer"
+                            : "p-2 flex items-center text-sm"
+                        }
+                        onClick={() => setTheme("system")}
+                      >
+                        {theme === "system" ? (
+                          <>
+                            <CgDarkMode className="mr-2 size-4 scale-100 transition-all" />
+                            System
+                          </>
+                        ) : (
+                          <span className="mr-2 ml-6">System</span>
+                        )}
+                      </MenuItem>
+                    </SubItemContent>
+                  </Portal>
+                </SubItem>
+                <SubItem>
+                  <SubItemTrigger
+                    className={
+                      isDesktop
+                        ? "cursor-pointer"
+                        : "p-2 flex items-center text-sm"
+                    }
+                  >
+                    <LuSunMoon className="mr-2 size-4" />
+                    <span>Theme</span>
+                  </SubItemTrigger>
+                  <Portal>
+                    <SubItemContent>
+                      {colorSchemes.map((scheme) => (
+                        <MenuItem
+                          key={scheme}
+                          className={
+                            isDesktop
+                              ? "cursor-pointer"
+                              : "p-2 flex items-center text-sm"
+                          }
+                          onClick={() => setColorScheme(scheme)}
+                        >
+                          {scheme === colorScheme ? (
+                            <>
+                              <IoColorPalette className="mr-2 size-4 rotate-0 scale-100 transition-all" />
+                              {friendlyColorSchemeName(scheme)}
+                            </>
+                          ) : (
+                            <span className="mr-2 ml-6">
+                              {friendlyColorSchemeName(scheme)}
+                            </span>
+                          )}
+                        </MenuItem>
+                      ))}
+                    </SubItemContent>
+                  </Portal>
+                </SubItem>
+              </DropdownMenuGroup>
+              <DropdownMenuLabel className={isDesktop ? "mt-3" : "mt-1"}>
+                Help
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <a href="https://docs.frigate.video">
+                <MenuItem
+                  className={
+                    isDesktop
+                      ? "cursor-pointer"
+                      : "p-2 flex items-center text-sm"
+                  }
+                >
+                  <LuLifeBuoy className="mr-2 size-4" />
+                  <span>Documentation</span>
+                </MenuItem>
+              </a>
+              <a href="https://github.com/blakeblackshear/frigate">
+                <MenuItem
+                  className={
+                    isDesktop
+                      ? "cursor-pointer"
+                      : "p-2 flex items-center text-sm"
+                  }
+                >
+                  <LuGithub className="mr-2 size-4" />
+                  <span>GitHub</span>
+                </MenuItem>
+              </a>
+              <DropdownMenuSeparator className={isDesktop ? "mt-3" : "mt-1"} />
               <MenuItem
                 className={
-                  isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                  isDesktop ? "cursor-pointer" : "p-2 flex items-center text-sm"
                 }
+                onClick={() => setRestartDialogOpen(true)}
               >
-                <LuLifeBuoy className="mr-2 size-4" />
-                <span>Documentation</span>
+                <LuRotateCw className="mr-2 size-4" />
+                <span>Restart Frigate</span>
               </MenuItem>
-            </a>
-            <a href="https://github.com/blakeblackshear/frigate">
-              <MenuItem
-                className={
-                  isDesktop ? "cursor-pointer" : "p-2 flex items-center"
-                }
-              >
-                <LuGithub className="mr-2 size-4" />
-                <span>GitHub</span>
-              </MenuItem>
-            </a>
-            <DropdownMenuSeparator className="mt-3" />
-            <MenuItem
-              className={isDesktop ? "cursor-pointer" : "p-2 flex items-center"}
-              onClick={() => setRestartDialogOpen(true)}
-            >
-              <LuRotateCw className="mr-2 size-4" />
-              <span>Restart Frigate</span>
-            </MenuItem>
+            </div>
           </Content>
         </Container>
       </div>

--- a/web/src/components/settings/GeneralSettings.tsx
+++ b/web/src/components/settings/GeneralSettings.tsx
@@ -57,6 +57,11 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import ActivityIndicator from "../indicators/activity-indicator";
+import { isDesktop } from "react-device-detect";
+import { Drawer, DrawerContent, DrawerTrigger } from "../ui/drawer";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { PopoverPortal } from "@radix-ui/react-popover";
+import { DialogClose } from "../ui/dialog";
 
 type GeneralSettings = {
   className?: string;
@@ -93,11 +98,20 @@ export default function GeneralSettings({ className }: GeneralSettings) {
     window.location.href = "/";
   };
 
+  const Container = isDesktop ? DropdownMenu : Drawer;
+  const Trigger = isDesktop ? DropdownMenuTrigger : DrawerTrigger;
+  const Content = isDesktop ? DropdownMenuContent : DrawerContent;
+  const MenuItem = isDesktop ? DropdownMenuItem : DialogClose;
+  const SubItem = isDesktop ? DropdownMenuSub : Popover;
+  const SubItemTrigger = isDesktop ? DropdownMenuSubTrigger : PopoverTrigger;
+  const SubItemContent = isDesktop ? DropdownMenuSubContent : PopoverContent;
+  const Portal = isDesktop ? DropdownMenuPortal : PopoverPortal;
+
   return (
     <>
       <div className={className}>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
+        <Container>
+          <Trigger asChild>
             <a href="#">
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -110,28 +124,40 @@ export default function GeneralSettings({ className }: GeneralSettings) {
                 </TooltipContent>
               </Tooltip>
             </a>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="md:w-72 mr-5">
+          </Trigger>
+          <Content className={isDesktop ? "w-72 mr-5" : "max-h-[75dvh]"}>
             <DropdownMenuLabel>System</DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <DropdownMenuGroup>
+            <DropdownMenuGroup className={isDesktop ? "" : "flex flex-col"}>
               <Link to="/storage">
-                <DropdownMenuItem>
-                  <LuHardDrive className="mr-2 h-4 w-4" />
+                <MenuItem
+                  className={
+                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                  }
+                >
+                  <LuHardDrive className="mr-2 size-4" />
                   <span>Storage</span>
-                </DropdownMenuItem>
+                </MenuItem>
               </Link>
               <Link to="/system">
-                <DropdownMenuItem>
-                  <LuActivity className="mr-2 h-4 w-4" />
+                <MenuItem
+                  className={
+                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                  }
+                >
+                  <LuActivity className="mr-2 size-4" />
                   <span>System metrics</span>
-                </DropdownMenuItem>
+                </MenuItem>
               </Link>
               <Link to="/logs">
-                <DropdownMenuItem>
-                  <LuList className="mr-2 h-4 w-4" />
+                <MenuItem
+                  className={
+                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                  }
+                >
+                  <LuList className="mr-2 size-4" />
                   <span>System logs</span>
-                </DropdownMenuItem>
+                </MenuItem>
               </Link>
             </DropdownMenuGroup>
             <DropdownMenuLabel className="mt-3">
@@ -140,74 +166,108 @@ export default function GeneralSettings({ className }: GeneralSettings) {
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
               <Link to="/settings">
-                <DropdownMenuItem>
-                  <LuSettings className="mr-2 h-4 w-4" />
+                <MenuItem
+                  className={
+                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                  }
+                >
+                  <LuSettings className="mr-2 size-4" />
                   <span>Settings</span>
-                </DropdownMenuItem>
+                </MenuItem>
               </Link>
               <Link to="/config">
-                <DropdownMenuItem>
-                  <LuPenSquare className="mr-2 h-4 w-4" />
+                <MenuItem
+                  className={
+                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                  }
+                >
+                  <LuPenSquare className="mr-2 size-4" />
                   <span>Configuration editor</span>
-                </DropdownMenuItem>
+                </MenuItem>
               </Link>
               <DropdownMenuLabel className="mt-3">Appearance</DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <DropdownMenuSub>
-                <DropdownMenuSubTrigger>
-                  <LuSunMoon className="mr-2 h-4 w-4" />
+              <SubItem>
+                <SubItemTrigger
+                  className={
+                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                  }
+                >
+                  <LuSunMoon className="mr-2 size-4" />
                   <span>Dark Mode</span>
-                </DropdownMenuSubTrigger>
-                <DropdownMenuPortal>
-                  <DropdownMenuSubContent>
-                    <DropdownMenuItem onClick={() => setTheme("light")}>
+                </SubItemTrigger>
+                <Portal>
+                  <SubItemContent>
+                    <MenuItem
+                      className={
+                        isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                      }
+                      onClick={() => setTheme("light")}
+                    >
                       {theme === "light" ? (
                         <>
-                          <LuSun className="mr-2 h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+                          <LuSun className="mr-2 size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
                           Light
                         </>
                       ) : (
                         <span className="mr-2 ml-6">Light</span>
                       )}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => setTheme("dark")}>
+                    </MenuItem>
+                    <MenuItem
+                      className={
+                        isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                      }
+                      onClick={() => setTheme("dark")}
+                    >
                       {theme === "dark" ? (
                         <>
-                          <LuMoon className="mr-2 h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+                          <LuMoon className="mr-2 size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
                           Dark
                         </>
                       ) : (
                         <span className="mr-2 ml-6">Dark</span>
                       )}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => setTheme("system")}>
+                    </MenuItem>
+                    <MenuItem
+                      className={
+                        isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                      }
+                      onClick={() => setTheme("system")}
+                    >
                       {theme === "system" ? (
                         <>
-                          <CgDarkMode className="mr-2 h-4 w-4 scale-100 transition-all" />
+                          <CgDarkMode className="mr-2 size-4 scale-100 transition-all" />
                           System
                         </>
                       ) : (
                         <span className="mr-2 ml-6">System</span>
                       )}
-                    </DropdownMenuItem>
-                  </DropdownMenuSubContent>
-                </DropdownMenuPortal>
-              </DropdownMenuSub>
-              <DropdownMenuSub>
-                <DropdownMenuSubTrigger>
-                  <LuSunMoon className="mr-2 h-4 w-4" />
+                    </MenuItem>
+                  </SubItemContent>
+                </Portal>
+              </SubItem>
+              <SubItem>
+                <SubItemTrigger
+                  className={
+                    isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                  }
+                >
+                  <LuSunMoon className="mr-2 size-4" />
                   <span>Theme</span>
-                </DropdownMenuSubTrigger>
-                <DropdownMenuPortal>
-                  <DropdownMenuSubContent>
+                </SubItemTrigger>
+                <Portal>
+                  <SubItemContent>
                     {colorSchemes.map((scheme) => (
-                      <DropdownMenuItem
+                      <MenuItem
                         key={scheme}
+                        className={
+                          isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                        }
                         onClick={() => setColorScheme(scheme)}
                       >
                         {scheme === colorScheme ? (
                           <>
-                            <IoColorPalette className="mr-2 h-4 w-4 rotate-0 scale-100 transition-all" />
+                            <IoColorPalette className="mr-2 size-4 rotate-0 scale-100 transition-all" />
                             {friendlyColorSchemeName(scheme)}
                           </>
                         ) : (
@@ -215,33 +275,44 @@ export default function GeneralSettings({ className }: GeneralSettings) {
                             {friendlyColorSchemeName(scheme)}
                           </span>
                         )}
-                      </DropdownMenuItem>
+                      </MenuItem>
                     ))}
-                  </DropdownMenuSubContent>
-                </DropdownMenuPortal>
-              </DropdownMenuSub>
+                  </SubItemContent>
+                </Portal>
+              </SubItem>
             </DropdownMenuGroup>
             <DropdownMenuLabel className="mt-3">Help</DropdownMenuLabel>
             <DropdownMenuSeparator />
             <a href="https://docs.frigate.video">
-              <DropdownMenuItem>
-                <LuLifeBuoy className="mr-2 h-4 w-4" />
+              <MenuItem
+                className={
+                  isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                }
+              >
+                <LuLifeBuoy className="mr-2 size-4" />
                 <span>Documentation</span>
-              </DropdownMenuItem>
+              </MenuItem>
             </a>
             <a href="https://github.com/blakeblackshear/frigate">
-              <DropdownMenuItem>
-                <LuGithub className="mr-2 h-4 w-4" />
+              <MenuItem
+                className={
+                  isDesktop ? "cursor-pointer" : "p-2 flex items-center"
+                }
+              >
+                <LuGithub className="mr-2 size-4" />
                 <span>GitHub</span>
-              </DropdownMenuItem>
+              </MenuItem>
             </a>
             <DropdownMenuSeparator className="mt-3" />
-            <DropdownMenuItem onClick={() => setRestartDialogOpen(true)}>
-              <LuRotateCw className="mr-2 h-4 w-4" />
+            <MenuItem
+              className={isDesktop ? "cursor-pointer" : "p-2 flex items-center"}
+              onClick={() => setRestartDialogOpen(true)}
+            >
+              <LuRotateCw className="mr-2 size-4" />
               <span>Restart Frigate</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+            </MenuItem>
+          </Content>
+        </Container>
       </div>
       {restartDialogOpen && (
         <AlertDialog


### PR DESCRIPTION
- Separate settings and account items so the default flex gap on mobile can apply to all items evenly
- Use drawer for mobile to make items easier to tap and so dropdown menu isn't trigger when tapping the home area