### PR TITLE
Environment variable substitution in YAML

### DIFF
--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -8,11 +8,16 @@ from pathlib import Path
 import yaml
 
 sys.path.insert(0, "/opt/frigate")
-from frigate.const import BIRDSEYE_PIPE  # noqa: E402
+from frigate.const import (  # noqa: E402
+    BIRDSEYE_PIPE,
+    YAML_EXT,
+)
 from frigate.ffmpeg_presets import (  # noqa: E402
     parse_preset_hardware_acceleration_encode,
 )
-
+from frigate.util.builtin import (
+    load_config_with_no_duplicates,
+)
 sys.path.remove("/opt/frigate")
 
 
@@ -36,8 +41,8 @@ try:
     with open(config_file) as f:
         raw_config = f.read()
 
-    if config_file.endswith((".yaml", ".yml")):
-        config: dict[str, any] = yaml.safe_load(raw_config)
+    if config_file.endswith(YAML_EXT):
+        config: dict[str, any] = load_config_with_no_duplicates(raw_config)
     elif config_file.endswith(".json"):
         config: dict[str, any] = json.loads(raw_config)
 except FileNotFoundError:


### PR DESCRIPTION
For environment variable substitution, Frigate uses variables that start with **FRIGATE_** and are enclosed in braces ({}).  

This choice likely stems from Frigate's use of Python's str.format function, where replacement fields must be surrounded by braces.
However, in YAML, braces are used for mapping, which necessitates enclosing variables in quotation marks. Additionally, using str.format requires writing specific code wherever environment variables are needed.  

By using **${FRIGATE_ }** for environment variables instead, we can exploit PyYAML's implicit resolver to handle all variable substitutions when loading the YAML file.
