### PR TITLE
Ensure persisted value is kept in sync with selected value

### DIFF
--- a/web/src/hooks/use-overlay-state.tsx
+++ b/web/src/hooks/use-overlay-state.tsx
@@ -38,11 +38,21 @@ export function usePersistedOverlayState<S extends string>(
   (value: S | undefined, replace?: boolean) => void,
   () => void,
 ] {
-  const [persistedValue, setPersistedValue, , deletePersistedValue] =
-    usePersistence<S>(key, defaultValue);
   const location = useLocation();
   const navigate = useNavigate();
   const currentLocationState = useMemo(() => location.state, [location]);
+
+  // currently selected value
+
+  const overlayStateValue = useMemo<S | undefined>(
+    () => location.state && location.state[key],
+    [location, key],
+  );
+
+  // saved value from previous session
+
+  const [persistedValue, setPersistedValue, , deletePersistedValue] =
+    usePersistence<S>(key, overlayStateValue);
 
   const setOverlayStateValue = useCallback(
     (value: S | undefined, replace: boolean = false) => {
@@ -54,11 +64,6 @@ export function usePersistedOverlayState<S extends string>(
     // we know that these deps are correct
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [key, currentLocationState, navigate],
-  );
-
-  const overlayStateValue = useMemo<S | undefined>(
-    () => location.state && location.state[key],
-    [location, key],
   );
 
   return [

--- a/web/src/hooks/use-persistence.ts
+++ b/web/src/hooks/use-persistence.ts
@@ -34,7 +34,6 @@ export function usePersistence<S>(
 
   useEffect(() => {
     setLoaded(false);
-    setInternalValue(defaultValue);
 
     async function load() {
       const value = await getData(key);


### PR DESCRIPTION
usePersistence was used internally across multiple parts of the code. The instance that had `setValue` called on it would have the correct value, but other instances would not update the internal value causing an old persistedValue to be used. This ensures that the persistedValue is always updated internally whenever setOverlayState is called