### PR TITLE
Fix cpu count when process name includes the word processor

### DIFF
--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -44,7 +44,7 @@ function get_cpus() {
             cpus=1
         fi
     else
-        cpus=$(grep -c processor /proc/cpuinfo)
+        cpus=$(grep -c ^processor /proc/cpuinfo)
     fi
 
     printf '%s' "$cpus"


### PR DESCRIPTION
As realized in:

- https://github.com/felipecrs/cgroup-scripts/pull/4