### PR TITLE
Re-center ptz controls in mobile landscape and prevent text selection

### DIFF
--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -525,7 +525,7 @@ function PtzControlPanel({
   );
 
   return (
-    <div className="absolute inset-x-2 bottom-[10%] flex flex-wrap items-center justify-center gap-1 md:left-[50%] md:-translate-x-[50%] md:flex-nowrap">
+    <div className="absolute inset-x-2 bottom-[10%] flex select-none flex-wrap items-center justify-center gap-1 md:left-[50%] md:-translate-x-[50%] md:flex-nowrap sm:landscape:ml-12">
       {ptz?.features?.includes("pt") && (
         <>
           <Button


### PR DESCRIPTION
Moving the ptz controls out of the transform wrapper meant that a text selection bubble was popping up when pressing and holding a button. Also, it shifted the div so that it was no longer centered over the camera image. The left margin is the same width as the mobile landscape sidebar, so it's back to being centered.