### PR TITLE
Filter alerts by camera group

### DIFF
--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -66,7 +66,11 @@ export default function LiveDashboardView({
   const eventUpdate = useFrigateReviews();
   const { data: allEvents, mutate: updateEvents } = useSWR<ReviewSegment[]>([
     "review",
-    { limit: 10, severity: "alert" },
+    {
+      limit: 10,
+      severity: "alert",
+      cameras: cameraGroup && cameras.filter((cam) => cam.name).join(","),
+    },
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
When a camera group is selected, only show the alerts that are relevant to those cameras