### PR TITLE
split out proxy from auth

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -66,13 +66,28 @@ database:
 # Optional: TLS configuration
 tls:
   # Optional: Enable TLS for port 8080 (default: shown below)
-  enabled: true
+  enabled: True
+
+# Optional: Proxy configuration
+proxy:
+  # Optional: Mapping for headers from upstream proxies. Only used if Frigate's auth
+  # is disabled.
+  # NOTE: Many authentication proxies pass a header downstream with the authenticated
+  #       user name. Not all values are supported. It must be a whitelisted header.
+  #       See the docs for more info.
+  header_map:
+    user: x-forwarded-user
+  # Optional: Url for logging out a user. This sets the location of the logout url in
+  # the UI.
+  logout_url: /api/logout
+  # Optional: Auth secret that is checked against the X-Proxy-Secret header sent from
+  # the proxy. If not set, all requests are trusted regardless of origin.
+  auth_secret: None
 
 # Optional: Authentication configuration
 auth:
-  # Optional: Authentication mode (default: shown below)
-  # Valid values are: native, proxy
-  mode: native
+  # Optional: Enable authentication
+  enabled: True
   # Optional: Reset the admin user password on startup (default: shown below)
   # New password is printed in the logs
   reset_admin_password: False
@@ -87,23 +102,14 @@ auth:
   # When the session is going to expire in less time than this setting,
   # it will be refreshed back to the session_length.
   refresh_time: 43200 # 12 hours
-  # Optional: Mapping for headers from upstream proxies. Only used in proxy auth mode.
-  # NOTE: Many authentication proxies pass a header downstream with the authenticated
-  #       user name. Not all values are supported. It must be a whitelisted header.
-  #       See the docs for more info.
-  header_map:
-    user: x-forwarded-user
   # Optional: Rate limiting for login failures to help prevent brute force
   # login attacks (default: shown below)
   # See the docs for more information on valid values
   failed_login_rate_limit: None
   # Optional: Trusted proxies for determining IP address to rate limit
   # NOTE: This is only used for rate limiting login attempts and does not bypass
-  # authentication in any way
+  # authentication. See the authentication docs for more details.
   trusted_proxies: []
-  # Optional: Url for logging out a user. This only needs to be set if you are using
-  # proxy mode.
-  logout_url: /api/logout
   # Optional: Number of hashing iterations for user passwords
   # As of Feb 2023, OWASP recommends 600000 iterations for PBKDF2-SHA256
   # NOTE: changing this value will not automatically update password hashes, you

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -21,7 +21,7 @@ from frigate.api.export import ExportBp
 from frigate.api.media import MediaBp
 from frigate.api.preview import PreviewBp
 from frigate.api.review import ReviewBp
-from frigate.config import AuthModeEnum, FrigateConfig
+from frigate.config import FrigateConfig
 from frigate.const import CONFIG_DIR
 from frigate.events.external import ExternalEventProcessor
 from frigate.models import Event, Timeline
@@ -86,9 +86,7 @@ def create_app(
     app.plus_api = plus_api
     app.camera_error_image = None
     app.stats_emitter = stats_emitter
-    app.jwt_token = (
-        get_jwt_secret() if frigate_config.auth.mode == AuthModeEnum.native else None
-    )
+    app.jwt_token = get_jwt_secret() if frigate_config.auth.enabled else None
     # update the request_address with the x-forwarded-for header from nginx
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1)
     # initialize the rate limiter for the login endpoint

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -176,6 +176,9 @@ def config():
     # remove the mqtt password
     config["mqtt"].pop("password", None)
 
+    # remove the proxy secret
+    config["proxy"].pop("auth_secret", None)
+
     for camera_name, camera in current_app.frigate_config.cameras.items():
         camera_dict = config["cameras"][camera_name]
 

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -27,7 +27,7 @@ from frigate.comms.dispatcher import Communicator, Dispatcher
 from frigate.comms.inter_process import InterProcessCommunicator
 from frigate.comms.mqtt import MqttClient
 from frigate.comms.ws import WebSocketClient
-from frigate.config import AuthModeEnum, FrigateConfig
+from frigate.config import FrigateConfig
 from frigate.const import (
     CACHE_DIR,
     CLIPS_DIR,
@@ -593,7 +593,7 @@ class FrigateApp:
             )
 
     def init_auth(self) -> None:
-        if self.config.auth.mode == AuthModeEnum.native:
+        if self.config.auth.enabled:
             if User.select().count() == 0:
                 password = secrets.token_hex(16)
                 password_hash = hash_password(

--- a/web/src/components/menu/AccountSettings.tsx
+++ b/web/src/components/menu/AccountSettings.tsx
@@ -26,7 +26,7 @@ type AccountSettingsProps = {
 export default function AccountSettings({ className }: AccountSettingsProps) {
   const { data: profile } = useSWR("profile");
   const { data: config } = useSWR("config");
-  const logoutUrl = config?.auth.logout_url || "/api/logout";
+  const logoutUrl = config?.proxy.logout_url || "/api/logout";
 
   const Container = isDesktop ? DropdownMenu : Drawer;
   const Trigger = isDesktop ? DropdownMenuTrigger : DrawerTrigger;


### PR DESCRIPTION
Splits the proxy config out from the auth config.

- The proxy isn't really about authentication, so it doesn't make sense to be an auth mode
- Adds the ability to configure a shared secret to validate that the request came from a known proxy