### PR TITLE
Remove dashboard fullscreen keyboard listener

### DIFF
--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -31,7 +31,6 @@ import { cn } from "@/lib/utils";
 import { LivePlayerError, LivePlayerMode } from "@/types/live";
 import { FaCompress, FaExpand } from "react-icons/fa";
 import { useResizeObserver } from "@/hooks/resize-observer";
-import useKeyboardListener from "@/hooks/use-keyboard-listener";
 
 type LiveDashboardViewProps = {
   cameras: CameraConfig[];
@@ -247,18 +246,6 @@ export default function LiveDashboardView({
     },
     [setPreferredLiveModes],
   );
-
-  useKeyboardListener(["f"], (key, modifiers) => {
-    if (!modifiers.down) {
-      return;
-    }
-
-    switch (key) {
-      case "f":
-        toggleFullscreen();
-        break;
-    }
-  });
 
   return (
     <div


### PR DESCRIPTION
https://github.com/blakeblackshear/frigate/pull/12924 introduced a bug in editing camera groups from the dashboard. Users couldn't enter a camera group name with "f" without the whole view going fullscreen.