### PR TITLE
Live view aspect calculation bugfix

### DIFF
--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -303,8 +303,10 @@ function MSEPlayer({
       className={className}
       playsInline
       preload="auto"
-      onLoadedData={onPlaying}
-      onLoadedMetadata={handleLoadedMetadata}
+      onLoadedData={() => {
+        handleLoadedMetadata?.();
+        onPlaying?.();
+      }}
       muted={!audioEnabled}
       onError={() => {
         if (wsRef.current) {


### PR DESCRIPTION
- Save video dimensions for live view in `onLoadedData` instead of `onLoadedMetadata`. Firefox and Chrome would get dimensions wrong with certain cameras.