### PR TITLE
Use zmq for event end queue and update python deps

### DIFF
--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -4,11 +4,11 @@ imutils == 0.5.*
 markupsafe == 2.1.*
 matplotlib == 3.7.*
 mypy == 1.6.1
-numpy == 1.23.*
+numpy == 1.26.*
 onvif_zeep == 0.2.12
 opencv-python-headless == 4.7.0.*
 paho-mqtt == 2.0.*
-pandas == 2.1.4
+pandas == 2.2.*
 peewee == 3.17.*
 peewee_migrate == 1.12.*
 psutil == 5.9.*

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -200,9 +200,6 @@ class FrigateApp:
             logging.getLogger("ws4py").setLevel("ERROR")
 
     def init_queues(self) -> None:
-        # Queues for clip processing
-        self.event_processed_queue: Queue = mp.Queue()
-
         # Queue for cameras to push tracked objects to
         self.detected_frames_queue: Queue = mp.Queue(
             maxsize=sum(camera.enabled for camera in self.config.cameras.values()) * 2
@@ -420,7 +417,6 @@ class FrigateApp:
             self.config,
             self.dispatcher,
             self.detected_frames_queue,
-            self.event_processed_queue,
             self.ptz_autotracker_thread,
             self.stop_event,
         )
@@ -517,7 +513,6 @@ class FrigateApp:
     def start_event_processor(self) -> None:
         self.event_processor = EventProcessor(
             self.config,
-            self.event_processed_queue,
             self.timeline_queue,
             self.stop_event,
         )
@@ -704,7 +699,6 @@ class FrigateApp:
             shm.unlink()
 
         for queue in [
-            self.event_processed_queue,
             self.detected_frames_queue,
             self.log_queue,
         ]:

--- a/frigate/comms/detections_updater.py
+++ b/frigate/comms/detections_updater.py
@@ -8,7 +8,7 @@ import zmq
 
 SOCKET_CONTROL = "inproc://control.detections_updater"
 SOCKET_PUB = "ipc:///tmp/cache/detect_pub"
-SOCKET_SUB = "ipc:///tmp/cache/detect_sun"
+SOCKET_SUB = "ipc:///tmp/cache/detect_sub"
 
 
 class DetectionTypeEnum(str, Enum):

--- a/frigate/comms/events_updater.py
+++ b/frigate/comms/events_updater.py
@@ -5,6 +5,7 @@ import zmq
 from frigate.events.types import EventStateEnum, EventTypeEnum
 
 SOCKET_PUSH_PULL = "ipc:///tmp/cache/events"
+SOCKET_PUSH_PULL_END = "ipc:///tmp/cache/events_ended"
 
 
 class EventUpdatePublisher:
@@ -37,7 +38,53 @@ class EventUpdateSubscriber:
     def check_for_update(
         self, timeout=1
     ) -> tuple[EventTypeEnum, EventStateEnum, str, dict[str, any]]:
-        """Returns updated config or None if no update."""
+        """Returns events or None if no update."""
+        try:
+            has_update, _, _ = zmq.select([self.socket], [], [], timeout)
+
+            if has_update:
+                return self.socket.recv_pyobj()
+        except zmq.ZMQError:
+            pass
+
+        return None
+
+    def stop(self) -> None:
+        self.socket.close()
+        self.context.destroy()
+
+
+class EventEndPublisher:
+    """Publishes events that have ended."""
+
+    def __init__(self) -> None:
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.PUSH)
+        self.socket.connect(SOCKET_PUSH_PULL_END)
+
+    def publish(
+        self, payload: tuple[EventTypeEnum, EventStateEnum, str, dict[str, any]]
+    ) -> None:
+        """There is no communication back to the processes."""
+        self.socket.send_pyobj(payload)
+
+    def stop(self) -> None:
+        self.socket.close()
+        self.context.destroy()
+
+
+class EventEndSubscriber:
+    """Receives events that have ended."""
+
+    def __init__(self) -> None:
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.PULL)
+        self.socket.bind(SOCKET_PUSH_PULL_END)
+
+    def check_for_update(
+        self, timeout=1
+    ) -> tuple[EventTypeEnum, EventStateEnum, str, dict[str, any]]:
+        """Returns events ended or None if no update."""
         try:
             has_update, _, _ = zmq.select([self.socket], [], [], timeout)
 

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -537,9 +537,7 @@ class CameraState:
                     ):
                         max_target_box = self.ptz_autotracker_thread.ptz_autotracker.tracked_object_metrics[
                             self.name
-                        ][
-                            "max_target_box"
-                        ]
+                        ]["max_target_box"]
                         side_length = max_target_box * (
                             max(
                                 self.camera_config.detect.width,

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -1224,7 +1224,6 @@ class TrackedObjectProcessor(threading.Thread):
                     break
 
                 event_id, camera = update
-                logger.error(f"got {camera} has finished {event_id}")
                 self.camera_states[camera].finished(event_id)
 
         self.detection_publisher.stop()


### PR DESCRIPTION
- remove usage of mp.queue for events end queue and use zmq
- update numpy and pandas.

tensorrt and jetson expect older versions of numpy, it is my understanding that when pip install is run there the package will be downgraded to the version needed.