### PR TITLE
config reference: add note about birdseye>layout>scaling_factor

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -149,7 +149,7 @@ birdseye:
   inactivity_threshold: 30
   # Optional: Configure the birdseye layout
   layout:
-    # Optional: Scaling factor for the layout calculator (default: shown below)
+    # Optional: Scaling factor for the layout calculator, range 1.0-5.0 (default: shown below)
     scaling_factor: 2.0
     # Optional: Maximum number of cameras to show at one time, showing the most recent (default: show all cameras)
     max_cameras: 1


### PR DESCRIPTION
Was trying different values to get a 5 camera layout to work and realized the max was 5. 