### PR TITLE
Make wsdl_dir path resolving more robust

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -1,8 +1,9 @@
 """Configure and control camera via onvif."""
 
 import logging
-import site
 from enum import Enum
+from importlib.util import find_spec
+from pathlib import Path
 
 import numpy
 from onvif import ONVIFCamera, ONVIFError
@@ -50,10 +51,7 @@ class OnvifController:
                             cam.onvif.port,
                             cam.onvif.user,
                             cam.onvif.password,
-                            wsdl_dir=site.getsitepackages()[0].replace(
-                                "dist-packages", "site-packages"
-                            )
-                            + "/wsdl",
+                            wsdl_dir=Path(find_spec("onvif").origin).parent / "../wsdl",
                         ),
                         "init": False,
                         "active": False,


### PR DESCRIPTION
Relying on importlib to resolve the path to the wsdl directory is more robust, since it traverses all site-packages directories, that are part of the PYTHONPATH.

```
>>> from importlib.util import find_spec
>>> from pathlib import Path
>>> Path(find_spec("onvif").origin).parent / "../wsdl"
PosixPath('/nix/store/awkcfajc6a0frwhvzib4pmmx0awa4bgj-python3-3.11.8-env/lib/python3.11/site-packages/onvif/../wsdl')
```

The `ONVIFCamera` object passes `wsdl_dir` into `os.path.join`, which accepts path-like objects since Python 3.6.

https://github.com/quatanium/python-onvif/blob/09ffc65b8cd9d141b6a386804e7af7028755034e/onvif/client.py#L343
https://docs.python.org/3/library/os.path.html#os.path.join