### PR TITLE
UI bugfixes and tweaks

### DIFF
--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -839,31 +839,32 @@ function MotionReview({
             return (
               <div key={camera.name} className={`relative ${spans}`}>
                 {motionData ? (
-                  <PreviewPlayer
-                    key={camera.name}
-                    className={`rounded-2xl ${spans} ${grow}`}
-                    camera={camera.name}
-                    timeRange={currentTimeRange}
-                    startTime={previewStart}
-                    cameraPreviews={relevantPreviews || []}
-                    isScrubbing={scrubbing}
-                    onControllerReady={(controller) => {
-                      videoPlayersRef.current[camera.name] = controller;
-                    }}
-                    onClick={() =>
-                      onOpenRecording({
-                        camera: camera.name,
-                        startTime: currentTime,
-                        severity: "significant_motion",
-                      })
-                    }
-                  />
+                  <>
+                    <PreviewPlayer
+                      className={`rounded-2xl ${spans} ${grow}`}
+                      camera={camera.name}
+                      timeRange={currentTimeRange}
+                      startTime={previewStart}
+                      cameraPreviews={relevantPreviews || []}
+                      isScrubbing={scrubbing}
+                      onControllerReady={(controller) => {
+                        videoPlayersRef.current[camera.name] = controller;
+                      }}
+                      onClick={() =>
+                        onOpenRecording({
+                          camera: camera.name,
+                          startTime: currentTime,
+                          severity: "significant_motion",
+                        })
+                      }
+                    />
+                    <div
+                      className={`review-item-ring pointer-events-none z-20 absolute rounded-lg inset-0 size-full -outline-offset-[2.8px] outline outline-[3px] ${detectionType ? `outline-severity_${detectionType} shadow-severity_${detectionType}` : "outline-transparent duration-500"}`}
+                    />
+                  </>
                 ) : (
                   <Skeleton className={`rounded-2xl ${spans} ${grow}`} />
                 )}
-                <div
-                  className={`review-item-ring pointer-events-none z-10 absolute rounded-lg inset-0 size-full -outline-offset-[2.8px] outline outline-[3px] ${detectionType ? `outline-severity_${detectionType} shadow-severity_${detectionType}` : "outline-transparent duration-500"}`}
-                />
               </div>
             );
           })}
@@ -894,7 +895,7 @@ function MotionReview({
             dense={isMobile}
           />
         ) : (
-          <Skeleton className="rounded-2xl size-full" />
+          <Skeleton className="size-full" />
         )}
       </div>
 

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -863,7 +863,9 @@ function MotionReview({
                     />
                   </>
                 ) : (
-                  <Skeleton className={`rounded-2xl ${spans} ${grow}`} />
+                  <Skeleton
+                    className={`rounded-2xl size-full ${spans} ${grow}`}
+                  />
                 )}
               </div>
             );


### PR DESCRIPTION
- Motion review timeline scrolling and rendering was super laggy on iOS only. There's likely a z-index bug in iOS - changing `z-10` to `z-20` on the outline div fixed the problem
- Don't round timeline skeleton
- Make preview player skeletons `size-full`