### PR TITLE
Use full resolution aspect ratio when available

### DIFF
--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -28,7 +28,7 @@ type HlsVideoPlayerProps = {
   onPlayerLoaded?: () => void;
   onTimeUpdate?: (time: number) => void;
   onPlaying?: () => void;
-  setLiveResolution?: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
+  setFullResolution?: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
 };
 export default function HlsVideoPlayer({
   videoRef,
@@ -39,7 +39,7 @@ export default function HlsVideoPlayer({
   onPlayerLoaded,
   onTimeUpdate,
   onPlaying,
-  setLiveResolution,
+  setFullResolution,
 }: HlsVideoPlayerProps) {
   // playback
 
@@ -50,14 +50,14 @@ export default function HlsVideoPlayer({
   const handleLoadedMetadata = useCallback(() => {
     setLoadedMetadata(true);
     if (videoRef.current) {
-      if (setLiveResolution) {
-        setLiveResolution({
+      if (setFullResolution) {
+        setFullResolution({
           width: videoRef.current.videoWidth,
           height: videoRef.current.videoHeight,
         });
       }
     }
-  }, [videoRef, setLiveResolution]);
+  }, [videoRef, setFullResolution]);
 
   useEffect(() => {
     if (!videoRef.current) {

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -1,8 +1,15 @@
-import { MutableRefObject, useEffect, useRef, useState } from "react";
+import {
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import Hls from "hls.js";
 import { isAndroid, isDesktop, isMobile } from "react-device-detect";
 import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
 import VideoControls from "./VideoControls";
+import { VideoResolutionType } from "@/types/live";
 
 // Android native hls does not seek correctly
 const USE_NATIVE_HLS = !isAndroid;
@@ -21,6 +28,7 @@ type HlsVideoPlayerProps = {
   onPlayerLoaded?: () => void;
   onTimeUpdate?: (time: number) => void;
   onPlaying?: () => void;
+  setLiveResolution?: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
 };
 export default function HlsVideoPlayer({
   videoRef,
@@ -31,12 +39,25 @@ export default function HlsVideoPlayer({
   onPlayerLoaded,
   onTimeUpdate,
   onPlaying,
+  setLiveResolution,
 }: HlsVideoPlayerProps) {
   // playback
 
   const hlsRef = useRef<Hls>();
   const [useHlsCompat, setUseHlsCompat] = useState(false);
   const [loadedMetadata, setLoadedMetadata] = useState(false);
+
+  const handleLoadedMetadata = useCallback(() => {
+    if (videoRef.current) {
+      setLoadedMetadata(true);
+      if (setLiveResolution) {
+        setLiveResolution({
+          width: videoRef.current.videoWidth,
+          height: videoRef.current.videoHeight,
+        });
+      }
+    }
+  }, [videoRef, setLiveResolution]);
 
   useEffect(() => {
     if (!videoRef.current) {
@@ -193,7 +214,7 @@ export default function HlsVideoPlayer({
               : undefined
           }
           onLoadedData={onPlayerLoaded}
-          onLoadedMetadata={() => setLoadedMetadata(true)}
+          onLoadedMetadata={handleLoadedMetadata}
           onEnded={onClipEnded}
           onError={(e) => {
             if (

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -48,8 +48,8 @@ export default function HlsVideoPlayer({
   const [loadedMetadata, setLoadedMetadata] = useState(false);
 
   const handleLoadedMetadata = useCallback(() => {
+    setLoadedMetadata(true);
     if (videoRef.current) {
-      setLoadedMetadata(true);
       if (setLiveResolution) {
         setLiveResolution({
           width: videoRef.current.videoWidth,

--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -27,7 +27,7 @@ type LivePlayerProps = {
   iOSCompatFullScreen?: boolean;
   pip?: boolean;
   onClick?: () => void;
-  setFullResolution: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
+  setFullResolution?: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
 };
 
 export default function LivePlayer({

--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -27,7 +27,7 @@ type LivePlayerProps = {
   iOSCompatFullScreen?: boolean;
   pip?: boolean;
   onClick?: () => void;
-  setLiveResolution: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
+  setFullResolution: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
 };
 
 export default function LivePlayer({
@@ -42,7 +42,7 @@ export default function LivePlayer({
   iOSCompatFullScreen = false,
   pip,
   onClick,
-  setLiveResolution,
+  setFullResolution,
 }: LivePlayerProps) {
   const [cameraHovered, setCameraHovered] = useState(false);
 
@@ -125,7 +125,7 @@ export default function LivePlayer({
           audioEnabled={playAudio}
           onPlaying={() => setLiveReady(true)}
           pip={pip}
-          setLiveResolution={setLiveResolution}
+          setFullResolution={setFullResolution}
         />
       );
     } else {

--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -145,12 +145,6 @@ export default function LivePlayer({
         height={cameraConfig.detect.height}
       />
     );
-    if (setLiveResolution) {
-      setLiveResolution({
-        width: cameraConfig.detect.width,
-        height: cameraConfig.detect.height,
-      });
-    }
   } else {
     player = <ActivityIndicator />;
   }

--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -8,7 +8,7 @@ import JSMpegPlayer from "./JSMpegPlayer";
 import { MdCircle } from "react-icons/md";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { useCameraActivity } from "@/hooks/use-camera-activity";
-import { LivePlayerMode } from "@/types/live";
+import { LivePlayerMode, VideoResolutionType } from "@/types/live";
 import useCameraLiveMode from "@/hooks/use-camera-live-mode";
 import { getIconForLabel } from "@/utils/iconUtil";
 import Chip from "../indicators/Chip";
@@ -27,6 +27,7 @@ type LivePlayerProps = {
   iOSCompatFullScreen?: boolean;
   pip?: boolean;
   onClick?: () => void;
+  setLiveResolution: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
 };
 
 export default function LivePlayer({
@@ -41,6 +42,7 @@ export default function LivePlayer({
   iOSCompatFullScreen = false,
   pip,
   onClick,
+  setLiveResolution,
 }: LivePlayerProps) {
   const [cameraHovered, setCameraHovered] = useState(false);
 
@@ -123,6 +125,7 @@ export default function LivePlayer({
           audioEnabled={playAudio}
           onPlaying={() => setLiveReady(true)}
           pip={pip}
+          setLiveResolution={setLiveResolution}
         />
       );
     } else {
@@ -142,6 +145,12 @@ export default function LivePlayer({
         height={cameraConfig.detect.height}
       />
     );
+    if (setLiveResolution) {
+      setLiveResolution({
+        width: cameraConfig.detect.width,
+        height: cameraConfig.detect.height,
+      });
+    }
   } else {
     player = <ActivityIndicator />;
   }

--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -1,5 +1,13 @@
 import { baseUrl } from "@/api/baseUrl";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { VideoResolutionType } from "@/types/live";
+import {
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 type MSEPlayerProps = {
   camera: string;
@@ -8,6 +16,7 @@ type MSEPlayerProps = {
   audioEnabled?: boolean;
   pip?: boolean;
   onPlaying?: () => void;
+  setLiveResolution?: React.Dispatch<SetStateAction<VideoResolutionType>>;
 };
 
 function MSEPlayer({
@@ -17,6 +26,7 @@ function MSEPlayer({
   audioEnabled = false,
   pip = false,
   onPlaying,
+  setLiveResolution,
 }: MSEPlayerProps) {
   let connectTS: number = 0;
 
@@ -49,6 +59,15 @@ function MSEPlayer({
   const wsURL = useMemo(() => {
     return `${baseUrl.replace(/^http/, "ws")}live/mse/api/ws?src=${camera}`;
   }, [camera]);
+
+  const handleLoadedMetadata = useCallback(() => {
+    if (videoRef.current && setLiveResolution) {
+      setLiveResolution({
+        width: videoRef.current.videoWidth,
+        height: videoRef.current.videoHeight,
+      });
+    }
+  }, [setLiveResolution]);
 
   const play = () => {
     const currentVideo = videoRef.current;
@@ -286,6 +305,7 @@ function MSEPlayer({
       playsInline
       preload="auto"
       onLoadedData={onPlaying}
+      onLoadedMetadata={handleLoadedMetadata}
       muted={!audioEnabled}
     />
   );

--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -16,7 +16,7 @@ type MSEPlayerProps = {
   audioEnabled?: boolean;
   pip?: boolean;
   onPlaying?: () => void;
-  setLiveResolution?: React.Dispatch<SetStateAction<VideoResolutionType>>;
+  setFullResolution?: React.Dispatch<SetStateAction<VideoResolutionType>>;
 };
 
 function MSEPlayer({
@@ -26,7 +26,7 @@ function MSEPlayer({
   audioEnabled = false,
   pip = false,
   onPlaying,
-  setLiveResolution,
+  setFullResolution,
 }: MSEPlayerProps) {
   let connectTS: number = 0;
 
@@ -61,13 +61,13 @@ function MSEPlayer({
   }, [camera]);
 
   const handleLoadedMetadata = useCallback(() => {
-    if (videoRef.current && setLiveResolution) {
-      setLiveResolution({
+    if (videoRef.current && setFullResolution) {
+      setFullResolution({
         width: videoRef.current.videoWidth,
         height: videoRef.current.videoHeight,
       });
     }
-  }, [setLiveResolution]);
+  }, [setFullResolution]);
 
   const play = () => {
     const currentVideo = videoRef.current;

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -25,7 +25,7 @@ type DynamicVideoPlayerProps = {
   onControllerReady: (controller: DynamicVideoController) => void;
   onTimestampUpdate?: (timestamp: number) => void;
   onClipEnded?: () => void;
-  setLiveResolution: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
+  setFullResolution: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
 };
 export default function DynamicVideoPlayer({
   className,
@@ -38,7 +38,7 @@ export default function DynamicVideoPlayer({
   onControllerReady,
   onTimestampUpdate,
   onClipEnded,
-  setLiveResolution,
+  setFullResolution,
 }: DynamicVideoPlayerProps) {
   const apiHost = useApiHost();
   const { data: config } = useSWR<FrigateConfig>("config");
@@ -185,7 +185,7 @@ export default function DynamicVideoPlayer({
           setIsLoading(false);
           setNoRecording(false);
         }}
-        setLiveResolution={setLiveResolution}
+        setFullResolution={setFullResolution}
       />
       <PreviewPlayer
         className={`${isScrubbing || isLoading ? "visible" : "hidden"} ${className}`}

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -9,6 +9,7 @@ import { DynamicVideoController } from "./DynamicVideoController";
 import HlsVideoPlayer from "../HlsVideoPlayer";
 import { TimeRange } from "@/types/timeline";
 import ActivityIndicator from "@/components/indicators/activity-indicator";
+import { VideoResolutionType } from "@/types/live";
 
 /**
  * Dynamically switches between video playback and scrubbing preview player.
@@ -24,6 +25,7 @@ type DynamicVideoPlayerProps = {
   onControllerReady: (controller: DynamicVideoController) => void;
   onTimestampUpdate?: (timestamp: number) => void;
   onClipEnded?: () => void;
+  setLiveResolution: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
 };
 export default function DynamicVideoPlayer({
   className,
@@ -36,6 +38,7 @@ export default function DynamicVideoPlayer({
   onControllerReady,
   onTimestampUpdate,
   onClipEnded,
+  setLiveResolution,
 }: DynamicVideoPlayerProps) {
   const apiHost = useApiHost();
   const { data: config } = useSWR<FrigateConfig>("config");
@@ -182,6 +185,7 @@ export default function DynamicVideoPlayer({
           setIsLoading(false);
           setNoRecording(false);
         }}
+        setLiveResolution={setLiveResolution}
       />
       <PreviewPlayer
         className={`${isScrubbing || isLoading ? "visible" : "hidden"} ${className}`}

--- a/web/src/types/live.ts
+++ b/web/src/types/live.ts
@@ -1,1 +1,5 @@
 export type LivePlayerMode = "webrtc" | "mse" | "jsmpeg" | "debug";
+export type VideoResolutionType = {
+  width: number;
+  height: number;
+};

--- a/web/src/types/record.ts
+++ b/web/src/types/record.ts
@@ -38,3 +38,6 @@ export type RecordingStartingPoint = {
   startTime: number;
   severity: ReviewSeverity;
 };
+
+export const ASPECT_VERTICAL_LAYOUT = 1.5;
+export const ASPECT_WIDE_LAYOUT = 2;

--- a/web/src/views/events/RecordingView.tsx
+++ b/web/src/views/events/RecordingView.tsx
@@ -42,6 +42,7 @@ import Logo from "@/components/Logo";
 import { Skeleton } from "@/components/ui/skeleton";
 import { FaVideo } from "react-icons/fa";
 import { VideoResolutionType } from "@/types/live";
+import { ASPECT_VERTICAL_LAYOUT, ASPECT_WIDE_LAYOUT } from "@/types/record";
 
 const SEGMENT_DURATION = 30;
 
@@ -215,19 +216,19 @@ export function RecordingView({
         return undefined;
       }
 
+      if (cam == mainCamera && fullResolution.width && fullResolution.height) {
+        return fullResolution.width / fullResolution.height;
+      }
+
       const camera = config.cameras[cam];
 
       if (!camera) {
         return undefined;
       }
 
-      if (fullResolution.width && fullResolution.height) {
-        return fullResolution.width / fullResolution.height;
-      } else {
-        return camera.detect.width / camera.detect.height;
-      }
+      return camera.detect.width / camera.detect.height;
     },
-    [config, fullResolution],
+    [config, fullResolution, mainCamera],
   );
 
   const mainCameraAspect = useMemo(() => {
@@ -235,9 +236,9 @@ export function RecordingView({
 
     if (!aspectRatio) {
       return "normal";
-    } else if (aspectRatio > 2) {
+    } else if (aspectRatio > ASPECT_WIDE_LAYOUT) {
       return "wide";
-    } else if (aspectRatio < 16 / 9) {
+    } else if (aspectRatio < ASPECT_VERTICAL_LAYOUT) {
       return "tall";
     } else {
       return "normal";

--- a/web/src/views/events/RecordingView.tsx
+++ b/web/src/views/events/RecordingView.tsx
@@ -190,7 +190,7 @@ export function RecordingView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentTime, scrubbing]);
 
-  const [liveResolution, setLiveResolution] = useState<VideoResolutionType>({
+  const [fullResolution, setFullResolution] = useState<VideoResolutionType>({
     width: 0,
     height: 0,
   });
@@ -198,7 +198,7 @@ export function RecordingView({
   const onSelectCamera = useCallback(
     (newCam: string) => {
       setMainCamera(newCam);
-      setLiveResolution({
+      setFullResolution({
         width: 0,
         height: 0,
       });
@@ -221,13 +221,13 @@ export function RecordingView({
         return undefined;
       }
 
-      if (liveResolution.width && liveResolution.height) {
-        return liveResolution.width / liveResolution.height;
+      if (fullResolution.width && fullResolution.height) {
+        return fullResolution.width / fullResolution.height;
       } else {
         return camera.detect.width / camera.detect.height;
       }
     },
-    [config, liveResolution],
+    [config, fullResolution],
   );
 
   const mainCameraAspect = useMemo(() => {
@@ -411,7 +411,7 @@ export function RecordingView({
                   mainControllerRef.current = controller;
                 }}
                 isScrubbing={scrubbing || exportMode == "timeline"}
-                setLiveResolution={setLiveResolution}
+                setFullResolution={setFullResolution}
               />
             </div>
             {isDesktop && (

--- a/web/src/views/events/RecordingView.tsx
+++ b/web/src/views/events/RecordingView.tsx
@@ -41,6 +41,7 @@ import MobileReviewSettingsDrawer from "@/components/overlay/MobileReviewSetting
 import Logo from "@/components/Logo";
 import { Skeleton } from "@/components/ui/skeleton";
 import { FaVideo } from "react-icons/fa";
+import { VideoResolutionType } from "@/types/live";
 
 const SEGMENT_DURATION = 30;
 
@@ -199,6 +200,11 @@ export function RecordingView({
 
   // motion timeline data
 
+  const [liveResolution, setLiveResolution] = useState<VideoResolutionType>({
+    width: 0,
+    height: 0,
+  });
+
   const getCameraAspect = useCallback(
     (cam: string) => {
       if (!config) {
@@ -211,9 +217,13 @@ export function RecordingView({
         return undefined;
       }
 
-      return camera.detect.width / camera.detect.height;
+      if (liveResolution.width && liveResolution.height) {
+        return liveResolution.width / liveResolution.height;
+      } else {
+        return camera.detect.width / camera.detect.height;
+      }
     },
-    [config],
+    [config, liveResolution],
   );
 
   const mainCameraAspect = useMemo(() => {
@@ -397,6 +407,7 @@ export function RecordingView({
                   mainControllerRef.current = controller;
                 }}
                 isScrubbing={scrubbing || exportMode == "timeline"}
+                setLiveResolution={setLiveResolution}
               />
             </div>
             {isDesktop && (

--- a/web/src/views/events/RecordingView.tsx
+++ b/web/src/views/events/RecordingView.tsx
@@ -190,20 +190,24 @@ export function RecordingView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentTime, scrubbing]);
 
+  const [liveResolution, setLiveResolution] = useState<VideoResolutionType>({
+    width: 0,
+    height: 0,
+  });
+
   const onSelectCamera = useCallback(
     (newCam: string) => {
       setMainCamera(newCam);
+      setLiveResolution({
+        width: 0,
+        height: 0,
+      });
       setPlaybackStart(currentTime);
     },
     [currentTime],
   );
 
   // motion timeline data
-
-  const [liveResolution, setLiveResolution] = useState<VideoResolutionType>({
-    width: 0,
-    height: 0,
-  });
 
   const getCameraAspect = useCallback(
     (cam: string) => {

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -150,15 +150,15 @@ export default function LiveCameraView({ camera }: LiveCameraViewProps) {
   const [fullscreen, setFullscreen] = useState(false);
   const [pip, setPip] = useState(false);
 
-  const [liveResolution, setLiveResolution] = useState<VideoResolutionType>({
+  const [fullResolution, setFullResolution] = useState<VideoResolutionType>({
     width: 0,
     height: 0,
   });
 
   const growClassName = useMemo(() => {
     let aspect;
-    if (liveResolution.width && liveResolution.height) {
-      aspect = liveResolution.width / liveResolution.height;
+    if (fullResolution.width && fullResolution.height) {
+      aspect = fullResolution.width / fullResolution.height;
     } else {
       aspect = camera.detect.width / camera.detect.height;
     }
@@ -184,7 +184,7 @@ export default function LiveCameraView({ camera }: LiveCameraViewProps) {
     } else {
       return "absolute top-2 bottom-2 left-[50%] -translate-x-[50%]";
     }
-  }, [camera, fullscreen, isPortrait, liveResolution]);
+  }, [camera, fullscreen, isPortrait, fullResolution]);
 
   const preferredLiveMode = useMemo(() => {
     if (isSafari || mic) {
@@ -199,12 +199,12 @@ export default function LiveCameraView({ camera }: LiveCameraViewProps) {
   }, [windowWidth, windowHeight]);
 
   const cameraAspectRatio = useMemo(() => {
-    if (liveResolution.width && liveResolution.height) {
-      return liveResolution.width / liveResolution.height;
+    if (fullResolution.width && fullResolution.height) {
+      return fullResolution.width / fullResolution.height;
     } else {
       return camera.detect.width / camera.detect.height;
     }
-  }, [camera, liveResolution]);
+  }, [camera, fullResolution]);
 
   const aspectRatio = useMemo<number>(() => {
     if (isMobile || fullscreen) {
@@ -362,7 +362,7 @@ export default function LiveCameraView({ camera }: LiveCameraViewProps) {
               iOSCompatFullScreen={isIOS}
               preferredLiveMode={preferredLiveMode}
               pip={pip}
-              setLiveResolution={setLiveResolution}
+              setFullResolution={setFullResolution}
             />
           </div>
           {camera.onvif.host != "" && (

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -20,6 +20,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { useResizeObserver } from "@/hooks/resize-observer";
 import useKeyboardListener from "@/hooks/use-keyboard-listener";
 import { CameraConfig } from "@/types/frigateConfig";
+import { VideoResolutionType } from "@/types/live";
 import { CameraPtzInfo } from "@/types/ptz";
 import { RecordingStartingPoint } from "@/types/record";
 import React, {
@@ -149,8 +150,18 @@ export default function LiveCameraView({ camera }: LiveCameraViewProps) {
   const [fullscreen, setFullscreen] = useState(false);
   const [pip, setPip] = useState(false);
 
+  const [liveResolution, setLiveResolution] = useState<VideoResolutionType>({
+    width: 0,
+    height: 0,
+  });
+
   const growClassName = useMemo(() => {
-    const aspect = camera.detect.width / camera.detect.height;
+    let aspect;
+    if (liveResolution.width && liveResolution.height) {
+      aspect = liveResolution.width / liveResolution.height;
+    } else {
+      aspect = camera.detect.width / camera.detect.height;
+    }
 
     if (isMobile) {
       if (isPortrait) {
@@ -173,7 +184,7 @@ export default function LiveCameraView({ camera }: LiveCameraViewProps) {
     } else {
       return "absolute top-2 bottom-2 left-[50%] -translate-x-[50%]";
     }
-  }, [camera, fullscreen, isPortrait]);
+  }, [camera, fullscreen, isPortrait, liveResolution]);
 
   const preferredLiveMode = useMemo(() => {
     if (isSafari || mic) {
@@ -188,8 +199,12 @@ export default function LiveCameraView({ camera }: LiveCameraViewProps) {
   }, [windowWidth, windowHeight]);
 
   const cameraAspectRatio = useMemo(() => {
-    return camera.detect.width / camera.detect.height;
-  }, [camera]);
+    if (liveResolution.width && liveResolution.height) {
+      return liveResolution.width / liveResolution.height;
+    } else {
+      return camera.detect.width / camera.detect.height;
+    }
+  }, [camera, liveResolution]);
 
   const aspectRatio = useMemo<number>(() => {
     if (isMobile || fullscreen) {
@@ -347,6 +362,7 @@ export default function LiveCameraView({ camera }: LiveCameraViewProps) {
               iOSCompatFullScreen={isIOS}
               preferredLiveMode={preferredLiveMode}
               pip={pip}
+              setLiveResolution={setLiveResolution}
             />
           </div>
           {camera.onvif.host != "" && (

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -167,7 +167,7 @@ export default function LiveCameraView({ camera }: LiveCameraViewProps) {
       if (isPortrait) {
         return "absolute left-2 right-2 top-[50%] -translate-y-[50%]";
       } else {
-        if (aspect > 16 / 9) {
+        if (aspect > 1.5) {
           return "p-2 absolute left-0 top-[50%] -translate-y-[50%]";
         } else {
           return "p-2 absolute top-2 bottom-2 left-[50%] -translate-x-[50%]";
@@ -176,7 +176,7 @@ export default function LiveCameraView({ camera }: LiveCameraViewProps) {
     }
 
     if (fullscreen) {
-      if (aspect > 16 / 9) {
+      if (aspect > 1.5) {
         return "absolute inset-x-2 top-[50%] -translate-y-[50%]";
       } else {
         return "absolute inset-y-2 left-[50%] -translate-x-[50%]";


### PR DESCRIPTION
Cameras can have a detect resolution aspect ratio that differs from a full resolution aspect ratio. This PR will dynamically adjust the recording and live view aspect based on the loaded metadata from the video player.