### PR TITLE
Minimal config in installation guide

### DIFF
--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -53,6 +53,9 @@ Users of the Snapcraft build of Docker cannot use storage locations outside your
 
 :::
 
+### Creating a minimal configuration
+For Frigate to start, you will need to have a valid configuration file inside your `config/` directory mentioned in the storage section of this page. You can find a minimal reference configuration with a dummy camera on the [full reference config page](https://docs.frigate.video/configuration/reference/).
+
 ### Calculating required shm-size
 
 Frigate utilizes shared memory to store frames during processing. The default `shm-size` provided by Docker is **64MB**.
@@ -77,6 +80,12 @@ $ python -c 'print("{:.2f}MB".format(((1280 * 720 * 1.5 * 9 + 270480) / 1048576)
 ```
 
 The shm size cannot be set per container for Home Assistant add-ons. However, this is probably not required since by default Home Assistant Supervisor allocates `/dev/shm` with half the size of your total memory. If your machine has 8GB of memory, chances are that Frigate will have access to up to 4GB without any additional configuration.
+
+:::warning
+
+Before proceeding, make sure you have setup a valid, minimal configuration, or full configuration if you already know what you are doing!
+
+:::
 
 ### Raspberry Pi 3/4
 

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -54,6 +54,7 @@ Users of the Snapcraft build of Docker cannot use storage locations outside your
 :::
 
 ### Creating a minimal configuration
+
 For Frigate to start, you will need to have a valid configuration file inside your `config/` directory mentioned in the storage section of this page. You can find a minimal reference configuration with a dummy camera on the [full reference config page](https://docs.frigate.video/configuration/reference/).
 
 ### Calculating required shm-size

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -28,6 +28,12 @@ Frigate uses the following locations for read/write operations in the container.
 - `/tmp/cache`: Cache location for recording segments. Initial recordings are written here before being checked and converted to mp4 and moved to the recordings folder. Segments generated via the `clip.mp4` endpoints are also concatenated and processed here. It is recommended to use a [`tmpfs`](https://docs.docker.com/storage/tmpfs/) mount for this.
 - `/dev/shm`: Internal cache for raw decoded frames in shared memory. It is not recommended to modify this directory or map it with docker. The minimum size is impacted by the `shm-size` calculations below.
 
+:::warning
+
+For Frigate to start, you will need to have a valid configuration file inside your `config/` directory mentioned above. You can find a minimal reference configuration with a dummy camera on the [full reference config page](https://docs.frigate.video/configuration/reference/).
+
+:::
+
 #### Common docker compose storage configurations
 
 Writing to a local disk or external USB drive:
@@ -53,10 +59,6 @@ Users of the Snapcraft build of Docker cannot use storage locations outside your
 
 :::
 
-### Creating a minimal configuration
-
-For Frigate to start, you will need to have a valid configuration file inside your `config/` directory mentioned in the storage section of this page. You can find a minimal reference configuration with a dummy camera on the [full reference config page](https://docs.frigate.video/configuration/reference/).
-
 ### Calculating required shm-size
 
 Frigate utilizes shared memory to store frames during processing. The default `shm-size` provided by Docker is **64MB**.
@@ -81,12 +83,6 @@ $ python -c 'print("{:.2f}MB".format(((1280 * 720 * 1.5 * 9 + 270480) / 1048576)
 ```
 
 The shm size cannot be set per container for Home Assistant add-ons. However, this is probably not required since by default Home Assistant Supervisor allocates `/dev/shm` with half the size of your total memory. If your machine has 8GB of memory, chances are that Frigate will have access to up to 4GB without any additional configuration.
-
-:::warning
-
-Before proceeding, make sure you have setup a valid, minimal configuration, or full configuration if you already know what you are doing!
-
-:::
 
 ### Raspberry Pi 3/4
 

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -30,7 +30,7 @@ Frigate uses the following locations for read/write operations in the container.
 
 :::warning
 
-For Frigate to start, you will need to have a valid configuration file inside your `config/` directory mentioned above. You can find a minimal reference configuration with a dummy camera on the [full reference config page](https://docs.frigate.video/configuration/reference/).
+For Frigate to start, it requires a valid configuration file inside the `/config/` directory mentioned above. There is a step by step guide to creating a minimal configuration in the [getting started guide](https://docs.frigate.video/guides/getting_started#configuring-frigate).
 
 :::
 


### PR DESCRIPTION
Hi all,

Firstly, thanks for such an amazing piece of software! I was going through the installation guide tonight to get my first Frigate setup going and encountered errors starting the container due to a missing config file, though this wasn't immediately clear, as I initially thought it was a `go2rtc` problem due to only seeing the bottom part of the logs in Portainer.

The error for the missing config wasn't **explicit** about it being a requirement too, it simply said it couldn't be found, so my assumption was a minimal config would be created automatically.

I think it'd be great to mention the requirement for a minimal configuration in order for the container to start. This is in the Getting Started guide already, but that's further down the page than Installation, so people might miss it.

<img width="292" alt="image" src="https://github.com/blakeblackshear/frigate/assets/104114845/32a0bdc4-b362-45b8-aa22-accb58e7dffc">

Specific changes:
+ Adds a subsection to the installation guide that mentions the requirement for a minimal config to start Frigate successfully.
+ Adds a warning not to proceed any further into the guide without this valid config

Potential concerns:
1. Two sources of truth for the minimal config - would it be better to link to the getting started guide?
2. Is the positioning of the warning and the subsection ideal?
3. Is the wording ideal? Does it create any potential confusion?

 I hope this PR helps. I did a search to see if there were any duplicates in PRs/Issues and couldn't find anything.

I apologise if I've missed something obvious and any of my assumptions here are incorrect, I come from a constructive place and just trying to make future Frigate installers' lives easier.

Regards,
Lachlan