### PR TITLE
Draw motion mask first

### DIFF
--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -498,6 +498,10 @@ class CameraState:
 
         frame_copy = cv2.cvtColor(frame_copy, cv2.COLOR_YUV2BGR_I420)
         # draw on the frame
+        if draw_options.get("mask"):
+            mask_overlay = np.where(self.camera_config.motion.mask == [0])
+            frame_copy[mask_overlay] = [0, 0, 0]
+
         if draw_options.get("bounding_boxes"):
             # draw the bounding boxes on the frame
             for obj in tracked_objects.values():
@@ -621,10 +625,6 @@ class CameraState:
                     else 2
                 )
                 cv2.drawContours(frame_copy, [zone.contour], -1, zone.color, thickness)
-
-        if draw_options.get("mask"):
-            mask_overlay = np.where(self.camera_config.motion.mask == [0])
-            frame_copy[mask_overlay] = [0, 0, 0]
 
         if draw_options.get("motion_boxes"):
             for m_box in motion_boxes:


### PR DESCRIPTION
This draws the motion mask before the other overlay elements (such as bounding boxes), so that they are still visible.

Before:
![image](https://github.com/blakeblackshear/frigate/assets/10095474/f8351c1f-6629-4932-a28e-296c9333200c)

After:
![image](https://github.com/blakeblackshear/frigate/assets/10095474/b929f72f-449f-4623-a49a-019c2e7aff0e)
