### PR TITLE
Timeline handlebar changes

### DIFF
--- a/web/src/components/timeline/ReviewTimeline.tsx
+++ b/web/src/components/timeline/ReviewTimeline.tsx
@@ -107,6 +107,7 @@ export function ReviewTimeline({
     showDraggableElement: showHandlebar,
     draggableElementTime: handlebarTime,
     setDraggableElementTime: setHandlebarTime,
+    alignSetTimeToSegment: true,
     initialScrollIntoViewOnly: onlyInitialHandlebarScroll,
     timelineDuration,
     timelineCollapsed: timelineCollapsed,

--- a/web/src/hooks/use-draggable-element.ts
+++ b/web/src/hooks/use-draggable-element.ts
@@ -323,21 +323,21 @@ function useDraggableElement({
           }
         }
 
+        const setTime = alignSetTimeToSegment
+          ? targetSegmentId
+          : targetSegmentId + segmentDuration * (offset / segmentHeight);
+
         updateDraggableElementPosition(
           newElementPosition,
-          targetSegmentId,
+          setTime,
           false,
           false,
         );
 
         if (setDraggableElementTime) {
-          if (alignSetTimeToSegment) {
-            setDraggableElementTime(targetSegmentId);
-          } else {
-            setDraggableElementTime(
-              targetSegmentId + segmentDuration * (offset / segmentHeight),
-            );
-          }
+          setDraggableElementTime(
+            targetSegmentId + segmentDuration * (offset / segmentHeight),
+          );
         }
 
         if (draggingAtTopEdge || draggingAtBottomEdge) {


### PR DESCRIPTION
- Always use full resolution when calling `setDraggableElementTime`
- Display second resolution on export handles (~7s at 30s segments)