### PR TITLE
Timeline performance improvements

### DIFF
--- a/web/src/components/timeline/EventSegment.tsx
+++ b/web/src/components/timeline/EventSegment.tsx
@@ -196,13 +196,16 @@ export function EventSegment({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [startTimestamp]);
 
-  const [segmentVisible, setSegmentVisible] = useState(false);
+  const [segmentRendered, setSegmentRendered] = useState(false);
   const segmentObserverRef = useRef<IntersectionObserver | null>(null);
-  const segmentRef = useRef<HTMLDivElement>(null);
+  const segmentRef = useRef(null);
+
   useEffect(() => {
     const segmentObserver = new IntersectionObserver(
       ([entry]) => {
-        setSegmentVisible(entry.isIntersecting);
+        if (entry.isIntersecting && !segmentRendered) {
+          setSegmentRendered(true);
+        }
       },
       { threshold: 0 },
     );
@@ -218,7 +221,18 @@ export function EventSegment({
         segmentObserverRef.current.disconnect();
       }
     };
-  }, []);
+  }, [segmentRendered]);
+
+  if (!segmentRendered) {
+    return (
+      <div
+        key={segmentKey}
+        ref={segmentRef}
+        data-segment-id={segmentKey}
+        className={`segment ${segmentClasses}`}
+      />
+    );
+  }
 
   return (
     <div
@@ -229,67 +243,63 @@ export function EventSegment({
       onClick={segmentClick}
       onTouchEnd={(event) => handleTouchStart(event, segmentClick)}
     >
-      {segmentVisible && (
-        <>
-          {showMinimap && (
-            <MinimapBounds
-              isFirstSegmentInMinimap={isFirstSegmentInMinimap}
-              isLastSegmentInMinimap={isLastSegmentInMinimap}
-              alignedMinimapStartTime={alignedMinimapStartTime}
-              alignedMinimapEndTime={alignedMinimapEndTime}
-              firstMinimapSegmentRef={firstMinimapSegmentRef}
-              dense={dense}
-            />
-          )}
+      {showMinimap && (
+        <MinimapBounds
+          isFirstSegmentInMinimap={isFirstSegmentInMinimap}
+          isLastSegmentInMinimap={isLastSegmentInMinimap}
+          alignedMinimapStartTime={alignedMinimapStartTime}
+          alignedMinimapEndTime={alignedMinimapEndTime}
+          firstMinimapSegmentRef={firstMinimapSegmentRef}
+          dense={dense}
+        />
+      )}
 
-          <Tick timestamp={timestamp} timestampSpread={timestampSpread} />
+      <Tick timestamp={timestamp} timestampSpread={timestampSpread} />
 
-          <Timestamp
-            isFirstSegmentInMinimap={isFirstSegmentInMinimap}
-            isLastSegmentInMinimap={isLastSegmentInMinimap}
-            timestamp={timestamp}
-            timestampSpread={timestampSpread}
-            segmentKey={segmentKey}
-          />
+      <Timestamp
+        isFirstSegmentInMinimap={isFirstSegmentInMinimap}
+        isLastSegmentInMinimap={isLastSegmentInMinimap}
+        timestamp={timestamp}
+        timestampSpread={timestampSpread}
+        segmentKey={segmentKey}
+      />
 
-          {severity.map((severityValue: number, index: number) => (
-            <React.Fragment key={index}>
-              {severityValue === displaySeverityType && (
-                <HoverCard openDelay={200} closeDelay={100}>
-                  <HoverCardTrigger asChild>
-                    <div className="absolute left-1/2 z-10 h-[8px] w-[20px] -translate-x-1/2 transform cursor-pointer md:w-[40px]">
-                      <div className="flex w-[20px] flex-row justify-center md:w-[40px]">
-                        <div className="flex justify-center">
-                          <div
-                            className="absolute left-1/2 z-10 ml-[2px] h-[8px] w-[8px] -translate-x-1/2 transform cursor-pointer"
-                            data-severity={severityValue}
-                          >
-                            <div
-                              key={`${segmentKey}_${index}_primary_data`}
-                              className={`h-[8px] w-full bg-gradient-to-r ${roundBottomPrimary ? "rounded-bl-full rounded-br-full" : ""} ${roundTopPrimary ? "rounded-tl-full rounded-tr-full" : ""} ${severityColors[severityValue]}`}
-                            ></div>
-                          </div>
-                        </div>
+      {severity.map((severityValue: number, index: number) => (
+        <React.Fragment key={index}>
+          {severityValue === displaySeverityType && (
+            <HoverCard openDelay={200} closeDelay={100}>
+              <HoverCardTrigger asChild>
+                <div className="absolute left-1/2 z-10 h-[8px] w-[20px] -translate-x-1/2 transform cursor-pointer md:w-[40px]">
+                  <div className="flex w-[20px] flex-row justify-center md:w-[40px]">
+                    <div className="flex justify-center">
+                      <div
+                        className="absolute left-1/2 z-10 ml-[2px] h-[8px] w-[8px] -translate-x-1/2 transform cursor-pointer"
+                        data-severity={severityValue}
+                      >
+                        <div
+                          key={`${segmentKey}_${index}_primary_data`}
+                          className={`h-[8px] w-full bg-gradient-to-r ${roundBottomPrimary ? "rounded-bl-full rounded-br-full" : ""} ${roundTopPrimary ? "rounded-tl-full rounded-tr-full" : ""} ${severityColors[severityValue]}`}
+                        ></div>
                       </div>
                     </div>
-                  </HoverCardTrigger>
-                  <HoverCardPortal>
-                    <HoverCardContent
-                      className="w-[250px] rounded-lg p-2 md:rounded-2xl"
-                      side="left"
-                    >
-                      <img
-                        className="rounded-lg"
-                        src={`${apiHost}${eventThumbnail.replace("/media/frigate/", "")}`}
-                      />
-                    </HoverCardContent>
-                  </HoverCardPortal>
-                </HoverCard>
-              )}
-            </React.Fragment>
-          ))}
-        </>
-      )}
+                  </div>
+                </div>
+              </HoverCardTrigger>
+              <HoverCardPortal>
+                <HoverCardContent
+                  className="w-[250px] rounded-lg p-2 md:rounded-2xl"
+                  side="left"
+                >
+                  <img
+                    className="rounded-lg"
+                    src={`${apiHost}${eventThumbnail.replace("/media/frigate/", "")}`}
+                  />
+                </HoverCardContent>
+              </HoverCardPortal>
+            </HoverCard>
+          )}
+        </React.Fragment>
+      ))}
     </div>
   );
 }

--- a/web/src/components/timeline/MotionReviewTimeline.tsx
+++ b/web/src/components/timeline/MotionReviewTimeline.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useCallback, useMemo, useRef, RefObject } from "react";
+import { useCallback, useMemo, useRef, RefObject } from "react";
 import MotionSegment from "./MotionSegment";
 import { useTimelineUtils } from "@/hooks/use-timeline-utils";
 import { MotionData, ReviewSegment, ReviewSeverity } from "@/types/review";
 import ReviewTimeline from "./ReviewTimeline";
