### PR TITLE
add shortcut for fullscreen in live view

### DIFF
--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -34,7 +34,6 @@ import { useResizeObserver } from "@/hooks/resize-observer";
 import useKeyboardListener, {
   KeyModifiers,
 } from "@/hooks/use-keyboard-listener";
-import { useSearchParams } from "react-router-dom";
 import { useSearchEffect } from "@/hooks/use-overlay-state";
 
 type LiveDashboardViewProps = {

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -31,6 +31,11 @@ import { cn } from "@/lib/utils";
 import { LivePlayerError, LivePlayerMode } from "@/types/live";
 import { FaCompress, FaExpand } from "react-icons/fa";
 import { useResizeObserver } from "@/hooks/resize-observer";
+import useKeyboardListener, {
+  KeyModifiers,
+} from "@/hooks/use-keyboard-listener";
+import { useSearchParams } from "react-router-dom";
+import { useSearchEffect } from "@/hooks/use-overlay-state";
 
 type LiveDashboardViewProps = {
   cameras: CameraConfig[];
@@ -246,6 +251,34 @@ export default function LiveDashboardView({
     },
     [setPreferredLiveModes],
   );
+
+  const onKeyboardShortcut = useCallback(
+    (key: string, modifiers: KeyModifiers) => {
+      if (!modifiers.down) {
+        return;
+      }
+
+      switch (key) {
+        case "f":
+          toggleFullscreen();
+          break;
+      }
+    },
+    [toggleFullscreen],
+  );
+
+  useKeyboardListener(["f"], onKeyboardShortcut);
+  const handleFullScreenQuery = useCallback(
+    (value: string) => {
+      const desiredState = value === "true";
+      if (fullscreen === desiredState) {
+        return;
+      }
+      toggleFullscreen;
+    },
+    [fullscreen, toggleFullscreen],
+  );
+  useSearchEffect("fullscreen", handleFullScreenQuery);
 
   return (
     <div

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -269,11 +269,9 @@ export default function LiveDashboardView({
   useKeyboardListener(["f"], onKeyboardShortcut);
   const handleFullScreenQuery = useCallback(
     (value: string) => {
-      const desiredState = value === "true";
-      if (fullscreen === desiredState) {
-        return;
+      if (!fullscreen) {
+          toggleFullscreen();
       }
-      toggleFullscreen;
     },
     [fullscreen, toggleFullscreen],
   );

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -34,7 +34,6 @@ import { useResizeObserver } from "@/hooks/resize-observer";
 import useKeyboardListener, {
   KeyModifiers,
 } from "@/hooks/use-keyboard-listener";
-import { useSearchEffect } from "@/hooks/use-overlay-state";
 
 type LiveDashboardViewProps = {
   cameras: CameraConfig[];
@@ -267,15 +266,6 @@ export default function LiveDashboardView({
   );
 
   useKeyboardListener(["f"], onKeyboardShortcut);
-  const handleFullScreenQuery = useCallback(
-    () => {
-      if (!fullscreen) {
-        toggleFullscreen();
-      }
-    },
-    [fullscreen, toggleFullscreen],
-  );
-  useSearchEffect("fullscreen", handleFullScreenQuery);
 
   return (
     <div

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -268,9 +268,9 @@ export default function LiveDashboardView({
 
   useKeyboardListener(["f"], onKeyboardShortcut);
   const handleFullScreenQuery = useCallback(
-    (value: string) => {
+    () => {
       if (!fullscreen) {
-          toggleFullscreen();
+        toggleFullscreen();
       }
     },
     [fullscreen, toggleFullscreen],


### PR DESCRIPTION
Hello, this PR adds keyboard shortcut `f` for full screen toggling in LiveView, and a `fullscreen` query param.
I can now with this set my kiosk headless raspberry to start with `${URL}/?group=my_group&fullscreen=true`

I know that changes made here might not align with your codebase standards, which I give you permission to take this PR over and modify it accordingly.

Thanks for the great software!