### PR TITLE
Live view not loading for MSE/JSMpeg if overriding live stream

### DIFF
--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -110,7 +110,7 @@ export default function LivePlayer({
       player = (
         <MSEPlayer
           className={`rounded-lg md:rounded-2xl size-full ${liveReady ? "" : "hidden"}`}
-          camera={cameraConfig.name}
+          camera={cameraConfig.live.stream_name}
           playbackEnabled={cameraActive}
           audioEnabled={playAudio}
           onPlaying={() => setLiveReady(true)}
@@ -129,7 +129,7 @@ export default function LivePlayer({
     player = (
       <JSMpegPlayer
         className="size-full flex justify-center rounded-lg md:rounded-2xl overflow-hidden"
-        camera={cameraConfig.name}
+        camera={cameraConfig.live.stream_name}
         width={cameraConfig.detect.width}
         height={cameraConfig.detect.height}
       />


### PR DESCRIPTION
0.14 dev builds have never worked for me viewing individual camera videos. A bit of digging around and it seems to be because the live stream components are being passed the camera name which is different to the actual stream in config (I use live->stream_name).