### PR TITLE
Live player fixes

### DIFF
--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -128,12 +128,12 @@ function MSEPlayer({
       setSafariPlaying(false);
     }
 
-    if (wsRef.current && wsState != WebSocket.CLOSED) {
+    if (wsRef.current) {
       setWsState(WebSocket.CLOSED);
       wsRef.current.close();
       wsRef.current = null;
     }
-  }, [wsState, bufferTimeout, safariPlaying]);
+  }, [bufferTimeout, safariPlaying]);
 
   const onOpen = () => {
     setWsState(WebSocket.OPEN);
@@ -359,7 +359,7 @@ function MSEPlayer({
   // ensure we disconnect for slower connections
 
   useEffect(() => {
-    if (wsState === WebSocket.OPEN && !playbackEnabled) {
+    if (wsRef.current?.readyState === WebSocket.OPEN && !playbackEnabled) {
       if (bufferTimeout) {
         clearTimeout(bufferTimeout);
         setBufferTimeout(undefined);

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -23,7 +23,7 @@ import DraggableGridLayout from "./DraggableGridLayout";
 import { IoClose } from "react-icons/io5";
 import { LuLayoutDashboard } from "react-icons/lu";
 import { cn } from "@/lib/utils";
-import { LivePlayerMode } from "@/types/live";
+import { LivePlayerError, LivePlayerMode } from "@/types/live";
 
 type LiveDashboardViewProps = {
   cameras: CameraConfig[];
@@ -184,6 +184,21 @@ export default function LiveDashboardView({
 
   const birdseyeConfig = useMemo(() => config?.birdseye, [config]);
 
+  const handleError = useCallback(
+    (cameraName: string, error: LivePlayerError) => {
+      setPreferredLiveModes((prevModes) => {
+        const newModes = { ...prevModes };
+        if (error === "mse-decode") {
+          newModes[cameraName] = "webrtc";
+        } else {
+          newModes[cameraName] = "jsmpeg";
+        }
+        return newModes;
+      });
+    },
+    [setPreferredLiveModes],
+  );
+
   return (
     <div
       className="scrollbar-container size-full overflow-y-auto px-1 pt-2 md:p-2"
@@ -315,17 +330,7 @@ export default function LiveDashboardView({
                 preferredLiveMode={preferredLiveModes[camera.name] ?? "mse"}
                 autoLive={autoLiveView}
                 onClick={() => onSelectCamera(camera.name)}
-                onError={(e) => {
-                  setPreferredLiveModes((prevModes) => {
-                    const newModes = { ...prevModes };
-                    if (e === "mse-decode") {
-                      newModes[camera.name] = "webrtc";
-                    } else {
-                      newModes[camera.name] = "jsmpeg";
-                    }
-                    return newModes;
-                  });
-                }}
+                onError={(e) => handleError(camera.name, e)}
               />
             );
           })}


### PR DESCRIPTION
- Check websocket readyState for disconnect
- Memoize onError functions to cut down on the number of renders
- Move ptz controls out of transformer component so that they don't zoom with the player itself
- Disable frigate's picture in picture button for Firefox. Firefox doesn't widely support the picture in picture API: 
https://developer.mozilla.org/en-US/docs/Web/API/Picture-in-Picture_API 
https://caniuse.com/picture-in-picture