### PR TITLE
Remove use_experimental config as part of config migration

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -607,8 +607,6 @@ ui:
   live_mode: mse
   # Optional: Set a timezone to use in the UI (default: use browser local time)
   # timezone: America/Denver
-  # Optional: Use an experimental recordings / camera view UI (default: shown below)
-  use_experimental: False
   # Optional: Set the time format used.
   # Options are browser, 12hour, or 24hour (default: shown below)
   time_format: browser

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -101,7 +101,6 @@ class UIConfig(FrigateBaseModel):
         default=LiveModeEnum.mse, title="Default Live Mode."
     )
     timezone: Optional[str] = Field(default=None, title="Override UI timezone.")
-    use_experimental: bool = Field(default=False, title="Experimental UI")
     time_format: TimeFormatEnum = Field(
         default=TimeFormatEnum.browser, title="Override UI time format."
     )
@@ -1351,12 +1350,11 @@ class FrigateConfig(FrigateBaseModel):
                 "timestamp_style": ...,
             },
             exclude_unset=True,
-            warnings="none",
         )
 
         for name, camera in config.cameras.items():
             merged_config = deep_merge(
-                camera.model_dump(exclude_unset=True, warnings="none"), global_config
+                camera.model_dump(exclude_unset=True), global_config
             )
             camera_config: CameraConfig = CameraConfig.model_validate(
                 {"name": name, **merged_config}
@@ -1467,7 +1465,7 @@ class FrigateConfig(FrigateBaseModel):
                 # Set runtime filter to create masks
                 camera_config.objects.filters[object] = RuntimeFilterConfig(
                     frame_shape=camera_config.frame_shape,
-                    **filter.model_dump(exclude_unset=True, warnings="none"),
+                    **filter.model_dump(exclude_unset=True),
                 )
 
             # Convert motion configuration
@@ -1479,9 +1477,7 @@ class FrigateConfig(FrigateBaseModel):
                 camera_config.motion = RuntimeMotionConfig(
                     frame_shape=camera_config.frame_shape,
                     raw_mask=camera_config.motion.mask,
-                    **camera_config.motion.model_dump(
-                        exclude_unset=True, warnings="none"
-                    ),
+                    **camera_config.motion.model_dump(exclude_unset=True),
                 )
             camera_config.motion.enabled_in_config = camera_config.motion.enabled
 
@@ -1518,9 +1514,7 @@ class FrigateConfig(FrigateBaseModel):
         for key, detector in config.detectors.items():
             adapter = TypeAdapter(DetectorConfig)
             model_dict = (
-                detector
-                if isinstance(detector, dict)
-                else detector.model_dump(warnings="none")
+                detector if isinstance(detector, dict) else detector.model_dump()
             )
             detector_config: DetectorConfig = adapter.validate_python(model_dict)
             if detector_config.model is None:
@@ -1541,8 +1535,8 @@ class FrigateConfig(FrigateBaseModel):
                         "Customizing more than a detector model path is unsupported."
                     )
             merged_model = deep_merge(
-                detector_config.model.model_dump(exclude_unset=True, warnings="none"),
-                config.model.model_dump(exclude_unset=True, warnings="none"),
+                detector_config.model.model_dump(exclude_unset=True),
+                config.model.model_dump(exclude_unset=True),
             )
 
             if "path" not in merged_model:

--- a/frigate/util/config.py
+++ b/frigate/util/config.py
@@ -81,6 +81,12 @@ def migrate_014(config: dict[str, dict[str, any]]) -> dict[str, dict[str, any]]:
         if not new_config["record"]:
             del new_config["record"]
 
+        if new_config.get("ui", {}).get("use_experimental"):
+            del new_config["ui"]["experimental"]
+
+            if not new_config["ui"]:
+                del new_config["ui"]
+
     # remove rtmp
     if new_config.get("ffmpeg", {}).get("output_args", {}).get("rtmp"):
         del new_config["ffmpeg"]["output_args"]["rtmp"]


### PR DESCRIPTION
`use_experimental` does nothing and is not something that makes sense to support. It should be removed from the schema and as part of the config migration