### PR TITLE
Use canvas2d renderer for jsmpeg player

### DIFF
--- a/web/src/components/player/JSMpegPlayer.tsx
+++ b/web/src/components/player/JSMpegPlayer.tsx
@@ -123,6 +123,7 @@ export default function JSMpegPlayer({
           {
             protocols: [],
             audio: false,
+            disableGl: true,
             videoBufferSize: 1024 * 1024 * 4,
             onVideoDecode: () => {
               if (!hasDataRef.current) {


### PR DESCRIPTION
Browsers have a limited number of WebGL contexts available. For users with a larger number of cameras, using WebGL may result in errors and broken streams. The Canvas2D renderer is more lightweight and should serve our needs just fine, without context limitations.