### PR TITLE
Make chroma listen on 127.0.0.1

### DIFF
--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/chroma/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/chroma/run
@@ -13,4 +13,4 @@ echo "[INFO] Starting ChromaDB..."
 
 # Replace the bash process with the Frigate process, redirecting stderr to stdout
 exec 2>&1
-exec /usr/local/chroma run --path /config/chroma --host 0.0.0.0
+exec /usr/local/chroma run --path /config/chroma --host 127.0.0.1


### PR DESCRIPTION
Currently chroma db binds to all IPs via `0.0.0.0` but it doesn't need to. Switched to `127.0.0.1` and it's working.

cc @hunterjm 