### PR TITLE
Fix flashing of previous still image when live player stops

### DIFF
--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -79,7 +79,7 @@ export default function LivePlayer({
     }
 
     if (!cameraActive) {
-      setLiveReady(false);
+      setTimeout(() => setLiveReady(false), 500);
     }
     // live mode won't change
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -90,6 +90,10 @@ export default function LivePlayer({
   const stillReloadInterval = useMemo(() => {
     if (!windowVisible || offline || !showStillWithoutActivity) {
       return -1; // no reason to update the image when the window is not visible
+    }
+
+    if (liveReady && !cameraActive) {
+      return 300;
     }
 
     if (liveReady) {
@@ -113,6 +117,7 @@ export default function LivePlayer({
     activeTracking,
     offline,
     windowVisible,
+    cameraActive,
   ]);
 
   useEffect(() => {
@@ -135,7 +140,7 @@ export default function LivePlayer({
       <WebRtcPlayer
         className={`size-full rounded-lg md:rounded-2xl ${liveReady ? "" : "hidden"}`}
         camera={cameraConfig.live.stream_name}
-        playbackEnabled={cameraActive}
+        playbackEnabled={cameraActive || liveReady}
         audioEnabled={playAudio}
         microphoneEnabled={micEnabled}
         iOSCompatFullScreen={iOSCompatFullScreen}
@@ -150,7 +155,7 @@ export default function LivePlayer({
         <MSEPlayer
           className={`size-full rounded-lg md:rounded-2xl ${liveReady ? "" : "hidden"}`}
           camera={cameraConfig.live.stream_name}
-          playbackEnabled={cameraActive}
+          playbackEnabled={cameraActive || liveReady}
           audioEnabled={playAudio}
           onPlaying={playerIsPlaying}
           pip={pip}
@@ -166,14 +171,16 @@ export default function LivePlayer({
       );
     }
   } else if (liveMode == "jsmpeg") {
-    if (cameraActive || !showStillWithoutActivity) {
+    if (cameraActive || !showStillWithoutActivity || liveReady) {
       player = (
         <JSMpegPlayer
           className="flex justify-center overflow-hidden rounded-lg md:rounded-2xl"
           camera={cameraConfig.name}
           width={cameraConfig.detect.width}
           height={cameraConfig.detect.height}
-          playbackEnabled={cameraActive || !showStillWithoutActivity}
+          playbackEnabled={
+            cameraActive || !showStillWithoutActivity || liveReady
+          }
           containerRef={containerRef ?? internalContainerRef}
           onPlaying={playerIsPlaying}
         />


### PR DESCRIPTION
When an object crosses a frame faster than ~60s and the live player switches on and then off, the previous still image is flashed up before a new still is loaded.

This PR ensures a new image is loaded before the player disappears.