### PR TITLE
Improve timeline auto scrolling

### DIFF
--- a/web/src/hooks/use-draggable-element.ts
+++ b/web/src/hooks/use-draggable-element.ts
@@ -547,11 +547,20 @@ function useDraggableElement({
       timelineElement.addEventListener("scroll", handleUserInteraction);
       timelineElement.addEventListener("mousedown", handleUserInteraction);
       timelineElement.addEventListener("mouseup", handleUserInteraction);
+      timelineElement.addEventListener("touchstart", handleUserInteraction);
+      timelineElement.addEventListener("touchmove", handleUserInteraction);
+      timelineElement.addEventListener("touchend", handleUserInteraction);
 
       return () => {
         timelineElement.removeEventListener("scroll", handleUserInteraction);
         timelineElement.removeEventListener("mousedown", handleUserInteraction);
         timelineElement.removeEventListener("mouseup", handleUserInteraction);
+        timelineElement.removeEventListener(
+          "touchstart",
+          handleUserInteraction,
+        );
+        timelineElement.removeEventListener("touchmove", handleUserInteraction);
+        timelineElement.removeEventListener("touchend", handleUserInteraction);
       };
     }
   }, [timelineRef]);

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -702,7 +702,6 @@ function Timeline({
             setExportEndTime={setExportEndTime}
             handlebarTime={currentTime}
             setHandlebarTime={setCurrentTime}
-            onlyInitialHandlebarScroll={true}
             events={mainCameraReviewItems}
             motion_events={motionData ?? []}
             severityType="significant_motion"


### PR DESCRIPTION
While footage is being played back, keep the timeline handlebar in view, but with a 3 second delay after user has finished interaction (scrolling, clicking/tapping) the timeline.

Improves https://github.com/blakeblackshear/frigate/discussions/13551