### PR TITLE
Fix Statusbar rendering NaN% for unsupported GPUs

### DIFF
--- a/web/src/components/Statusbar.tsx
+++ b/web/src/components/Statusbar.tsx
@@ -81,6 +81,10 @@ export default function Statusbar() {
 
           const gpu = parseInt(stats.gpu);
 
+          if (isNaN(gpu)) {
+            return;
+          }
+
           return (
             <Link key={gpuTitle} to="/system#general">
               {" "}
@@ -97,7 +101,7 @@ export default function Statusbar() {
                         : "text-danger"
                   }`}
                 />
-                {gpuTitle} {isNaN(gpu) ? 'unknown' : `${gpu}%`}
+                {gpuTitle} {gpu}%
               </div>
             </Link>
           );

--- a/web/src/components/Statusbar.tsx
+++ b/web/src/components/Statusbar.tsx
@@ -97,7 +97,7 @@ export default function Statusbar() {
                         : "text-danger"
                   }`}
                 />
-                {gpuTitle} {gpu}%
+                {gpuTitle} {isNaN(gpu) ? 'unknown' : `${gpu}%`}
               </div>
             </Link>
           );


### PR DESCRIPTION
Noticed a small bug when using v0.14 on my RPI
<img width="376" alt="image" src="https://github.com/blakeblackshear/frigate/assets/5631509/7a4c52b4-b162-4eb4-8060-e22b5b633819">

Updated to completely hide GPU when unsupported instead of displaying `NaN%`