### PR TITLE
Use ffmpeg from deb-multimedia.org for trixie (and generally update container to use trixie base image).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,19 +18,19 @@ version:
 	echo 'VERSION = "$(VERSION)-$(COMMIT_HASH)"' > frigate/version.py
 
 local: version
-	docker buildx build --target=frigate --tag frigate:latest --load --file docker/main/Dockerfile .
+	docker buildx build --progress plain --target=frigate --tag frigate:latest --load --file docker/main/Dockerfile .
 
 amd64:
-	docker buildx build --platform linux/amd64 --target=frigate --tag $(IMAGE_REPO):$(VERSION)-$(COMMIT_HASH) --file docker/main/Dockerfile .
+	docker buildx build --progress plain --platform linux/amd64 --target=frigate --tag $(IMAGE_REPO):$(VERSION)-$(COMMIT_HASH) --file docker/main/Dockerfile .
 
 arm64:
-	docker buildx build --platform linux/arm64 --target=frigate --tag $(IMAGE_REPO):$(VERSION)-$(COMMIT_HASH) --file docker/main/Dockerfile .
+	docker buildx build --progress plain --platform linux/arm64 --target=frigate --tag $(IMAGE_REPO):$(VERSION)-$(COMMIT_HASH) --file docker/main/Dockerfile .
 
 build: version amd64 arm64
-	docker buildx build --platform linux/arm64/v8,linux/amd64 --target=frigate --tag $(IMAGE_REPO):$(VERSION)-$(COMMIT_HASH) --file docker/main/Dockerfile .
+	docker buildx build --progress plain --platform linux/arm64/v8,linux/amd64 --target=frigate --tag $(IMAGE_REPO):$(VERSION)-$(COMMIT_HASH) --file docker/main/Dockerfile .
 
 push: push-boards
-	docker buildx build --push --platform linux/arm64/v8,linux/amd64 --target=frigate --tag $(IMAGE_REPO):${GITHUB_REF_NAME}-$(COMMIT_HASH) --file docker/main/Dockerfile .
+	docker buildx build --progress plain --push --platform linux/arm64/v8,linux/amd64 --target=frigate --tag $(IMAGE_REPO):${GITHUB_REF_NAME}-$(COMMIT_HASH) --file docker/main/Dockerfile .
 
 run: local
 	docker run --rm --publish=5000:5000 --volume=${PWD}/config:/config frigate:latest

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -286,7 +286,7 @@ RUN set -eux; \
     DEBIAN_FRONTEND=noninteractive; \
     export DEBIAN_FRONTEND; \
     apt -y update; \
-    apt -y install nodejs make; \
+    apt -y install nodejs npm make; \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     npm install -g npm@10
 

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -1,22 +1,21 @@
 # syntax=docker/dockerfile:1.6
 
-# https://askubuntu.com/questions/972516/debian-frontend-environment-variable
-ARG DEBIAN_FRONTEND=noninteractive
-
-ARG BASE_IMAGE=debian:11
-ARG SLIM_BASE=debian:11-slim
+ARG BASE_IMAGE=debian:testing
+ARG SLIM_BASE=debian:testing-slim
 
 FROM ${BASE_IMAGE} AS base
 
-FROM --platform=${BUILDPLATFORM} debian:11 AS base_host
+FROM --platform=${BUILDPLATFORM} ${BASE_IMAGE} AS base_host
 
 FROM ${SLIM_BASE} AS slim-base
 
 FROM slim-base AS wget
-ARG DEBIAN_FRONTEND
-RUN apt-get update \
-    && apt-get install -y wget xz-utils \
-    && rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    DEBIAN_FRONTEND=noninteractive; \
+    export DEBIAN_FRONTEND; \
+    apt -y update; \
+    apt -y install wget xz-utils; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 WORKDIR /rootfs
 
 FROM base AS nginx
