### PR TITLE
Fix default model for rknn detector

### DIFF
--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -23,7 +23,6 @@ model_chache_dir = "/config/model_cache/rknn_cache/"
 class RknnDetectorConfig(BaseDetectorConfig):
     type: Literal[DETECTOR_KEY]
     num_cores: int = Field(default=0, ge=0, le=3, title="Number of NPU cores to use.")
-    purge_model_cache: bool = Field(default=True)
 
 
 class Rknn(DetectionApi):
@@ -36,7 +35,9 @@ class Rknn(DetectionApi):
         core_mask = 2**config.num_cores - 1
         soc = self.get_soc()
 
-        model_props = self.parse_model_input(config.model.path, soc)
+        model_path = config.model.path or "deci-fp16-yolonas_s"
+
+        model_props = self.parse_model_input(model_path, soc)
 
         if model_props["preset"]:
             config.model.model_type = model_props["model_type"]


### PR DESCRIPTION
Currently, rknn doesn't use yolonas_s by default and will crash instead, if no model is specified. This was reported [here](https://github.com/blakeblackshear/frigate/discussions/11502#discussioncomment-10242359).

I have an unrelated issue but wanted to hear some feedback before opening a separate thread for it:
There is an issue that causes FFmpeg on Rockchip boards to crash sometimes. If this issue occurs, it causes frigates whole detection process to crash silently for this camera. There is no entry in the logs and the sub-process won't restart.
Even though this issue is specific to the rockchip platform, crashes and bugs can happen on all devices. I think it would make sense to implement a health-check in Frigate that periodically checks if all sub-processes for detection and recording still run. Any thoughts on this?