### PR TITLE
Simplify timezone math

### DIFF
--- a/web/src/components/player/PreviewPlayer.tsx
+++ b/web/src/components/player/PreviewPlayer.tsx
@@ -10,7 +10,7 @@ import useSWR from "swr";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { Preview } from "@/types/preview";
 import { PreviewPlayback } from "@/types/playback";
-import { getTimestampOffset, isCurrentHour } from "@/utils/dateUtil";
+import { isCurrentHour } from "@/utils/dateUtil";
 import { baseUrl } from "@/api/baseUrl";
 import { isAndroid, isChrome, isMobile } from "react-device-detect";
 import { TimeRange } from "@/types/timeline";
@@ -41,13 +41,11 @@ export default function PreviewPlayer({
   const [currentHourFrame, setCurrentHourFrame] = useState<string>();
 
   const currentPreview = useMemo(() => {
-    const timeRangeOffset = getTimestampOffset(timeRange.before);
-
     return cameraPreviews.find(
       (preview) =>
         preview.camera == camera &&
-        Math.round(preview.start) >= timeRange.after + timeRangeOffset &&
-        Math.floor(preview.end) <= timeRange.before + timeRangeOffset,
+        Math.round(preview.start) >= timeRange.after &&
+        Math.floor(preview.end) <= timeRange.before,
     );
   }, [cameraPreviews, camera, timeRange]);
 
@@ -242,14 +240,11 @@ function PreviewVideoPlayer({
       return;
     }
 
-    // account for minutes offset in timezone
-    const timeRangeOffset = getTimestampOffset(timeRange.before);
-
     const preview = cameraPreviews.find(
       (preview) =>
         preview.camera == camera &&
-        Math.round(preview.start) >= timeRange.after + timeRangeOffset &&
-        Math.floor(preview.end) <= timeRange.before + timeRangeOffset,
+        Math.round(preview.start) >= timeRange.after &&
+        Math.floor(preview.end) <= timeRange.before,
     );
 
     if (preview != currentPreview) {

--- a/web/src/pages/Events.tsx
+++ b/web/src/pages/Events.tsx
@@ -12,7 +12,6 @@ import {
   ReviewSummary,
   SegmentedReviewData,
 } from "@/types/review";
-import { getTimestampOffset } from "@/utils/dateUtil";
 import EventView from "@/views/events/EventView";
 import { RecordingView } from "@/views/events/RecordingView";
 import axios from "axios";
@@ -225,10 +224,10 @@ export default function Events() {
   // preview videos
   const previewTimes = useMemo(() => {
     // offset by timezone minutes
-    const timestampOffset = getTimestampOffset(Date.now() / 1000);
+    const timestampOffset = 0;
 
     const startDate = new Date(selectedTimeRange.after * 1000);
-    startDate.setMinutes(0, 0, 0);
+    startDate.setUTCMinutes(0, 0, 0);
 
     const endDate = new Date(selectedTimeRange.before * 1000);
     endDate.setHours(endDate.getHours() + 1, 0, 0, 0);

--- a/web/src/pages/Events.tsx
+++ b/web/src/pages/Events.tsx
@@ -223,9 +223,6 @@ export default function Events() {
 
   // preview videos
   const previewTimes = useMemo(() => {
-    // offset by timezone minutes
-    const timestampOffset = 0;
-
     const startDate = new Date(selectedTimeRange.after * 1000);
     startDate.setUTCMinutes(0, 0, 0);
 
@@ -233,8 +230,8 @@ export default function Events() {
     endDate.setHours(endDate.getHours() + 1, 0, 0, 0);
 
     return {
-      after: startDate.getTime() / 1000 + timestampOffset,
-      before: endDate.getTime() / 1000 + timestampOffset,
+      after: startDate.getTime() / 1000,
+      before: endDate.getTime() / 1000,
     };
   }, [selectedTimeRange]);
 

--- a/web/src/utils/dateUtil.ts
+++ b/web/src/utils/dateUtil.ts
@@ -269,15 +269,6 @@ export const getUTCOffset = (
   );
 };
 
-/**
- * Gets the minute offset in seconds of the current timezone from UTC.
- * Any timezones with an offset in hours will return 0,
- * any timezones with an offset of 30 or 45 minutes will return that amount in seconds.
- */
-export function getTimestampOffset(timestamp: number) {
-  return (getUTCOffset(new Date(timestamp * 1000)) % 60) * 60;
-}
-
 export function getRangeForTimestamp(timestamp: number) {
   const date = new Date(timestamp * 1000);
   date.setMinutes(0, 0, 0);
@@ -301,9 +292,7 @@ export function getEndOfDayTimestamp(date: Date) {
 
 export function isCurrentHour(timestamp: number) {
   const now = new Date();
-  now.setMinutes(0, 0, 0);
+  now.setUTCMinutes(0, 0, 0);
 
-  const timeShift = getTimestampOffset(timestamp);
-
-  return timestamp + timeShift > now.getTime() / 1000;
+  return timestamp > now.getTime() / 1000;
 }

--- a/web/src/utils/timelineUtil.tsx
+++ b/web/src/utils/timelineUtil.tsx
@@ -131,13 +131,12 @@ export function getChunkedTimeDay(timeRange: TimeRange): TimeRange[] {
   endOfThisHour.setSeconds(0, 0);
   const data: TimeRange[] = [];
   const startDay = new Date(timeRange.after * 1000);
-  startDay.setMinutes(0, 0, 0);
-
+  startDay.setUTCMinutes(0, 0, 0);
   let start = startDay.getTime() / 1000;
   let end = 0;
 
   for (let i = 0; i < 24; i++) {
-    startDay.setHours(startDay.getHours() + 1, 0, 0, 0);
+    startDay.setHours(startDay.getHours() + 1);
 
     if (startDay > endOfThisHour) {
       break;


### PR DESCRIPTION
Trying to get the time range chunks to fit the current timezone does not work well when the recordings and previews are saved in UTC. Instead, we should make the time range chunks fit UTC