### PR TITLE
updating HACS installation instructions

### DIFF
--- a/docs/docs/integrations/home-assistant.md
+++ b/docs/docs/integrations/home-assistant.md
@@ -25,7 +25,7 @@ Available via HACS as a default repository. To install:
 - Use [HACS](https://hacs.xyz/) to install the integration:
 
 ```
-Home Assistant > HACS > Integrations > "Explore & Add Integrations" > Frigate
+Home Assistant > HACS > Click in the Search bar and type "Frigate" > Frigate
 ```
 
 - Restart Home Assistant.


### PR DESCRIPTION
Based on the following version information:
```
Core: 2024.6.4
Frontend: 20240610.1
```

The previous installation instructions no longer worked for me. When I clicked on the "Explore & Add Integrations" button it said that it was being removed. Instead this is the UI I was presented.

![image](https://github.com/user-attachments/assets/d0972831-a25a-49e8-9557-17e1cd1a1d20)

Unless you notice the "Filtering by Downloaded" (which I believe is by default) you won't know to type in the search box for other possible add-ons (i.e. Frigate).

Just wanted to update this in case any other newer people run across this.