### PR TITLE
Use refs in liveReady timeout

### DIFF
--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -73,6 +73,15 @@ export default function LivePlayer({
   const liveMode = useCameraLiveMode(cameraConfig, preferredLiveMode);
 
   const [liveReady, setLiveReady] = useState(false);
+
+  const liveReadyRef = useRef(liveReady);
+  const cameraActiveRef = useRef(cameraActive);
+
+  useEffect(() => {
+    liveReadyRef.current = liveReady;
+    cameraActiveRef.current = cameraActive;
+  }, [liveReady, cameraActive]);
+
   useEffect(() => {
     if (!autoLive || !liveReady) {
       return;
@@ -80,7 +89,7 @@ export default function LivePlayer({
 
     if (!cameraActive) {
       const timer = setTimeout(() => {
-        if (!cameraActive) {
+        if (liveReadyRef.current && !cameraActiveRef.current) {
           setLiveReady(false);
         }
       }, 500);

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -79,7 +79,7 @@ export default function LiveDashboardView({
 
     return cameras
       .map((cam) => cam.name)
-      .filter((cam) => config.camera_groups[cameraGroup].cameras.includes(cam))
+      .filter((cam) => config.camera_groups[cameraGroup]?.cameras.includes(cam))
       .join(",");
   }, [cameras, cameraGroup, config, includeBirdseye]);
 


### PR DESCRIPTION
- Be mindful of js closures - need refs to see the most updated value
- Null check on camera group