### PR TITLE
Added support to auto select last opened video camera on settings page using global state context provider

### DIFF
--- a/web/src/context/global-state-provider.tsx
+++ b/web/src/context/global-state-provider.tsx
@@ -1,0 +1,36 @@
+// GlobalStateContext.tsx
+import React, { createContext, useState, ReactNode, useContext } from "react";
+
+interface GlobalStateContextType {
+  lastSelectedCamera: string;
+  setLastSelectedCamera: (camera: string) => void;
+}
+
+const GlobalStateContext = createContext<GlobalStateContextType | undefined>(
+  undefined,
+);
+
+const GlobalStateProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [lastSelectedCamera, setLastSelectedCamera] = useState<string>("");
+
+  return (
+    <GlobalStateContext.Provider
+      value={{ lastSelectedCamera, setLastSelectedCamera }}
+    >
+      {children}
+    </GlobalStateContext.Provider>
+  );
+};
+
+const useGlobalState = (): GlobalStateContextType => {
+  const context = useContext(GlobalStateContext);
+  if (context === undefined) {
+    throw new Error("useGlobalState must be used within a GlobalStateProvider");
+  }
+  return context;
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export { GlobalStateProvider, useGlobalState };

--- a/web/src/context/providers.tsx
+++ b/web/src/context/providers.tsx
@@ -5,19 +5,22 @@ import { ApiProvider } from "@/api";
 import { IconContext } from "react-icons";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { StatusBarMessagesProvider } from "@/context/statusbar-provider";
+import { GlobalStateProvider } from "@/context/global-state-provider";
 
 type TProvidersProps = {
   children: ReactNode;
 };
 
-function providers({ children }: TProvidersProps) {
+function Providers({ children }: TProvidersProps) {
   return (
     <RecoilRoot>
       <ApiProvider>
         <ThemeProvider defaultTheme="system" storageKey="frigate-ui-theme">
           <TooltipProvider>
             <IconContext.Provider value={{ size: "20" }}>
-              <StatusBarMessagesProvider>{children}</StatusBarMessagesProvider>
+              <StatusBarMessagesProvider>
+                <GlobalStateProvider>{children}</GlobalStateProvider>
+              </StatusBarMessagesProvider>
             </IconContext.Provider>
           </TooltipProvider>
         </ThemeProvider>
@@ -26,4 +29,4 @@ function providers({ children }: TProvidersProps) {
   );
 }
 
-export default providers;
+export default Providers;

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -8,11 +8,14 @@ import { FrigateConfig } from "@/types/frigateConfig";
 import LiveBirdseyeView from "@/views/live/LiveBirdseyeView";
 import LiveCameraView from "@/views/live/LiveCameraView";
 import LiveDashboardView from "@/views/live/LiveDashboardView";
+import { useGlobalState } from "@/context/global-state-provider";
 import { useEffect, useMemo, useRef } from "react";
 import useSWR from "swr";
 
 function Live() {
   const { data: config } = useSWR<FrigateConfig>("config");
+
+  const { setLastSelectedCamera } = useGlobalState();
 
   // selection
 
@@ -21,6 +24,11 @@ function Live() {
     "cameraGroup",
     "default" as string,
   );
+
+  const handleCameraChange = (camera: string) => {
+    setLastSelectedCamera(camera);
+    setSelectedCameraName(camera);
+  };
 
   useSearchEffect("group", (cameraGroup) => {
     if (config && cameraGroup) {
@@ -115,7 +123,7 @@ function Live() {
           cameras={cameras}
           cameraGroup={cameraGroup ?? "default"}
           includeBirdseye={includesBirdseye}
-          onSelectCamera={setSelectedCameraName}
+          onSelectCamera={handleCameraChange}
           fullscreen={fullscreen}
           toggleFullscreen={toggleFullscreen}
         />

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -35,6 +35,7 @@ import ObjectSettingsView from "@/views/settings/ObjectSettingsView";
 import MotionTunerView from "@/views/settings/MotionTunerView";
 import MasksAndZonesView from "@/views/settings/MasksAndZonesView";
 import AuthenticationView from "@/views/settings/AuthenticationView";
+import { useGlobalState } from "@/context/global-state-provider";
 
 export default function Settings() {
   const settingsViews = [
@@ -52,6 +53,7 @@ export default function Settings() {
   const tabsRef = useRef<HTMLDivElement | null>(null);
 
   const { data: config } = useSWR<FrigateConfig>("config");
+  const { lastSelectedCamera } = useGlobalState();
 
   // TODO: confirm leave page
   const [unsavedChanges, setUnsavedChanges] = useState(false);
@@ -67,7 +69,8 @@ export default function Settings() {
       .sort((aConf, bConf) => aConf.ui.order - bConf.ui.order);
   }, [config]);
 
-  const [selectedCamera, setSelectedCamera] = useState<string>("");
+  const [selectedCamera, setSelectedCamera] =
+    useState<string>(lastSelectedCamera);
 
   const [filterZoneMask, setFilterZoneMask] = useState<PolygonType[]>();
 


### PR DESCRIPTION
Linked Issue: https://github.com/blakeblackshear/frigate/issues/12904

# Problem
Opening setting page does not track the last selected camera and defaults to first camera

[Screencast from 18-08-24 05:58:13 PM IST.webm](https://github.com/user-attachments/assets/53b3efdd-42a2-4a73-8b82-22771e582543)

# Solution
1. Using a global state context provider to share common state across components
2. Setting up the lastSelectedCamera from the Live View 
3. Using the lastSelectedCamera to initialize the selection

[Screencast from 18-08-24 06:47:48 PM IST.webm](https://github.com/user-attachments/assets/0c0bc408-a2d2-4589-8c42-b0ff84914e62)

# Test Outcome

[Screencast from 18-08-24 06:46:00 PM IST.webm](https://github.com/user-attachments/assets/bb1d1fa5-4e4c-4660-83d7-902040f8e890)


