### PR TITLE
Restore arm32 support

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -147,11 +147,18 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
 RUN wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py \
     && python3 get-pip.py "pip"
 
+RUN apt-get -qq update && apt-get -qq install -y \
+    python3-numpy python3-matplotlib python3-opencv python3-scipy python3-pandas python3-onnx python3-lxml python3-zmq
+
 COPY docker/main/requirements.txt /requirements.txt
-RUN pip3 install -r /requirements.txt
+RUN PIP_IGNORE_INSTALLED=0 pip3 install -r /requirements.txt
+
+RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps filterpy norfair==2.1.1
+
+RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps zeep==3.0.0 onvif_zeep
 
 COPY docker/main/requirements-wheels.txt /requirements-wheels.txt
-RUN pip3 wheel --wheel-dir=/wheels -r /requirements-wheels.txt
+RUN PIP_IGNORE_INSTALLED=0 pip3 wheel --wheel-dir=/wheels -r /requirements-wheels.txt
 
 
 # Collect deps in a single layer
@@ -181,6 +188,9 @@ ENV PATH="/usr/lib/btbn-ffmpeg/bin:/usr/local/go2rtc/bin:/usr/local/nginx/sbin:$
 # Install dependencies
 RUN --mount=type=bind,source=docker/main/install_deps.sh,target=/deps/install_deps.sh \
     /deps/install_deps.sh
+
+COPY --from=wheels /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
+COPY --from=wheels /usr/lib/python3/dist-packages /usr/lib/python3/dist-packages
 
 RUN --mount=type=bind,from=wheels,source=/wheels,target=/deps/wheels \
     python3 -m pip install --upgrade pip && \

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -153,11 +153,13 @@ RUN apt-get -qq update && apt-get -qq install -y \
 COPY docker/main/requirements.txt /requirements.txt
 RUN PIP_IGNORE_INSTALLED=0 pip3 install -r /requirements.txt
 
-RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps filterpy norfair==2.1.1
+RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps rich filterpy==1.4.5 norfair==2.1.1
 
-RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps onvif
+RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps norfair==2.2.0
 
-RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps zeep==3.0.0 onvif_zeep
+RUN PIP_IGNORE_INSTALLED=0 pip3 install onvif_zeep
+
+#RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps zeep==3.0.0 onvif_zeep
 
 COPY docker/main/requirements-wheels.txt /requirements-wheels.txt
 RUN PIP_IGNORE_INSTALLED=0 pip3 wheel --wheel-dir=/wheels -r /requirements-wheels.txt

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -155,6 +155,8 @@ RUN PIP_IGNORE_INSTALLED=0 pip3 install -r /requirements.txt
 
 RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps filterpy norfair==2.1.1
 
+RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps onvif
+
 RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps zeep==3.0.0 onvif_zeep
 
 COPY docker/main/requirements-wheels.txt /requirements-wheels.txt
@@ -191,6 +193,8 @@ RUN --mount=type=bind,source=docker/main/install_deps.sh,target=/deps/install_de
 
 COPY --from=wheels /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
 COPY --from=wheels /usr/lib/python3/dist-packages /usr/lib/python3/dist-packages
+COPY --from=wheels /usr/share/matplotlib /usr/share/matplotlib
+COPY --from=wheels /etc/matplotlibrc /etc/matplotlibrc
 
 RUN --mount=type=bind,from=wheels,source=/wheels,target=/deps/wheels \
     python3 -m pip install --upgrade pip && \

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -153,17 +153,11 @@ RUN apt-get -qq update && apt-get -qq install -y \
 COPY docker/main/requirements.txt /requirements.txt
 RUN PIP_IGNORE_INSTALLED=0 pip3 install -r /requirements.txt
 
-RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps rich filterpy==1.4.5 norfair==2.1.1
-
-RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps norfair==2.2.0
-
-RUN PIP_IGNORE_INSTALLED=0 pip3 install onvif_zeep
-
-#RUN PIP_IGNORE_INSTALLED=0 pip3 install --no-deps zeep==3.0.0 onvif_zeep
+RUN PIP_IGNORE_INSTALLED=0 pip3 install rich filterpy==1.4.5 zeep==3.0.0 onvif_zeep && \
+    pip3 install --no-deps norfair==2.2.0
 
 COPY docker/main/requirements-wheels.txt /requirements-wheels.txt
 RUN PIP_IGNORE_INSTALLED=0 pip3 wheel --wheel-dir=/wheels -r /requirements-wheels.txt