@@ -28,6 +27,7 @@ ENV CCACHE_MAXSIZE 2G
 RUN --mount=type=tmpfs,target=/tmp --mount=type=tmpfs,target=/var/cache/apt \
     --mount=type=bind,source=docker/main/build_nginx.sh,target=/deps/build_nginx.sh \
     --mount=type=cache,target=/root/.ccache \
+    set -eux; \
     /deps/build_nginx.sh
 
 FROM scratch AS go2rtc
@@ -38,6 +38,7 @@ ADD --link --chmod=755 "https://github.com/AlexxIT/go2rtc/releases/download/v1.9
 FROM wget AS tempio
 ARG TARGETARCH
 RUN --mount=type=bind,source=docker/main/install_tempio.sh,target=/deps/install_tempio.sh \
+    set -eux; \
     /deps/install_tempio.sh
 
 ####
@@ -49,22 +50,27 @@ RUN --mount=type=bind,source=docker/main/install_tempio.sh,target=/deps/install_
 ####
 # Download and Convert OpenVino model
 FROM base_host AS ov-converter
-ARG DEBIAN_FRONTEND
 
 # Install OpenVino Runtime and Dev library
 COPY docker/main/requirements-ov.txt /requirements-ov.txt
-RUN apt-get -qq update \
-    && apt-get -qq install -y wget python3 python3-dev python3-distutils gcc pkg-config libhdf5-dev \
-    && wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py \
-    && python3 get-pip.py "pip" \
-    && pip install -r /requirements-ov.txt
+RUN set -eux; \
+    DEBIAN_FRONTEND=noninteractive; \
+    export DEBIAN_FRONTEND; \
+    apt -qq update; \
+    apt -qq -y install wget python3 python3-dev python3-setuptools python3-pip gcc pkg-config libhdf5-dev; \
+    pip install --break-system-packages -r /requirements-ov.txt; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* ~/.cache/pip
 
 # Get OpenVino Model
 RUN --mount=type=bind,source=docker/main/build_ov_model.py,target=/build_ov_model.py \
-    mkdir /models && cd /models \
-    && wget http://download.tensorflow.org/models/object_detection/ssdlite_mobilenet_v2_coco_2018_05_09.tar.gz \
-    && tar -xvf ssdlite_mobilenet_v2_coco_2018_05_09.tar.gz \
-    && python3 /build_ov_model.py
+    set -eux; \
+    mkdir -p /models; \
+    cd /models; \
+    weights_tarball=ssdlite_mobilenet_v2_coco_2018_05_09.tar.gz; \
+    wget http://download.tensorflow.org/models/object_detection/$weights_tarball; \
+    tar xzf $weights_tarball; \
+    python3 /build_ov_model.py; \
+    rm -f $weights_tarball
 
 ####
 #
@@ -81,95 +87,111 @@ ENV CCACHE_MAXSIZE 2G
 
 # Build libUSB without udev.  Needed for Openvino NCS2 support
 WORKDIR /opt
