### PR TITLE
Initial support for Hailo-8L

### DIFF
--- a/docker/hailo8l/pyhailort_build_scripts/generate_wheel_conf.py
+++ b/docker/hailo8l/pyhailort_build_scripts/generate_wheel_conf.py
@@ -1,23 +1,30 @@
-import os
 import json
-import sys
+import os
 import platform
+import sys
 import sysconfig
+
 
 def extract_toolchain_info(compiler):
     # Remove the "-gcc" or "-g++" suffix if present
-    if compiler.endswith('-gcc') or compiler.endswith('-g++'):
-        compiler = compiler.rsplit('-', 1)[0]
+    if compiler.endswith("-gcc") or compiler.endswith("-g++"):
+        compiler = compiler.rsplit("-", 1)[0]
 
     # Extract the toolchain and ABI part (e.g., "gnu")
-    toolchain_parts = compiler.split('-')
-    abi_conventions = next((part for part in toolchain_parts if part in ['gnu', 'musl', 'eabi', 'uclibc']), '')
+    toolchain_parts = compiler.split("-")
+    abi_conventions = next(
+        (part for part in toolchain_parts if part in ["gnu", "musl", "eabi", "uclibc"]),
+        "",
+    )
 
     return abi_conventions
 
+
 def generate_wheel_conf():
-    conf_file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "wheel_conf.json")
-    
+    conf_file_path = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "wheel_conf.json"
+    )
+
     # Extract current system and Python version information
     py_version = f"cp{sys.version_info.major}{sys.version_info.minor}"
     arch = platform.machine()
@@ -25,7 +32,7 @@ def generate_wheel_conf():
     libc_version = platform.libc_ver()[1]
 
     # Get the compiler information
-    compiler = sysconfig.get_config_var('CC')
+    compiler = sysconfig.get_config_var("CC")
     abi_conventions = extract_toolchain_info(compiler)
 
     # Create the new configuration data
@@ -37,8 +44,8 @@ def generate_wheel_conf():
         "abi": abi_conventions,
         "extension": {
             "posix": "so",
-            "nt": "pyd"  # Windows
-        }[os.name]
+            "nt": "pyd",  # Windows
+        }[os.name],
     }
 
     # If the file exists, load the existing data
@@ -54,6 +61,7 @@ def generate_wheel_conf():
     # Write the updated data to the file
     with open(conf_file_path, "w") as conf_file:
         json.dump(conf_data, conf_file, indent=4)
+
 
 if __name__ == "__main__":
     generate_wheel_conf()

--- a/docker/hailo8l/pyhailort_build_scripts/setup.py
+++ b/docker/hailo8l/pyhailort_build_scripts/setup.py
@@ -1,37 +1,24 @@
-import os
 import json
-from setuptools import setup, find_packages
-from setuptools.command.install import install as _install
+import os
+
+from setuptools import find_packages, setup
 from wheel.bdist_wheel import bdist_wheel as orig_bdist_wheel
+
 
 class NonPurePythonBDistWheel(orig_bdist_wheel):
     """Makes the wheel platform-dependent so it can be based on the _pyhailort architecture"""
+
     def finalize_options(self):
         orig_bdist_wheel.finalize_options(self)
         self.root_is_pure = False
 
 
-def _get_arch():
-    conf_file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "wheel_conf.json")
-    with open(conf_file_path, "r") as conf_file:
-        content = json.load(conf_file)
-    return content['arch']
-
-def _get_system():
-    conf_file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "wheel_conf.json")
-    with open(conf_file_path, "r") as conf_file:
-        content = json.load(conf_file)
-    return content['system']
-
-def _get_abi():
-    conf_file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "wheel_conf.json")
-    with open(conf_file_path, "r") as conf_file:
-        content = json.load(conf_file)
-    return content['abi']
-
 def _get_hailort_lib_path():
-    lib_filename = f"libhailort.so"
-    lib_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), f"hailo_platform/pyhailort/{lib_filename}")
+    lib_filename = "libhailort.so"
+    lib_path = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)),
+        f"hailo_platform/pyhailort/{lib_filename}",
+    )
     if os.path.exists(lib_path):
         print(f"Found libhailort shared library at: {lib_path}")
     else:
@@ -39,35 +26,44 @@ def _get_hailort_lib_path():
         raise FileNotFoundError(f"libhailort shared library not found at: {lib_path}")
     return lib_path
 
+
 def _get_pyhailort_lib_path():
-    conf_file_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "wheel_conf.json")
+    conf_file_path = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "wheel_conf.json"
+    )
     if not os.path.isfile(conf_file_path):
         raise FileNotFoundError(f"Configuration file not found: {conf_file_path}")
 
     with open(conf_file_path, "r") as conf_file:
         content = json.load(conf_file)
-        py_version = content['py_version']
-        arch = content['arch']
-        system = content['system']
-        extension = content['extension']
-        abi = content['abi']
-        
+        py_version = content["py_version"]
+        arch = content["arch"]
+        system = content["system"]
+        extension = content["extension"]
+        abi = content["abi"]
+
         # Construct the filename directly
         lib_filename = f"_pyhailort.cpython-{py_version.split('cp')[1]}-{arch}-{system}-{abi}.{extension}"
-        lib_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), f"hailo_platform/pyhailort/{lib_filename}")
+        lib_path = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            f"hailo_platform/pyhailort/{lib_filename}",
+        )
 
         if os.path.exists(lib_path):
             print(f"Found _pyhailort shared library at: {lib_path}")
         else:
             print(f"Error: _pyhailort shared library not found at: {lib_path}")
-            raise FileNotFoundError(f"_pyhailort shared library not found at: {lib_path}")
+            raise FileNotFoundError(
+                f"_pyhailort shared library not found at: {lib_path}"
+            )
 
         return lib_path
+
 
 def _get_package_paths():
     packages = []
     pyhailort_lib = _get_pyhailort_lib_path()
-    hailort_lib =  _get_hailort_lib_path()
+    hailort_lib = _get_hailort_lib_path()
     if pyhailort_lib:
         packages.append(pyhailort_lib)
     if hailort_lib:
@@ -75,6 +71,7 @@ def _get_package_paths():
     packages.append(os.path.abspath("hailo_tutorials/notebooks/*"))
     packages.append(os.path.abspath("hailo_tutorials/hefs/*"))
     return packages
+
 
 if __name__ == "__main__":
     setup(


### PR DESCRIPTION
Added file for Hailo-8L detector including dockerfile, h8l.mk, h8l.hcl, hailo8l.py, ci.yml and ssd_mobilenat_v1.hef as the inference network.

Added files to help with the installation of Hailo-8L dependences like generate_wheel_conf.py, requirements-wheel-h8l.txt and modified setup.py to try and work with any hardware.

Updated docs to reflect Initial Hailo-8L support including oject_detectors.md,  hardware.md and installation.md.