-import { isDesktop } from "react-device-detect";
 import { useMotionSegmentUtils } from "@/hooks/use-motion-segment-utils";
 
 export type MotionReviewTimelineProps = {
@@ -164,42 +163,6 @@ export function MotionReviewTimeline({
       motionOnly,
     ],
   );
-
-  const segmentsObserver = useRef<IntersectionObserver | null>(null);
-  useEffect(() => {
-    if (selectedTimelineRef.current && segments && isDesktop) {
-      segmentsObserver.current = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              const segmentId = entry.target.getAttribute("data-segment-id");
-
-              const segmentElements =
-                internalTimelineRef.current?.querySelectorAll(
-                  `[data-segment-id="${segmentId}"] .motion-segment`,
-                );
-              segmentElements?.forEach((segmentElement) => {
-                segmentElement.classList.remove("hidden");
-                segmentElement.classList.add("animate-in");
-              });
-            }
-          });
-        },
-        { threshold: 0 },
-      );
-
-      // Get all segment divs and observe each one
-      const segmentDivs =
-        selectedTimelineRef.current.querySelectorAll(".segment.has-data");
-      segmentDivs.forEach((segmentDiv) => {
-        segmentsObserver.current?.observe(segmentDiv);
-      });
-    }
-
-    return () => {
-      segmentsObserver.current?.disconnect();
-    };
-  }, [selectedTimelineRef, segments]);
 
   return (
     <ReviewTimeline


### PR DESCRIPTION
- Use an intersection observer to only render segments after they have come into view.
- Remove desktop animation classes on motion segments.