### PR TITLE
set correct labelmap for rknn detector

### DIFF
--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -18,6 +18,8 @@ RUN --mount=type=bind,from=rk-wheels,source=/rk-wheels,target=/deps/rk-wheels \
 WORKDIR /opt/frigate/
 COPY --from=rootfs / /
 
+COPY docker/rockchip/labelmap-coco.txt /
+
 ADD https://github.com/MarcA711/rknn-toolkit2/releases/download/v2.0.0/librknnrt.so /usr/lib/
 
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffmpeg

--- a/docker/rockchip/labelmap-coco.txt
+++ b/docker/rockchip/labelmap-coco.txt
@@ -1,0 +1,80 @@
+0  person
+1  bicycle
+2  car
+3  motorcycle
+4  airplane
+5  car
+6  train
+7  car
+8  boat
+9  traffic light
+10  fire hydrant
+11  stop sign
+12  parking meter
+13  bench
+14  bird
+15  cat
+16  dog
+17  horse
+18  sheep
+19  cow
+20  elephant
+21  bear
+22  zebra
+23  giraffe
+24  backpack
+25  umbrella
+26  handbag
+27  tie
+28  suitcase
+29  frisbee
+30  skis
+31  snowboard
+32  sports ball
+33  kite
+34  baseball bat
+35  baseball glove
+36  skateboard
+37  surfboard
+38  tennis racket
+39  bottle
+40  wine glass
+41  cup
+42  fork
+43  knife
+44  spoon
+45  bowl
+46  banana
+47  apple
+48  sandwich
+49  orange
+50  broccoli
+51  carrot
+52  hot dog
+53  pizza
+54  donut
+55  cake
+56  chair
+57  couch
+58  potted plant
+59  bed
+60  dining table
+61  toilet
+62  tv
+63  laptop
+64  mouse
+65  remote
+66  keyboard
+67  cell phone
+68  microwave
+69  oven
+70  toaster
+71  sink
+72  refrigerator
+73  book
+74  clock
+75  vase
+76  scissors
+77  teddy bear
+78  hair drier
+79  toothbrush

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -350,6 +350,12 @@ model: # required
   input_tensor: nhwc
 ```
 
+:::note
+
+Some models use a different labelmap than Frigate's default labelmap `/labelmap.txt` that is also shown [in the docs](/configuration/objects) (e.g. `deci-fp16-yolonas_s` uses the labelmap `/labelmap-coco.txt`). If you use one of the models provided by Frigate (e.g. `model: path: deci-fp16-yolonas_s`) **and** don't set the `model: labelmap_path:` option in your `config.yml`, Frigate will automatically load the correct labelmap. Even if you use one of the models provided Frigate, you can provide your own `my_labelmap.txt` and set `model: labelmap_path:` to use a custom labelmap. If you use your own model, you are responsible for providing a correct labelmap and setting the option `model: labelmap_path:` accordingly.
+
+:::
+
 ### Choosing a model
 
 :::warning

--- a/frigate/detectors/detector_config.py
+++ b/frigate/detectors/detector_config.py
@@ -133,6 +133,12 @@ class ModelConfig(BaseModel):
         for key, val in enumerate(enabled_labels):
             self._colormap[val] = tuple(int(round(255 * c)) for c in cmap(key)[:3])
 
+    def load_labelmap(self, path):
+        self._merged_labelmap = {
+            **load_labels(path),
+            **self.labelmap,
+        }
+
     model_config = ConfigDict(extra="forbid", protected_namespaces=())
 
 

--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -40,13 +40,15 @@ class Rknn(DetectionApi):
 
         if model_props["preset"]:
             config.model.model_type = model_props["model_type"]
+            if config.model.labelmap_path == None:
+                config.model.load_labelmap("/labelmap-coco.txt")
 
         if model_props["model_type"] == ModelTypeEnum.yolonas:
-            logger.info("""
-                        You are using yolo-nas with weights from DeciAI.
-                        These weights are subject to their license and can't be used commercially.
-                        For more information, see: https://docs.deci.ai/super-gradients/latest/LICENSE.YOLONAS.html
-                        """)
+            logger.info(
+                "You are using yolo-nas with weights from DeciAI. "
+                "These weights are subject to their license and can't be used commercially. "
+                "For more information, see: https://docs.deci.ai/super-gradients/latest/LICENSE.YOLONAS.html"
+            )
 
         from rknnlite.api import RKNNLite
 


### PR DESCRIPTION
As discussed [here](https://github.com/blakeblackshear/frigate/discussions/11502#discussioncomment-9582338), the labelmap for the models provided by frigate's rknn detector are wrong.
I tried to implement a function to load the correct (ms-coco) labelmap, but it doesn't work. I played a video of a cat (id 15 in yolonas and in the new `labelmap-coco.txt` that I try to load) but Frigate show it is a bird (which has id 15 in default labelmap.txt). I checked:
- the detector really returns id 15
- the new function `load_labelmap` that I implemented gets called correctly
- `load_labels` inside the `load_labelmap` function return the correct dictionary with cat as ID 15 (and not 16 like in the default labelmap)
- `self.labelmap` inside the `load_labelmap` function is empty `{}` (so it doesn't override anything)

Does anybody have an idea why it still says it is a bird? I see no difference to the way Frigate+ overrides the labelmap. Is it working correctly for Frigate+?

@blakeblackshear I think the way I implemented this function is the way the user expects it to. The correct labelmap is loaded if the user doesn't change the labelmap_path, if he sets a custom labelmap_path it won't be changed. I even explained it in detail in the docs. I think this will work for everyone. If you still has concerns, please tell me.