### PR TITLE
Improve polygon undo function

### DIFF
--- a/web/src/components/settings/PolygonEditControls.tsx
+++ b/web/src/components/settings/PolygonEditControls.tsx
@@ -21,12 +21,31 @@ export default function PolygonEditControls({
 
     const updatedPolygons = [...polygons];
     const activePolygon = updatedPolygons[activePolygonIndex];
-    updatedPolygons[activePolygonIndex] = {
-      ...activePolygon,
-      points: [...activePolygon.points.slice(0, -1)],
-      isFinished: false,
-    };
-    setPolygons(updatedPolygons);
+
+    if (
+      activePolygon.points.length > 0 &&
+      activePolygon.pointsOrder &&
+      activePolygon.pointsOrder.length > 0
+    ) {
+      const lastPointOrderIndex = activePolygon.pointsOrder.indexOf(
+        Math.max(...activePolygon.pointsOrder),
+      );
+
+      updatedPolygons[activePolygonIndex] = {
+        ...activePolygon,
+        points: [
+          ...activePolygon.points.slice(0, lastPointOrderIndex),
+          ...activePolygon.points.slice(lastPointOrderIndex + 1),
+        ],
+        pointsOrder: [
+          ...activePolygon.pointsOrder.slice(0, lastPointOrderIndex),
+          ...activePolygon.pointsOrder.slice(lastPointOrderIndex + 1),
+        ],
+        isFinished: false,
+      };
+
+      setPolygons(updatedPolygons);
+    }
   };
 
   const reset = () => {

--- a/web/src/types/canvas.ts
+++ b/web/src/types/canvas.ts
@@ -7,8 +7,8 @@ export type Polygon = {
   type: PolygonType;
   objects: string[];
   points: number[][];
+  pointsOrder?: number[];
   isFinished: boolean;
-  // isUnsaved: boolean;
   color: number[];
 };
 


### PR DESCRIPTION
The undo button in the mask/zone editor was only removing the very last point in the points array, even if that point was not added last in time (like if a point was added on a line between two existing points, for instance). This PR simplifies the logic of adding points and handles removing the correct point when clicking the undo button.