### PR TITLE
Fix frigate startup stats

### DIFF
--- a/web/src/hooks/use-stats.ts
+++ b/web/src/hooks/use-stats.ts
@@ -18,6 +18,12 @@ export default function useStats(stats: FrigateStats | undefined) {
       return problems;
     }
 
+    // if frigate has just started
+    // don't look for issues
+    if (stats.service.uptime < 120) {
+      return problems;
+    }
+
     // check detectors for high inference speeds
     Object.entries(stats["detectors"]).forEach(([key, det]) => {
       if (det["inference_speed"] > InferenceThreshold.error) {

--- a/web/src/types/stats.ts
+++ b/web/src/types/stats.ts
@@ -47,7 +47,7 @@ export type ServiceStats = {
   last_updated: number;
   storage: { [path: string]: StorageStats };
   temperatures: { [apex: string]: number };
-  update: number;
+  uptime: number;
   latest_version: string;
   version: string;
 };


### PR DESCRIPTION
ensures that issues won't be shown in the status bar if frigate has just started