### PR TITLE
Redesign log page and pull logs in chunks

### DIFF
--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -159,9 +159,9 @@ def config():
     config["plus"] = {"enabled": current_app.plus_api.is_active()}
 
     for detector, detector_config in config["detectors"].items():
-        detector_config["model"][
-            "labelmap"
-        ] = current_app.frigate_config.model.merged_labelmap
+        detector_config["model"]["labelmap"] = (
+            current_app.frigate_config.model.merged_labelmap
+        )
 
     return jsonify(config)
 

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -159,9 +159,9 @@ def config():
     config["plus"] = {"enabled": current_app.plus_api.is_active()}
 
     for detector, detector_config in config["detectors"].items():
-        detector_config["model"]["labelmap"] = (
-            current_app.frigate_config.model.merged_labelmap
-        )
+        detector_config["model"][
+            "labelmap"
+        ] = current_app.frigate_config.model.merged_labelmap
 
     return jsonify(config)
 
@@ -425,11 +425,19 @@ def logs(service: str):
             404,
         )
 
+    start = request.args.get("start", type=int, default=0)
+    end = request.args.get("start", type=int)
+
     try:
         file = open(service_location, "r")
         contents = file.read()
         file.close()
-        return contents, 200
+
+        lines = contents.splitlines()
+        return make_response(
+            jsonify({"totalLines": len(lines), "lines": lines[start:end]}),
+            200,
+        )
     except FileNotFoundError as e:
         logger.error(e)
         return make_response(

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -426,7 +426,7 @@ def logs(service: str):
         )
 
     start = request.args.get("start", type=int, default=0)
-    end = request.args.get("start", type=int)
+    end = request.args.get("end", type=int)
 
     try:
         file = open(service_location, "r")

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -446,7 +446,7 @@ def logs(service: str):
             newKey = cleanLine[0:keyLength]
 
             if newKey == currentKey:
-                currentLine += f"\n{cleanLine[dateEnd:].strip()}"
+                currentLine += f"{cleanLine[dateEnd:].strip()}\n"
                 continue
             else:
                 logLines.append(currentLine)

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -446,10 +446,12 @@ def logs(service: str):
             newKey = cleanLine[0:keyLength]
 
             if newKey == currentKey:
-                currentLine += f"{cleanLine[dateEnd:].strip()}\n"
+                currentLine += f"\n{cleanLine[dateEnd:].strip()}"
                 continue
             else:
-                logLines.append(currentLine)
+                if len(currentLine) > 0:
+                    logLines.append(currentLine)
+
                 currentKey = newKey
                 currentLine = cleanLine
 

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -152,9 +152,9 @@ def config():
     config["plus"] = {"enabled": current_app.plus_api.is_active()}
 
     for detector, detector_config in config["detectors"].items():
