### PR TITLE
Optimistic state bug fix

### DIFF
--- a/web/src/hooks/use-optimistic-state.ts
+++ b/web/src/hooks/use-optimistic-state.ts
@@ -3,11 +3,11 @@ import { useState, useEffect, useCallback, useRef } from "react";
 type OptimisticStateResult<T> = [T, (newValue: T) => void];
 
 const useOptimisticState = <T>(
-  initialState: T,
+  currentState: T,
   setState: (newValue: T) => void,
   delay: number = 20,
 ): OptimisticStateResult<T> => {
-  const [optimisticValue, setOptimisticValue] = useState<T>(initialState);
+  const [optimisticValue, setOptimisticValue] = useState<T>(currentState);
   const debounceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleValueChange = useCallback(
@@ -36,6 +36,16 @@ const useOptimisticState = <T>(
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (currentState != optimisticValue) {
+      setOptimisticValue(currentState);
+    }
+    // sometimes an external action will cause the currentState to change
+    // without handleValueChange being called. In this case
+    // we need to update the optimistic value so the UI reflects the change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentState]);
 
   return [optimisticValue, handleValueChange];
 };


### PR DESCRIPTION
There are some scenarios where the UI uses optimistic state but the current state can be changed outside of where the optimistic state would be used. This fix ensures that if the original state changes and it does not match the optimistic state that we keep them in sync.