-
 
 # Collect deps in a single layer
 FROM scratch AS deps-rootfs
@@ -193,7 +187,7 @@ ENV PATH="/usr/lib/btbn-ffmpeg/bin:/usr/local/go2rtc/bin:/usr/local/nginx/sbin:$
 RUN --mount=type=bind,source=docker/main/install_deps.sh,target=/deps/install_deps.sh \
     /deps/install_deps.sh
 
-COPY --from=wheels /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
+COPY --from=wheels /usr/local/lib/python3.9/dist-packages /usr/local/lib/python3.9/dist-packages
 COPY --from=wheels /usr/lib/python3/dist-packages /usr/lib/python3/dist-packages
 COPY --from=wheels /usr/share/matplotlib /usr/share/matplotlib
 COPY --from=wheels /etc/matplotlibrc /etc/matplotlibrc

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -14,7 +14,10 @@ apt-get -qq install --no-install-recommends -y \
     python3-pip \
     curl \
     jq \
-    nethogs
+    nethogs \
+    libopencv-*4.5
+#   libopencv-core4.5 libopencv-contrib4.5 libopencv-shape4.5 libopencv-stitching4.5
+
 
 # ensure python3 defaults to python3.9
 update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -16,6 +16,14 @@ apt-get -qq install --no-install-recommends -y \
     jq \
     nethogs
 
+# Use latest distro-provided numpy-related libraries, rather than building wheels from scatch
+apt-get -qq install --no-install-recommends --no-install-suggests -y \
+    python3-numpy python3-matplotlib python3-opencv python3-scipy -y
+
+# Again, avoid complicated wheel build for lxml and onif_zeep by using distro-provided libraries
+apt-get -qq install --no-install-recommends --no-install-suggests -y \
+    python3-lxml -y
+
 # ensure python3 defaults to python3.9
 update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
 
