### PR TITLE
Fix aarch64 build

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -51,7 +51,7 @@ ARG DEBIAN_FRONTEND
 # Install OpenVino Runtime and Dev library
 COPY docker/main/requirements-ov.txt /requirements-ov.txt
 RUN apt-get -qq update \
-    && apt-get -qq install -y wget python3 python3-distutils \
+    && apt-get -qq install -y wget python3 python3-distutils pkg-config libhdf5-dev gcc python3-dev \
     && wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py \
     && python3 get-pip.py "pip" \
     && pip install -r /requirements-ov.txt

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -51,7 +51,7 @@ ARG DEBIAN_FRONTEND
 # Install OpenVino Runtime and Dev library
 COPY docker/main/requirements-ov.txt /requirements-ov.txt
 RUN apt-get -qq update \
-    && apt-get -qq install -y wget python3 python3-distutils pkg-config libhdf5-dev gcc python3-dev \
+    && apt-get -qq install -y wget python3 python3-dev python3-distutils gcc pkg-config libhdf5-dev \
     && wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py \
     && python3 get-pip.py "pip" \
     && pip install -r /requirements-ov.txt


### PR DESCRIPTION
Hi,
I tried do build frigate from current dev branch. During build process frigate tries to get a wheel for h5py as openvino requirement:
https://github.com/blakeblackshear/frigate/blob/ff2948a76b8f864ff927564faec83f5ba8a51112/docker/main/Dockerfile#L53-L57

This fails, because h5py doesn't provide wheels for aarch64. So it tries to build from source but the build dependencies are missing:
```
80.86       running build_ext
80.86       Building h5py requires pkg-config unless the HDF5 path is explicitly specified using the environment variable HDF5_DIR. For more information and details, see https://docs.h5py.org/en/stable/build.html#custom-installation
80.86       error: pkg-config probably not installed: FileNotFoundError(2, 'No such file or directory')
80.86       [end of output]
```
It works after adding installing these build deps: `pkg-config libhdf5-dev gcc python3-dev`.