### PR TITLE
Improve efficiency of log and metrics pages

### DIFF
--- a/web/src/components/graph/CameraGraph.tsx
+++ b/web/src/components/graph/CameraGraph.tsx
@@ -1,42 +1,48 @@
 import { useTheme } from "@/context/theme-provider";
 import { FrigateConfig } from "@/types/frigateConfig";
-import { Threshold } from "@/types/graph";
 import { useCallback, useEffect, useMemo } from "react";
 import Chart from "react-apexcharts";
 import { isMobileOnly } from "react-device-detect";
+import { MdCircle } from "react-icons/md";
 import useSWR from "swr";
 
-type ThresholdBarGraphProps = {
+const GRAPH_COLORS = ["#5C7CFA", "#ED5CFA", "#FAD75C"];
+
+type CameraLineGraphProps = {
   graphId: string;
-  name: string;
   unit: string;
-  threshold: Threshold;
+  dataLabels: string[];
   updateTimes: number[];
   data: ApexAxisChartSeries;
 };
-export function ThresholdBarGraph({
+export function CameraLineGraph({
   graphId,
-  name,
   unit,
-  threshold,
+  dataLabels,
   updateTimes,
   data,
-}: ThresholdBarGraphProps) {
+}: CameraLineGraphProps) {
   const { data: config } = useSWR<FrigateConfig>("config", {
     revalidateOnFocus: false,
   });
 
-  const lastValue = useMemo<number>(
-    // @ts-expect-error y is valid
-    () => data[0].data[data[0].data.length - 1]?.y ?? 0,
-    [data],
-  );
+  const lastValues = useMemo<number[] | undefined>(() => {
+    if (!dataLabels || !data || data.length == 0) {
+      return undefined;
+    }
+
+    return dataLabels.map(
+      (_, labelIdx) =>
+        // @ts-expect-error y is valid
+        data[labelIdx].data[data[labelIdx].data.length - 1]?.y ?? 0,
+    ) as number[];
+  }, [data, dataLabels]);
 
   const { theme, systemTheme } = useTheme();
 
   const formatTime = useCallback(
     (val: unknown) => {
-      const date = new Date(updateTimes[Math.round(val as number) - 1] * 1000);
+      const date = new Date(updateTimes[Math.round(val as number)] * 1000);
       return date.toLocaleTimeString([], {
         hour12: config?.ui.time_format != "24hour",
         hour: "2-digit",
@@ -60,17 +66,7 @@ export function ThresholdBarGraph({
           enabled: false,
         },
       },
-      colors: [
-        ({ value }: { value: number }) => {
-          if (value >= threshold.error) {
-            return "#FA5252";
-          } else if (value >= threshold.warning) {
-            return "#FF9966";
-          } else {
-            return "#217930";
-          }
-        },
-      ],
+      colors: GRAPH_COLORS,
       grid: {
         show: false,
       },
@@ -80,23 +76,11 @@ export function ThresholdBarGraph({
       dataLabels: {
         enabled: false,
       },
-      plotOptions: {
-        bar: {
-          distributed: true,
-        },
-      },
-      states: {
-        active: {
-          filter: {
-            type: "none",
-          },
-        },
+      stroke: {
+        width: 1,
       },
       tooltip: {
         theme: systemTheme || theme,
-        y: {
-          formatter: (val) => `${val}${unit}`,
-        },
       },
       markers: {
         size: 0,
@@ -123,7 +107,7 @@ export function ThresholdBarGraph({
         min: 0,
       },
     } as ApexCharts.ApexOptions;
-  }, [graphId, threshold, unit, systemTheme, theme, formatTime]);
+  }, [graphId, systemTheme, theme, formatTime]);
 
   useEffect(() => {
     ApexCharts.exec(graphId, "updateOptions", options, true, true);
@@ -131,14 +115,24 @@ export function ThresholdBarGraph({
 
   return (
     <div className="flex w-full flex-col">
-      <div className="flex items-center gap-1">
-        <div className="text-xs text-muted-foreground">{name}</div>
-        <div className="text-xs text-primary">
-          {lastValue}
-          {unit}
+      {lastValues && (
+        <div className="flex items-center gap-2.5">
+          {dataLabels.map((label, labelIdx) => (
+            <div key={label} className="flex items-center gap-1">
+              <MdCircle
+                className="size-2"
+                style={{ color: GRAPH_COLORS[labelIdx] }}
+              />
+              <div className="text-xs text-muted-foreground">{label}</div>
+              <div className="text-xs text-primary">
+                {lastValues[labelIdx]}
+                {unit}
+              </div>
+            </div>
+          ))}
         </div>
-      </div>
-      <Chart type="bar" options={options} series={data} height="120" />
+      )}
+      <Chart type="line" options={options} series={data} height="120" />
     </div>
   );
 }

--- a/web/src/components/graph/StorageGraph.tsx
+++ b/web/src/components/graph/StorageGraph.tsx
@@ -1,0 +1,120 @@
+import { useTheme } from "@/context/theme-provider";
+import { useEffect, useMemo } from "react";
+import Chart from "react-apexcharts";
+
+const getUnitSize = (MB: number) => {
+  if (MB === null || isNaN(MB) || MB < 0) return "Invalid number";
+  if (MB < 1024) return `${MB.toFixed(2)} MiB`;
+  if (MB < 1048576) return `${(MB / 1024).toFixed(2)} GiB`;
+
+  return `${(MB / 1048576).toFixed(2)} TiB`;
+};
+
+type StorageGraphProps = {
+  graphId: string;
+  used: number;
+  total: number;
+};
+export function StorageGraph({ graphId, used, total }: StorageGraphProps) {
+  const { theme, systemTheme } = useTheme();
+
+  const options = useMemo(() => {
+    return {
+      chart: {
+        id: graphId,
+        background: (systemTheme || theme) == "dark" ? "#404040" : "#E5E5E5",
+        selection: {
+          enabled: false,
+        },
+        toolbar: {
+          show: false,
+        },
+        zoom: {
+          enabled: false,
+        },
+      },
+      grid: {
+        show: false,
+        padding: {
+          bottom: -40,
+          top: -60,
+          left: -20,
+          right: 0,
+        },
+      },
+      legend: {
+        show: false,
+      },
+      dataLabels: {
+        enabled: false,
+      },
+      plotOptions: {
+        bar: {
+          horizontal: true,
+        },
+      },
+      states: {
+        active: {
+          filter: {
+            type: "none",
+          },
+        },
+        hover: {
+          filter: {
+            type: "none",
+          },
+        },
+      },
+      tooltip: {
+        enabled: false,
+      },
+      xaxis: {
+        axisBorder: {
+          show: false,
+        },
+        axisTicks: {
+          show: false,
+        },
+        labels: {
+          show: false,
+        },
+      },
+      yaxis: {
+        show: false,
+        min: 0,
+        max: 100,
+      },
+    } as ApexCharts.ApexOptions;
+  }, [graphId, systemTheme, theme]);
+
+  useEffect(() => {
+    ApexCharts.exec(graphId, "updateOptions", options, true, true);
+  }, [graphId, options]);
+
+  return (
+    <div className="flex w-full flex-col gap-2.5">
+      <div className="flex w-full items-center justify-between gap-1">
+        <div className="flex items-center gap-1">
+          <div className="text-xs text-primary">{getUnitSize(used)}</div>
+          <div className="text-xs text-primary">/</div>
+          <div className="text-xs text-muted-foreground">
+            {getUnitSize(total)}
+          </div>
+        </div>
+        <div className="text-xs text-primary">
+          {Math.round((used / total) * 100)}%
+        </div>
+      </div>
+      <div className="h-5 overflow-hidden rounded-md">
+        <Chart
+          type="bar"
+          options={options}
+          series={[
+            { data: [{ x: "storage", y: Math.round((used / total) * 100) }] },
+          ]}
+          height="100%"
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -35,7 +35,7 @@ function Logs() {
 
   const logPageSize = useMemo(() => {
     if (isMobileOnly) {
-      return 10;
+      return 15;
     }
 
     if (isTablet) {

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -20,6 +20,7 @@ import ActivityIndicator from "@/components/indicators/activity-indicator";
 import { cn } from "@/lib/utils";
 import { MdVerticalAlignBottom } from "react-icons/md";
 import { parseLogLines } from "@/utils/logUtil";
+import useKeyboardListener from "@/hooks/use-keyboard-listener";
 
 type LogRange = { start: number; end: number };
 
@@ -225,6 +226,40 @@ function Logs() {
   // log selection
 
   const [selectedLog, setSelectedLog] = useState<LogLine>();
+
+  // interaction
+
+  useKeyboardListener(
+    ["PageDown", "PageUp", "ArrowDown", "ArrowUp"],
+    (key, down, _) => {
+      if (!down) {
+        return;
+      }
+
+      switch (key) {
+        case "PageDown":
+          contentRef.current?.scrollBy({
+            top: 480,
+          });
+          break;
+        case "PageUp":
+          contentRef.current?.scrollBy({
+            top: -480,
+          });
+          break;
+        case "ArrowDown":
+          contentRef.current?.scrollBy({
+            top: 48,
+          });
+          break;
+        case "ArrowUp":
+          contentRef.current?.scrollBy({
+            top: -48,
+          });
+          break;
+      }
+    },
+  );
 
   return (
     <div className="flex size-full flex-col p-2">

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { LogData, LogLine, LogSeverity } from "@/types/log";
+import { LogData, LogLine, LogSeverity, LogType, logTypes } from "@/types/log";
 import copy from "copy-to-clipboard";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import axios from "axios";
@@ -10,24 +10,18 @@ import { LogLevelFilterButton } from "@/components/filter/LogLevelFilter";
 import { FaCopy } from "react-icons/fa6";
 import { Toaster } from "@/components/ui/sonner";
 import { toast } from "sonner";
-import { isDesktop } from "react-device-detect";
+import {
+  isDesktop,
+  isMobile,
+  isMobileOnly,
+  isTablet,
+} from "react-device-detect";
 import ActivityIndicator from "@/components/indicators/activity-indicator";
 import { cn } from "@/lib/utils";
 import { MdVerticalAlignBottom } from "react-icons/md";
-
-const logTypes = ["frigate", "go2rtc", "nginx"] as const;
-type LogType = (typeof logTypes)[number];
+import { parseLogLines } from "@/utils/logUtil";
 
 type LogRange = { start: number; end: number };
-
-const frigateDateStamp = /\[[\d\s-:]*]/;
-const frigateSeverity = /(DEBUG)|(INFO)|(WARNING)|(ERROR)/;
-const frigateSection = /[\w.]*/;
-
-const goSeverity = /(DEB )|(INF )|(WRN )|(ERR )/;
-const goSection = /\[[\w]*]/;
-
-const ngSeverity = /(GET)|(POST)|(PUT)|(PATCH)|(DELETE)/;
 
 function Logs() {
   const [logService, setLogService] = useState<LogType>("frigate");
@@ -38,24 +32,38 @@ function Logs() {
 
   // log data handling
 
+  const logPageSize = useMemo(() => {
+    if (isMobileOnly) {
+      return 10;
+    }
+
+    if (isTablet) {
+      return 25;
+    }
+
+    return 40;
+  }, []);
+
   const [logRange, setLogRange] = useState<LogRange>({ start: 0, end: 0 });
   const [logs, setLogs] = useState<string[]>([]);
+  const [logLines, setLogLines] = useState<LogLine[]>([]);
 
   useEffect(() => {
     axios
-      .get(`logs/${logService}?start=-100`)
+      .get(`logs/${logService}?start=-${logPageSize}`)
       .then((resp) => {
         if (resp.status == 200) {
           const data = resp.data as LogData;
           setLogRange({
-            start: Math.max(0, data.totalLines - 100),
+            start: Math.max(0, data.totalLines - logPageSize),
             end: data.totalLines,
           });
           setLogs(data.lines);
+          setLogLines(parseLogLines(logService, data.lines));
         }
       })
       .catch(() => {});
-  }, [logService]);
+  }, [logPageSize, logService]);
 
   useEffect(() => {
     if (!logs || logs.length == 0) {
@@ -75,6 +83,10 @@ function Logs() {
                 end: data.totalLines,
               });
               setLogs([...logs, ...data.lines]);
+              setLogLines([
+                ...logLines,
+                ...parseLogLines(logService, data.lines),
+              ]);
             }
           }
         })
@@ -86,136 +98,11 @@ function Logs() {
         clearTimeout(id);
       }
     };
-  }, [logs, logService, logRange]);
+    // we need to listen on the current range of visible items
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [logLines, logService, logRange]);
 
   // convert to log data
-
-  const logLines = useMemo<LogLine[]>(() => {
-    if (!logs) {
-      return [];
-    }
-
-    if (logService == "frigate") {
-      return logs
-        .map((line) => {
-          const match = frigateDateStamp.exec(line);
-
-          if (!match) {
-            const infoIndex = line.indexOf("[INFO]");
-
-            if (infoIndex != -1) {
-              return {
-                dateStamp: line.substring(0, 19),
-                severity: "info",
-                section: "startup",
-                content: line.substring(infoIndex + 6).trim(),
-              };
-            }
-
-            return {
-              dateStamp: line.substring(0, 19),
-              severity: "unknown",
-              section: "unknown",
-              content: line.substring(30).trim(),
-            };
-          }
-
-          const sectionMatch = frigateSection.exec(
-            line.substring(match.index + match[0].length).trim(),
-          );
-
-          if (!sectionMatch) {
-            return null;
-          }
-
-          return {
-            dateStamp: match.toString().slice(1, -1),
-            severity: frigateSeverity
-              .exec(line)
-              ?.at(0)
-              ?.toString()
-              ?.toLowerCase() as LogSeverity,
-            section: sectionMatch.toString(),
-            content: line
-              .substring(line.indexOf(":", match.index + match[0].length) + 2)
-              .trim(),
-          };
-        })
-        .filter((value) => value != null) as LogLine[];
-    } else if (logService == "go2rtc") {
-      return logs
-        .map((line) => {
-          if (line.length == 0) {
-            return null;
-          }
-
-          const severity = goSeverity.exec(line);
-
-          let section =
-            goSection.exec(line)?.toString()?.slice(1, -1) ?? "startup";
-
-          if (frigateSeverity.exec(section)) {
-            section = "startup";
-          }
-
-          let contentStart;
-
-          if (section == "startup") {
-            if (severity) {
-              contentStart = severity.index + severity[0].length;
-            } else {
-              contentStart = line.lastIndexOf("]") + 1;
-            }
-          } else {
-            contentStart = line.indexOf(section) + section.length + 2;
-          }
-
-          let severityCat: LogSeverity;
-          switch (severity?.at(0)?.toString().trim()) {
-            case "INF":
-              severityCat = "info";
-              break;
-            case "WRN":
-              severityCat = "warning";
-              break;
-            case "ERR":
-              severityCat = "error";
-              break;
-            case "DBG":
-            case "TRC":
-              severityCat = "debug";
-              break;
-            default:
-              severityCat = "info";
-          }
-
-          return {
-            dateStamp: line.substring(0, 19),
-            severity: severityCat,
-            section: section,
-            content: line.substring(contentStart).trim(),
-          };
-        })
-        .filter((value) => value != null) as LogLine[];
-    } else if (logService == "nginx") {
-      return logs
-        .map((line) => {
-          if (line.length == 0) {
-            return null;
-          }
-
-          return {
-            dateStamp: line.substring(0, 19),
-            severity: "info",
-            section: ngSeverity.exec(line)?.at(0)?.toString() ?? "META",
-            content: line.substring(line.indexOf(" ", 20)).trim(),
-          };
-        })
-        .filter((value) => value != null) as LogLine[];
-    } else {
-      return [];
-    }
-  }, [logs, logService]);
 
   const handleCopyLogs = useCallback(() => {
     if (logs) {
@@ -261,31 +148,38 @@ function Logs() {
       }
 
       try {
-        startObserver.current = new IntersectionObserver((entries) => {
-          if (entries[0].isIntersecting && logRange.start > 0) {
-            const start = Math.max(0, logRange.start - 100);
+        startObserver.current = new IntersectionObserver(
+          (entries) => {
+            if (entries[0].isIntersecting && logRange.start > 0) {
+              const start = Math.max(0, logRange.start - logPageSize);
 
-            axios
-              .get(`logs/${logService}?start=${start}&end=${logRange.start}`)
-              .then((resp) => {
-                if (resp.status == 200) {
-                  const data = resp.data as LogData;
+              axios
+                .get(`logs/${logService}?start=${start}&end=${logRange.start}`)
+                .then((resp) => {
+                  if (resp.status == 200) {
+                    const data = resp.data as LogData;
 
-                  if (data.lines.length > 0) {
-                    setLogRange({
-                      start: start,
-                      end: logRange.end,
-                    });
-                    setLogs([...data.lines, ...logs]);
+                    if (data.lines.length > 0) {
+                      setLogRange({
+                        start: start,
+                        end: logRange.end,
+                      });
+                      setLogs([...data.lines, ...logs]);
+                      setLogLines([
+                        ...parseLogLines(logService, data.lines),
+                        ...logLines,
+                      ]);
+                    }
                   }
-                }
-              })
-              .catch(() => {});
-            contentRef.current?.scrollBy({
-              top: 10,
-            });
-          }
-        });
+                })
+                .catch(() => {});
+              contentRef.current?.scrollBy({
+                top: 10,
+              });
+            }
+          },
+          { rootMargin: `${10 * (isMobile ? 64 : 48)}px 0px 0px 0px` },
+        );
         if (node) startObserver.current.observe(node);
       } catch (e) {
         // no op
@@ -346,6 +240,7 @@ function Logs() {
           onValueChange={(value: LogType) => {
             if (value) {
               setLogs([]);
+              setLogLines([]);
               setFilterSeverity(undefined);
               setLogService(value);
             }

--- a/web/src/types/log.ts
+++ b/web/src/types/log.ts
@@ -11,3 +11,6 @@ export type LogLine = {
   section: string;
   content: string;
 };
+
+export const logTypes = ["frigate", "go2rtc", "nginx"] as const;
+export type LogType = (typeof logTypes)[number];

--- a/web/src/utils/logUtil.ts
+++ b/web/src/utils/logUtil.ts
@@ -1,0 +1,133 @@
+import { LogLine, LogSeverity, LogType } from "@/types/log";
+
+const frigateDateStamp = /\[[\d\s-:]*]/;
+const frigateSeverity = /(DEBUG)|(INFO)|(WARNING)|(ERROR)/;
+const frigateSection = /[\w.]*/;
+
+const goSeverity = /(DEB )|(INF )|(WRN )|(ERR )/;
+const goSection = /\[[\w]*]/;
+
+const ngSeverity = /(GET)|(POST)|(PUT)|(PATCH)|(DELETE)/;
+
+export function parseLogLines(logService: LogType, logs: string[]) {
+  if (logService == "frigate") {
+    return logs
+      .map((line) => {
+        const match = frigateDateStamp.exec(line);
+
+        if (!match) {
+          const infoIndex = line.indexOf("[INFO]");
+
+          if (infoIndex != -1) {
+            return {
+              dateStamp: line.substring(0, 19),
+              severity: "info",
+              section: "startup",
+              content: line.substring(infoIndex + 6).trim(),
+            };
+          }
+
+          return {
+            dateStamp: line.substring(0, 19),
+            severity: "unknown",
+            section: "unknown",
+            content: line.substring(30).trim(),
+          };
+        }
+
+        const sectionMatch = frigateSection.exec(
+          line.substring(match.index + match[0].length).trim(),
+        );
+
+        if (!sectionMatch) {
+          return null;
+        }
+
+        return {
+          dateStamp: match.toString().slice(1, -1),
+          severity: frigateSeverity
+            .exec(line)
+            ?.at(0)
+            ?.toString()
+            ?.toLowerCase() as LogSeverity,
+          section: sectionMatch.toString(),
+          content: line
+            .substring(line.indexOf(":", match.index + match[0].length) + 2)
+            .trim(),
+        };
+      })
+      .filter((value) => value != null) as LogLine[];
+  } else if (logService == "go2rtc") {
+    return logs
+      .map((line) => {
+        if (line.length == 0) {
+          return null;
+        }
+
+        const severity = goSeverity.exec(line);
+
+        let section =
+          goSection.exec(line)?.toString()?.slice(1, -1) ?? "startup";
+
+        if (frigateSeverity.exec(section)) {
+          section = "startup";
+        }
+
+        let contentStart;
+
+        if (section == "startup") {
+          if (severity) {
+            contentStart = severity.index + severity[0].length;
+          } else {
+            contentStart = line.lastIndexOf("]") + 1;
+          }
+        } else {
+          contentStart = line.indexOf(section) + section.length + 2;
+        }
+
+        let severityCat: LogSeverity;
+        switch (severity?.at(0)?.toString().trim()) {
+          case "INF":
+            severityCat = "info";
+            break;
+          case "WRN":
+            severityCat = "warning";
+            break;
+          case "ERR":
+            severityCat = "error";
+            break;
+          case "DBG":
+          case "TRC":
+            severityCat = "debug";
+            break;
+          default:
+            severityCat = "info";
+        }
+
+        return {
+          dateStamp: line.substring(0, 19),
+          severity: severityCat,
+          section: section,
+          content: line.substring(contentStart).trim(),
+        };
+      })
+      .filter((value) => value != null) as LogLine[];
+  } else if (logService == "nginx") {
+    return logs
+      .map((line) => {
+        if (line.length == 0) {
+          return null;
+        }
+
+        return {
+          dateStamp: line.substring(0, 19),
+          severity: "info",
+          section: ngSeverity.exec(line)?.at(0)?.toString() ?? "META",
+          content: line.substring(line.indexOf(" ", 20)).trim(),
+        };
+      })
+      .filter((value) => value != null) as LogLine[];
+  }
+
+  return [];
+}

--- a/web/src/views/system/CameraMetrics.tsx
+++ b/web/src/views/system/CameraMetrics.tsx
@@ -43,7 +43,7 @@ export default function CameraMetrics({
     }
 
     if (updatedStats.service.last_updated > lastUpdated) {
-      setStatsHistory([...statsHistory, updatedStats]);
+      setStatsHistory([...statsHistory.slice(1), updatedStats]);
       setLastUpdated(Date.now() / 1000);
     }
   }, [initialStats, updatedStats, statsHistory, lastUpdated, setLastUpdated]);

--- a/web/src/views/system/CameraMetrics.tsx
+++ b/web/src/views/system/CameraMetrics.tsx
@@ -1,5 +1,5 @@
 import { useFrigateStats } from "@/api/ws";
-import { CameraLineGraph } from "@/components/graph/SystemGraph";
+import { CameraLineGraph } from "@/components/graph/CameraGraph";
 import { Skeleton } from "@/components/ui/skeleton";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { FrigateStats } from "@/types/stats";

--- a/web/src/views/system/GeneralMetrics.tsx
+++ b/web/src/views/system/GeneralMetrics.tsx
@@ -12,8 +12,8 @@ import {
 } from "@/types/graph";
 import { Button } from "@/components/ui/button";
 import VainfoDialog from "@/components/overlay/VainfoDialog";
-import { ThresholdBarGraph } from "@/components/graph/SystemGraph";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ThresholdBarGraph } from "@/components/graph/SystemGraph";
 
 type GeneralMetricsProps = {
   lastUpdated: number;

--- a/web/src/views/system/GeneralMetrics.tsx
+++ b/web/src/views/system/GeneralMetrics.tsx
@@ -57,7 +57,7 @@ export default function GeneralMetrics({
     }
 
     if (updatedStats.service.last_updated > lastUpdated) {
-      setStatsHistory([...statsHistory, updatedStats]);
+      setStatsHistory([...statsHistory.slice(1), updatedStats]);
       setLastUpdated(Date.now() / 1000);
     }
   }, [initialStats, updatedStats, statsHistory, lastUpdated, setLastUpdated]);

--- a/web/src/views/system/StorageMetrics.tsx
+++ b/web/src/views/system/StorageMetrics.tsx
@@ -1,4 +1,4 @@
-import { StorageGraph } from "@/components/graph/SystemGraph";
+import { StorageGraph } from "@/components/graph/StorageGraph";
 import { FrigateStats } from "@/types/stats";
 import { useMemo } from "react";
 import useSWR from "swr";


### PR DESCRIPTION
logs

- only parse log lines once instead of each time the logs are appended
- use different log page sizes depending on the device type
- implement custom keyboard handlers for up / down keys on log page

metrics

- manually insert 0 values on graphs when there is not enough natural data to fill the graph
- don't expand the size of the stats list when new items come in