### PR TITLE
Fix typo in record/export.py

### DIFF
--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -74,7 +74,7 @@ class RecordingExporter(threading.Thread):
 
         if datetime.datetime.fromtimestamp(
             self.start_time
-        ) < datetime.datetime.now().astimezone(datetime.timezone.dst).replace(
+        ) < datetime.datetime.now().astimezone(datetime.timezone.utc).replace(
             minute=0, second=0, microsecond=0
         ):
             # has preview mp4


### PR DESCRIPTION
A recent change added a call to
`datetime.datetime.now().astimezone(datetime.timezone.dst)`. The `datetime.timezone.dst` argument should be `datetime.timezone.utc`.

Fixes #11785