### PR TITLE
Install onnxruntime with openvino execution provider

### DIFF
--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -29,6 +29,7 @@ setproctitle == 1.3.*
 ws4py == 0.5.*
 unidecode == 1.3.*
 # OpenVino & ONNX
+openvino == 2024.1.*
 onnxruntime-openvino == 1.18.*
 # Embeddings
 onnx_clip == 4.0.*

--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -29,7 +29,7 @@ setproctitle == 1.3.*
 ws4py == 0.5.*
 unidecode == 1.3.*
 # OpenVino & ONNX
-onnxruntime-openvino == 1.19.*
+onnxruntime-openvino == 1.18.*
 # Embeddings
 onnx_clip == 4.0.*
 chromadb == 0.5.0

--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -28,8 +28,8 @@ norfair == 2.2.*
 setproctitle == 1.3.*
 ws4py == 0.5.*
 unidecode == 1.3.*
-onnxruntime == 1.18.*
-openvino == 2024.1.*
+# OpenVino & ONNX
+onnxruntime-openvino == 1.19.*
 # Embeddings
 onnx_clip == 4.0.*
 chromadb == 0.5.0


### PR DESCRIPTION
This installs onnxruntime with openvino 2024.1, along with the execution providers. This will use openvino when running onnx models like the CLIP models for semantic search