### PR TITLE
Fix rounding for MB for some stats

### DIFF
--- a/web/src/components/graph/SystemGraph.tsx
+++ b/web/src/components/graph/SystemGraph.tsx
@@ -150,7 +150,7 @@ export function ThresholdBarGraph({
 
 const getUnitSize = (MB: number) => {
   if (isNaN(MB) || MB < 0) return "Invalid number";
-  if (MB < 1024) return `${MB} MiB`;
+  if (MB < 1024) return `${MB.toFixed(2)} MiB`;
   if (MB < 1048576) return `${(MB / 1024).toFixed(2)} GiB`;
 
   return `${(MB / 1048576).toFixed(2)} TiB`;


### PR DESCRIPTION
This seems minorly more consistent now? Probably only want 1 or 0 decimal places for MiB specifically though?

Before this adjustment, this seemed excessive:
<img width="466" alt="image" src="https://github.com/blakeblackshear/frigate/assets/4219348/a1d64756-b5f4-4106-941f-c4186ba8156d">

I think there are more adjustments to be made here, one would be keeping units consistent between used/total might make things more readable, it is kind of nitpicky so I will just leave it for now

<img width="458" alt="image" src="https://github.com/blakeblackshear/frigate/assets/4219348/601297ca-dad4-4787-8c94-6a936161e1e3">

