### PR TITLE
Adjust stationary reqs depending on state

### DIFF
--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -22,8 +22,9 @@ from frigate.util.object import average_boxes, median_of_boxes
 logger = logging.getLogger(__name__)
 
 
-THRESHOLD_ACTIVE_IOU = 0.35
-THRESHOLD_STATIONARY_IOU = 0.7
+THRESHOLD_KNOWN_ACTIVE_IOU = 0.2
+THRESHOLD_STATIONARY_CHECK_IOU = 0.6
+THRESHOLD_ACTIVE_CHECK_IOU = 0.9
 MAX_STATIONARY_HISTORY = 10
 
 
@@ -146,7 +147,7 @@ class NorfairTracker(ObjectTracker):
 
     # tracks the current position of the object based on the last N bounding boxes
     # returns False if the object has moved outside its previous position
-    def update_position(self, id: str, box: list[int, int, int, int]):
+    def update_position(self, id: str, box: list[int, int, int, int], stationary: bool):
         xmin, ymin, xmax, ymax = box
         position = self.positions[id]
         self.stationary_box_history[id].append(box)
@@ -162,7 +163,7 @@ class NorfairTracker(ObjectTracker):
 
         # object has minimal or zero iou
         # assume object is active
-        if avg_iou < THRESHOLD_ACTIVE_IOU:
+        if avg_iou < THRESHOLD_KNOWN_ACTIVE_IOU:
             self.positions[id] = {
                 "xmins": [xmin],
                 "ymins": [ymin],
@@ -175,8 +176,12 @@ class NorfairTracker(ObjectTracker):
             }
             return False
 
+        threshold = (
+            THRESHOLD_STATIONARY_CHECK_IOU if stationary else THRESHOLD_ACTIVE_CHECK_IOU
+        )
+
         # object has iou below threshold, check median to reduce outliers
-        if avg_iou < THRESHOLD_STATIONARY_IOU:
+        if avg_iou < threshold:
             median_iou = intersection_over_union(
                 (
                     position["xmin"],
@@ -189,7 +194,7 @@ class NorfairTracker(ObjectTracker):
 
             # if the median iou drops below the threshold
             # assume object is no longer stationary
-            if median_iou < THRESHOLD_STATIONARY_IOU:
+            if median_iou < threshold:
                 self.positions[id] = {
                     "xmins": [xmin],
                     "ymins": [ymin],
@@ -240,8 +245,12 @@ class NorfairTracker(ObjectTracker):
     def update(self, track_id, obj):
         id = self.track_id_map[track_id]
         self.disappeared[id] = 0
+        stationary = (
+            self.tracked_objects[id]["motionless_count"]
+            >= self.detect_config.stationary.threshold
+        )
         # update the motionless count if the object has not moved to a new position
-        if self.update_position(id, obj["box"]):
+        if self.update_position(id, obj["box"], stationary):
             self.tracked_objects[id]["motionless_count"] += 1
             if self.is_expired(id):
                 self.deregister(id, track_id)


### PR DESCRIPTION
Certain camera perspectives never considered an object moving. This PR makes the requirements to become stationary while active higher, and keeps the same settings as before once the object becomes stationary