### PR TITLE
Automatically configure streams for cameras in go2rtc

### DIFF
--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -178,5 +178,5 @@ if config.get("birdseye", {}).get("restream", False):
         go2rtc_config["streams"] = {"birdseye": ffmpeg_cmd}
 
 # Write go2rtc_config to /dev/shm/go2rtc.yaml
-with open("/workspace/frigate/go2rtc.yaml", "w") as f:
+with open("/dev/shm/go2rtc.yaml", "w") as f:
     yaml.dump(go2rtc_config, f)

--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -116,11 +116,12 @@ if int(os.environ["LIBAVFORMAT_VERSION_MAJOR"]) < 59:
             "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"
         )
 
-# add stream for each camera if user has not configured a stream already.
-# this will ensure that all features are available to the user
+# create blank streams list
 if not go2rtc_config.get("streams"):
     go2rtc_config["streams"] = {}
 
+# add stream for each camera if user has not configured a stream already.
+# this will ensure that all features are available to the user
 for camera_name, camera in config.get("cameras", {}).items():
     name = camera.get("live", {}).get("stream_name") or camera_name
 
@@ -133,11 +134,11 @@ for camera_name, camera in config.get("cameras", {}).items():
     if not inputs:
         continue
     elif len(inputs) == 1:
-        go2rtc_config["streams"][name] = [inputs[0]["path"]]
+        go2rtc_config["streams"][name] = [f"ffmpeg:{inputs[0]["path"]}"]
     else:
         for input in inputs:
             if "detect" in input["roles"]:
-                go2rtc_config["streams"][name] = [input["path"]]
+                go2rtc_config["streams"][name] = [f"ffmpeg:{input["path"]}"]
                 break
 
 # apply variable substitution to streams


### PR DESCRIPTION
When users don't configure streams in go2rtc it reduces features in the UI and in external applications such as home assistant. This PR will ensure that the option to use go2rtc is enabled by default, using the stream from the cameras config (detect if multiple are specified) for the go2rtc config. 

jsmpeg will still be used in cases where low bandwidth is an issue