### PR TITLE
Fix X-Proxy-Secret header passthrough

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/proxy_trusted_headers.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/proxy_trusted_headers.conf
@@ -1,3 +1,6 @@
+# Header used to validate reverse proxy trust
+proxy_set_header X-Proxy-Secret $http_x_proxy_secret;
+
 # these headers will be copied to the /auth request and are available
 # to be mapped in the config to Frigate's remote-user header
 


### PR DESCRIPTION
This fixes header not being forwarded to frigate by nginx.