### PR TITLE
Bug fix for ONVIF cameras, adjust_time parameter added

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -613,7 +613,7 @@ cameras:
       user: admin
       # Optional: password for login.
       password: admin
-      # Optional: Ignores time synchronization mismatchs between the camera and the server during authentication. 
+      # Optional: Ignores time synchronization mismatches between the camera and the server during authentication. 
       # Using NTP on both ends is recommended and this should only be set to True in a "safe" environment due to the security risk it represents. 
       ignore_time_mismatch: False
       # Optional: PTZ camera object autotracking. Keeps a moving object in

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -613,6 +613,9 @@ cameras:
       user: admin
       # Optional: password for login.
       password: admin
+      # Optional: Ignores time synchronization mismatchs between the camera and the server during authentication. 
+      # Using NTP on both ends is recommended and this should only be set to True in a "safe" environment due to the security risk it represents. 
+      ignore_time_mismatch: False
       # Optional: PTZ camera object autotracking. Keeps a moving object in
       # the center of the frame by automatically moving the PTZ camera.
       autotracking:

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -281,7 +281,7 @@ class OnvifConfig(FrigateBaseModel):
     )
     ignore_time_mismatch: bool = Field(
         default=False, 
-        title="Onvif Ignore Time Synchronization Mismatch Between Camera and Server"
+        title="Onvif Ignore Time Synchronization Mismatch Between Camera and Server",
     )
 
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -279,6 +279,7 @@ class OnvifConfig(FrigateBaseModel):
         default_factory=PtzAutotrackConfig,
         title="PTZ auto tracking config.",
     )
+    adjust_time: Optional[bool] = Field(default=False, title="Onvif Adjust Time WSSE Authentication")
 
 
 class RetainModeEnum(str, Enum):

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -279,7 +279,10 @@ class OnvifConfig(FrigateBaseModel):
         default_factory=PtzAutotrackConfig,
         title="PTZ auto tracking config.",
     )
-    ignore_time_mismatch: bool = Field(default=False, title="Onvif Ignore Time Synchronization Mismatch Between Camera and Server")
+    ignore_time_mismatch: bool = Field(
+        default=False, 
+        title="Onvif Ignore Time Synchronization Mismatch Between Camera and Server"
+    )
 
 
 class RetainModeEnum(str, Enum):

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -280,7 +280,7 @@ class OnvifConfig(FrigateBaseModel):
         title="PTZ auto tracking config.",
     )
     ignore_time_mismatch: bool = Field(
-        default=False, 
+        default=False,
         title="Onvif Ignore Time Synchronization Mismatch Between Camera and Server",
     )
 

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -279,7 +279,7 @@ class OnvifConfig(FrigateBaseModel):
         default_factory=PtzAutotrackConfig,
         title="PTZ auto tracking config.",
     )
-    adjust_time: Optional[bool] = Field(default=False, title="Onvif Adjust Time WSSE Authentication")
+    ignore_time_mismatch: bool = Field(default=False, title="Onvif Ignore Time Synchronization Mismatch Between Camera and Server")
 
 
 class RetainModeEnum(str, Enum):

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -54,6 +54,7 @@ class OnvifController:
                             wsdl_dir=str(
                                 Path(find_spec("onvif").origin).parent / "wsdl"
                             ).replace("dist-packages/onvif", "site-packages"),
+                            adjust_time=cam.onvif.adjust_time,
                         ),
                         "init": False,
                         "active": False,

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -54,7 +54,7 @@ class OnvifController:
                             wsdl_dir=str(
                                 Path(find_spec("onvif").origin).parent / "wsdl"
                             ).replace("dist-packages/onvif", "site-packages"),
-                            adjust_time=cam.onvif.adjust_time,
+                            adjust_time=cam.onvif.ignore_time_mismatch,
                         ),
                         "init": False,
                         "active": False,


### PR DESCRIPTION
Adds the adjust_time parameter which allows users to fix an issue with onvif authentication where time is not synchronized between computer and camera.
This was very useful for dealing with Amcrest PTZ cameras.
I tested this feature by building the current v0.13.2 stable release docker image and now my camera's PTZ is working great :)