### PR TITLE
Add confirmation dialog before deleting review items

### DIFF
--- a/web/src/components/filter/ReviewActionGroup.tsx
+++ b/web/src/components/filter/ReviewActionGroup.tsx
@@ -1,10 +1,21 @@
 import { FaCircleCheck } from "react-icons/fa6";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import axios from "axios";
 import { Button } from "../ui/button";
 import { isDesktop } from "react-device-detect";
 import { FaCompactDisc } from "react-icons/fa";
 import { HiTrash } from "react-icons/hi";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../ui/alert-dialog";
+import useKeyboardListener from "@/hooks/use-keyboard-listener";
 
 type ReviewActionGroupProps = {
   selectedReviews: string[];
@@ -34,49 +45,94 @@ export default function ReviewActionGroup({
     pullLatestData();
   }, [selectedReviews, setSelectedReviews, pullLatestData]);
 
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [bypassDialog, setBypassDialog] = useState(false);
+
+  useKeyboardListener(["Shift"], (_, modifiers) => {
+    setBypassDialog(modifiers.shift);
+  });
+
+  const handleDelete = useCallback(() => {
+    if (bypassDialog) {
+      onDelete();
+    } else {
+      setDeleteDialogOpen(true);
+    }
+  }, [bypassDialog, onDelete]);
+
   return (
-    <div className="absolute inset-x-2 inset-y-0 flex items-center justify-between gap-2 bg-background py-2 md:left-auto">
-      <div className="mx-1 flex items-center justify-center text-sm text-muted-foreground">
-        <div className="p-1">{`${selectedReviews.length} selected`}</div>
-        <div className="p-1">{"|"}</div>
-        <div
-          className="cursor-pointer p-2 text-primary hover:rounded-lg hover:bg-secondary"
-          onClick={onClearSelected}
-        >
-          Unselect
+    <>
+      <AlertDialog
+        open={deleteDialogOpen}
+        onOpenChange={() => setDeleteDialogOpen(!deleteDialogOpen)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm Delete</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogDescription>
+            Are you sure you want to delete all recorded video associated with
+            the selected review items?
+            <br />
+            <br />
+            Hold the <em>Shift</em> key to bypass this dialog in the future.
+          </AlertDialogDescription>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction className="bg-destructive" onClick={onDelete}>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <div className="absolute inset-x-2 inset-y-0 flex items-center justify-between gap-2 bg-background py-2 md:left-auto">
+        <div className="mx-1 flex items-center justify-center text-sm text-muted-foreground">
+          <div className="p-1">{`${selectedReviews.length} selected`}</div>
+          <div className="p-1">{"|"}</div>
+          <div
+            className="cursor-pointer p-2 text-primary hover:rounded-lg hover:bg-secondary"
+            onClick={onClearSelected}
+          >
+            Unselect
+          </div>
         </div>
-      </div>
-      <div className="flex items-center gap-1 md:gap-2">
-        {selectedReviews.length == 1 && (
+        <div className="flex items-center gap-1 md:gap-2">
+          {selectedReviews.length == 1 && (
+            <Button
+              className="flex items-center gap-2 p-2"
+              size="sm"
+              onClick={() => {
+                onExport(selectedReviews[0]);
+                onClearSelected();
+              }}
+            >
+              <FaCompactDisc className="text-secondary-foreground" />
+              {isDesktop && <div className="text-primary">Export</div>}
+            </Button>
+          )}
           <Button
             className="flex items-center gap-2 p-2"
             size="sm"
-            onClick={() => {
-              onExport(selectedReviews[0]);
-              onClearSelected();
-            }}
+            onClick={onMarkAsReviewed}
           >
-            <FaCompactDisc className="text-secondary-foreground" />
-            {isDesktop && <div className="text-primary">Export</div>}
+            <FaCircleCheck className="text-secondary-foreground" />
+            {isDesktop && <div className="text-primary">Mark as reviewed</div>}
           </Button>
-        )}
-        <Button
-          className="flex items-center gap-2 p-2"
-          size="sm"
-          onClick={onMarkAsReviewed}
-        >
-          <FaCircleCheck className="text-secondary-foreground" />
-          {isDesktop && <div className="text-primary">Mark as reviewed</div>}
-        </Button>
-        <Button
-          className="flex items-center gap-2 p-2"
-          size="sm"
-          onClick={onDelete}
-        >
-          <HiTrash className="text-secondary-foreground" />
-          {isDesktop && <div className="text-primary">Delete</div>}
-        </Button>
+          <Button
+            className="flex items-center gap-2 p-2"
+            size="sm"
+            onClick={handleDelete}
+          >
+            <HiTrash className="text-secondary-foreground" />
+            {isDesktop && (
+              <div className="text-primary">
+                {bypassDialog ? "Delete Now" : "Delete"}
+              </div>
+            )}
+          </Button>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/web/src/components/player/VideoControls.tsx
+++ b/web/src/components/player/VideoControls.tsx
@@ -141,7 +141,7 @@ export default function VideoControls({
   }, [volume, muted]);
 
   const onKeyboardShortcut = useCallback(
-    (key: string, modifiers: KeyModifiers) => {
+    (key: string | null, modifiers: KeyModifiers) => {
       if (!modifiers.down) {
         return;
       }

--- a/web/src/hooks/use-keyboard-listener.tsx
+++ b/web/src/hooks/use-keyboard-listener.tsx
@@ -4,11 +4,12 @@ export type KeyModifiers = {
   down: boolean;
   repeat: boolean;
   ctrl: boolean;
+  shift: boolean;
 };
 
 export default function useKeyboardListener(
   keys: string[],
-  listener: (key: string, modifiers: KeyModifiers) => void,
+  listener: (key: string | null, modifiers: KeyModifiers) => void,
 ) {
   const keyDownListener = useCallback(
     (e: KeyboardEvent) => {
@@ -16,13 +17,18 @@ export default function useKeyboardListener(
         return;
       }
 
+      const modifiers = {
+        down: true,
+        repeat: e.repeat,
+        ctrl: e.ctrlKey || e.metaKey,
+        shift: e.shiftKey,
+      };
+
       if (keys.includes(e.key)) {
         e.preventDefault();
-        listener(e.key, {
-          down: true,
-          repeat: e.repeat,
-          ctrl: e.ctrlKey || e.metaKey,
-        });
+        listener(e.key, modifiers);
+      } else if (e.key === "Shift" || e.key === "Control" || e.key === "Meta") {
+        listener(null, modifiers);
       }
     },
     [keys, listener],
@@ -34,9 +40,18 @@ export default function useKeyboardListener(
         return;
       }
 
+      const modifiers = {
+        down: false,
+        repeat: false,
+        ctrl: false,
+        shift: false,
+      };
+
       if (keys.includes(e.key)) {
         e.preventDefault();
-        listener(e.key, { down: false, repeat: false, ctrl: false });
+        listener(e.key, modifiers);
+      } else if (e.key === "Shift" || e.key === "Control" || e.key === "Meta") {
+        listener(null, modifiers);
       }
     },
     [keys, listener],

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -31,9 +31,7 @@ import { cn } from "@/lib/utils";
 import { LivePlayerError, LivePlayerMode } from "@/types/live";
 import { FaCompress, FaExpand } from "react-icons/fa";
 import { useResizeObserver } from "@/hooks/resize-observer";
-import useKeyboardListener, {
-  KeyModifiers,
-} from "@/hooks/use-keyboard-listener";
+import useKeyboardListener from "@/hooks/use-keyboard-listener";
 
 type LiveDashboardViewProps = {
   cameras: CameraConfig[];
@@ -250,22 +248,17 @@ export default function LiveDashboardView({
     [setPreferredLiveModes],
   );
 
-  const onKeyboardShortcut = useCallback(
-    (key: string, modifiers: KeyModifiers) => {
-      if (!modifiers.down) {
-        return;
-      }
+  useKeyboardListener(["f"], (key, modifiers) => {
+    if (!modifiers.down) {
+      return;
+    }
 
-      switch (key) {
-        case "f":
-          toggleFullscreen();
-          break;
-      }
-    },
-    [toggleFullscreen],
-  );
-
-  useKeyboardListener(["f"], onKeyboardShortcut);
+    switch (key) {
+      case "f":
+        toggleFullscreen();
+        break;
+    }
+  });
 
   return (
     <div


### PR DESCRIPTION
This PR adds a confirmation dialog to ensure users know that they are deleting recordings / history when they delete review items. Holding the shift key on desktops will bypass the dialog.