### PR TITLE
No need to check for h264 onvif profile

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -94,7 +94,6 @@ class OnvifController:
         for key, onvif_profile in enumerate(profiles):
             if (
                 onvif_profile.VideoEncoderConfiguration
-                and onvif_profile.VideoEncoderConfiguration.Encoding == "H264"
                 and onvif_profile.PTZConfiguration
                 and (
                     onvif_profile.PTZConfiguration.DefaultContinuousPanTiltVelocitySpace
@@ -103,6 +102,7 @@ class OnvifController:
                     is not None
                 )
             ):
+                # use the first profile that has a valid ptz configuration
                 profile = onvif_profile
                 logger.debug(f"Selected Onvif profile for {camera_name}: {profile}")
                 break


### PR DESCRIPTION
Since we're only using onvif for ptz controls and autotracking, we don't need to check the profile for H264 encoding.