### PR TITLE
Disable web assembly for jsmpeg player

### DIFF
--- a/web/src/components/player/JSMpegPlayer.tsx
+++ b/web/src/components/player/JSMpegPlayer.tsx
@@ -124,6 +124,7 @@ export default function JSMpegPlayer({
             protocols: [],
             audio: false,
             disableGl: true,
+            disableWebAssembly: true,
             videoBufferSize: 1024 * 1024 * 4,
             onVideoDecode: () => {
               if (!hasDataRef.current) {


### PR DESCRIPTION
With canvas2d rendering, Chrome never continues playback without web assembly disabled. There seems to be a negligible performance difference.