### PR TITLE
Fix crash on mobile review

### DIFF
--- a/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
+++ b/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
@@ -109,6 +109,9 @@ export default function MobileReviewSettingsDrawer({
     const cameras = filter?.cameras || Object.keys(config.cameras);
 
     cameras.forEach((camera) => {
+      if (camera == "birdseye") {
+        return;
+      }
       const cameraConfig = config.cameras[camera];
       cameraConfig.objects.track.forEach((label) => {
         labels.add(label);


### PR DESCRIPTION
When a camera group includes birdseye, the mobile review pane would crash. This PR matches the desktop code to exclude birdseye from the iterator.