### PR TITLE
Update web readme

### DIFF
--- a/web/.vscode/extensions.json
+++ b/web/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+      "dbaeumer.vscode-eslint"
+    ]
+  }

--- a/web/README.md
+++ b/web/README.md
@@ -1,30 +1,10 @@
-# React + TypeScript + Vite
-
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default {
-  // other rules...
-  parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-    project: ['./tsconfig.json', './tsconfig.node.json'],
-    tsconfigRootDir: __dirname,
-  },
-}
+# To run
+```bash
+npm install
+PROXY_HOST=<ip_address:port> npm run dev
 ```
 
-- Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
-- Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+# Tech stack
+- React
+- TypeScript
+- Vite

--- a/web/README.md
+++ b/web/README.md
@@ -1,10 +1,21 @@
-# To run
+This is the Frigate frontend which connects to and provides a User Interface to the Python backend.
+
+# Installing
+Within `/web`, run:
+
 ```bash
 npm install
+```
+
+# Running
+Within `/web`, run:
+
+```bash
 PROXY_HOST=<ip_address:port> npm run dev
 ```
 
-# Tech stack
-- React
-- TypeScript
-- Vite
+The Proxy Host can point to your existing Frigate instance. Otherwise defaults to `localhost:5000` if running Frigate on the same machine.
+
+# Extensions
+Install these IDE extensions for an improved development experience:
+- eslint

--- a/web/README.md
+++ b/web/README.md
@@ -1,13 +1,17 @@
 This is the Frigate frontend which connects to and provides a User Interface to the Python backend.
 
-# Installing
+# Web Development
+
+## Installing Web Dependencies Via NPM
+
 Within `/web`, run:
 
 ```bash
 npm install
 ```
 
-# Running
+## Running development frontend
+
 Within `/web`, run:
 
 ```bash
@@ -16,6 +20,6 @@ PROXY_HOST=<ip_address:port> npm run dev
 
 The Proxy Host can point to your existing Frigate instance. Otherwise defaults to `localhost:5000` if running Frigate on the same machine.
 
-# Extensions
+## Extensions
 Install these IDE extensions for an improved development experience:
 - eslint


### PR DESCRIPTION
Replacing the default Vite readme with some hopefully helpful information on how to run the `/web` project.

I also added the eslint plugin as a recommended extension for vscode.

Will add to this if I discover anything else that might be helpful