### PR TITLE
Fix: KeyError when specifying custom rknn model

### DIFF
--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -36,7 +36,7 @@ class Rknn(DetectionApi):
         core_mask = 2**config.num_cores - 1
         soc = self.get_soc()
 
-        model_props = self.parse_model_input(config.model.path, soc)
+        model_props = self.parse_model_input(config, soc)
 
         if model_props["preset"]:
             config.model.model_type = model_props["model_type"]
@@ -75,7 +75,9 @@ class Rknn(DetectionApi):
 
         return soc
 
-    def parse_model_input(self, model_path, soc):
+    def parse_model_input(self, config, soc):
+        model_path = config.model.path
+
         model_props = {}
 
         # find out if user provides his own model
@@ -83,6 +85,12 @@ class Rknn(DetectionApi):
         if "/" in model_path:
             model_props["preset"] = False
             model_props["path"] = model_path
+            if config.model.model_type:
+                model_props["model_type"] = config.model.model_type
+            else:
+                raise Exception(
+                    "You must specify model_type if specifying your own model file."
+                )
         else:
             model_props["preset"] = True
 


### PR DESCRIPTION
I recently upgraded to 14 beta3 and as part of my upgrade path, I noticed that we removed yolo for license reasons so during the upgrade, I changed my configs and pulled my own model. However, when I did, I got a Key Error exception that kept complaining that model_type was not specified despite me explicitly configuring it. When looking in the code, I noticed this bug; the config wasn't being read into the dictionary when you specify your own path and hence the error. 

Note: I've only spent 5 minutes reading this code and have no notion of established practices in this code base; please feel free to edit as needed or ask me to do what's needed here. I didn't find any unit tests in my quick glance through the code base. 