### PR TITLE
Issue 10845

### DIFF
--- a/frigate/output/birdseye.py
+++ b/frigate/output/birdseye.py
@@ -282,7 +282,9 @@ class BirdsEyeFrameManager:
         self.canvas = Canvas(width, height, config.birdseye.layout.scaling_factor)
         self.stop_event = stop_event
         self.inactivity_threshold = config.birdseye.inactivity_threshold
-        self.min_display_duration = config.birdseye.min_display_duration  # New parameter
+        self.min_display_duration = (
+            config.birdseye.min_display_duration 
+        )# New parameter
 
         if config.birdseye.layout.max_cameras:
             self.last_refresh_time = 0
@@ -449,7 +451,10 @@ class BirdsEyeFrameManager:
             reset_layout = True
 
         # Ensure the current camera has been displayed for at least min_display_duration seconds
-        if len(self.active_cameras) == 1 and now - self.last_camera_switch_time < self.min_display_duration:
+        if (
+            len(self.active_cameras) == 1 
+            and now - self.last_camera_switch_time < self.min_display_duration
+        ):
             reset_layout = False
 
         # reset the layout if it needs to be different


### PR DESCRIPTION
To solve the problem of frequent camera switching, we need to add a new configuration parameter `min_display_duration` to the `BirdsEyeFrameManager` class and modify the `update_frame` method to ensure that a camera view is displayed for at least the specified duration before switching.
Modify the `update_frame` method to check if the current camera has been displayed for at least `min_display_duration` seconds before switching to another camera.