### PR TITLE
Fix unclean shutdown of ZMQ

### DIFF
--- a/frigate/comms/detections_updater.py
+++ b/frigate/comms/detections_updater.py
@@ -26,9 +26,8 @@ class DetectionProxyRunner(threading.Thread):
 
     def run(self) -> None:
         """Run the proxy."""
-        control = self.context.socket(zmq.SUB)
+        control = self.context.socket(zmq.REP)
         control.connect(SOCKET_CONTROL)
-        control.setsockopt_string(zmq.SUBSCRIBE, "")
         incoming = self.context.socket(zmq.XSUB)
         incoming.bind(SOCKET_PUB)
         outgoing = self.context.socket(zmq.XPUB)
@@ -46,13 +45,13 @@ class DetectionProxy:
 
     def __init__(self) -> None:
         self.context = zmq.Context()
-        self.control = self.context.socket(zmq.PUB)
+        self.control = self.context.socket(zmq.REQ)
         self.control.bind(SOCKET_CONTROL)
         self.runner = DetectionProxyRunner(self.context)
         self.runner.start()
 
     def stop(self) -> None:
-        self.control.send_string("TERMINATE")  # tell the proxy to stop
+        self.control.send("TERMINATE".encode())  # tell the proxy to stop
         self.runner.join()
         self.context.destroy()
 


### PR DESCRIPTION
According to the [ZMQ documentation](https://libzmq.readthedocs.io/en/latest/zmq_proxy_steerable.html), the control socket is expected to be a REP or PAIR. This fixes that and lets `proxy_steerable` shutdown cleanly when receiving a `TERMINATE` command.