-        detector_config["model"][
-            "labelmap"
-        ] = current_app.frigate_config.model.merged_labelmap
+        detector_config["model"]["labelmap"] = (
+            current_app.frigate_config.model.merged_labelmap
+        )
 
     return jsonify(config)
 

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -90,6 +90,17 @@ function Logs() {
           const match = frigateDateStamp.exec(line);
 
           if (!match) {
+            const infoIndex = line.indexOf("[INFO]");
+
+            if (infoIndex != -1) {
+              return {
+                dateStamp: line.substring(0, 19),
+                severity: "info",
+                section: "starutp",
+                content: line.substring(infoIndex + 6).trim(),
+              };
+            }
+
             return null;
           }
 
@@ -340,7 +351,7 @@ function Logs() {
           </div>
         </div>
         {logLines.length > 0 &&
-          [...Array(logRange.end - 1).keys()].map((idx) => {
+          [...Array(logRange.end).keys()].map((idx) => {
             const logLine =
               idx >= logRange.start
                 ? logLines[idx - logRange.start]

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -96,7 +96,7 @@ function Logs() {
               return {
                 dateStamp: line.substring(0, 19),
                 severity: "info",
-                section: "starutp",
+                section: "startup",
                 content: line.substring(infoIndex + 6).trim(),
               };
             }

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -246,16 +246,16 @@ function Logs() {
       return;
     }
 
-    if (logLines.length < 100) {
-      setInitialScroll(true);
-      return;
-    }
-
     if (initialScroll) {
       return;
     }
 
     if (!contentRef.current) {
+      return;
+    }
+
+    if (contentRef.current.scrollHeight <= contentRef.current.clientHeight) {
+      setInitialScroll(true);
       return;
     }
 

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -237,7 +237,7 @@ function Logs() {
     },
     // we need to listen on the current range of visible items
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [logRange],
+    [logRange, initialScroll],
   );
 
   useEffect(() => {

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -209,7 +209,7 @@ function Logs() {
 
       try {
         startObserver.current = new IntersectionObserver((entries) => {
-          if (entries[0].isIntersecting) {
+          if (entries[0].isIntersecting && logRange.start > 0) {
             const start = Math.max(0, logRange.start - 100);
 
             axios

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -179,7 +179,7 @@ function Logs() {
 
   // scroll to bottom
 
-  const [atBottom, setAtBottom] = useState(false);
+  const [initialScroll, setInitialScroll] = useState(false);
 
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [endVisible, setEndVisible] = useState(true);
@@ -203,7 +203,7 @@ function Logs() {
     (node: HTMLElement | null) => {
       if (startObserver.current) startObserver.current.disconnect();
 
-      if (logs.length == 0 || !atBottom) {
+      if (logs.length == 0 || !initialScroll) {
         return;
       }
 
@@ -242,16 +242,16 @@ function Logs() {
 
   useEffect(() => {
     if (logLines.length == 0) {
-      setAtBottom(false);
+      setInitialScroll(false);
       return;
     }
 
     if (logLines.length < 100) {
-      setAtBottom(true);
+      setInitialScroll(true);
       return;
     }
 
-    if (atBottom) {
+    if (initialScroll) {
       return;
     }
 
@@ -263,7 +263,7 @@ function Logs() {
       top: contentRef.current?.scrollHeight,
       behavior: "instant",
     });
-    setTimeout(() => setAtBottom(true), 300);
+    setTimeout(() => setInitialScroll(true), 300);
     // we need to listen on the current range of visible items
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [logLines, logService]);
@@ -306,7 +306,7 @@ function Logs() {
         </div>
       </div>
 
-      {!endVisible && (
+      {initialScroll && !endVisible && (
         <Button
           className="absolute bottom-8 left-[50%] -translate-x-[50%] rounded-xl bg-accent-foreground text-white bg-gray-400 z-20 p-2"
           variant="secondary"
@@ -344,8 +344,8 @@ function Logs() {
             idx >= logRange.start ? (
               <LogLineData
                 key={`${idx}-${logService}`}
-                startRef={idx == logRange.start ? startLogRef : undefined}
-                className={atBottom ? "" : "invisible"}
+                startRef={idx == logRange.start + 10 ? startLogRef : undefined}
+                className={initialScroll ? "" : "invisible"}
                 offset={idx}
                 line={logLines[idx - logRange.start]}
               />

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { LogLine, LogSeverity } from "@/types/log";
+import { LogData, LogLine, LogSeverity } from "@/types/log";
 import copy from "copy-to-clipboard";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { IoIosAlert } from "react-icons/io";
@@ -23,13 +23,13 @@ const ngSeverity = /(GET)|(POST)|(PATCH)|(DELETE)/;
 function Logs() {
   const [logService, setLogService] = useState<LogType>("frigate");
 
-  const { data: frigateLogs } = useSWR<string>("logs/frigate", {
+  const { data: frigateLogs } = useSWR<LogData>("logs/frigate", {
     refreshInterval: 1000,
   });
-  const { data: go2rtcLogs } = useSWR<string>("logs/go2rtc", {
+  const { data: go2rtcLogs } = useSWR<LogData>("logs/go2rtc", {
     refreshInterval: 1000,
   });
-  const { data: nginxLogs } = useSWR<string>("logs/nginx", {
+  const { data: nginxLogs } = useSWR<LogData>("logs/nginx", {
     refreshInterval: 1000,
   });
 
@@ -43,7 +43,7 @@ function Logs() {
     } else if (logService == "nginx") {
       return nginxLogs;
     } else {
-      return "unknown logs";
+      return undefined;
     }
   }, [logService, frigateLogs, go2rtcLogs, nginxLogs]);
 
@@ -53,8 +53,7 @@ function Logs() {
         return [];
       }
 
-      return frigateLogs
-        .split("\n")
+      return frigateLogs.lines
         .map((line) => {
           const match = frigateDateStamp.exec(line);
 
@@ -89,8 +88,7 @@ function Logs() {
         return [];
       }
 
-      return go2rtcLogs
-        .split("\n")
+      return go2rtcLogs.lines
         .map((line) => {
           if (line.length == 0) {
             return null;
@@ -130,8 +128,7 @@ function Logs() {
         return [];
       }
 
-      return nginxLogs
-        .split("\n")
+      return nginxLogs.lines
         .map((line) => {
           if (line.length == 0) {
             return null;
@@ -152,7 +149,7 @@ function Logs() {
 
   const handleCopyLogs = useCallback(() => {
     if (logs) {
-      copy(logs);
+      copy(logs.lines.join("\n"));
     }
   }, [logs]);
 

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -288,7 +288,7 @@ function LogLineData({ line, offset }: LogLineDataProps) {
 
   return (
     <div
-      className={`py-2 grid grid-cols-5 sm:grid-cols-8 md:grid-cols-12 gap-2 ${offset % 2 == 0 ? "bg-secondary" : "bg-secondary/80"} border-t border-l`}
+      className={`py-2 grid grid-cols-5 sm:grid-cols-8 md:grid-cols-12 gap-2 ${offset % 2 == 0 ? "bg-secondary" : "bg-secondary/80"} border-t border-x`}
     >
       <div
         className={`h-full p-1 flex items-center gap-2 capitalize ${severityClassName}`}

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -235,6 +235,8 @@ function Logs() {
         // no op
       }
     },
+    // we need to listen on the current range of visible items
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [logRange],
   );
 

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -323,7 +323,7 @@ function Logs() {
 
       <div
         ref={contentRef}
-        className="w-full h-min my-2 font-mono text-sm rounded py-4 sm:py-2 whitespace-pre-wrap overflow-auto"
+        className="w-full h-min my-2 font-mono text-sm rounded py-4 sm:py-2 whitespace-pre-wrap overflow-auto no-scrollbar"
       >
         <div className="py-2 sticky top-0 -translate-y-1/4 grid grid-cols-5 sm:grid-cols-8 md:grid-cols-12 bg-background *:p-2">
           <div className="p-1 flex items-center capitalize border-y border-l">

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -340,19 +340,28 @@ function Logs() {
           </div>
         </div>
         {logLines.length > 0 &&
-          [...Array(logRange.end - 1).keys()].map((idx) =>
-            idx >= logRange.start ? (
-              <LogLineData
-                key={`${idx}-${logService}`}
-                startRef={idx == logRange.start + 10 ? startLogRef : undefined}
-                className={initialScroll ? "" : "invisible"}
-                offset={idx}
-                line={logLines[idx - logRange.start]}
-              />
-            ) : (
-              <div key={`${idx}-${logService}`} className="h-12" />
-            ),
-          )}
+          [...Array(logRange.end - 1).keys()].map((idx) => {
+            const logLine =
+              idx >= logRange.start
+                ? logLines[idx - logRange.start]
+                : undefined;
+
+            if (logLine) {
+              return (
+                <LogLineData
+                  key={`${idx}-${logService}`}
+                  startRef={
+                    idx == logRange.start + 10 ? startLogRef : undefined
+                  }
+                  className={initialScroll ? "" : "invisible"}
+                  offset={idx}
+                  line={logLines[idx - logRange.start]}
+                />
+              );
+            }
+
+            return <div key={`${idx}-${logService}`} className="h-12" />;
+          })}
         {logLines.length > 0 && <div id="page-bottom" ref={endLogRef} />}
       </div>
     </div>

--- a/web/src/types/log.ts
+++ b/web/src/types/log.ts
@@ -1,0 +1,8 @@
+export type LogSeverity = "info" | "warning" | "error" | "debug";
+
+export type LogLine = {
+  dateStamp: string;
+  severity: LogSeverity;
+  section: string;
+  content: string;
+};

--- a/web/src/types/log.ts
+++ b/web/src/types/log.ts
@@ -1,3 +1,8 @@
+export type LogData = {
+  lineCount: number;
+  lines: string[];
+};
+
 export type LogSeverity = "info" | "warning" | "error" | "debug";
 
 export type LogLine = {

--- a/web/src/types/log.ts
+++ b/web/src/types/log.ts
@@ -1,5 +1,5 @@
 export type LogData = {
-  lineCount: number;
+  totalLines: number;
   lines: string[];
 };
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -12,24 +12,24 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "http://localhost:5000",
+        target: "http://192.168.50.106:5000",
         ws: true,
       },
       "/vod": {
-        target: "http://localhost:5000",
+        target: "http://192.168.50.106:5000",
       },
       "/clips": {
-        target: "http://localhost:5000",
+        target: "http://192.168.50.106:5000",
       },
       "/exports": {
-        target: "http://localhost:5000",
+        target: "http://192.168.50.106:5000",
       },
       "/ws": {
-        target: "ws://localhost:5000",
+        target: "ws://192.168.50.106:5000",
         ws: true,
       },
       "/live": {
-        target: "ws://localhost:5000",
+        target: "ws://192.168.50.106:5000",
         changeOrigin: true,
         ws: true,
       },


### PR DESCRIPTION
- show last 100 lines by default and lazy load as you scroll up
- only load the currently selected logs every 5 seconds
- parse logs and show in table instead of directly as text