### PR TITLE
Log warning for high detect fps

### DIFF
--- a/frigate/config.py
+++ b/frigate/config.py
@@ -1445,7 +1445,7 @@ class FrigateConfig(FrigateBaseModel):
             # Warn if detect fps > 10
             if camera_config.detect.fps > 10:
                 logger.warning(
-                    "{camera_config.name} has a detect fps set higher than 10 fps. This does not need to match your camera's fps rate and may cause performance issues. Recommended value is 5 fps."
+                    f"{camera_config.name} detect fps is set to {camera_config.detect.fps}. This does NOT need to match your camera's frame rate. High values could lead to reduced performance. Recommended value is 5."
                 )
 
             # Default min_initialized configuration

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -1442,6 +1442,12 @@ class FrigateConfig(FrigateBaseModel):
                         else False
                     )
 
+            # Warn if detect fps > 10
+            if camera_config.detect.fps > 10:
+                logger.warning(
+                    "{camera_config.name} has a detect fps set higher than 10 fps. This does not need to match your camera's fps rate and may cause performance issues. Recommended value is 5 fps."
+                )
+
             # Default min_initialized configuration
             min_initialized = int(camera_config.detect.fps / 2)
             if camera_config.detect.min_initialized is None:


### PR DESCRIPTION
Many users tend to run a `detect` fps much higher than is necessary for reliable object detection, often times on resource-constrained devices. This should help mitigate some future support issues.