### PR TITLE
Bugfixes and small UI tweaks

### DIFF
--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -440,7 +440,7 @@ export function CameraGroupRow({
     <>
       <div
         key={group[0]}
-        className="flex md:p-1 rounded-lg flex-row items-center justify-between md:mx-2 my-1.5 transition-background duration-100"
+        className="flex md:p-1 rounded-lg flex-row items-center justify-between my-1.5 transition-background duration-100"
       >
         <div className={`flex items-center`}>
           <p className="cursor-default">{group[0]}</p>

--- a/web/src/components/settings/PolygonItem.tsx
+++ b/web/src/components/settings/PolygonItem.tsx
@@ -206,7 +206,7 @@ export default function PolygonItem({
 
       <div
         key={index}
-        className="flex p-1 rounded-lg flex-row items-center justify-between mx-2 my-1.5 transition-background duration-100"
+        className="flex p-1 rounded-lg flex-row items-center justify-between my-1.5 transition-background duration-100"
         data-index={index}
         onMouseEnter={() => setHoveredPolygonIndex(index)}
         onMouseLeave={() => setHoveredPolygonIndex(null)}

--- a/web/src/components/timeline/EventReviewTimeline.tsx
+++ b/web/src/components/timeline/EventReviewTimeline.tsx
@@ -147,9 +147,11 @@ export function EventReviewTimeline({
         });
       }
     }
+    // don't scroll when segments update from unreviewed -> reviewed
+    // we know that these deps are correct
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     selectedTimelineRef,
-    segments,
     showMinimap,
     alignStartDateToTimeline,
     visibleTimestamps,

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -103,9 +103,9 @@ export default function EventView({
 
     if (filter?.showReviewed == 1) {
       return {
-        alert: summary.total_alert,
-        detection: summary.total_detection,
-        significant_motion: summary.total_motion,
+        alert: summary.total_alert ?? 0,
+        detection: summary.total_detection ?? 0,
+        significant_motion: summary.total_motion ?? 0,
       };
     } else {
       return {


### PR DESCRIPTION
- Always show 0 for counts when alerts/detections are null
- Don't scroll into view when segments update from unreviewed --> reviewed. When reviewing items without the minimap showing, playback begins and the timeline/handlebar scrolls into view. But when the segments object updates, `scrollIntoView` runs again unnecessarily, causing undesirable scrolling behavior. Removing `segments` as a dep fixes the issue.
- Remove a few margins to better match figma