### PR TITLE
move clip.mp4 backend to clips folder

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -131,6 +131,8 @@ http {
                 image/jpeg jpg;
             }
 
+            expires 7d;
+            add_header Cache-Control "public";
             autoindex on;
             root /media/frigate;
         }

--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -1232,7 +1232,7 @@ def preview_gif(camera_name: str, start_ts, end_ts, max_cache_age=2592000):
 
 @MediaBp.route("/<camera_name>/start/<int:start_ts>/end/<int:end_ts>/preview.mp4")
 @MediaBp.route("/<camera_name>/start/<float:start_ts>/end/<float:end_ts>/preview.mp4")
-def preview_mp4(camera_name: str, start_ts, end_ts, max_cache_age=2592000):
+def preview_mp4(camera_name: str, start_ts, end_ts, max_cache_age=604800):
     file_name = f"preview_{camera_name}_{start_ts}-{end_ts}.mp4"
 
     if len(file_name) > 1000:

--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -459,7 +459,7 @@ def recording_clip(camera_name, start_ts, end_ts):
         )
 
     file_name = secure_filename(file_name)
-    path = os.path.join(CACHE_DIR, file_name)
+    path = os.path.join(CLIPS_DIR, f"cache/{file_name}")
 
     if not os.path.exists(path):
         ffmpeg_cmd = [
@@ -511,7 +511,7 @@ def recording_clip(camera_name, start_ts, end_ts):
         response.headers["Content-Disposition"] = "attachment; filename=%s" % file_name
     response.headers["Content-Length"] = os.path.getsize(path)
     response.headers["X-Accel-Redirect"] = (
-        f"/cache/{file_name}"  # nginx: https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ignore_headers
+        f"/clips/cache/{file_name}"  # nginx: https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ignore_headers
     )
 
     return response
@@ -1233,7 +1233,7 @@ def preview_gif(camera_name: str, start_ts, end_ts, max_cache_age=2592000):
 @MediaBp.route("/<camera_name>/start/<int:start_ts>/end/<int:end_ts>/preview.mp4")
 @MediaBp.route("/<camera_name>/start/<float:start_ts>/end/<float:end_ts>/preview.mp4")
 def preview_mp4(camera_name: str, start_ts, end_ts, max_cache_age=2592000):
-    file_name = f"clip_{camera_name}_{start_ts}-{end_ts}.mp4"
+    file_name = f"preview_{camera_name}_{start_ts}-{end_ts}.mp4"
 
     if len(file_name) > 1000:
         return make_response(

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -100,7 +100,7 @@ class FrigateApp:
         for d in [
             CONFIG_DIR,
             RECORD_DIR,
-            CLIPS_DIR,
+            f"{CLIPS_DIR}/cache",
             CACHE_DIR,
             MODEL_CACHE_DIR,
             EXPORT_DIR,

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -82,7 +82,7 @@ class RecordingMaintainer(threading.Thread):
             for d in os.listdir(CACHE_DIR)
             if os.path.isfile(os.path.join(CACHE_DIR, d))
             and d.endswith(".mp4")
-            and not d.startswith("clip_")
+            and not d.startswith("preview_")
         ]
 
         files_in_use = []

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -300,7 +300,7 @@ class CameraWatchdog(threading.Thread):
                 for d in os.listdir(CACHE_DIR)
                 if os.path.isfile(os.path.join(CACHE_DIR, d))
                 and d.endswith(".mp4")
-                and not d.startswith("clip_")
+                and not d.startswith("preview_")
             ]
         )
         newest_segment_time = latest_segment


### PR DESCRIPTION
- Moves clips outside of the cache folder since it often causes the cache to fill
- Retaining preview clips in cache for longer to reduce the frequency of regenerating them
- Allow the browser to cache files in /clips for 7d