### PR TITLE
Cleanup config validation

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -1511,20 +1511,15 @@ class FrigateConfig(FrigateBaseModel):
             if detector_config.model is None:
                 detector_config.model = config.model
             else:
-                model = detector_config.model
-                schema = ModelConfig.model_json_schema()["properties"]
-                if (
-                    model.width != schema["width"]["default"]
-                    or model.height != schema["height"]["default"]
-                    or model.labelmap_path is not None
-                    or model.labelmap
-                    or model.input_tensor != schema["input_tensor"]["default"]
-                    or model.input_pixel_format
-                    != schema["input_pixel_format"]["default"]
-                ):
+                path = detector_config.model.path
+                detector_config.model = config.model
+                detector_config.model.path = path
+
+                if "path" not in model_dict or len(model_dict.keys()) > 1:
                     logger.warning(
                         "Customizing more than a detector model path is unsupported."
                     )
+
             merged_model = deep_merge(
                 detector_config.model.model_dump(exclude_unset=True),
                 config.model.model_dump(exclude_unset=True),

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -1511,10 +1511,10 @@ class FrigateConfig(FrigateBaseModel):
             )
             detector_config: DetectorConfig = adapter.validate_python(model_dict)
             if detector_config.model is None:
-                detector_config.model = config.model
+                detector_config.model = config.model.model_copy()
             else:
                 path = detector_config.model.path
-                detector_config.model = config.model
+                detector_config.model = config.model.model_copy()
                 detector_config.model.path = path
 
                 if "path" not in model_dict or len(model_dict.keys()) > 1:

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -1505,7 +1505,9 @@ class FrigateConfig(FrigateBaseModel):
         for key, detector in config.detectors.items():
             adapter = TypeAdapter(DetectorConfig)
             model_dict = (
-                detector if isinstance(detector, dict) else detector.model_dump()
+                detector
+                if isinstance(detector, dict)
+                else detector.model_dump(warnings="none")
             )
             detector_config: DetectorConfig = adapter.validate_python(model_dict)
             if detector_config.model is None:
@@ -1521,8 +1523,8 @@ class FrigateConfig(FrigateBaseModel):
                     )
 
             merged_model = deep_merge(
-                detector_config.model.model_dump(exclude_unset=True),
-                config.model.model_dump(exclude_unset=True),
+                detector_config.model.model_dump(exclude_unset=True, warnings="none"),
+                config.model.model_dump(exclude_unset=True, warnings="none"),
             )
 
             if "path" not in merged_model:

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -82,7 +82,7 @@ class TestConfig(unittest.TestCase):
                 },
                 "edgetpu": {
                     "type": "edgetpu",
-                    "model": {"path": "/edgetpu_model.tflite", "width": 160},
+                    "model": {"path": "/edgetpu_model.tflite"},
                 },
                 "openvino": {
                     "type": "openvino",
@@ -111,11 +111,6 @@ class TestConfig(unittest.TestCase):
         assert runtime_config.detectors["cpu"].model.path == "/cpu_model.tflite"
         assert runtime_config.detectors["edgetpu"].model.path == "/edgetpu_model.tflite"
         assert runtime_config.detectors["openvino"].model.path == "/etc/hosts"
-
-        assert runtime_config.model.width == 512
-        assert runtime_config.detectors["cpu"].model.width == 320
-        assert runtime_config.detectors["edgetpu"].model.width == 160
-        assert runtime_config.detectors["openvino"].model.width == 512
 
     def test_invalid_mqtt_config(self):
         config = {


### PR DESCRIPTION
The full detector config has default values which override the main model config. We know that only the path can be changed between models so it can be cleaned up.