### PR TITLE
feat: apply ingress path to app paths

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,7 +24,7 @@ const Logs = lazy(() => import("@/pages/Logs"));
 function App() {
   return (
     <Providers>
-      <BrowserRouter>
+      <BrowserRouter basename={window.baseUrl}>
         <Wrapper>
           <div className="size-full overflow-hidden">
             {isDesktop && <Sidebar />}


### PR DESCRIPTION
When serving Frigate at a subpath, the paths that show in the URL bar and that wind up in your browser history are anchored at the web root. I.e., you go to `https://example.com/frigate/,` it changes to `https://example.com/,` and clicking around works as expected, but the `frigate/` prefix is gone.

It's confusing if you don't know that the URL's are entirely virtual. Also, your browser history is useless, since the URL's point to e.g. `https://example.com/#kitchen`, but visiting that URL will land you at the site's root. 

Most of the work is already done. Nginx injects javascript to set `window.baseURL` based on the X-Ingress-Path header. This change passes that to BrowserRouter so that it'll be part of the URLs it shows.

Fixes #4526