### PR TITLE
Live player fixes

### DIFF
--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -209,15 +209,6 @@ export default function LivePlayer({
     player = <ActivityIndicator />;
   }
 
-  useEffect(() => {
-    console.log(
-      cameraConfig.name,
-      cameraConfig.live.stream_name,
-      "switching to",
-      preferredLiveMode,
-    );
-  }, [preferredLiveMode]);
-
   return (
     <div
       ref={cameraRef ?? internalContainerRef}

--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -13,7 +13,6 @@ import {
   LivePlayerMode,
   VideoResolutionType,
 } from "@/types/live";
-import useCameraLiveMode from "@/hooks/use-camera-live-mode";
 import { getIconForLabel } from "@/utils/iconUtil";
 import Chip from "../indicators/Chip";
 import { capitalizeFirstLetter } from "@/utils/stringUtil";
@@ -25,7 +24,7 @@ type LivePlayerProps = {
   containerRef?: React.MutableRefObject<HTMLDivElement | null>;
   className?: string;
   cameraConfig: CameraConfig;
-  preferredLiveMode?: LivePlayerMode;
+  preferredLiveMode: LivePlayerMode;
   showStillWithoutActivity?: boolean;
   windowVisible?: boolean;
   playAudio?: boolean;
@@ -69,8 +68,6 @@ export default function LivePlayer({
   );
 
   // camera live state
-
-  const liveMode = useCameraLiveMode(cameraConfig, preferredLiveMode);
 
   const [liveReady, setLiveReady] = useState(false);
 
@@ -152,7 +149,7 @@ export default function LivePlayer({
   let player;
   if (!autoLive) {
     player = null;
-  } else if (liveMode == "webrtc") {
+  } else if (preferredLiveMode == "webrtc") {
     player = (
       <WebRtcPlayer
         className={`size-full rounded-lg md:rounded-2xl ${liveReady ? "" : "hidden"}`}
@@ -166,7 +163,7 @@ export default function LivePlayer({
         onError={onError}
       />
     );
-  } else if (liveMode == "mse") {
+  } else if (preferredLiveMode == "mse") {
     if ("MediaSource" in window || "ManagedMediaSource" in window) {
       player = (
         <MSEPlayer
@@ -187,7 +184,7 @@ export default function LivePlayer({
         </div>
       );
     }
-  } else if (liveMode == "jsmpeg") {
+  } else if (preferredLiveMode == "jsmpeg") {
     if (cameraActive || !showStillWithoutActivity || liveReady) {
       player = (
         <JSMpegPlayer
@@ -208,6 +205,10 @@ export default function LivePlayer({
   } else {
     player = <ActivityIndicator />;
   }
+
+  useEffect(() => {
+    console.log(cameraConfig.name, "switching to", preferredLiveMode);
+  }, [preferredLiveMode]);
 
   return (
     <div

--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -35,6 +35,7 @@ type LivePlayerProps = {
   onClick?: () => void;
   setFullResolution?: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
   onError?: (error: LivePlayerError) => void;
+  onResetLiveMode?: () => void;
 };
 
 export default function LivePlayer({
@@ -53,6 +54,7 @@ export default function LivePlayer({
   onClick,
   setFullResolution,
   onError,
+  onResetLiveMode,
 }: LivePlayerProps) {
   const internalContainerRef = useRef<HTMLDivElement | null>(null);
   // camera activity
@@ -88,6 +90,7 @@ export default function LivePlayer({
       const timer = setTimeout(() => {
         if (liveReadyRef.current && !cameraActiveRef.current) {
           setLiveReady(false);
+          onResetLiveMode?.();
         }
       }, 500);
 
@@ -207,7 +210,12 @@ export default function LivePlayer({
   }
 
   useEffect(() => {
-    console.log(cameraConfig.name, "switching to", preferredLiveMode);
+    console.log(
+      cameraConfig.name,
+      cameraConfig.live.stream_name,
+      "switching to",
+      preferredLiveMode,
+    );
   }, [preferredLiveMode]);
 
   return (

--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -139,6 +139,13 @@ function MSEPlayer({
     }
   }, [bufferTimeout]);
 
+  const handlePause = useCallback(() => {
+    // don't let the user pause the live stream
+    if (isPlaying && playbackEnabled) {
+      videoRef.current?.play();
+    }
+  }, [isPlaying, playbackEnabled]);
+
   const onOpen = () => {
     setWsState(WebSocket.OPEN);
 
@@ -402,7 +409,7 @@ function MSEPlayer({
         lastJumpTimeRef.current = Date.now();
       }}
       muted={!audioEnabled}
-      onPause={() => videoRef.current?.play()}
+      onPause={handlePause}
       onProgress={() => {
         const bufferTime = getBufferedTime(videoRef.current);
 

--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -308,8 +308,10 @@ function MSEPlayer({
     if (!videoRef.current) return;
 
     const now = Date.now();
+
+    // we either recently just started streaming or recently
+    // jumped to live, so don't jump to live again right away
     if (now - lastJumpTimeRef.current < BUFFERING_COOLDOWN_TIMEOUT) {
-      console.log("Cooldown period active, skipping jump");
       return;
     }
 
@@ -319,7 +321,6 @@ function MSEPlayer({
       // Jump to the live edge
       videoRef.current.currentTime = liveEdge;
       lastJumpTimeRef.current = now;
-      console.log("Jumped to live");
     }
   };
 
@@ -413,7 +414,6 @@ function MSEPlayer({
       onPause={() => videoRef.current?.play()}
       onProgress={() => {
         const bufferTime = getBufferedTime(videoRef.current);
-        console.log(bufferTime);
 
         // if we have > 3 seconds of buffered data and we're still not playing,
         // something might be wrong - maybe codec issue, no audio, etc
@@ -424,7 +424,7 @@ function MSEPlayer({
           onPlaying?.();
         }
 
-        // if we have > 1 second of buffered data and we're playing, we may have
+        // if we have > 2 seconds of buffered data and we're playing, we may have
         // drifted from actual live time, so seek to the end of buffered data
         if (
           videoRef.current &&

--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -32,7 +32,7 @@ function MSEPlayer({
   onError,
 }: MSEPlayerProps) {
   const RECONNECT_TIMEOUT: number = 10000;
-  const BUFFERING_COOLDOWN_TIMEOUT: number = 5000;
+  // const BUFFERING_COOLDOWN_TIMEOUT: number = 5000;
 
   const CODECS: string[] = [
     "avc1.640029", // H.264 high 4.1 (Chromecast 1st and 2nd Gen)
@@ -49,9 +49,9 @@ function MSEPlayer({
   const [isPlaying, setIsPlaying] = useState(false);
   const lastJumpTimeRef = useRef(0);
 
-  const MAX_BUFFER_ENTRIES = 10; // Size of the rolling window
-  const bufferTimes = useRef<number[]>([]);
-  const bufferIndex = useRef(0);
+  // const MAX_BUFFER_ENTRIES = 10; // Size of the rolling window
+  // const bufferTimes = useRef<number[]>([]);
+  // const bufferIndex = useRef(0);
 
   const [wsState, setWsState] = useState<number>(WebSocket.CLOSED);
   const [connectTS, setConnectTS] = useState<number>(0);
@@ -315,12 +315,12 @@ function MSEPlayer({
     return video.buffered.end(video.buffered.length - 1) - video.currentTime;
   };
 
-  const calculateAdaptiveBufferThreshold = () => {
-    const filledEntries = bufferTimes.current.length;
-    const sum = bufferTimes.current.reduce((a, b) => a + b, 0);
-    const averageBufferTime = filledEntries ? sum / filledEntries : 0;
-    return averageBufferTime * 1.5;
-  };
+  // const calculateAdaptiveBufferThreshold = () => {
+  //   const filledEntries = bufferTimes.current.length;
+  //   const sum = bufferTimes.current.reduce((a, b) => a + b, 0);
+  //   const averageBufferTime = filledEntries ? sum / filledEntries : 0;
+  //   return averageBufferTime * 1.5;
+  // };
 
   useEffect(() => {
     if (!playbackEnabled) {
@@ -413,17 +413,17 @@ function MSEPlayer({
       onProgress={() => {
         const bufferTime = getBufferedTime(videoRef.current);
 
-        if (videoRef.current && videoRef.current.playbackRate === 1) {
-          if (bufferTimes.current.length < MAX_BUFFER_ENTRIES) {
-            bufferTimes.current.push(bufferTime);
-          } else {
-            bufferTimes.current[bufferIndex.current] = bufferTime;
-            bufferIndex.current =
-              (bufferIndex.current + 1) % MAX_BUFFER_ENTRIES;
-          }
-        }
+        // if (videoRef.current && videoRef.current.playbackRate === 1) {
+        //   if (bufferTimes.current.length < MAX_BUFFER_ENTRIES) {
+        //     bufferTimes.current.push(bufferTime);
+        //   } else {
+        //     bufferTimes.current[bufferIndex.current] = bufferTime;
+        //     bufferIndex.current =
+        //       (bufferIndex.current + 1) % MAX_BUFFER_ENTRIES;
+        //   }
+        // }
 
-        const bufferThreshold = calculateAdaptiveBufferThreshold();
+        // const bufferThreshold = calculateAdaptiveBufferThreshold();
 
         // if we have > 3 seconds of buffered data and we're still not playing,
         // something might be wrong - maybe codec issue, no audio, etc
@@ -437,31 +437,31 @@ function MSEPlayer({
         // if we're above our rolling average threshold or have > 3 seconds of
         // buffered data and we're playing, we may have drifted from actual live
         // time, so increase playback rate to compensate
-        if (
-          videoRef.current &&
-          isPlaying &&
-          playbackEnabled &&
-          (bufferTime > bufferThreshold || bufferTime > 3) &&
-          Date.now() - lastJumpTimeRef.current > BUFFERING_COOLDOWN_TIMEOUT
-        ) {
-          videoRef.current.playbackRate = 1.1;
-          console.log(
-            camera,
-            "increasing playback rate",
-            bufferTime,
-            bufferThreshold,
-          );
-        } else {
-          if (videoRef.current) {
-            console.log(
-              camera,
-              "normal playback rate",
-              bufferTime,
-              bufferThreshold,
-            );
-            videoRef.current.playbackRate = 1;
-          }
-        }
+        // if (
+        //   videoRef.current &&
+        //   isPlaying &&
+        //   playbackEnabled &&
+        //   (bufferTime > bufferThreshold || bufferTime > 3) &&
+        //   Date.now() - lastJumpTimeRef.current > BUFFERING_COOLDOWN_TIMEOUT
+        // ) {
+        //   videoRef.current.playbackRate = 1.1;
+        //   console.log(
+        //     camera,
+        //     "increasing playback rate",
+        //     bufferTime,
+        //     bufferThreshold,
+        //   );
+        // } else {
+        //   if (videoRef.current) {
+        //     console.log(
+        //       camera,
+        //       "normal playback rate",
+        //       bufferTime,
+        //       bufferThreshold,
+        //     );
+        //     videoRef.current.playbackRate = 1;
+        //   }
+        // }
 
         if (onError != undefined) {
           if (videoRef.current?.paused) {

--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -32,7 +32,7 @@ function MSEPlayer({
   onError,
 }: MSEPlayerProps) {
   const RECONNECT_TIMEOUT: number = 10000;
-  // const BUFFERING_COOLDOWN_TIMEOUT: number = 5000;
+  const BUFFERING_COOLDOWN_TIMEOUT: number = 5000;
 
   const CODECS: string[] = [
     "avc1.640029", // H.264 high 4.1 (Chromecast 1st and 2nd Gen)
@@ -49,9 +49,9 @@ function MSEPlayer({
   const [isPlaying, setIsPlaying] = useState(false);
   const lastJumpTimeRef = useRef(0);
 
-  // const MAX_BUFFER_ENTRIES = 10; // Size of the rolling window
-  // const bufferTimes = useRef<number[]>([]);
-  // const bufferIndex = useRef(0);
+  const MAX_BUFFER_ENTRIES = 10; // Size of the rolling window  of buffered times
+  const bufferTimes = useRef<number[]>([]);
+  const bufferIndex = useRef(0);
 
   const [wsState, setWsState] = useState<number>(WebSocket.CLOSED);
   const [connectTS, setConnectTS] = useState<number>(0);
@@ -315,12 +315,12 @@ function MSEPlayer({
     return video.buffered.end(video.buffered.length - 1) - video.currentTime;
   };
 
-  // const calculateAdaptiveBufferThreshold = () => {
-  //   const filledEntries = bufferTimes.current.length;
-  //   const sum = bufferTimes.current.reduce((a, b) => a + b, 0);
-  //   const averageBufferTime = filledEntries ? sum / filledEntries : 0;
-  //   return averageBufferTime * 1.5;
-  // };
+  const calculateAdaptiveBufferThreshold = () => {
+    const filledEntries = bufferTimes.current.length;
+    const sum = bufferTimes.current.reduce((a, b) => a + b, 0);
+    const averageBufferTime = filledEntries ? sum / filledEntries : 0;
+    return averageBufferTime * 1.5;
+  };
 
   useEffect(() => {
     if (!playbackEnabled) {
@@ -413,17 +413,17 @@ function MSEPlayer({
       onProgress={() => {
         const bufferTime = getBufferedTime(videoRef.current);
 
-        // if (videoRef.current && videoRef.current.playbackRate === 1) {
-        //   if (bufferTimes.current.length < MAX_BUFFER_ENTRIES) {
-        //     bufferTimes.current.push(bufferTime);
-        //   } else {
-        //     bufferTimes.current[bufferIndex.current] = bufferTime;
-        //     bufferIndex.current =
-        //       (bufferIndex.current + 1) % MAX_BUFFER_ENTRIES;
-        //   }
-        // }
+        if (videoRef.current && videoRef.current.playbackRate === 1) {
+          if (bufferTimes.current.length < MAX_BUFFER_ENTRIES) {
+            bufferTimes.current.push(bufferTime);
+          } else {
+            bufferTimes.current[bufferIndex.current] = bufferTime;
+            bufferIndex.current =
+              (bufferIndex.current + 1) % MAX_BUFFER_ENTRIES;
+          }
+        }
 
-        // const bufferThreshold = calculateAdaptiveBufferThreshold();
+        const bufferThreshold = calculateAdaptiveBufferThreshold();
 
         // if we have > 3 seconds of buffered data and we're still not playing,
         // something might be wrong - maybe codec issue, no audio, etc
@@ -437,31 +437,19 @@ function MSEPlayer({
         // if we're above our rolling average threshold or have > 3 seconds of
         // buffered data and we're playing, we may have drifted from actual live
         // time, so increase playback rate to compensate
-        // if (
-        //   videoRef.current &&
-        //   isPlaying &&
-        //   playbackEnabled &&
-        //   (bufferTime > bufferThreshold || bufferTime > 3) &&
-        //   Date.now() - lastJumpTimeRef.current > BUFFERING_COOLDOWN_TIMEOUT
-        // ) {
-        //   videoRef.current.playbackRate = 1.1;
-        //   console.log(
-        //     camera,
-        //     "increasing playback rate",
-        //     bufferTime,
-        //     bufferThreshold,
-        //   );
-        // } else {
-        //   if (videoRef.current) {
-        //     console.log(
-        //       camera,
-        //       "normal playback rate",
-        //       bufferTime,
-        //       bufferThreshold,
-        //     );
-        //     videoRef.current.playbackRate = 1;
-        //   }
-        // }
+        if (
+          videoRef.current &&
+          isPlaying &&
+          playbackEnabled &&
+          (bufferTime > bufferThreshold || bufferTime > 3) &&
+          Date.now() - lastJumpTimeRef.current > BUFFERING_COOLDOWN_TIMEOUT
+        ) {
+          videoRef.current.playbackRate = 1.1;
+        } else {
+          if (videoRef.current) {
+            videoRef.current.playbackRate = 1;
+          }
+        }
 
         if (onError != undefined) {
           if (videoRef.current?.paused) {

--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -308,26 +308,6 @@ function MSEPlayer({
     return video.buffered.end(video.buffered.length - 1) - video.currentTime;
   };
 
-  const jumpToLive = () => {
-    if (!videoRef.current) return;
-
-    const now = Date.now();
-
-    // we either recently just started streaming or recently
-    // jumped to live, so don't jump to live again right away
-    if (now - lastJumpTimeRef.current < BUFFERING_COOLDOWN_TIMEOUT) {
-      return;
-    }
-
-    const buffered = videoRef.current.buffered;
-    if (buffered.length > 0) {
-      const liveEdge = buffered.end(buffered.length - 1);
-      // Jump to the live edge
-      videoRef.current.currentTime = liveEdge;
-      lastJumpTimeRef.current = now;
-    }
-  };
-
   const calculateAdaptiveBufferThreshold = () => {
     const filledEntries = bufferTimes.current.length;
     const sum = bufferTimes.current.reduce((a, b) => a + b, 0);
@@ -457,7 +437,6 @@ function MSEPlayer({
           (bufferTime > bufferThreshold || bufferTime > 3) &&
           Date.now() - lastJumpTimeRef.current > BUFFERING_COOLDOWN_TIMEOUT
         ) {
-          // jumpToLive();
           videoRef.current.playbackRate = 1.1;
           console.log(
             camera,

--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -274,7 +274,7 @@ function MSEPlayer({
     onmessageRef.current["mse"] = (msg) => {
       if (msg.type !== "mse") return;
 
-      console.log(msg.value);
+      console.log(camera, "codecs", msg.value);
 
       let sb: SourceBuffer | undefined;
       try {
@@ -346,12 +346,6 @@ function MSEPlayer({
     if (!videoRef.current) return;
 
     const now = Date.now();
-
-    // we either recently just started streaming or recently
-    // jumped to live, so don't jump to live again right away
-    if (now - lastJumpTimeRef.current < BUFFERING_COOLDOWN_TIMEOUT) {
-      return;
-    }
 
     const buffered = videoRef.current.buffered;
     if (buffered.length > 0) {

--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -224,8 +224,10 @@ function MSEPlayer({
               onDisconnect();
             }
             if (isIOS || isSafari) {
+              console.log(camera, "Safari MSE sourceopen error");
               onError?.("mse-decode");
             } else {
+              console.log(camera, "MSE sourceopen error");
               onError?.("startup");
             }
           });
@@ -254,8 +256,10 @@ function MSEPlayer({
               onDisconnect();
             }
             if (isIOS || isSafari) {
+              console.log(camera, "Safari MSE sourceopen error");
               onError?.("mse-decode");
             } else {
+              console.log(camera, "MSE sourceopen error");
               onError?.("startup");
             }
           });
@@ -481,6 +485,7 @@ function MSEPlayer({
           (bufferThreshold > 10 || bufferTime > 10)
         ) {
           onDisconnect();
+          console.log(camera, "MSE stream buffer is > 10 seconds");
           onError?.("stalled");
         }
 
@@ -533,6 +538,7 @@ function MSEPlayer({
                 videoRef.current
               ) {
                 onDisconnect();
+                console.log(camera, "MSE buffer timeout > 3 seconds");
                 onError("stalled");
               }
             }, 3000),
@@ -547,6 +553,7 @@ function MSEPlayer({
           if (wsRef.current) {
             onDisconnect();
           }
+          console.log(camera, "MSE network error");
           onError?.("startup");
         }
 
@@ -558,6 +565,7 @@ function MSEPlayer({
           if (wsRef.current) {
             onDisconnect();
           }
+          console.log(camera, "Safari MSE decoding error");
           onError?.("mse-decode");
         }
 
@@ -567,6 +575,7 @@ function MSEPlayer({
           onDisconnect();
           if (errorCount >= 3) {
             // too many mse errors, try jsmpeg
+            console.log(camera, "too many MSE errors");
             onError?.("startup");
           } else {
             reconnect(5000);

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -298,7 +298,12 @@ export interface FrigateConfig {
     retry_interval: number;
   };
 
-  go2rtc: Record<string, unknown>;
+  go2rtc: {
+    streams: string[];
+    webrtc: {
+      candidates: string[];
+    };
+  };
 
   camera_groups: { [groupName: string]: CameraGroupConfig };
 

--- a/web/src/views/live/DraggableGridLayout.tsx
+++ b/web/src/views/live/DraggableGridLayout.tsx
@@ -41,6 +41,7 @@ import {
   TooltipContent,
 } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
+import useCameraLiveMode from "@/hooks/use-camera-live-mode";
 
 type DraggableGridLayoutProps = {
   cameras: CameraConfig[];
@@ -55,7 +56,6 @@ type DraggableGridLayoutProps = {
   setIsEditMode: React.Dispatch<React.SetStateAction<boolean>>;
   fullscreen: boolean;
   toggleFullscreen: () => void;
-  resetPreferredLiveMode: (camera: string) => void;
 };
 export default function DraggableGridLayout({
   cameras,
@@ -70,43 +70,14 @@ export default function DraggableGridLayout({
   setIsEditMode,
   fullscreen,
   toggleFullscreen,
-  resetPreferredLiveMode,
 }: DraggableGridLayoutProps) {
   const { data: config } = useSWR<FrigateConfig>("config");
   const birdseyeConfig = useMemo(() => config?.birdseye, [config]);
 
   // preferred live modes per camera
 
-  const [preferredLiveModes, setPreferredLiveModes] = useState<{
-    [key: string]: LivePlayerMode;
-  }>({});
-
-  useEffect(() => {
-    if (!cameras) return;
-
-    const mseSupported =
-      "MediaSource" in window || "ManagedMediaSource" in window;
-
-    const newPreferredLiveModes = cameras.reduce(
-      (acc, camera) => {
-        const isRestreamed =
-          config &&
-          Object.keys(config.go2rtc.streams || {}).includes(
-            camera.live.stream_name,
-          );
-
-        if (!mseSupported) {
-          acc[camera.name] = isRestreamed ? "webrtc" : "jsmpeg";
-        } else {
-          acc[camera.name] = isRestreamed ? "mse" : "jsmpeg";
-        }
-        return acc;
-      },
-      {} as { [key: string]: LivePlayerMode },
-    );
-
-    setPreferredLiveModes(newPreferredLiveModes);
-  }, [cameras, config, windowVisible]);
+  const { preferredLiveModes, setPreferredLiveModes, resetPreferredLiveMode } =
+    useCameraLiveMode(cameras, windowVisible);
 
   const ResponsiveGridLayout = useMemo(() => WidthProvider(Responsive), []);
 

--- a/web/src/views/live/DraggableGridLayout.tsx
+++ b/web/src/views/live/DraggableGridLayout.tsx
@@ -55,6 +55,7 @@ type DraggableGridLayoutProps = {
   setIsEditMode: React.Dispatch<React.SetStateAction<boolean>>;
   fullscreen: boolean;
   toggleFullscreen: () => void;
+  resetPreferredLiveMode: (camera: string) => void;
 };
 export default function DraggableGridLayout({
   cameras,
@@ -69,6 +70,7 @@ export default function DraggableGridLayout({
   setIsEditMode,
   fullscreen,
   toggleFullscreen,
+  resetPreferredLiveMode,
 }: DraggableGridLayoutProps) {
   const { data: config } = useSWR<FrigateConfig>("config");
   const birdseyeConfig = useMemo(() => config?.birdseye, [config]);
@@ -477,6 +479,7 @@ export default function DraggableGridLayout({
                       return newModes;
                     });
                   }}
+                  onResetLiveMode={() => resetPreferredLiveMode(camera.name)}
                 >
                   {isEditMode && showCircles && <CornerCircles />}
                 </LivePlayerGridItem>
@@ -635,6 +638,7 @@ type LivePlayerGridItemProps = {
   preferredLiveMode: LivePlayerMode;
   onClick: () => void;
   onError: (e: LivePlayerError) => void;
+  onResetLiveMode: () => void;
 };
 
 const LivePlayerGridItem = React.forwardRef<
@@ -655,6 +659,7 @@ const LivePlayerGridItem = React.forwardRef<
       preferredLiveMode,
       onClick,
       onError,
+      onResetLiveMode,
       ...props
     },
     ref,
@@ -676,6 +681,7 @@ const LivePlayerGridItem = React.forwardRef<
           preferredLiveMode={preferredLiveMode}
           onClick={onClick}
           onError={onError}
+          onResetLiveMode={onResetLiveMode}
           containerRef={ref as React.RefObject<HTMLDivElement>}
         />
         {children}

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -294,10 +294,8 @@ export default function LiveCameraView({
           config &&
           config.go2rtc?.webrtc?.candidates?.length > 0
         ) {
-          // console.log(camera.name, "switching to webrtc");
           setWebRTC(true);
         } else {
-          // console.log(camera.name, "switching to jsmpeg");
           setWebRTC(false);
           setLowBandwidth(true);
         }

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -286,14 +286,25 @@ export default function LiveCameraView({
     }
   }, [fullscreen, isPortrait, cameraAspectRatio, containerAspectRatio]);
 
-  const handleError = useCallback((e: LivePlayerError) => {
-    if (e == "mse-decode") {
-      setWebRTC(true);
-    } else {
-      setWebRTC(false);
-      setLowBandwidth(true);
-    }
-  }, []);
+  const handleError = useCallback(
+    (e: LivePlayerError) => {
+      if (e) {
+        if (
+          !webRTC &&
+          config &&
+          config.go2rtc?.webrtc?.candidates?.length > 0
+        ) {
+          // console.log(camera.name, "switching to webrtc");
+          setWebRTC(true);
+        } else {
+          // console.log(camera.name, "switching to jsmpeg");
+          setWebRTC(false);
+          setLowBandwidth(true);
+        }
+      }
+    },
+    [config, webRTC],
+  );
 
   return (
     <TransformWrapper minScale={1.0} wheel={{ smoothStep: 0.005 }}>

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -227,6 +227,10 @@ export default function LiveCameraView({
       return "webrtc";
     }
 
+    if (!isRestreamed) {
+      return "jsmpeg";
+    }
+
     return "mse";
   }, [lowBandwidth, mic, webRTC, isRestreamed]);
 

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -30,8 +30,8 @@ import { LuLayoutDashboard } from "react-icons/lu";
 import { cn } from "@/lib/utils";
 import { LivePlayerError } from "@/types/live";
 import { FaCompress, FaExpand } from "react-icons/fa";
-import { useResizeObserver } from "@/hooks/resize-observer";
 import useCameraLiveMode from "@/hooks/use-camera-live-mode";
+import { useResizeObserver } from "@/hooks/resize-observer";
 
 type LiveDashboardViewProps = {
   cameras: CameraConfig[];

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -230,8 +230,6 @@ export default function LiveDashboardView({
           newModes[cameraName] = isRestreamed ? "mse" : "jsmpeg";
         }
 
-        console.log("resetting", cameraName, "to", newModes[cameraName]);
-
         return newModes;
       });
     },

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -31,7 +31,6 @@ import { cn } from "@/lib/utils";
 import { LivePlayerError } from "@/types/live";
 import { FaCompress, FaExpand } from "react-icons/fa";
 import { useResizeObserver } from "@/hooks/resize-observer";
-import useKeyboardListener from "@/hooks/use-keyboard-listener";
 import useCameraLiveMode from "@/hooks/use-camera-live-mode";
 
 type LiveDashboardViewProps = {
@@ -221,18 +220,6 @@ export default function LiveDashboardView({
     },
     [setPreferredLiveModes],
   );
-
-  useKeyboardListener(["f"], (key, modifiers) => {
-    if (!modifiers.down) {
-      return;
-    }
-
-    switch (key) {
-      case "f":
-        toggleFullscreen();
-        break;
-    }
-  });
 
   return (
     <div

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -214,6 +214,30 @@ export default function LiveDashboardView({
     setPreferredLiveModes(newPreferredLiveModes);
   }, [cameras, config, windowVisible]);
 
+  const resetPreferredLiveMode = useCallback(
+    (cameraName: string) => {
+      const mseSupported =
+        "MediaSource" in window || "ManagedMediaSource" in window;
+      const isRestreamed =
+        config && Object.keys(config.go2rtc.streams || {}).includes(cameraName);
+
+      setPreferredLiveModes((prevModes) => {
+        const newModes = { ...prevModes };
+
+        if (!mseSupported) {
+          newModes[cameraName] = isRestreamed ? "webrtc" : "jsmpeg";
+        } else {
+          newModes[cameraName] = isRestreamed ? "mse" : "jsmpeg";
+        }
+
+        console.log("resetting", cameraName, "to", newModes[cameraName]);
+
+        return newModes;
+      });
+    },
+    [config],
+  );
+
   const cameraRef = useCallback(
     (node: HTMLElement | null) => {
       if (!visibleCameraObserver.current) {
@@ -394,6 +418,7 @@ export default function LiveDashboardView({
                   autoLive={autoLiveView}
                   onClick={() => onSelectCamera(camera.name)}
                   onError={(e) => handleError(camera.name, e)}
+                  onResetLiveMode={() => resetPreferredLiveMode(camera.name)}
                 />
               );
             })}
@@ -442,6 +467,7 @@ export default function LiveDashboardView({
           setIsEditMode={setIsEditMode}
           fullscreen={fullscreen}
           toggleFullscreen={toggleFullscreen}
+          resetPreferredLiveMode={resetPreferredLiveMode}
         />
       )}
     </div>


### PR DESCRIPTION
- Fix MSE player falling behind actual live when network conditions are not perfect. Safari/iOS will jump ahead (setting `playbackRate` causes Safari/iOS to re-buffer), all other browsers will dynamically increase playback rate based on a rolling average of buffer time.
- Fix bug where streams would not fall back to WebRTC if MSE failed, leaving users with an endless activity indicator. User must explicitly have `candidates` defined in their go2rtc config for fallback to occur. If WebRTC is configured but fails, fallback to jsmpeg occurs. This particular behavior is for single camera live views only. Dashboard cameras streaming MSE will always fall back to jsmpeg to preserve bandwidth.
- Refactor `useCameraLiveMode` hook to reset intelligently selected live mode back to default when camera goes inactive if the mode was changed because of an error during playback

This code has been tested by users and found to work well. It resolves the issues in https://github.com/blakeblackshear/frigate/discussions/13064, https://github.com/blakeblackshear/frigate/discussions/13126, and https://github.com/blakeblackshear/frigate/discussions/13047