### PR TITLE
Try webrtc when mse fails with decoding error

### DIFF
--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -138,6 +138,7 @@ export default function LivePlayer({
         iOSCompatFullScreen={iOSCompatFullScreen}
         onPlaying={() => setLiveReady(true)}
         pip={pip}
+        onError={onError}
       />
     );
   } else if (liveMode == "mse") {

--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -316,24 +316,22 @@ function MSEPlayer({
         if (isSafari || isIOS) {
           onPlaying?.();
         }
-        return onError != undefined
-          ? () => {
-              if (videoRef.current?.paused) {
-                return;
-              }
+        if (onError != undefined) {
+          if (videoRef.current?.paused) {
+            return;
+          }
 
-              if (bufferTimeout) {
-                clearTimeout(bufferTimeout);
-                setBufferTimeout(undefined);
-              }
+          if (bufferTimeout) {
+            clearTimeout(bufferTimeout);
+            setBufferTimeout(undefined);
+          }
 
-              setBufferTimeout(
-                setTimeout(() => {
-                  onError("stalled");
-                }, 3000),
-              );
-            }
-          : undefined;
+          setBufferTimeout(
+            setTimeout(() => {
+              onError("stalled");
+            }, 3000),
+          );
+        }
       }}
       onError={(e) => {
         if (
@@ -349,6 +347,8 @@ function MSEPlayer({
           (isSafari || isIOS)
         ) {
           onError?.("mse-decode");
+          clearTimeout(bufferTimeout);
+          setBufferTimeout(undefined);
         }
 
         if (wsRef.current) {

--- a/web/src/types/live.ts
+++ b/web/src/types/live.ts
@@ -31,4 +31,4 @@ export type LiveStreamMetadata = {
   consumers: LiveConsumerMetadata[];
 };
 
-export type LivePlayerError = "stalled" | "startup";
+export type LivePlayerError = "stalled" | "startup" | "mse-decode";

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -190,6 +190,7 @@ export default function LiveCameraView({
 
   const [audio, setAudio] = useState(false);
   const [mic, setMic] = useState(false);
+  const [webRTC, setWebRTC] = useState(false);
   const [pip, setPip] = useState(false);
   const [lowBandwidth, setLowBandwidth] = useState(false);
 
@@ -199,6 +200,14 @@ export default function LiveCameraView({
   });
 
   const preferredLiveMode = useMemo(() => {
+    if (webRTC && isRestreamed) {
+      return "webrtc";
+    }
+
+    if (webRTC && !isRestreamed) {
+      return "jsmpeg";
+    }
+
     if (mic) {
       return "webrtc";
     }
@@ -208,7 +217,7 @@ export default function LiveCameraView({
     }
 
     return "mse";
-  }, [lowBandwidth, mic]);
+  }, [lowBandwidth, mic, webRTC, isRestreamed]);
 
   // layout state
 
@@ -426,7 +435,14 @@ export default function LiveCameraView({
                 pip={pip}
                 setFullResolution={setFullResolution}
                 containerRef={containerRef}
-                onError={() => setLowBandwidth(true)}
+                onError={(e) => {
+                  if (e == "mse-decode") {
+                    setWebRTC(true);
+                  } else {
+                    setWebRTC(false);
+                    setLowBandwidth(true);
+                  }
+                }}
               />
             </div>
             {camera.onvif.host != "" && (

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -200,16 +200,16 @@ export default function LiveCameraView({
   });
 
   const preferredLiveMode = useMemo(() => {
+    if (mic) {
+      return "webrtc";
+    }
+
     if (webRTC && isRestreamed) {
       return "webrtc";
     }
 
     if (webRTC && !isRestreamed) {
       return "jsmpeg";
-    }
-
-    if (mic) {
-      return "webrtc";
     }
 
     if (lowBandwidth) {


### PR DESCRIPTION
On iOS and Safari desktop, some MSE streams with particular codecs never fire `loadeddata` and thus `onPlaying` never gets called and the player remains invisible, even though MSE data is streaming over the websocket.

Additionally, these particular streams tend to raise `MEDIA_ERR_DECODE`. 

This PR checks for this very particular condition and falls back to webrtc if available. If webrtc times out, jsmpeg is used.