### PR TITLE
Fix array out of range error in reviews

### DIFF
--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -589,7 +589,7 @@ function DetectionReview({
                   </div>
                 );
               })
-            : itemsToReview ??
+            : (itemsToReview ?? 0) > 0 &&
               Array(itemsToReview)
                 .fill(0)
                 .map((_, idx) => (

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -589,7 +589,8 @@ function DetectionReview({
                   </div>
                 );
               })
-            : Array(itemsToReview)
+            : itemsToReview ??
+              Array(itemsToReview)
                 .fill(0)
                 .map((_, idx) => (
                   <Skeleton key={idx} className="size-full aspect-video" />


### PR DESCRIPTION
Loading reviews for a date in the past that had no reviews caused an array out of range error.