### PR TITLE
Don't modalize the export drawer on iOS

### DIFF
--- a/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
+++ b/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
@@ -13,7 +13,7 @@ import { GeneralFilterContent } from "../filter/ReviewFilterGroup";
 import { toast } from "sonner";
 import axios from "axios";
 import SaveExportOverlay from "./SaveExportOverlay";
-import { isMobile } from "react-device-detect";
+import { isIOS, isMobile } from "react-device-detect";
 
 type DrawerMode = "none" | "select" | "export" | "calendar" | "filter";
 
@@ -281,6 +281,7 @@ export default function MobileReviewSettingsDrawer({
         onCancel={() => setMode("none")}
       />
       <Drawer
+        modal={!(isIOS && drawerMode == "export")}
         open={drawerMode != "none"}
         onOpenChange={(open) => {
           if (!open) {


### PR DESCRIPTION
Something with radix/shadcn's overlay causes the iOS time picker input to display offscreen. This fix sets `modal` to `false` on the mobile review settings drawer when exporting so that the native iOS time picker can be used.