### PR TITLE
UI tweaks

### DIFF
--- a/web/src/components/camera/AutoUpdatingCameraImage.tsx
+++ b/web/src/components/camera/AutoUpdatingCameraImage.tsx
@@ -69,7 +69,7 @@ export default function AutoUpdatingCameraImage({
       <CameraImage
         camera={camera}
         onload={handleLoad}
-        searchParams={`cache=${key}${searchParams && `&${searchParams}`}`}
+        searchParams={`cache=${key}${searchParams ? `&${searchParams}` : ""}`}
         className={cameraClasses}
       />
       {showFps ? <span className="text-xs">Displaying at {fps}fps</span> : null}

--- a/web/src/components/player/PreviewPlayer.tsx
+++ b/web/src/components/player/PreviewPlayer.tsx
@@ -84,7 +84,7 @@ export default function PreviewPlayer({
   return (
     <div
       className={cn(
-        "flex size-full items-center justify-center rounded-lg text-white md:rounded-2xl",
+        "flex size-full items-center justify-center rounded-lg bg-background_alt text-primary md:rounded-2xl",
         className,
       )}
     >
@@ -322,7 +322,7 @@ function PreviewVideoPlayer({
         )}
       </video>
       {cameraPreviews && !currentPreview && (
-        <div className="absolute inset-0 flex items-center justify-center rounded-lg text-white md:rounded-2xl">
+        <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-background_alt text-primary md:rounded-2xl">
           No Preview Found
         </div>
       )}
@@ -535,7 +535,7 @@ function PreviewFramesPlayer({
         onLoad={onImageLoaded}
       />
       {previewFrames?.length === 0 && (
-        <div className="-y-translate-1/2 align-center absolute inset-x-0 top-1/2 rounded-lg bg-black text-center text-white md:rounded-2xl">
+        <div className="-y-translate-1/2 align-center absolute inset-x-0 top-1/2 rounded-lg bg-background_alt text-center text-primary md:rounded-2xl">
           No Preview Found
         </div>
       )}

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -30,7 +30,7 @@ import {
   useState,
 } from "react";
 import { isDesktop, isMobile } from "react-device-detect";
-import { LuFolderCheck } from "react-icons/lu";
+import { LuFolderCheck, LuFolderX } from "react-icons/lu";
 import { MdCircle } from "react-icons/md";
 import useSWR from "swr";
 import MotionReviewTimeline from "@/components/timeline/MotionReviewTimeline";
@@ -857,6 +857,15 @@ function MotionReview({
       alignStartDateToTimeline,
     ],
   );
+
+  if (motionData?.length === 0) {
+    return (
+      <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center text-center">
+        <LuFolderX className="size-16" />
+        No motion data found
+      </div>
+    );
+  }
 
   if (!relevantPreviews) {
     return <ActivityIndicator />;


### PR DESCRIPTION
- Prevent "undefined" from being displayed in searchParams string. When `searchParams` is undefined, the expression with a logical `&&` evaluates to `undefined`. So the string ends up being `/latest.jpg?cache=1717728081280undefined`. This fix corrects this bug and mimics the existing code in the `ResizingCameraImage` component.
- Display a message when a selected review period has no motion data rather than a spinning activity indicator. Should help mitigate issues from users who look at motion review immediately after upgrading. 
- Use theme colors for "no preview found" divs. `text-white` would go unseen on the default theme in light mode.
