### PR TITLE
Force X axis labels to be rotated correctly

### DIFF
--- a/web/src/components/graph/SystemGraph.tsx
+++ b/web/src/components/graph/SystemGraph.tsx
@@ -110,6 +110,7 @@ export function ThresholdBarGraph({
         tickAmount: isMobileOnly ? 3 : 4,
         tickPlacement: "on",
         labels: {
+          rotate: 0,
           offsetX: -18,
           formatter: formatTime,
         },
@@ -352,6 +353,7 @@ export function CameraLineGraph({
         tickAmount: isMobileOnly ? 3 : 4,
         tickPlacement: "on",
         labels: {
+          rotate: 0,
           offsetX: isMobileOnly ? -18 : 0,
           formatter: formatTime,
         },

--- a/web/src/components/graph/SystemGraph.tsx
+++ b/web/src/components/graph/SystemGraph.tsx
@@ -107,7 +107,7 @@ export function ThresholdBarGraph({
         size: 0,
       },
       xaxis: {
-        tickAmount: isMobileOnly ? 3 : 4,
+        tickAmount: 3,
         tickPlacement: "on",
         labels: {
           offsetX: -18,
@@ -349,7 +349,7 @@ export function CameraLineGraph({
         size: 0,
       },
       xaxis: {
-        tickAmount: isMobileOnly ? 3 : 4,
+        tickAmount: 3,
         tickPlacement: "on",
         labels: {
           offsetX: isMobileOnly ? -18 : 0,

--- a/web/src/components/graph/SystemGraph.tsx
+++ b/web/src/components/graph/SystemGraph.tsx
@@ -107,7 +107,7 @@ export function ThresholdBarGraph({
         size: 0,
       },
       xaxis: {
-        tickAmount: 3,
+        tickAmount: isMobileOnly ? 3 : 4,
         tickPlacement: "on",
         labels: {
           offsetX: -18,
@@ -349,7 +349,7 @@ export function CameraLineGraph({
         size: 0,
       },
       xaxis: {
-        tickAmount: 3,
+        tickAmount: isMobileOnly ? 3 : 4,
         tickPlacement: "on",
         labels: {
           offsetX: isMobileOnly ? -18 : 0,


### PR DESCRIPTION
There are a bunch of ways to fix this but it seemed simplest to me...open to whatever you all want

Before the change sometimes I would get tilted X axis labels to fit and it would mess up the entire layout
<img width="1047" alt="Screenshot 2024-04-28 at 9 10 50 PM" src="https://github.com/blakeblackshear/frigate/assets/4219348/4f0481cd-5ab5-4bab-9530-d05ef3dc83b7">

We could adjust paddings, we could adjust label formats, or we could just do this for now and not special case it
