### PR TITLE
Draggable grid fixes

### DIFF
--- a/web/src/views/live/DraggableGridLayout.tsx
+++ b/web/src/views/live/DraggableGridLayout.tsx
@@ -201,14 +201,6 @@ export default function DraggableGridLayout({
   ]);
 
   useEffect(() => {
-    if (currentGridLayout) {
-      setGridLayout(currentGridLayout);
-    }
-    // we know that these deps are correct
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEditMode, setGridLayout]);
-
-  useEffect(() => {
     if (isGridLayoutLoaded) {
       if (gridLayout) {
         // set current grid layout from loaded

--- a/web/src/views/live/DraggableGridLayout.tsx
+++ b/web/src/views/live/DraggableGridLayout.tsx
@@ -97,8 +97,9 @@ export default function DraggableGridLayout({
   const [showCircles, setShowCircles] = useState(true);
 
   useEffect(() => {
+    setIsEditMode(false);
     setEditGroup(false);
-  }, [cameraGroup]);
+  }, [cameraGroup, setIsEditMode]);
 
   // camera state
 
@@ -185,8 +186,6 @@ export default function DraggableGridLayout({
         y: 0, // don't set y, grid does automatically
         w: width,
         h: height,
-        isDraggable: isEditMode,
-        isResizable: isEditMode,
       };
 
       optionsMap.push(options);
@@ -195,7 +194,6 @@ export default function DraggableGridLayout({
     return optionsMap;
   }, [
     cameras,
-    isEditMode,
     isGridLayoutLoaded,
     currentGridLayout,
     includeBirdseye,
@@ -204,17 +202,7 @@ export default function DraggableGridLayout({
 
   useEffect(() => {
     if (currentGridLayout) {
-      const updatedGridLayout = currentGridLayout.map((layout) => ({
-        ...layout,
-        isDraggable: isEditMode,
-        isResizable: isEditMode,
-      }));
-      if (isEditMode) {
-        setGridLayout(updatedGridLayout);
-        setCurrentGridLayout(updatedGridLayout);
-      } else {
-        setGridLayout(updatedGridLayout);
-      }
+      setGridLayout(currentGridLayout);
     }
     // we know that these deps are correct
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -406,6 +394,8 @@ export default function DraggableGridLayout({
             onResize={handleResize}
             onResizeStart={() => setShowCircles(false)}
             onResizeStop={handleLayoutChange}
+            isDraggable={isEditMode}
+            isResizable={isEditMode}
           >
             {includeBirdseye && birdseyeConfig?.enabled && (
               <BirdseyeLivePlayerGridItem


### PR DESCRIPTION
- Use globals on grid for resizing/dragging flags

Any users before beta 3 will likely have dragging/resizing issues after this fix is applied and will need to clear their grid layouts from Settings --> General.