-RUN apt-get update && apt-get install -y unzip build-essential automake libtool ccache pkg-config
-RUN --mount=type=cache,target=/root/.ccache wget -q https://github.com/libusb/libusb/archive/v1.0.26.zip -O v1.0.26.zip && \
-    unzip v1.0.26.zip && cd libusb-1.0.26 && \
-    ./bootstrap.sh && \
-    ./configure CC='ccache gcc' CCX='ccache g++' --disable-udev --enable-shared && \
-    make -j $(nproc --all)
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libusb-1.0-0-dev && \
-    rm -rf /var/lib/apt/lists/*
-WORKDIR /opt/libusb-1.0.26/libusb
-RUN /bin/mkdir -p '/usr/local/lib' && \
-    /bin/bash ../libtool  --mode=install /usr/bin/install -c libusb-1.0.la '/usr/local/lib' && \
-    /bin/mkdir -p '/usr/local/include/libusb-1.0' && \
-    /usr/bin/install -c -m 644 libusb.h '/usr/local/include/libusb-1.0' && \
-    /bin/mkdir -p '/usr/local/lib/pkgconfig' && \
-    cd  /opt/libusb-1.0.26/ && \
-    /usr/bin/install -c -m 644 libusb-1.0.pc '/usr/local/lib/pkgconfig' && \
+RUN --mount=type=cache,target=/root/.ccache \
+    set -eux; \
+    DEBIAN_FRONTEND=noninteractive; \
+    export DEBIAN_FRONTEND; \
+    apt -y update; \
+    apt -y install unzip build-essential automake libtool ccache pkg-config; \
+    apt -y install --no-install-recommends libusb-1.0-0-dev; \
+    libusb_version=1.0.27; \
+    wget -q https://github.com/libusb/libusb/archive/v${libusb_version}.zip -O v${libusb_version}.zip; \
+    unzip v${libusb_version}.zip; \
+    cd libusb-${libusb_version}; \
+    ./bootstrap.sh; \
+    ./configure CC='ccache gcc' CCX='ccache g++' --disable-udev --enable-shared; \
+    make -j $(nproc --all); \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+WORKDIR /opt/libusb-1.0.27/libusb
+RUN set -eux; \
+    /bin/mkdir -p '/usr/local/lib'; \
+    /bin/bash ../libtool  --mode=install /usr/bin/install -c libusb-1.0.la '/usr/local/lib'; \
+    /bin/mkdir -p '/usr/local/include/libusb-1.0'; \
+    /usr/bin/install -c -m 644 libusb.h '/usr/local/include/libusb-1.0'; \
+    /bin/mkdir -p '/usr/local/lib/pkgconfig'; \
+    cd /opt/libusb-1.0.27/; \
+    /usr/bin/install -c -m 644 libusb-1.0.pc '/usr/local/lib/pkgconfig'; \
     ldconfig
 
 FROM wget AS models
 
 # Get model and labels
-RUN wget -qO edgetpu_model.tflite https://github.com/google-coral/test_data/raw/release-frogfish/ssdlite_mobiledet_coco_qat_postprocess_edgetpu.tflite
-RUN wget -qO cpu_model.tflite https://github.com/google-coral/test_data/raw/release-frogfish/ssdlite_mobiledet_coco_qat_postprocess.tflite
+RUN set -eux; \
+    wget -qO edgetpu_model.tflite https://github.com/google-coral/test_data/raw/release-frogfish/ssdlite_mobiledet_coco_qat_postprocess_edgetpu.tflite; \
+    wget -qO cpu_model.tflite https://github.com/google-coral/test_data/raw/release-frogfish/ssdlite_mobiledet_coco_qat_postprocess.tflite
 COPY labelmap.txt .
 # Copy OpenVino model
 COPY --from=ov-converter /models/ssdlite_mobilenet_v2.xml openvino-model/
 COPY --from=ov-converter /models/ssdlite_mobilenet_v2.bin openvino-model/
-RUN wget -q https://github.com/openvinotoolkit/open_model_zoo/raw/master/data/dataset_classes/coco_91cl_bkgr.txt -O openvino-model/coco_91cl_bkgr.txt && \
-    sed -i 's/truck/car/g' openvino-model/coco_91cl_bkgr.txt
-# Get Audio Model and labels
-RUN wget -qO - https://www.kaggle.com/api/v1/models/google/yamnet/tfLite/classification-tflite/1/download | tar xvz && mv 1.tflite cpu_audio_model.tflite
+RUN set -eux; \
+    wget -q https://github.com/openvinotoolkit/open_model_zoo/raw/master/data/dataset_classes/coco_91cl_bkgr.txt -O openvino-model/coco_91cl_bkgr.txt; \
+    sed -i 's/truck/car/g' openvino-model/coco_91cl_bkgr.txt; \
+    wget -qO - https://www.kaggle.com/api/v1/models/google/yamnet/tfLite/classification-tflite/1/download | \
+        tar xzf -; \
+    mv 1.tflite cpu_audio_model.tflite # Get Audio Model and labels
 COPY audio-labelmap.txt .
 
 
 FROM wget AS s6-overlay
 ARG TARGETARCH
 RUN --mount=type=bind,source=docker/main/install_s6_overlay.sh,target=/deps/install_s6_overlay.sh \
+    set -eux; \
     /deps/install_s6_overlay.sh
 
 
 FROM base AS wheels
-ARG DEBIAN_FRONTEND
 ARG TARGETARCH
 
 # Use a separate container to build wheels to prevent build dependencies in final image
-RUN apt-get -qq update \
-    && apt-get -qq install -y \
-    apt-transport-https \
-    gnupg \
-    wget \
-    # the key fingerprint can be obtained from https://ftp-master.debian.org/keys.html
-    && wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xA4285295FC7B1A81600062A9605C66F00D6C9793" | \
-    gpg --dearmor > /usr/share/keyrings/debian-archive-bullseye-stable.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/debian-archive-bullseye-stable.gpg] http://deb.debian.org/debian bullseye main contrib non-free" | \
-    tee /etc/apt/sources.list.d/debian-bullseye-nonfree.list \
-    && apt-get -qq update \
-    && apt-get -qq install -y \
-    python3.9 \
-    python3.9-dev \
+RUN set -eux; \
+    DEBIAN_FRONTEND=noninteractive; \
+    export DEBIAN_FRONTEND; \
+    apt -qq -y update; \
+    apt -qq -y install apt-transport-https gnupg wget ca-certificates; \
+    (echo "deb https://cdn-aws.deb.debian.org/debian testing main contrib non-free non-free-firmware"; \
+     echo "deb https://cdn-aws.deb.debian.org/debian stable main contrib non-free non-free-firmware"; \
+     echo "deb https://cdn-aws.deb.debian.org/debian stable-updates main contrib non-free non-free-firmware"; \
+     echo "deb https://cdn-aws.deb.debian.org/debian-security/ stable-security main contrib non-free non-free-firmware") | \
+        tee /etc/apt/sources.list.d/debian-testing-nonfree.list; \
+
+    apt -y -qq update; \
+    apt -y -qq install python3 python3-dev python3-pip python3-setuptools \
     # opencv dependencies
-    build-essential cmake git pkg-config libgtk-3-dev \
-    libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
-    libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev \
-    gfortran openexr libatlas-base-dev libssl-dev\
-    libtbb2 libtbb-dev libdc1394-22-dev libopenexr-dev \
-    libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev \
+        build-essential cmake git pkg-config libgtk-3-dev \
+        libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
+        libxvidcore-dev libx264-dev libjpeg-dev libpng-dev libtiff-dev \
+        gfortran openexr libatlas-base-dev libssl-dev\
+        libtbbmalloc2 libtbb-dev libdc1394-dev libopenexr-dev \
+        libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev \
     # sqlite3 dependencies
-    tclsh \
+        tclsh \
     # scipy dependencies
-    gcc gfortran libopenblas-dev liblapack-dev && \
-    rm -rf /var/lib/apt/lists/*
-
-# Ensure python3 defaults to python3.9
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
-
-RUN wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py \
-    && python3 get-pip.py "pip"
+        gcc gfortran libopenblas-dev liblapack-dev; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 COPY docker/main/requirements.txt /requirements.txt
-RUN pip3 install -r /requirements.txt
+RUN set -eux; \
+    mkdir -p /root/wheel-build; \
+    cd /root/wheel-build; \
+    pip3 download nvidia-pyindex==1.0.9; \
+    tar xzf nvidia-pyindex-1.0.9.tar.gz; \
+    cd nvidia-pyindex-1.0.9; \
+    pip3 wheel .; \
+    pip3 install --break-system-packages nvidia_pyindex*whl; \
+    mkdir -p /wheels; \
+    mv *.whl /wheels; \
+    cd; \
+    pip3 install --break-system-packages -r /requirements.txt; \
+    rm -rf /root/.cache/pip /root/wheel-build
 
 # Build pysqlite3 from source to support ChromaDB
 COPY docker/main/build_pysqlite3.sh /build_pysqlite3.sh
-RUN /build_pysqlite3.sh
+RUN set -eux; \
+    /build_pysqlite3.sh
 
 COPY docker/main/requirements-wheels.txt /requirements-wheels.txt
-RUN pip3 wheel --wheel-dir=/wheels -r /requirements-wheels.txt
-
+RUN set -eux; \
+    pip3 wheel --wheel-dir=/wheels -r /requirements-wheels.txt
 
 # Collect deps in a single layer
 FROM scratch AS deps-rootfs
@@ -186,7 +208,6 @@ COPY docker/main/rootfs/ /
 FROM slim-base AS deps
 ARG TARGETARCH
 
-ARG DEBIAN_FRONTEND
 # http://stackoverflow.com/questions/48162574/ddg#49462622
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
 
@@ -201,19 +222,37 @@ ENV ALLOW_RESET=True
 # Disable tokenizer parallelism warning
 ENV TOKENIZERS_PARALLELISM=true
 
-ENV PATH="/usr/lib/btbn-ffmpeg/bin:/usr/local/go2rtc/bin:/usr/local/tempio/bin:/usr/local/nginx/sbin:${PATH}"
+ENV PATH="/usr/local/go2rtc/bin:/usr/local/tempio/bin:/usr/local/nginx/sbin:${PATH}"
 
 # Install dependencies
 RUN --mount=type=bind,source=docker/main/install_deps.sh,target=/deps/install_deps.sh \
+    set -eux; \
+    DEBIAN_FRONTEND=noninteractive; \
+    export DEBIAN_FRONTEND; \
+    keyring_pkg=deb-multimedia-keyring_2016.8.1_all.deb; \
+    apt -y update; \
+    apt -y install wget; \
+    wget -O /root/$keyring_pkg https://www.deb-multimedia.org/pool/main/d/deb-multimedia-keyring/$keyring_pkg; \
+    dpkg -i /root/$keyring_pkg; \
+    rm -f /root/$keyring_pkg; \
+    echo 'deb https://debian-mirrors.sdinet.de/deb-multimedia testing main non-free' > /etc/apt/sources.list.d/deb-multimedia.list; \
+    apt -y update; \
+    apt -y install ffmpeg; \
     /deps/install_deps.sh
 
 RUN --mount=type=bind,from=wheels,source=/wheels,target=/deps/wheels \
-    python3 -m pip install --upgrade pip && \
-    pip3 install -U /deps/wheels/*.whl
+    set -eux; \
+    DEBIAN_FRONTEND=noninteractive; \
+    export DEBIAN_FRONTEND; \
+    apt -y update; \
+    apt -y install python3-pip; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
+    pip3 install --break-system-packages -U /deps/wheels/*.whl
 
 COPY --from=deps-rootfs / /
 
-RUN ldconfig
+RUN set -eux; \
+    ldconfig
 
 EXPOSE 5000
 EXPOSE 8554
@@ -238,24 +277,23 @@ FROM deps AS devcontainer
 COPY docker/main/fake_frigate_run /etc/s6-overlay/s6-rc.d/frigate/run
 
 # Create symbolic link to the frigate source code, as go2rtc's create_config.sh uses it
-RUN mkdir -p /opt/frigate \
-    && ln -svf /workspace/frigate/frigate /opt/frigate/frigate
+RUN set -eux; \
+    mkdir -p /opt/frigate; \
+    ln -sf /workspace/frigate/frigate /opt/frigate/frigate
 
 # Install Node 20
-RUN curl -SLO https://deb.nodesource.com/nsolid_setup_deb.sh && \
-    chmod 500 nsolid_setup_deb.sh && \
-    ./nsolid_setup_deb.sh 20 && \
-    apt-get install nodejs -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm install -g npm@10
+RUN set -eux; \
+    DEBIAN_FRONTEND=noninteractive; \
+    export DEBIAN_FRONTEND; \
+    apt -y update; \
+    apt -y install nodejs make; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
+    npm install -g npm@10
 
 WORKDIR /workspace/frigate
 
-RUN apt-get update \
-    && apt-get install make -y \
-    && rm -rf /var/lib/apt/lists/*
-
 RUN --mount=type=bind,source=./docker/main/requirements-dev.txt,target=/workspace/frigate/requirements-dev.txt \
+    set -eux; \
     pip3 install -r requirements-dev.txt
 
 HEALTHCHECK NONE
@@ -269,12 +307,14 @@ FROM --platform=$BUILDPLATFORM node:20 AS web-build
 
 WORKDIR /work
 COPY web/package.json web/package-lock.json ./
-RUN npm install
+RUN set -eux; \
+    npm install
 
 COPY web/ ./
-RUN npm run build \
-    && mv dist/BASE_PATH/monacoeditorwork/* dist/assets/ \
-    && rm -rf dist/BASE_PATH
+RUN set -eux; \
+    npm run build; \
+    mv dist/BASE_PATH/monacoeditorwork/* dist/assets/; \
+    rm -rf dist/BASE_PATH
 
 # Collect final files in a single layer
 FROM scratch AS rootfs

--- a/docker/main/build_nginx.sh
+++ b/docker/main/build_nginx.sh
@@ -8,15 +8,22 @@ SECURE_TOKEN_MODULE_VERSION="1.5"
 SET_MISC_MODULE_VERSION="v0.33"
 NGX_DEVEL_KIT_VERSION="v0.3.3"
 
-cp /etc/apt/sources.list /etc/apt/sources.list.d/sources-src.list
-sed -i 's|deb http|deb-src http|g' /etc/apt/sources.list.d/sources-src.list
-apt-get update
+DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND
 
-apt-get -yqq build-dep nginx
-
-apt-get -yqq install --no-install-recommends ca-certificates wget
+cat <<EOF > /etc/apt/sources.list.d/debian-src.list
+deb-src http://cdn-aws.deb.debian.org/debian testing main contrib non-free non-free-firmware
+EOF
+apt -y update
+apt -y install --no-install-recommends ca-certificates wget
+cat <<EOF > /etc/apt/sources.list.d/debian-src.list
+deb-src https://cdn-aws.deb.debian.org/debian testing main contrib non-free non-free-firmware
+EOF
 update-ca-certificates -f
-apt install -y ccache
+
+apt -y update
+apt -yqq build-dep nginx
+apt -y install ccache
 
 export PATH="/usr/lib/ccache:$PATH"
 

--- a/docker/main/build_ov_model.py
+++ b/docker/main/build_ov_model.py
@@ -3,8 +3,10 @@ from openvino.tools import mo
 from pathlib import Path
 from site import getsitepackages
 
+
 def transformations_config_location(path: Path):
     return path / 'openvino' / 'tools' / 'mo' / 'front' / 'tf' / 'ssd_v2_support.json'
+
 
 configs = [transformations_config_location(Path(path)) for path in getsitepackages()]
 assert len(configs) > 0, 'Expected at least one transformations config to exist but none existed.'

--- a/docker/main/build_ov_model.py
+++ b/docker/main/build_ov_model.py
@@ -1,10 +1,18 @@
 import openvino as ov
 from openvino.tools import mo
+from pathlib import Path
+from site import getsitepackages
+
+def transformations_config_location(path: Path):
+    return path / 'openvino' / 'tools' / 'mo' / 'front' / 'tf' / 'ssd_v2_support.json'
+
+configs = [transformations_config_location(Path(path)) for path in getsitepackages()]
+assert len(configs) > 0, 'Expected at least one transformations config to exist but none existed.'
 
 ov_model = mo.convert_model(
     "/models/ssdlite_mobilenet_v2_coco_2018_05_09/frozen_inference_graph.pb",
     compress_to_fp16=True,
-    transformations_config="/usr/local/lib/python3.9/dist-packages/openvino/tools/mo/front/tf/ssd_v2_support.json",
+    transformations_config=configs[0],
     tensorflow_object_detection_api_pipeline_config="/models/ssdlite_mobilenet_v2_coco_2018_05_09/pipeline.config",
     reverse_input_channels=True,
 )

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -2,6 +2,9 @@
 
 set -euxo pipefail
 
+DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND
+
 apt-get -qq update
 
 apt-get -qq install --no-install-recommends -y \
@@ -10,76 +13,81 @@ apt-get -qq install --no-install-recommends -y \
     wget \
     procps vainfo \
     unzip locales tzdata libxml2 xz-utils \
-    python3.9 \
+    python3 \
     python3-pip \
     curl \
     jq \
     nethogs
-
-# ensure python3 defaults to python3.9
-update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
 
 mkdir -p -m 600 /root/.gnupg
 
 # add coral repo
 curl -fsSLo - https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
     gpg --dearmor -o /etc/apt/trusted.gpg.d/google-cloud-packages-archive-keyring.gpg
-echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | tee /etc/apt/sources.list.d/coral-edgetpu.list
+echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" > /etc/apt/sources.list.d/coral-edgetpu.list
 echo "libedgetpu1-max libedgetpu/accepted-eula select true" | debconf-set-selections
 
 # enable non-free repo in Debian
 if grep -q "Debian" /etc/issue; then
-    sed -i -e's/ main/ main contrib non-free/g' /etc/apt/sources.list
+    sed -i -e's/ main/ main contrib non-free non-free-firmware/g' /etc/apt/sources.list.d/debian.sources
+    echo "deb https://cdn-aws.deb.debian.org/debian unstable main contrib non-free non-free-firmware" > /etc/apt/sources.list.d/debian-unstable.list
+    {
+        echo 'Package: *'
+        echo 'Pin: release a=unstable'
+        echo 'Pin-Priority: 300'
+    } > /etc/apt/preferences.d/unstable
 fi
 
 # coral drivers
 apt-get -qq update
-apt-get -qq install --no-install-recommends --no-install-suggests -y \
-    libedgetpu1-max python3-tflite-runtime python3-pycoral
+apt-get -y install --no-install-recommends --no-install-suggests libedgetpu1-max python3-numpy
 
-# btbn-ffmpeg -> amd64
-if [[ "${TARGETARCH}" == "amd64" ]]; then
-    mkdir -p /usr/lib/btbn-ffmpeg
-    wget -qO btbn-ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-09-04-18-56/ffmpeg-n7.0.2-15-g0458a86656-linux64-gpl-7.0.tar.xz"
-    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/btbn-ffmpeg --strip-components 1
-    rm -rf btbn-ffmpeg.tar.xz /usr/lib/btbn-ffmpeg/doc /usr/lib/btbn-ffmpeg/bin/ffplay
-fi
+# Google have abandoned the Coral Edge TPU and the version of pycoral in their repo only works with Python 3.9.
+# The open source community have stepped up and have updated pycoral to work with newer versions of TFLite and Python.
+# See: https://github.com/google-coral/pycoral/issues/85#issuecomment-2282233714
 
-# ffmpeg -> arm64
-if [[ "${TARGETARCH}" == "arm64" ]]; then
-    mkdir -p /usr/lib/btbn-ffmpeg
-    wget -qO btbn-ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-09-04-18-56/ffmpeg-n7.0.2-15-g0458a86656-linuxarm64-gpl-7.0.tar.xz"
-    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/btbn-ffmpeg --strip-components 1
-    rm -rf btbn-ffmpeg.tar.xz /usr/lib/btbn-ffmpeg/doc /usr/lib/btbn-ffmpeg/bin/ffplay
-fi
+case "${TARGETARCH}" in
+    amd64)
+        tflite_wheel=https://github.com/feranick/TFlite-builds/releases/download/v2.17.0/tflite_runtime-2.17.0-cp312-cp312-linux_x86_64.whl
+        pycoral_wheel=https://github.com/feranick/pycoral/releases/download/2.0.2TF2.17.0/pycoral-2.0.2-cp312-cp312-linux_x86_64.whl
+        ;;
+    arm64)
+        tflite_wheel=https://github.com/feranick/TFlite-builds/releases/download/v2.17.0/tflite_runtime-2.17.0-cp312-cp312-linux_aarch64.whl
+        pycoral_wheel=https://github.com/feranick/pycoral/releases/download/2.0.2TF2.17.0/pycoral-2.0.2-cp312-cp312-linux_aarch64.whl
+        ;;
+    *)
+        echo Pycoral is not supported on target architecture "${TARGETARCH}". 1>&2
+        exit 1
+        ;;
+esac
 
+pip install --break-system-packages "${tflite_wheel}"
+pip install --break-system-packages "${pycoral_wheel}"
+    
 # arch specific packages
-if [[ "${TARGETARCH}" == "amd64" ]]; then
-    # use debian bookworm for hwaccel packages
-    echo 'deb https://deb.debian.org/debian bookworm main contrib non-free' >/etc/apt/sources.list.d/debian-bookworm.list
-    apt-get -qq update
-    apt-get -qq install --no-install-recommends --no-install-suggests -y \
-        intel-opencl-icd \
-        mesa-va-drivers radeontop libva-drm2 intel-media-va-driver-non-free i965-va-driver libmfx1 intel-gpu-tools
-    # something about this dependency requires it to be installed in a separate call rather than in the line above
-    apt-get -qq install --no-install-recommends --no-install-suggests -y \
-        i965-va-driver-shaders
-    rm -f /etc/apt/sources.list.d/debian-bookworm.list
-fi
-
-if [[ "${TARGETARCH}" == "arm64" ]]; then
-    apt-get -qq install --no-install-recommends --no-install-suggests -y \
-        libva-drm2 mesa-va-drivers
-fi
+case "${TARGETARCH}" in
+    amd64)
+        apt -y -qq install --no-install-recommends --no-install-suggests \
+            intel-opencl-icd \
+            mesa-va-drivers radeontop libva-drm2 intel-media-va-driver-non-free i965-va-driver libmfx1 intel-gpu-tools
+        # something about this dependency requires it to be installed in a separate call rather than in the line above
+        apt -y -qq install --no-install-recommends --no-install-suggests \
+            i965-va-driver-shaders
+        ;;
+    arm64)
+        apt -y -qq install --no-install-recommends --no-install-suggests \
+            libva-drm2 mesa-va-drivers
+        ;;
+esac
 
 # install vulkan
 apt-get -qq install --no-install-recommends --no-install-suggests -y \
     libvulkan1 mesa-vulkan-drivers
 
-apt-get purge gnupg apt-transport-https xz-utils -y
-apt-get clean autoclean -y
-apt-get autoremove --purge -y
-rm -rf /var/lib/apt/lists/*
+apt-get -y purge gnupg apt-transport-https xz-utils
+apt-get -y clean autoclean
+apt-get -y autoremove --purge
+rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # Install yq, for frigate-prepare and go2rtc echo source
 curl -fsSL \


### PR DESCRIPTION
## What this change is

This change migrates the frigate container build to use Debian trixie as the base image. This permits us to use newer upstream packages (and, for example, stop needing to use a custom ffmpeg build). The main hitch was the need for Python 3.9 for Pycoral from the Google apt repository, for Coral Edge TPU support. Fortunately, the open source community has stepped up, and there are now TFLite and Pycoral wheels available for Python 3.10-3.12 as well.

## Testing done

Container built using

```shell
make local
```

and tests run successfully using

```shell
make run_tests
```