### PR TITLE
Don't timeshift recordings

### DIFF
--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -12,7 +12,6 @@ import ActivityIndicator from "@/components/indicators/activity-indicator";
 import { VideoResolutionType } from "@/types/live";
 import axios from "axios";
 import { cn } from "@/lib/utils";
-import { getTimestampOffset } from "@/utils/dateUtil";
 
 /**
  * Dynamically switches between video playback and scrubbing preview player.
@@ -148,14 +147,13 @@ export default function DynamicVideoPlayer({
 
   // state of playback player
 
-  const recordingParams = useMemo(() => {
-    const timeRangeOffset = getTimestampOffset(timeRange.before);
-
-    return {
-      before: timeRange.before + timeRangeOffset,
-      after: timeRange.after + timeRangeOffset,
-    };
-  }, [timeRange]);
+  const recordingParams = useMemo(
+    () => ({
+      before: timeRange.before,
+      after: timeRange.after,
+    }),
+    [timeRange],
+  );
   const { data: recordings } = useSWR<Recording[]>(
     [`${camera}/recordings`, recordingParams],
     { revalidateOnFocus: false },


### PR DESCRIPTION
Recordings are all stored in UTC without regard to hour so we don't need to shift the recordings