### PR TITLE
OpenVino - Error clarification for compile_model function

### DIFF
--- a/frigate/detectors/plugins/openvino.py
+++ b/frigate/detectors/plugins/openvino.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import numpy as np
 import openvino as ov
@@ -34,6 +35,12 @@ class OvDetector(DetectionApi):
                 "OpenVINO AUTO device type is not currently supported. Attempting to use GPU instead."
             )
             detector_config.device = "GPU"
+
+        if(not os.path.isfile(detector_config.model.path)):
+            logger.error(
+                f"OpenVino model file {detector_config.model.path} not found."
+            )
+            raise FileNotFoundError
 
         self.interpreter = self.ov_core.compile_model(
             model=detector_config.model.path, device_name=detector_config.device

--- a/frigate/detectors/plugins/openvino.py
+++ b/frigate/detectors/plugins/openvino.py
@@ -36,10 +36,8 @@ class OvDetector(DetectionApi):
             )
             detector_config.device = "GPU"
 
-        if(not os.path.isfile(detector_config.model.path)):
-            logger.error(
-                f"OpenVino model file {detector_config.model.path} not found."
-            )
+        if not os.path.isfile(detector_config.model.path):
+            logger.error(f"OpenVino model file {detector_config.model.path} not found.")
             raise FileNotFoundError
 
         self.interpreter = self.ov_core.compile_model(


### PR DESCRIPTION
If openvino's compile_model function returns an error, you may think that the model has been loaded correctly and that the model contains an error, whereas this could be due to the file not being found:
`Unable to read the model: /invalid_path.xml Please check that model format: xml is supported and the model is correct. Available frontends: tf onnx ir tflite paddle pytorch`

In this commit, we check the existence of the model file before calling model_compile and throw an error if the file doesn't exist.