### PR TITLE
Use portal on all sidebar tooltips

### DIFF
--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -59,6 +59,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { toast } from "sonner";
 import ActivityIndicator from "../indicators/activity-indicator";
 import { ScrollArea, ScrollBar } from "../ui/scroll-area";
+import { TooltipPortal } from "@radix-ui/react-tooltip";
 
 type CameraGroupSelectorProps = {
   className?: string;
@@ -137,9 +138,11 @@ export function CameraGroupSelector({ className }: CameraGroupSelectorProps) {
                 <MdHome className="size-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent className="capitalize" side="right">
-              All Cameras
-            </TooltipContent>
+            <TooltipPortal>
+              <TooltipContent className="capitalize" side="right">
+                All Cameras
+              </TooltipContent>
+            </TooltipPortal>
           </Tooltip>
           {groups.map(([name, config]) => {
             return (
@@ -161,9 +164,11 @@ export function CameraGroupSelector({ className }: CameraGroupSelectorProps) {
                     {getIconForGroup(config.icon)}
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent className="capitalize" side="right">
-                  {name}
-                </TooltipContent>
+                <TooltipPortal>
+                  <TooltipContent className="capitalize" side="right">
+                    {name}
+                  </TooltipContent>
+                </TooltipPortal>
               </Tooltip>
             );
           })}

--- a/web/src/components/menu/AccountSettings.tsx
+++ b/web/src/components/menu/AccountSettings.tsx
@@ -3,6 +3,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { TooltipPortal } from "@radix-ui/react-tooltip";
 import { isDesktop } from "react-device-detect";
 import { VscAccount } from "react-icons/vsc";
 
@@ -19,9 +20,11 @@ export default function AccountSettings({ className }: AccountSettingsProps) {
           <VscAccount className="size-5 md:m-[6px]" />
         </div>
       </TooltipTrigger>
-      <TooltipContent side="right">
-        <p>Account</p>
-      </TooltipContent>
+      <TooltipPortal>
+        <TooltipContent side="right">
+          <p>Account</p>
+        </TooltipContent>
+      </TooltipPortal>
     </Tooltip>
   );
 }

--- a/web/src/components/menu/GeneralSettings.tsx
+++ b/web/src/components/menu/GeneralSettings.tsx
@@ -65,6 +65,7 @@ import {
   DialogPortal,
   DialogTrigger,
 } from "../ui/dialog";
+import { TooltipPortal } from "@radix-ui/react-tooltip";
 
 type GeneralSettingsProps = {
   className?: string;
@@ -124,9 +125,11 @@ export default function GeneralSettings({ className }: GeneralSettingsProps) {
                     <LuSettings className="size-5 md:m-[6px]" />
                   </div>
                 </TooltipTrigger>
-                <TooltipContent side="right">
-                  <p>Settings</p>
-                </TooltipContent>
+                <TooltipPortal>
+                  <TooltipContent side="right">
+                    <p>Settings</p>
+                  </TooltipContent>
+                </TooltipPortal>
               </Tooltip>
             </a>
           </Trigger>


### PR DESCRIPTION
Safari desktop was still hiding some sidebar tooltips (camera groups and settings/account). The portal tag was already wrapping the nav items, this PR wraps the missing ones.