### PR TITLE
Always save previews in UTC offset

### DIFF
--- a/frigate/output/preview.py
+++ b/frigate/output/preview.py
@@ -180,6 +180,7 @@ class PreviewRecorder:
         # end segment at end of hour
         self.segment_end = (
             (datetime.datetime.now() + datetime.timedelta(hours=1))
+            .astimezone(datetime.timezone.utc)
             .replace(minute=0, second=0, microsecond=0)
             .timestamp()
         )
@@ -192,6 +193,7 @@ class PreviewRecorder:
         # check for existing items in cache
         start_ts = (
             datetime.datetime.now()
+            .astimezone(datetime.timezone.utc)
             .replace(minute=0, second=0, microsecond=0)
             .timestamp()
         )
@@ -300,6 +302,7 @@ class PreviewRecorder:
             # reset frame cache
             self.segment_end = (
                 (datetime.datetime.now() + datetime.timedelta(hours=1))
+                .astimezone(datetime.timezone.utc)
                 .replace(minute=0, second=0, microsecond=0)
                 .timestamp()
             )


### PR DESCRIPTION
For servers that have a non-zero minutes offset in the timezone frigate would save previews with that offset to UTC. This causes a discrepancy between the frontend and backend leading to previews not working