### PR TITLE
Persist live view muted/unmuted for session only

### DIFF
--- a/web/src/hooks/use-session-persistence.ts
+++ b/web/src/hooks/use-session-persistence.ts
@@ -1,14 +1,14 @@
 import { useCallback, useState } from "react";
 
-type useSessionStorageReturn<S> = [
+type useSessionPersistenceReturn<S> = [
   value: S | undefined,
   setValue: (value: S | undefined) => void,
 ];
 
-export function useSessionStorage<S>(
+export function useSessionPersistence<S>(
   key: string,
   defaultValue: S | undefined = undefined,
-): useSessionStorageReturn<S> {
+): useSessionPersistenceReturn<S> {
   const [storedValue, setStoredValue] = useState(() => {
     try {
       const value = window.sessionStorage.getItem(key);

--- a/web/src/hooks/use-session-state.ts
+++ b/web/src/hooks/use-session-state.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from "react";
+
+type useSessionStorageReturn<S> = [
+  value: S | undefined,
+  setValue: (value: S | undefined) => void,
+];
+
+export function useSessionStorage<S>(
+  key: string,
+  defaultValue: S | undefined = undefined,
+): useSessionStorageReturn<S> {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const value = window.sessionStorage.getItem(key);
+
+      if (value) {
+        return JSON.parse(value);
+      } else {
+        window.sessionStorage.setItem(key, JSON.stringify(defaultValue));
+        return defaultValue;
+      }
+    } catch (err) {
+      return defaultValue;
+    }
+  });
+
+  const setValue = useCallback(
+    (newValue: S | undefined) => {
+      try {
+        window.sessionStorage.setItem(key, JSON.stringify(newValue));
+        // eslint-disable-next-line no-empty
+      } catch (err) {}
+      setStoredValue(newValue);
+    },
+    [key],
+  );
+
+  return [storedValue, setValue];
+}

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -78,6 +78,7 @@ import { useNavigate } from "react-router-dom";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 import useSWR from "swr";
 import { cn } from "@/lib/utils";
+import { useSessionStorage } from "@/hooks/use-session-state";
 
 type LiveCameraViewProps = {
   config?: FrigateConfig;
@@ -194,7 +195,7 @@ export default function LiveCameraView({
 
   // playback state
 
-  const [audio, setAudio] = useState(false);
+  const [audio, setAudio] = useSessionStorage("liveAudio", false);
   const [mic, setMic] = useState(false);
   const [webRTC, setWebRTC] = useState(false);
   const [pip, setPip] = useState(false);
@@ -404,7 +405,7 @@ export default function LiveCameraView({
                   className="p-2 md:p-0"
                   variant={fullscreen ? "overlay" : "primary"}
                   Icon={audio ? GiSpeaker : GiSpeakerOff}
-                  isActive={audio}
+                  isActive={audio ?? false}
                   title={`${audio ? "Disable" : "Enable"} Camera Audio`}
                   onClick={() => setAudio(!audio)}
                 />

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -78,7 +78,7 @@ import { useNavigate } from "react-router-dom";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 import useSWR from "swr";
 import { cn } from "@/lib/utils";
-import { useSessionStorage } from "@/hooks/use-session-state";
+import { useSessionPersistence } from "@/hooks/use-session-persistence";
 
 type LiveCameraViewProps = {
   config?: FrigateConfig;
@@ -195,7 +195,7 @@ export default function LiveCameraView({
 
   // playback state
 
-  const [audio, setAudio] = useSessionStorage("liveAudio", false);
+  const [audio, setAudio] = useSessionPersistence("liveAudio", false);
   const [mic, setMic] = useState(false);
   const [webRTC, setWebRTC] = useState(false);
   const [pip, setPip] = useState(false);


### PR DESCRIPTION
History view already persists muted/unmuted state when reviewing footage. This PR persists the muted/unmuted state for individual camera Live view by using session storage. Default state for a new browser session is muted.