### PR TITLE
Prevent ptz keyboard shortcuts from reopening presets menu

### DIFF
--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -626,7 +626,10 @@ function PtzControlPanel({
               <BsThreeDotsVertical />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="scrollbar-container max-h-[40dvh] overflow-y-auto">
+          <DropdownMenuContent
+            className="scrollbar-container max-h-[40dvh] overflow-y-auto"
+            onCloseAutoFocus={(e) => e.preventDefault()}
+          >
             {ptz?.presets.map((preset) => {
               return (
                 <DropdownMenuItem


### PR DESCRIPTION
On single live camera view, when selecting a ptz preset and then immediately using the keyboard shortcuts for ptz movement, the dropdown menu would reopen and the arrow keys would start selecting other preset names.