### PR TITLE
Don't allow periods in zone or camera group names

### DIFF
--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -551,6 +551,14 @@ export function CameraGroupEdit({
           message: "Camera group name already exists.",
         },
       )
+      .refine(
+        (value: string) => {
+          return !value.includes(".");
+        },
+        {
+          message: "Camera group name must not contain a period.",
+        },
+      )
       .refine((value: string) => value.toLowerCase() !== "default", {
         message: "Invalid camera group name.",
       }),

--- a/web/src/components/settings/ZoneEditPane.tsx
+++ b/web/src/components/settings/ZoneEditPane.tsx
@@ -106,6 +106,14 @@ export default function ZoneEditPane({
         {
           message: "Zone name already exists on this camera.",
         },
+      )
+      .refine(
+        (value: string) => {
+          return !value.includes(".");
+        },
+        {
+          message: "Zone name must not contain a period.",
+        },
       ),
     inertia: z.coerce
       .number()


### PR DESCRIPTION
The API calls to update the config fail when a `.` is in the name, as in https://github.com/blakeblackshear/frigate/discussions/13397