### PR TITLE
Add ability to seek video -0.1/+0.1 seconds with ctrl/meta modifier key to down/up arrow

### DIFF
--- a/web/src/components/player/VideoControls.tsx
+++ b/web/src/components/player/VideoControls.tsx
@@ -148,16 +148,24 @@ export default function VideoControls({
 
       switch (key) {
         case "ArrowDown":
-          onSeek(-1);
+          if (modifiers.ctrl) {
+            onSeek(-0.1);
+          } else {
+            onSeek(-1);
+          }
           break;
         case "ArrowLeft":
           onSeek(-10);
           break;
+        case "ArrowUp":
+          if (modifiers.ctrl) {
+            onSeek(1 / 30);
+          } else {
+            onSeek(1);
+          }
+          break;
         case "ArrowRight":
           onSeek(10);
-          break;
-        case "ArrowUp":
-          onSeek(1);
           break;
         case "f":
           if (toggleFullscreen && !modifiers.repeat) {


### PR DESCRIPTION
The current down/up arrow action is to seek the video back/forward by 1 second, which may not give the precision necessary to find a specific frame of video.

While the [support for precisely setting the current playback time in browsers is inconsistent](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/currentTime#usage_notes), 0.1 seconds is a predictable common supported value:

> For example, with reduced time precision, the result of video.currentTime will always be a multiple of 0.002, or a multiple of 0.1 (or privacy.resistFingerprinting.reduceTimerPrecision.microseconds) with privacy.resistFingerprinting enabled.

[Related discussion on this feature](https://github.com/blakeblackshear/frigate/discussions/12448).