### PR TITLE
Use camera name instead of stream_name for jsmpeg players

### DIFF
--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -171,7 +171,7 @@ export default function LivePlayer({
       player = (
         <JSMpegPlayer
           className="flex justify-center overflow-hidden rounded-lg md:rounded-2xl"
-          camera={cameraConfig.live.stream_name}
+          camera={cameraConfig.name}
           width={cameraConfig.detect.width}
           height={cameraConfig.detect.height}
           playbackEnabled={cameraActive || !showStillWithoutActivity}

--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -384,6 +384,7 @@ function MSEPlayer({
         onPlaying?.();
       }}
       muted={!audioEnabled}
+      onPause={() => videoRef.current?.play()}
       onProgress={() => {
         if ((isSafari || isIOS) && !safariPlaying) {
           setSafariPlaying(true);


### PR DESCRIPTION
For users who define a `stream_name` for a particular camera that doesn't match an actual camera name, falling back to the jsmpeg player in a low bandwidth or error situation would cause the player to go blank because there is no jsmpeg stream being produced by frigate at that url.