### PR TITLE
Implement common post_processing

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -80,7 +80,7 @@ model:
   # Valid values are nhwc or nchw (default: shown below)
   input_tensor: nhwc
   # Optional: Object detection model type, currently only used with the OpenVINO detector
-  # Valid values are ssd, yolox (default: shown below)
+  # Valid values are ssd, yolox, yolonas (default: shown below)
   model_type: ssd
   # Optional: Label name modifications. These are merged into the standard labelmap.
   labelmap:

--- a/frigate/detectors/detection_api.py
+++ b/frigate/detectors/detection_api.py
@@ -1,5 +1,7 @@
 import logging
+from frigate.detectors.detector_config import ModelTypeEnum
 from abc import ABC, abstractmethod
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -9,8 +11,63 @@ class DetectionApi(ABC):
 
     @abstractmethod
     def __init__(self, detector_config):
-        pass
+        self.detector_config = detector_config
+        self.thresh = 0.5
+        self.height = detector_config.model.height
+        self.width = detector_config.model.width
 
     @abstractmethod
     def detect_raw(self, tensor_input):
         pass
+
+    def yolonas(self, output):
+        """
+        @param output: output of inference
+        expected shape: [np.array(1, N, 4), np.array(1, N, 80)]
+        where N depends on the input size e.g. N=2100 for 320x320 images
+
+        @return: best results: np.array(20, 6) where each row is
+        in this order (class_id, score, y1/height, x1/width, y2/height, x2/width)
+        """
+
+        N = output[0].shape[1]
+
+        boxes = output[0].reshape(N, 4)
+        scores = output[1].reshape(N, 80)
+
+        class_ids = np.argmax(scores, axis=1)
+        scores = scores[np.arange(N), class_ids]
+
+        args_best = np.argwhere(scores > self.thresh)[:, 0]
+
+        num_matches = len(args_best)
+        if num_matches == 0:
+            return np.zeros((20, 6), np.float32)
+        elif num_matches > 20:
+            args_best20 = np.argpartition(scores[args_best], -20)[-20:]
+            args_best = args_best[args_best20]
+
+        boxes = boxes[args_best]
+        class_ids = class_ids[args_best]
+        scores = scores[args_best]
+
+        boxes = np.transpose(
+            np.vstack(
+                (
+                    boxes[:, 1]/self.height,
+                    boxes[:, 0]/self.width,
+                    boxes[:, 3]/self.height,
+                    boxes[:, 2]/self.width,
+                )
+            )
+        )
+
+        results = np.hstack((class_ids[..., np.newaxis], scores[..., np.newaxis], boxes))
+
+        return np.resize(results, (20,6))
+
+    def post_process(self, output):
+        if self.detector_config.model.model_type == ModelTypeEnum.yolonas:
+            return self.yolonas(output)
+        else:
+            raise ValueError(f'Model type "{self.detector_config.model.model_type}" is currently not supported.')

--- a/frigate/detectors/detection_api.py
+++ b/frigate/detectors/detection_api.py
@@ -22,7 +22,7 @@ class DetectionApi(ABC):
     def detect_raw(self, tensor_input):
         pass
 
-    def yolonas(self, output):
+    def post_process_yolonas(self, output):
         """
         @param output: output of inference
         expected shape: [np.array(1, N, 4), np.array(1, N, 80)]

--- a/frigate/detectors/detection_api.py
+++ b/frigate/detectors/detection_api.py
@@ -1,7 +1,9 @@
 import logging
-from frigate.detectors.detector_config import ModelTypeEnum
 from abc import ABC, abstractmethod
+
 import numpy as np
+
+from frigate.detectors.detector_config import ModelTypeEnum
 
 logger = logging.getLogger(__name__)
 
@@ -54,20 +56,24 @@ class DetectionApi(ABC):
         boxes = np.transpose(
             np.vstack(
                 (
-                    boxes[:, 1]/self.height,
-                    boxes[:, 0]/self.width,
-                    boxes[:, 3]/self.height,
-                    boxes[:, 2]/self.width,
+                    boxes[:, 1] / self.height,
+                    boxes[:, 0] / self.width,
+                    boxes[:, 3] / self.height,
+                    boxes[:, 2] / self.width,
                 )
             )
         )
 
-        results = np.hstack((class_ids[..., np.newaxis], scores[..., np.newaxis], boxes))
+        results = np.hstack(
+            (class_ids[..., np.newaxis], scores[..., np.newaxis], boxes)
+        )
 
-        return np.resize(results, (20,6))
+        return np.resize(results, (20, 6))
 
     def post_process(self, output):
         if self.detector_config.model.model_type == ModelTypeEnum.yolonas:
             return self.yolonas(output)
         else:
-            raise ValueError(f'Model type "{self.detector_config.model.model_type}" is currently not supported.')
+            raise ValueError(
+                f'Model type "{self.detector_config.model.model_type}" is currently not supported.'
+            )

--- a/frigate/detectors/detector_config.py
+++ b/frigate/detectors/detector_config.py
@@ -30,6 +30,7 @@ class InputTensorEnum(str, Enum):
 class ModelTypeEnum(str, Enum):
     ssd = "ssd"
     yolox = "yolox"
+    yolonas = "yolonas"
 
 
 class ModelConfig(BaseModel):


### PR DESCRIPTION
This PR implements a structure to store post_processing in a common place for all detectors to avoid duplicate code and make it easier to support new models.

### Steps to invoke post_processing from a detector:

```
class Rknn(DetectionApi):
    def __init__(self, config: RknnDetectorConfig):
        super().__init__(config)
        ...
 
    def detect_raw(self, tensor_input):
        output = inference(tensor_input)
        return self.post_process(output)
```

In case you want to implement your own post-processing for a model (for example to use hardware acceleration using opencl), reimplement the method like this:

```
def yolonas(self, output):
    if gpu_found:
        # implement hw post_processing ...
        return results
    else:
        return super().yolonas(output)
```

However, use this only if your implementation is significantly faster than the default implementation.

### Steps to add a new model:

- add entry to `ModelTypeEnum` in `frigate/detector/detector_config.py`
- add model identifier to `docs/docs/reference.md`
- implement a new method in `frigate/detectors/detection_api.py`
  - try to implement post-processing using numpy, as all platforms use this
- call the method from `post_processing` in `frigate/detectors/detection_api.py`

