### PR TITLE
Updated Dockerfiles to be able to build for Jetpack 6

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -115,6 +115,11 @@ FROM base AS wheels
 ARG DEBIAN_FRONTEND
 ARG TARGETARCH
 
+RUN apt-get update && \
+    apt-get install software-properties-common -y && \
+    add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get update
+
 # Use a separate container to build wheels to prevent build dependencies in final image
 RUN apt-get -qq update \
     && apt-get -qq install -y \
@@ -130,12 +135,13 @@ RUN apt-get -qq update \
     && apt-get -qq install -y \
     python3.9 \
     python3.9-dev \
+    python3.9-distutils \
     # opencv dependencies
     build-essential cmake git pkg-config libgtk-3-dev \
     libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
     libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev \
     gfortran openexr libatlas-base-dev libssl-dev\
-    libtbb2 libtbb-dev libdc1394-22-dev libopenexr-dev \
+    libtbb2 libtbb-dev libdc1394-dev libopenexr-dev \
     libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev \
     # scipy dependencies
     gcc gfortran libopenblas-dev liblapack-dev && \
@@ -184,7 +190,7 @@ RUN --mount=type=bind,source=docker/main/install_deps.sh,target=/deps/install_de
 
 RUN --mount=type=bind,from=wheels,source=/wheels,target=/deps/wheels \
     python3 -m pip install --upgrade pip && \
