### PR TITLE
Add example of single pcie coral

### DIFF
--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -87,7 +87,7 @@ detectors:
 detectors:
   coral:
     type: edgetpu
-    device: pci:0
+    device: pci
 ```
 
 ### Multiple PCIE/M.2 Corals

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -81,6 +81,15 @@ detectors:
     device: ""
 ```
 
+### Single PCIE/M.2 Coral
+
+```yaml
+detectors:
+  coral:
+    type: edgetpu
+    device: pci:0
+```
+
 ### Multiple PCIE/M.2 Corals
 
 ```yaml


### PR DESCRIPTION
Provide symmetry with single/multiple PCIe board configs cf. USB.  It seems simple, but this would have helped me get my PCIe M.2 working.