### PR TITLE
Support ONVIF exceptions when sending pan-tilt commands

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -349,7 +349,10 @@ class OnvifController:
                 }
             }
 
-        onvif.get_service("ptz").ContinuousMove(move_request)
+        try:
+            onvif.get_service("ptz").ContinuousMove(move_request)
+        except ONVIFError as e:
+            logger.warning(f"Onvif sending move request to {camera_name} failed: {e}")
 
     def _move_relative(self, camera_name: str, pan, tilt, zoom, speed) -> None:
         if "pt-r-fov" not in self.cams[camera_name]["features"]:


### PR DESCRIPTION
**Issue**
Uncatched ONVIF library exceptions makes Frigate disconnecting from MQTT.

**Analysis**
When used with some cameras like Tapo C210,  the ONVIF library raises unknown exceptions  when moving camera up/down or left/right and reaching the limits.

**Solution**
Catch any ONVIF exception when sending move commands via PTZ.