### PR TITLE
Non-modal dropdown menus

### DIFF
--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -468,7 +468,7 @@ export function CameraGroupRow({
 
         {isMobile && (
           <>
-            <DropdownMenu>
+            <DropdownMenu modal={false}>
               <DropdownMenuTrigger>
                 <HiOutlineDotsVertical className="size-5" />
               </DropdownMenuTrigger>

--- a/web/src/components/filter/ReviewFilterGroup.tsx
+++ b/web/src/components/filter/ReviewFilterGroup.tsx
@@ -365,6 +365,7 @@ export function CamerasFilterButton({
 
   return (
     <DropdownMenu
+      modal={false}
       open={open}
       onOpenChange={(open) => {
         if (!open) {

--- a/web/src/components/menu/AccountSettings.tsx
+++ b/web/src/components/menu/AccountSettings.tsx
@@ -34,7 +34,7 @@ export default function AccountSettings({ className }: AccountSettingsProps) {
   const MenuItem = isDesktop ? DropdownMenuItem : DialogClose;
 
   return (
-    <Container>
+    <Container modal={!isDesktop}>
       <Trigger>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/web/src/components/menu/GeneralSettings.tsx
+++ b/web/src/components/menu/GeneralSettings.tsx
@@ -114,7 +114,7 @@ export default function GeneralSettings({ className }: GeneralSettingsProps) {
 
   return (
     <>
-      <Container>
+      <Container modal={!isDesktop}>
         <Trigger>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/web/src/components/player/VideoControls.tsx
+++ b/web/src/components/player/VideoControls.tsx
@@ -230,6 +230,7 @@ export default function VideoControls({
       )}
       {features.playbackRate && (
         <DropdownMenu
+          modal={false}
           onOpenChange={(open) => {
             if (setControlsOpen) {
               setControlsOpen(open);

--- a/web/src/components/settings/PolygonItem.tsx
+++ b/web/src/components/settings/PolygonItem.tsx
@@ -266,7 +266,7 @@ export default function PolygonItem({
 
         {isMobile && (
           <>
-            <DropdownMenu>
+            <DropdownMenu modal={false}>
               <DropdownMenuTrigger>
                 <HiOutlineDotsVertical className="size-5" />
               </DropdownMenuTrigger>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -284,6 +284,7 @@ function CameraSelectButton({
 
   return (
     <DropdownMenu
+      modal={false}
       open={open}
       onOpenChange={(open: boolean) => {
         if (!open) {

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -583,7 +583,7 @@ function PtzControlPanel({
         </>
       )}
       {(ptz?.presets?.length ?? 0) > 0 && (
-        <DropdownMenu>
+        <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>
             <Button>
               <BsThreeDotsVertical />


### PR DESCRIPTION
No need for modality on dropdown menus - accessibility is decreased (with modal as false, screen readers now have access to the entire screen instead of just the dropdown content), but Frigate is inherently a visual application.