### PR TITLE
strip whitespaces when loading secrets

### DIFF
--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -21,9 +21,9 @@ FRIGATE_ENV_VARS = {k: v for k, v in os.environ.items() if k.startswith("FRIGATE
 if os.path.isdir("/run/secrets"):
     for secret_file in os.listdir("/run/secrets"):
         if secret_file.startswith("FRIGATE_"):
-            FRIGATE_ENV_VARS[secret_file] = Path(
-                os.path.join("/run/secrets", secret_file)
-            ).read_text().strip()
+            FRIGATE_ENV_VARS[secret_file] = (
+                Path(os.path.join("/run/secrets", secret_file)).read_text().strip()
+            )
 
 config_file = os.environ.get("CONFIG_FILE", "/config/config.yml")
 

--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -23,7 +23,7 @@ if os.path.isdir("/run/secrets"):
         if secret_file.startswith("FRIGATE_"):
             FRIGATE_ENV_VARS[secret_file] = Path(
                 os.path.join("/run/secrets", secret_file)
-            ).read_text()
+            ).read_text().strip()
 
 config_file = os.environ.get("CONFIG_FILE", "/config/config.yml")
 

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -89,7 +89,7 @@ def get_jwt_secret() -> str:
     # check docker secrets
     elif os.path.isfile(os.path.join("/run/secrets", JWT_SECRET_ENV_VAR)):
         logger.debug(f"Using jwt secret from {JWT_SECRET_ENV_VAR} docker secret file.")
-        jwt_secret = Path(os.path.join("/run/secrets", JWT_SECRET_ENV_VAR)).read_text()
+        jwt_secret = Path(os.path.join("/run/secrets", JWT_SECRET_ENV_VAR)).read_text().strip()
     # check for the addon options file
     elif os.path.isfile("/data/options.json"):
         with open("/data/options.json") as f:

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -89,7 +89,9 @@ def get_jwt_secret() -> str:
     # check docker secrets
     elif os.path.isfile(os.path.join("/run/secrets", JWT_SECRET_ENV_VAR)):
         logger.debug(f"Using jwt secret from {JWT_SECRET_ENV_VAR} docker secret file.")
-        jwt_secret = Path(os.path.join("/run/secrets", JWT_SECRET_ENV_VAR)).read_text().strip()
+        jwt_secret = (
+            Path(os.path.join("/run/secrets", JWT_SECRET_ENV_VAR)).read_text().strip()
+        )
     # check for the addon options file
     elif os.path.isfile("/data/options.json"):
         with open("/data/options.json") as f:

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -62,9 +62,9 @@ FRIGATE_ENV_VARS = {k: v for k, v in os.environ.items() if k.startswith("FRIGATE
 if os.path.isdir("/run/secrets") and os.access("/run/secrets", os.R_OK):
     for secret_file in os.listdir("/run/secrets"):
         if secret_file.startswith("FRIGATE_"):
-            FRIGATE_ENV_VARS[secret_file] = Path(
-                os.path.join("/run/secrets", secret_file)
-            ).read_text().strip()
+            FRIGATE_ENV_VARS[secret_file] = (
+                Path(os.path.join("/run/secrets", secret_file)).read_text().strip()
+            )
 
 DEFAULT_TRACKED_OBJECTS = ["person"]
 DEFAULT_ALERT_OBJECTS = ["person", "car"]

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -64,7 +64,7 @@ if os.path.isdir("/run/secrets") and os.access("/run/secrets", os.R_OK):
         if secret_file.startswith("FRIGATE_"):
             FRIGATE_ENV_VARS[secret_file] = Path(
                 os.path.join("/run/secrets", secret_file)
-            ).read_text()
+            ).read_text().strip()
 
 DEFAULT_TRACKED_OBJECTS = ["person"]
 DEFAULT_ALERT_OBJECTS = ["person", "car"]

--- a/frigate/plus.py
+++ b/frigate/plus.py
@@ -42,7 +42,7 @@ class PlusApi:
             and os.access("/run/secrets", os.R_OK)
             and PLUS_ENV_VAR in os.listdir("/run/secrets")
         ):
-            self.key = Path(os.path.join("/run/secrets", PLUS_ENV_VAR)).read_text()
+            self.key = Path(os.path.join("/run/secrets", PLUS_ENV_VAR)).read_text().strip()
         # check for the addon options file
         elif os.path.isfile("/data/options.json"):
             with open("/data/options.json") as f:

--- a/frigate/plus.py
+++ b/frigate/plus.py
@@ -42,7 +42,9 @@ class PlusApi:
             and os.access("/run/secrets", os.R_OK)
             and PLUS_ENV_VAR in os.listdir("/run/secrets")
         ):
-            self.key = Path(os.path.join("/run/secrets", PLUS_ENV_VAR)).read_text().strip()
+            self.key = (
+                Path(os.path.join("/run/secrets", PLUS_ENV_VAR)).read_text().strip()
+            )
         # check for the addon options file
         elif os.path.isfile("/data/options.json"):
             with open("/data/options.json") as f:


### PR DESCRIPTION
Thanks for an awesome project.

I encountered an issue when using secrets files. When a secret file is created with a text editor (vim, nano, etc) it usually adds a newline character to the end of the file.

This causes the following issue in frigate when using secrets for an rtsp password:
```
WRN [rtsp] error="streams: parse \"rtsp://username:some_secret_password\\n@10.0.4.100/Streaming/channels/102\": net/url: invalid control character in URL" stream=my_camera
```
After the proposed changes, it successfully removed the newline character and loaded the secret succesfully.

Proposed changes will strip all whitespaces (`'\n'`, `'\t'`, `' '`) from the left and right of the secret.