### PR TITLE
Bugfix: loitering_time can be zero

### DIFF
--- a/web/src/components/settings/ZoneEditPane.tsx
+++ b/web/src/components/settings/ZoneEditPane.tsx
@@ -245,7 +245,7 @@ export default function ZoneEditPane({
       }
 
       let loiteringTimeQuery = "";
-      if (loitering_time) {
+      if (loitering_time >= 0) {
         loiteringTimeQuery = `&cameras.${polygon?.camera}.zones.${zoneName}.loitering_time=${loitering_time}`;
       }
 


### PR DESCRIPTION
Ensure a `lotering_time` value of `0` can be entered in the zone edit form.