### PR TITLE
fix: remove contradictory ffmpeg param, resolve missing preview

### DIFF
--- a/frigate/output/preview.py
+++ b/frigate/output/preview.py
@@ -78,7 +78,7 @@ class FFMpegConverter(threading.Thread):
         self.ffmpeg_cmd = parse_preset_hardware_acceleration_encode(
             config.ffmpeg.hwaccel_args,
             input="-f concat -y -protocol_whitelist pipe,file -safe 0 -i /dev/stdin",
-            output=f"-g {PREVIEW_KEYFRAME_INTERVAL}{' -fpsmax 2' if int(os.getenv('LIBAVFORMAT_VERSION_MAJOR', '59')) >= 59 else ''} -bf 0 -b:v {PREVIEW_QUALITY_BIT_RATES[self.config.record.preview.quality]} {FPS_VFR_PARAM} -movflags +faststart -pix_fmt yuv420p {self.path}",
+            output=f"-g {PREVIEW_KEYFRAME_INTERVAL} -bf 0 -b:v {PREVIEW_QUALITY_BIT_RATES[self.config.record.preview.quality]} {FPS_VFR_PARAM} -movflags +faststart -pix_fmt yuv420p {self.path}",
             type=EncodeTypeEnum.preview,
         )
 


### PR DESCRIPTION
Issue described and all details given in this support ticket - https://github.com/blakeblackshear/frigate/discussions/11714

Seems `-fpsmax` and `-fps_mode vfr` are contradictory params since version 6.0

More info about ffmpeg changes - https://github.com/FFmpeg/FFmpeg/commit/260f3918937463f1b90e1b77cba80b917f3cb8c1