### PR TITLE
Update FFmpeg for Rockchip

### DIFF
--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -113,20 +113,6 @@ if int(os.environ["LIBAVFORMAT_VERSION_MAJOR"]) < 59:
             "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"
         )
 
-# add hardware acceleration presets for rockchip devices
-# may be removed if frigate uses a go2rtc version that includes these presets
-if go2rtc_config.get("ffmpeg") is None:
-    go2rtc_config["ffmpeg"] = {
-        "h264/rk": "-c:v h264_rkmpp_encoder -g 50 -bf 0",
-        "h265/rk": "-c:v hevc_rkmpp_encoder -g 50 -bf 0",
-    }
-else:
-    if go2rtc_config["ffmpeg"].get("h264/rk") is None:
-        go2rtc_config["ffmpeg"]["h264/rk"] = "-c:v h264_rkmpp_encoder -g 50 -bf 0"
-
-    if go2rtc_config["ffmpeg"].get("h265/rk") is None:
-        go2rtc_config["ffmpeg"]["h265/rk"] = "-c:v hevc_rkmpp_encoder -g 50 -bf 0"
-
 for name in go2rtc_config.get("streams", {}):
     stream = go2rtc_config["streams"][name]
 

--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -25,5 +25,5 @@ ADD https://github.com/MarcA711/rknpu2/releases/download/v1.5.2/librknnrt_rk3588
 
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffmpeg
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffprobe
-ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-1/ffmpeg /usr/lib/btbn-ffmpeg/bin/
-ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-1/ffprobe /usr/lib/btbn-ffmpeg/bin/
+ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-3/ffmpeg /usr/lib/btbn-ffmpeg/bin/
+ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-3/ffprobe /usr/lib/btbn-ffmpeg/bin/


### PR DESCRIPTION
Changes:
- update FFmpeg
- update docs
- remove go2rtc presets for older FFmpeg version

ToDo/ known issues:
- reimplement hardware object detection; I want to use yolonas as model, but I am not sure if there will be new license issues, does anybody have experience with this?
- include hardware acceleration presets for go2rtc (see https://github.com/AlexxIT/go2rtc/issues/979)
- there is a hardware limitation that can lead to crashes (see https://github.com/rockchip-linux/mpp/issues/560)