@@ -78,7 +86,14 @@ apt-get autoremove --purge -y
 rm -rf /var/lib/apt/lists/*
 
 # Install yq, for frigate-prepare and go2rtc echo source
+if [[ "${TARGETARCH}" == "arm" ]]; then
+curl -fsSL \
+    "https://github.com/mikefarah/yq/releases/download/v4.33.3/yq_linux_arm" \
+    --output /usr/local/bin/yq
+chmod +x /usr/local/bin/yq
+else
 curl -fsSL \
     "https://github.com/mikefarah/yq/releases/download/v4.33.3/yq_linux_$(dpkg --print-architecture)" \
     --output /usr/local/bin/yq
 chmod +x /usr/local/bin/yq
+fi

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -16,14 +16,6 @@ apt-get -qq install --no-install-recommends -y \
     jq \
     nethogs
 
-# Use latest distro-provided numpy-related libraries, rather than building wheels from scatch
-apt-get -qq install --no-install-recommends --no-install-suggests -y \
-    python3-numpy python3-matplotlib python3-opencv python3-scipy -y
-
-# Again, avoid complicated wheel build for lxml and onif_zeep by using distro-provided libraries
-apt-get -qq install --no-install-recommends --no-install-suggests -y \
-    python3-lxml -y
-
 # ensure python3 defaults to python3.9
 update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
 

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -15,7 +15,9 @@ apt-get -qq install --no-install-recommends -y \
     curl \
     jq \
     nethogs \
-    libopencv-*4.5
+    libopencv-*4.5 \
+    libxslt1.1 \
+    liblbfgsb0
 #   libopencv-core4.5 libopencv-contrib4.5 libopencv-shape4.5 libopencv-stitching4.5
 
 

--- a/docker/main/install_s6_overlay.sh
+++ b/docker/main/install_s6_overlay.sh
@@ -6,6 +6,8 @@ s6_version="3.1.5.0"
 
 if [[ "${TARGETARCH}" == "amd64" ]]; then
     s6_arch="x86_64"
+elif [[ "${TARGETARCH}" == "arm" ]]; then
+    s6_arch="armhf"
 elif [[ "${TARGETARCH}" == "arm64" ]]; then
     s6_arch="aarch64"
 fi

--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -2,11 +2,11 @@ click == 8.1.*
 Flask == 3.0.*
 imutils == 0.5.*
 markupsafe == 2.1.*
-matplotlib == 3.8.*
+# matplotlib == 3.8.*
 mypy == 1.6.1
-numpy == 1.26.*
+# numpy == 1.26.*
 onvif_zeep == 0.2.12
-opencv-python-headless == 4.9.0.*
+# opencv-python-headless == 4.9.0.*
 paho-mqtt == 2.0.*
 pandas == 2.2.*
 peewee == 3.17.*
@@ -22,8 +22,8 @@ tzlocal == 5.2
 types-PyYAML == 6.0.*
 requests == 2.31.*
 types-requests == 2.31.*
-scipy == 1.13.*
-norfair == 2.2.*
+# scipy == 1.13.*
+# norfair == 2.2.*
 setproctitle == 1.3.*
 ws4py == 0.5.*
 unidecode == 1.3.*

--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -5,10 +5,10 @@ markupsafe == 2.1.*
 # matplotlib == 3.8.*
 mypy == 1.6.1
 # numpy == 1.26.*
-onvif_zeep == 0.2.12
+# onvif_zeep == 0.2.12
 # opencv-python-headless == 4.9.0.*
 paho-mqtt == 2.0.*
-pandas == 2.2.*
+# pandas == 2.2.*
 peewee == 3.17.*
 peewee_migrate == 1.12.*
 psutil == 5.9.*
@@ -16,18 +16,18 @@ pydantic == 2.7.*
 git+https://github.com/fbcotter/py3nvml#egg=py3nvml
 PyYAML == 6.0.*
 pytz == 2024.1
-pyzmq == 26.0.*
+#pyzmq == 26.0.*
 ruamel.yaml == 0.18.*
 tzlocal == 5.2
 types-PyYAML == 6.0.*
 requests == 2.31.*
 types-requests == 2.31.*
 # scipy == 1.13.*
-# norfair == 2.2.*
+#norfair == 2.1.1
 setproctitle == 1.3.*
 ws4py == 0.5.*
 unidecode == 1.3.*
-onnxruntime == 1.16.*
+#onnxruntime == 1.16.*
 # Openvino Library - Custom built with MYRIAD support
 openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.3.1/openvino-2022.3.1-1-cp39-cp39-manylinux_2_31_x86_64.whl; platform_machine == 'x86_64'
 openvino @ https://github.com/NateMeyer/openvino-wheels/releases/download/multi-arch_2022.3.1/openvino-2022.3.1-1-cp39-cp39-linux_aarch64.whl; platform_machine == 'aarch64'

--- a/docker/main/requirements.txt
+++ b/docker/main/requirements.txt
@@ -1,2 +1,6 @@
+--only-binary :all:
 scikit-build == 0.17.*
 nvidia-pyindex
+norfair == 2.1.1
+zeep == 3.0.0
+onvif_zeep

--- a/docker/main/requirements.txt
+++ b/docker/main/requirements.txt
@@ -1,3 +1,2 @@
 scikit-build == 0.17.*
 nvidia-pyindex
-rich

--- a/docker/main/requirements.txt
+++ b/docker/main/requirements.txt
@@ -1,6 +1,3 @@
---only-binary :all:
 scikit-build == 0.17.*
 nvidia-pyindex
-norfair == 2.1.1
-zeep == 3.0.0
-onvif_zeep
+rich

--- a/docker/rpi/Dockerfile
+++ b/docker/rpi/Dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 FROM deps AS rpi-deps
 ARG TARGETARCH
 
-RUN rm -rf /usr/lib/btbn-ffmpeg/
+RUN if [[ "${TARGETARCH}" == "arm64" ]]; then rm -rf /usr/lib/btbn-ffmpeg/; fi
 
 # Install dependencies
 RUN --mount=type=bind,source=docker/rpi/install_deps.sh,target=/deps/install_deps.sh \

--- a/docker/rpi/install_deps.sh
+++ b/docker/rpi/install_deps.sh
@@ -27,4 +27,11 @@ if [[ "${TARGETARCH}" == "arm64" ]]; then
     echo "deb [signed-by=/usr/share/keyrings/raspbian.gpg] https://archive.raspberrypi.org/debian/ bullseye main" | tee /etc/apt/sources.list.d/raspi.list
     apt-get -qq update
     apt-get -qq install --no-install-recommends --no-install-suggests -y ffmpeg
+# ffmpeg -> arm32
+elif [[ "${TARGETARCH}" == "arm" ]]; then
+    # add raspberry pi repo
+    gpg --no-default-keyring --keyring /usr/share/keyrings/raspbian.gpg --keyserver keyserver.ubuntu.com --recv-keys 9165938D90FDDD2E
+    echo "deb [signed-by=/usr/share/keyrings/raspbian.gpg] http://raspbian.raspberrypi.org/raspbian/ bullseye main contrib non-free rpi" | tee /etc/apt/sources.list.d/raspi.list
+    apt-get -qq update
+    apt-get -qq install --no-install-recommends --no-install-suggests -y ffmpeg
 fi

--- a/docker/rpi/rpi.hcl
+++ b/docker/rpi/rpi.hcl
@@ -1,12 +1,12 @@
 target deps {
   dockerfile = "docker/main/Dockerfile"
-  platforms = ["linux/arm64"]
+  platforms = ["linux/arm64","linux/arm/v7"]
   target = "deps"
 }
 
 target rootfs {
   dockerfile = "docker/main/Dockerfile"
-  platforms = ["linux/arm64"]
+  platforms = ["linux/arm64","linux/arm/v7"]
   target = "rootfs"
 }
 
@@ -16,5 +16,5 @@ target rpi {
     deps = "target:deps",
     rootfs = "target:rootfs"
   }
-  platforms = ["linux/arm64"]
+  platforms = ["linux/arm64","linux/arm/v7"]
 }

--- a/frigate/comms/detections_updater.py
+++ b/frigate/comms/detections_updater.py
@@ -19,7 +19,7 @@ class DetectionTypeEnum(str, Enum):
 
 
 class DetectionProxyRunner(threading.Thread):
-    def __init__(self, context: zmq.Context[zmq.Socket]) -> None:
+    def __init__(self, context ) -> None:
         threading.Thread.__init__(self)
         self.name = "detection_proxy"
         self.context = context

--- a/frigate/motion/improved_motion.py
+++ b/frigate/motion/improved_motion.py
@@ -19,7 +19,6 @@ class ImprovedMotionDetector(MotionDetector):
         config: MotionConfig,
         fps: int,
         name="improved",
-        blur_radius=1,
         interpolation=cv2.INTER_NEAREST,
         contrast_frame_history=50,
     ):
@@ -42,7 +41,6 @@ class ImprovedMotionDetector(MotionDetector):
         self.mask = np.where(resized_mask == [0])
         self.save_images = False
         self.calibrating = True
-        self.blur_radius = blur_radius
         self.interpolation = interpolation
         self.contrast_values = np.zeros((contrast_frame_history, 2), np.uint8)
         self.contrast_values[:, 1:2] = 255
@@ -104,7 +102,7 @@ class ImprovedMotionDetector(MotionDetector):
         # Setting masked pixels to zero, to match the average frame at startup
         resized_frame[self.mask] = [0]
 
-        resized_frame = gaussian_filter(resized_frame, sigma=1, radius=self.blur_radius)
+        resized_frame = gaussian_filter(resized_frame, sigma=1)
 
         if self.save_images:
             blurred_saved = resized_frame.copy()


### PR DESCRIPTION
I understand 32-bit Raspberry Pi support was removed after 0.12.1, but here I have made changes to make supporting it simple going forward. 

I understand the hassle of supporting armv7 was previously because of building wheels for numpy, etc. There is no need to be building those from scratch - the Debian Bullseye distribution provides pre-built packages that can be leveraged instead.

This reduces the overall build time for **_all_** architectures, not just arm32, because it relies on pre-built binaries. It also removes the headache of architecture-specific build problems.