### PR TITLE
fix(nginx): use 1 worker process

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -1,6 +1,6 @@
 daemon off;
 user root;
-worker_processes auto;
+worker_processes 1;
 
 error_log /dev/stdout warn;
 pid /var/run/nginx.pid;


### PR DESCRIPTION
The value 'auto' will create a worker process for each CPU thread, which can be problematic in containerised environments with CPU limits. A single NGINX worker process should be more than sufficient.

Fixes: #10898