-    pip3 install -U /deps/wheels/*.whl
+    pip3 install --ignore-installed -U /deps/wheels/*.whl
 
 COPY --from=deps-rootfs / /
 

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -4,6 +4,10 @@ set -euxo pipefail
 
 apt-get -qq update
 
+apt-get -qq install software-properties-common -y
+add-apt-repository ppa:deadsnakes/ppa -y
+apt-get update -qq
+
 apt-get -qq install --no-install-recommends -y \
     apt-transport-https \
     gnupg \
@@ -11,6 +15,7 @@ apt-get -qq install --no-install-recommends -y \
     procps vainfo \
     unzip locales tzdata libxml2 xz-utils \
     python3.9 \
+    python3.9-distutils \
     python3-pip \
     curl \
     jq \
@@ -35,7 +40,16 @@ fi
 # coral drivers
 apt-get -qq update
 apt-get -qq install --no-install-recommends --no-install-suggests -y \
-    libedgetpu1-max python3-tflite-runtime python3-pycoral
+    libedgetpu1-max
+
+# apt-get -qq install --no-install-recommends --no-install-suggests -y \
+#     libedgetpu1-max python3-tflite-runtime python3-pycoral
+
+pip3 install --extra-index-url https://google-coral.github.io/py-repo/ tflite_runtime
+
+apt install gdal-bin python3-gdal -y
+
+pip3 install --extra-index-url https://google-coral.github.io/py-repo/ pycoral
 
 # btbn-ffmpeg -> amd64
 if [[ "${TARGETARCH}" == "amd64" ]]; then

--- a/docker/tensorrt/Dockerfile.arm64
+++ b/docker/tensorrt/Dockerfile.arm64
@@ -7,10 +7,15 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE} AS build-wheels
 ARG DEBIAN_FRONTEND
 
+RUN apt-get update && \
+    apt-get install software-properties-common -y && \
+    add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get update
+
 # Use a separate container to build wheels to prevent build dependencies in final image
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       python3.9 python3.9-dev \
+       python3.9 python3.9-dev python3.9-distutils \
        wget build-essential cmake git \
     && rm -rf /var/lib/apt/lists/*
 
@@ -24,6 +29,15 @@ RUN wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py \
 FROM build-wheels AS trt-wheels
 ARG DEBIAN_FRONTEND
 ARG TARGETARCH
+
+RUN apt-key adv --fetch-key https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+
+RUN echo "deb https://repo.download.nvidia.com/jetson/common r36.3 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
+RUN echo "deb https://repo.download.nvidia.com/jetson/t234 r36.3 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
+RUN echo "deb https://repo.download.nvidia.com/jetson/ffmpeg r36.3 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
+
+RUN mkdir -p /opt/nvidia/l4t-packages/
+RUN touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 # python-tensorrt build deps are 3.4 GB!
 RUN apt-get update \

--- a/docker/tensorrt/Dockerfile.arm64
+++ b/docker/tensorrt/Dockerfile.arm64
@@ -77,7 +77,7 @@ RUN --mount=type=bind,source=docker/tensorrt/build_jetson_ffmpeg.sh,target=/deps
 # Frigate w/ TensorRT for NVIDIA Jetson platforms
 FROM tensorrt-base AS frigate-tensorrt
 RUN apt-get update \
-    && apt-get install -y python-is-python3 libprotobuf17  \
+    && apt-get install -y python-is-python3 libprotobuf23  \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rm -rf /usr/lib/btbn-ffmpeg/

--- a/docker/tensorrt/Dockerfile.base
+++ b/docker/tensorrt/Dockerfile.base
@@ -10,6 +10,14 @@ FROM ${TRT_BASE} AS trt-deps
 
 ARG COMPUTE_LEVEL
 
+RUN apt-get update && \
+    apt-get install software-properties-common -y && \
+    add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get update
+
+RUN echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | tee /etc/apt/sources.list.d/coral-edgetpu.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+
 RUN apt-get update \
     && apt-get install -y git build-essential cuda-nvcc-* cuda-nvtx-* libnvinfer-dev libnvinfer-plugin-dev libnvparsers-dev libnvonnxparsers-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/tensorrt/build_jetson_ffmpeg.sh
+++ b/docker/tensorrt/build_jetson_ffmpeg.sh
@@ -14,7 +14,21 @@ apt-get -qq install -y --no-install-recommends libx264-dev libx265-dev
 pushd /tmp
 
 # Install libnvmpi to enable nvmpi decoders (h264_nvmpi, hevc_nvmpi)
-if [ -e /usr/local/cuda-10.2 ]; then
+if [ -e /usr/local/cuda-12.2 ]; then
+    # assume Jetpack 6.X
+    apt-key adv --fetch-key https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+
+    echo "deb https://repo.download.nvidia.com/jetson/common r36.3 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
+    echo "deb https://repo.download.nvidia.com/jetson/t234 r36.3 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
+    echo "deb https://repo.download.nvidia.com/jetson/ffmpeg r36.3 main" >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
+
+    mkdir -p /opt/nvidia/l4t-packages/
+    touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
+
+    apt-get update
+
+    apt-get install nvidia-l4t-jetson-multimedia-api -o Dpkg::Options::="--force-confold" --force-yes -y
+elif [ -e /usr/local/cuda-10.2 ]; then
     # assume Jetpack 4.X
     wget -q https://developer.nvidia.com/embedded/L4T/r32_Release_v5.0/T186/Jetson_Multimedia_API_R32.5.0_aarch64.tbz2 -O jetson_multimedia_api.tbz2
 else

--- a/docker/tensorrt/detector/build_python_tensorrt.sh
+++ b/docker/tensorrt/detector/build_python_tensorrt.sh
@@ -12,7 +12,7 @@ if [[ "${TARGETARCH}" == "arm64" ]]; then
   # Get python-tensorrt source
   mkdir /workspace
   cd /workspace
-  git clone -b ${TENSORRT_VER} https://github.com/NVIDIA/TensorRT.git --depth=1
+  git clone -b release/8.6 https://github.com/NVIDIA/TensorRT.git --depth=1
 
   # Collect dependencies
   EXT_PATH=/workspace/external && mkdir -p $EXT_PATH
@@ -22,7 +22,7 @@ if [[ "${TARGETARCH}" == "arm64" ]]; then
 
   # Build wheel
   cd /workspace/TensorRT/python
-  EXT_PATH=$EXT_PATH PYTHON_MAJOR_VERSION=3 PYTHON_MINOR_VERSION=9 TARGET_ARCHITECTURE=aarch64 /bin/bash ./build.sh
-  mv build/dist/*.whl /trt-wheels/
+  EXT_PATH=$EXT_PATH PYTHON_MAJOR_VERSION=3 PYTHON_MINOR_VERSION=9 TARGET_ARCHITECTURE=aarch64 TENSORRT_MODULE=tensorrt /bin/bash ./build.sh
+  mv build/bindings_wheel/dist/*.whl /trt-wheels/
 
 fi

--- a/docker/tensorrt/detector/rootfs/etc/s6-overlay/s6-rc.d/trt-model-prepare/run
+++ b/docker/tensorrt/detector/rootfs/etc/s6-overlay/s6-rc.d/trt-model-prepare/run
@@ -58,7 +58,7 @@ fi
 # order to run libyolo here.
 # On Jetpack 5.0, these libraries are not mounted by the runtime and are supplied by the image.
 if [[ "$(arch)" == "aarch64" ]]; then
-    if [[ ! -e /usr/lib/aarch64-linux-gnu/tegra ]]; then
+    if [[ ! -e /usr/lib/aarch64-linux-gnu/tegra-egl ]]; then
         echo "ERROR: Container must be launched with nvidia runtime"
         exit 1
     elif [[ ! -e /usr/lib/aarch64-linux-gnu/libnvinfer.so.8 ||


### PR DESCRIPTION
Spent a good day or so trying to get the base images for Jetpack 6 to be able to be used to build Frigate. Since it now is based on Ubuntu 22, that means that it also does not have Python 3.9.

So, you have to use deadsnakes, and there are a few other packages that need to have different versions installed.

Tried to make a minimal footprint, and this definitely can get cleaned up a bit and more conditionals thrown in. Wanted to get this PR up just in case others also were curious if it was possible before we actually clean it up to merge.

Successfully built using:
```
ARCH=arm64 BASE_IMAGE=nvcr.io/nvidia/l4t-tensorrt:r8.6.2-runtime  \
SLIM_BASE=nvcr.io/nvidia/l4t-tensorrt:r8.6.2-runtime \
TRT_BASE=nvcr.io/nvidia/tensorrt:24.04-py3 \
docker buildx bake --load --file=docker/tensorrt/trt.hcl \
  --set tensorrt.tags=frigate:latest-tensorrt-jp6 tensorrt
```

Container running for the first time, generating the TensorRT file:
<img width="1320" alt="Screenshot 2024-05-09 at 11 09 35 PM" src="https://github.com/blakeblackshear/frigate/assets/7525989/39c8d206-924a-4f67-ae08-0fcaca133041">

It appears to also be using GPU:
<img width="856" alt="Screenshot 2024-05-09 at 11 10 30 PM" src="https://github.com/blakeblackshear/frigate/assets/7525989/27556fc1-4bd0-4f5e-889e-516170b0235c">
