### PR TITLE
Refactor Search Page

### DIFF
--- a/web/src/components/filter/SearchFilterGroup.tsx
+++ b/web/src/components/filter/SearchFilterGroup.tsx
@@ -417,7 +417,9 @@ function ZoneFilterButton({
       <div
         className={`hidden md:block ${selectedZones?.length ? "text-selected-foreground" : "text-primary"}`}
       >
-        {selectedZones?.length ? `${selectedZones.length} Zones` : "All Zones"}
+        {selectedZones?.length
+          ? `${selectedZones.length} Zone${selectedZones.length > 1 ? "s" : ""}`
+          : "All Zones"}
       </div>
     </Button>
   );
@@ -558,6 +560,7 @@ export function ZoneFilterContent({
         <Button
           onClick={() => {
             setCurrentZones?.(undefined);
+            updateZoneFilter?.(undefined);
           }}
         >
           Reset
@@ -731,7 +734,7 @@ export function SubFilterContent({
         </Button>
         <Button
           onClick={() => {
-            setCurrentSubLabels(undefined);
+            updateSubLabelFilter(undefined);
           }}
         >
           Reset

--- a/web/src/components/filter/SearchFilterGroup.tsx
+++ b/web/src/components/filter/SearchFilterGroup.tsx
@@ -37,7 +37,9 @@ export default function SearchFilterGroup({
   filterList,
   onUpdateFilter,
 }: SearchFilterGroupProps) {
-  const { data: config } = useSWR<FrigateConfig>("config");
+  const { data: config } = useSWR<FrigateConfig>("config", {
+    revalidateOnFocus: false,
+  });
 
   const allLabels = useMemo<string[]>(() => {
     if (filterList?.labels) {
@@ -147,6 +149,11 @@ export default function SearchFilterGroup({
     [filter, onUpdateFilter],
   );
 
+  const showAllFilters = useMemo(
+    () => isDesktop || !config?.semantic_search?.enabled,
+    [config],
+  );
+
   return (
     <div className="flex justify-center gap-2">
       {filters.includes("cameras") && (
@@ -159,7 +166,7 @@ export default function SearchFilterGroup({
           }}
         />
       )}
-      {isDesktop && filters.includes("date") && (
+      {showAllFilters && filters.includes("date") && (
         <CalendarRangeFilterButton
           range={
             filter?.after == undefined || filter?.before == undefined
@@ -173,7 +180,7 @@ export default function SearchFilterGroup({
           updateSelectedRange={onUpdateSelectedRange}
         />
       )}
-      {isDesktop && filters.includes("general") && (
+      {showAllFilters && filters.includes("general") && (
         <GeneralFilterButton
           allLabels={filterValues.labels}
           selectedLabels={filter?.labels}
@@ -193,7 +200,7 @@ export default function SearchFilterGroup({
           }
         />
       )}
-      {isMobile && mobileSettingsFeatures.length > 0 && (
+      {!showAllFilters && mobileSettingsFeatures.length > 0 && (
         <MobileReviewSettingsDrawer
           features={mobileSettingsFeatures}
           filter={filter}

--- a/web/src/components/filter/SearchFilterGroup.tsx
+++ b/web/src/components/filter/SearchFilterGroup.tsx
@@ -477,7 +477,7 @@ function ZoneFilterButton({
       <div
         className={`hidden md:block ${selectedZones?.length ? "text-selected-foreground" : "text-primary"}`}
       >
-        Filter
+        {selectedZones?.length ? `${selectedZones.length} Zones` : "All Zones"}
       </div>
     </Button>
   );
@@ -654,7 +654,9 @@ function SubFilterButton({
       <div
         className={`hidden md:block ${selectedSubLabels?.length ? "text-selected-foreground" : "text-primary"}`}
       >
-        Filter
+        {selectedSubLabels?.length
+          ? `${selectedSubLabels.length} Sub Labels`
+          : "All Sub Labels"}
       </div>
     </Button>
   );

--- a/web/src/components/icons/SubFilterIcon.tsx
+++ b/web/src/components/icons/SubFilterIcon.tsx
@@ -1,0 +1,25 @@
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+import { FaCog, FaFilter } from "react-icons/fa";
+
+type SubFilterIconProps = {
+  className?: string;
+  onClick?: () => void;
+};
+
+const SubFilterIcon = forwardRef<HTMLDivElement, SubFilterIconProps>(
+  ({ className, onClick }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn("relative flex items-center", className)}
+        onClick={onClick}
+      >
+        <FaFilter className="size-full" />
+        <FaCog className="absolute size-3 translate-x-3 translate-y-3/4" />
+      </div>
+    );
+  },
+);
+
+export default SubFilterIcon;

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -114,12 +114,15 @@ export default function SearchDetailDialog({
                   <div className="flex flex-row items-center gap-2 text-sm capitalize">
                     {getIconForLabel(search.label, "size-4 text-primary")}
                     {search.label}
+                    {search.sub_label && ` (${search.sub_label})`}
                   </div>
                 </div>
                 <div className="flex flex-col gap-1.5">
                   <div className="text-sm text-primary/40">Score</div>
                   <div className="text-sm">
-                    {Math.round(search.score * 100)}%
+                    {Math.round(search.data.top_score * 100)}%
+                    {search.sub_label &&
+                      ` (${Math.round((search.data.sub_label_score ?? 0) * 100)}%)`}
                   </div>
                 </div>
                 <div className="flex flex-col gap-1.5">

--- a/web/src/components/player/PreviewThumbnailPlayer.tsx
+++ b/web/src/components/player/PreviewThumbnailPlayer.tsx
@@ -329,7 +329,9 @@ function PreviewContent({
   } else if (isCurrentHour(review.start_time)) {
     return (
       <InProgressPreview
-        review={review}
+        camera={review.camera}
+        startTime={review.start_time}
+        endTime={review.end_time}
         timeRange={timeRange}
         setReviewed={setReviewed}
         setIgnoreClick={setIgnoreClick}

--- a/web/src/components/player/SearchThumbnailPlayer.tsx
+++ b/web/src/components/player/SearchThumbnailPlayer.tsx
@@ -14,7 +14,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import ImageLoadingIndicator from "../indicators/ImageLoadingIndicator";
 import ActivityIndicator from "../indicators/activity-indicator";
 import { capitalizeFirstLetter } from "@/utils/stringUtil";
-import { VideoPreview } from "../preview/ScrubbablePreview";
+import { InProgressPreview, VideoPreview } from "../preview/ScrubbablePreview";
 import { Preview } from "@/types/preview";
 import { SearchResult } from "@/types/search";
 import useContextMenu from "@/hooks/use-contextmenu";
@@ -272,6 +272,7 @@ function PreviewContent({
   onTimeUpdate,
 }: PreviewContentProps) {
   // preview
+  const now = useMemo(() => Date.now() / 1000, []);
 
   if (relevantPreview) {
     return (
@@ -287,6 +288,21 @@ function PreviewContent({
       />
     );
   } else if (isCurrentHour(searchResult.start_time)) {
-    return <div />;
+    return (
+      <InProgressPreview
+        camera={searchResult.camera}
+        startTime={searchResult.start_time}
+        endTime={searchResult.end_time}
+        timeRange={{
+          before: now,
+          after: searchResult.start_time,
+        }}
+        setIgnoreClick={setIgnoreClick}
+        isPlayingBack={isPlayingBack}
+        onTimeUpdate={onTimeUpdate}
+        windowVisible={true}
+        setReviewed={() => {}}
+      />
+    );
   }
 }

--- a/web/src/hooks/use-api-filter.ts
+++ b/web/src/hooks/use-api-filter.ts
@@ -1,5 +1,6 @@
 import { FilterType } from "@/types/filter";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 type useApiFilterReturn<F extends FilterType> = [
   filter: F | undefined,
@@ -17,6 +18,93 @@ export default function useApiFilter<
   const [filter, setFilter] = useState<F | undefined>(undefined);
   const searchParams = useMemo(() => {
     if (filter == undefined) {
+      return {};
+    }
+
+    const search: { [key: string]: string } = {};
+
+    Object.entries(filter).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        if (value.length == 0) {
+          // empty array means all so ignore
+        } else {
+          search[key] = value.join(",");
+        }
+      } else {
+        if (value != undefined) {
+          search[key] = `${value}`;
+        }
+      }
+    });
+
+    return search;
+  }, [filter]);
+
+  return [filter, setFilter, searchParams];
+}
+
+export function useApiFilterArgs<
+  F extends FilterType,
+>(): useApiFilterReturn<F> {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const setFilter = useCallback(
+    (filter: F) => {
+      let search = "";
+
+      Object.entries(filter).forEach(([key, value]) => {
+        let char = "";
+        if (search.length == 0) {
+          char = "?";
+        } else {
+          char = "&";
+        }
+
+        if (Array.isArray(value)) {
+          if (value.length == 0) {
+            // empty array means all so ignore
+          } else {
+            search += `${char}${key}=${value.join(",")}`;
+          }
+        } else {
+          if (value != undefined) {
+            search += `${char}${key}=${value}`;
+          }
+        }
+      });
+
+      navigate(`${location.pathname}${search}`, { ...location.state });
+    },
+    [location, navigate],
+  );
+
+  const filter = useMemo<F>(() => {
+    const search = location?.search?.substring(1);
+
+    if (search == undefined || search.length == 0) {
+      return {} as F;
+    }
+
+    const filter: { [key: string]: unknown } = {};
+
+    search.split("&").forEach((full) => {
+      const [key, value] = full.split("=");
+
+      if (isNaN(parseFloat(value))) {
+        filter[key] = value.includes(",") ? value.split(",") : [value];
+      } else {
+        if (value != undefined) {
+          filter[key] = `${value}`;
+        }
+      }
+    });
+
+    return filter as F;
+  }, [location?.search]);
+
+  const searchParams = useMemo(() => {
+    if (filter == undefined || Object.keys(filter).length == 0) {
       return {};
     }
 

--- a/web/src/hooks/use-api-filter.ts
+++ b/web/src/hooks/use-api-filter.ts
@@ -1,6 +1,26 @@
 import { FilterType } from "@/types/filter";
 import { useCallback, useMemo, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
+
+function getStringifiedArgs(filter: FilterType) {
+  const search: { [key: string]: string } = {};
+
+  Object.entries(filter).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      if (value.length == 0) {
+        // empty array means all so ignore
+      } else {
+        search[key] = value.join(",");
+      }
+    } else {
+      if (value != undefined) {
+        search[key] = `${value}`;
+      }
+    }
+  });
+
+  return search;
+}
 
 type useApiFilterReturn<F extends FilterType> = [
   filter: F | undefined,
@@ -21,23 +41,7 @@ export default function useApiFilter<
       return {};
     }
 
-    const search: { [key: string]: string } = {};
-
-    Object.entries(filter).forEach(([key, value]) => {
-      if (Array.isArray(value)) {
-        if (value.length == 0) {
-          // empty array means all so ignore
-        } else {
-          search[key] = value.join(",");
-        }
-      } else {
-        if (value != undefined) {
-          search[key] = `${value}`;
-        }
-      }
-    });
-
-    return search;
+    return getStringifiedArgs(filter);
   }, [filter]);
 
   return [filter, setFilter, searchParams];
@@ -46,51 +50,21 @@ export default function useApiFilter<
 export function useApiFilterArgs<
   F extends FilterType,
 >(): useApiFilterReturn<F> {
-  const location = useLocation();
-  const navigate = useNavigate();
+  const [rawParams, setRawParams] = useSearchParams();
 
   const setFilter = useCallback(
-    (filter: F) => {
-      let search = "";
-
-      Object.entries(filter).forEach(([key, value]) => {
-        let char = "";
-        if (search.length == 0) {
-          char = "?";
-        } else {
-          char = "&";
-        }
-
-        if (Array.isArray(value)) {
-          if (value.length == 0) {
-            // empty array means all so ignore
-          } else {
-            search += `${char}${key}=${value.join(",")}`;
-          }
-        } else {
-          if (value != undefined) {
-            search += `${char}${key}=${value}`;
-          }
-        }
-      });
-
-      navigate(`${location.pathname}${search}`, { ...location.state });
-    },
-    [location, navigate],
+    (newFilter: F) => setRawParams(getStringifiedArgs(newFilter)),
+    [setRawParams],
   );
 
   const filter = useMemo<F>(() => {
-    const search = location?.search?.substring(1);
-
-    if (search == undefined || search.length == 0) {
+    if (rawParams.size == 0) {
       return {} as F;
     }
 
     const filter: { [key: string]: unknown } = {};
 
-    search.split("&").forEach((full) => {
-      const [key, value] = full.split("=");
-
+    rawParams.forEach((value, key) => {
       if (isNaN(parseFloat(value))) {
         filter[key] = value.includes(",") ? value.split(",") : [value];
       } else {
@@ -101,30 +75,14 @@ export function useApiFilterArgs<
     });
 
     return filter as F;
-  }, [location?.search]);
+  }, [rawParams]);
 
   const searchParams = useMemo(() => {
     if (filter == undefined || Object.keys(filter).length == 0) {
       return {};
     }
 
-    const search: { [key: string]: string } = {};
-
-    Object.entries(filter).forEach(([key, value]) => {
-      if (Array.isArray(value)) {
-        if (value.length == 0) {
-          // empty array means all so ignore
-        } else {
-          search[key] = value.join(",");
-        }
-      } else {
-        if (value != undefined) {
-          search[key] = `${value}`;
-        }
-      }
-    });
-
-    return search;
+    return getStringifiedArgs(filter);
   }, [filter]);
 
   return [filter, setFilter, searchParams];

--- a/web/src/hooks/use-navigation.ts
+++ b/web/src/hooks/use-navigation.ts
@@ -19,7 +19,9 @@ export const ID_PLAYGROUND = 6;
 export default function useNavigation(
   variant: "primary" | "secondary" = "primary",
 ) {
-  const { data: config } = useSWR<FrigateConfig>("config");
+  const { data: config } = useSWR<FrigateConfig>("config", {
+    revalidateOnFocus: false,
+  });
 
   return useMemo(
     () =>
@@ -44,7 +46,6 @@ export default function useNavigation(
           icon: IoSearch,
           title: "Search",
           url: "/search",
-          enabled: config?.semantic_search?.enabled,
         },
         {
           id: ID_EXPORT,
@@ -70,6 +71,6 @@ export default function useNavigation(
           enabled: ENV !== "production",
         },
       ] as NavData[],
-    [config?.plus.enabled, config?.semantic_search.enabled, variant],
+    [config?.plus.enabled, variant],
   );
 }

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -102,6 +102,7 @@ export default function Search() {
         after: searchSearchParams["after"],
         search_type: searchSearchParams["search_type"],
         limit: Object.keys(searchSearchParams).length == 0 ? 20 : null,
+        in_progress: 0,
         include_thumbnails: 0,
       },
     ];

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -67,6 +67,7 @@ export default function Search() {
           query: similaritySearch.id,
           cameras: searchSearchParams["cameras"],
           labels: searchSearchParams["labels"],
+          sub_labels: searchSearchParams["subLabels"],
           zones: searchSearchParams["zones"],
           before: searchSearchParams["before"],
           after: searchSearchParams["after"],
@@ -83,6 +84,7 @@ export default function Search() {
           query: searchTerm,
           cameras: searchSearchParams["cameras"],
           labels: searchSearchParams["labels"],
+          sub_labels: searchSearchParams["subLabels"],
           zones: searchSearchParams["zones"],
           before: searchSearchParams["before"],
           after: searchSearchParams["after"],
@@ -97,6 +99,7 @@ export default function Search() {
       {
         cameras: searchSearchParams["cameras"],
         labels: searchSearchParams["labels"],
+        sub_labels: searchSearchParams["subLabels"],
         zones: searchSearchParams["zones"],
         before: searchSearchParams["before"],
         after: searchSearchParams["after"],

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -101,6 +101,7 @@ export default function Search() {
         before: searchSearchParams["before"],
         after: searchSearchParams["after"],
         search_type: searchSearchParams["search_type"],
+        limit: Object.keys(searchSearchParams).length == 0 ? 20 : null,
         include_thumbnails: 0,
       },
     ];

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -60,10 +60,6 @@ export default function Search() {
   }, [search]);
 
   const searchQuery = useMemo(() => {
-    if (searchTerm.length == 0) {
-      return null;
-    }
-
     if (similaritySearch) {
       return [
         "events/search",
@@ -80,10 +76,25 @@ export default function Search() {
       ];
     }
 
+    if (searchTerm) {
+      return [
+        "events/search",
+        {
+          query: searchTerm,
+          cameras: searchSearchParams["cameras"],
+          labels: searchSearchParams["labels"],
+          zones: searchSearchParams["zones"],
+          before: searchSearchParams["before"],
+          after: searchSearchParams["after"],
+          search_type: searchSearchParams["search_type"],
+          include_thumbnails: 0,
+        },
+      ];
+    }
+
     return [
-      "events/search",
+      "events",
       {
-        query: searchTerm,
         cameras: searchSearchParams["cameras"],
         labels: searchSearchParams["labels"],
         zones: searchSearchParams["zones"],

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -1,4 +1,4 @@
-import useApiFilter from "@/hooks/use-api-filter";
+import { useApiFilterArgs } from "@/hooks/use-api-filter";
 import { useCameraPreviews } from "@/hooks/use-camera-previews";
 import { useOverlayState } from "@/hooks/use-overlay-state";
 import { FrigateConfig } from "@/types/frigateConfig";
@@ -27,7 +27,7 @@ export default function Search() {
   // search filter
 
   const [searchFilter, setSearchFilter, searchSearchParams] =
-    useApiFilter<SearchFilter>();
+    useApiFilterArgs<SearchFilter>();
 
   const onUpdateFilter = useCallback(
     (newFilter: SearchFilter) => {

--- a/web/src/types/search.ts
+++ b/web/src/types/search.ts
@@ -18,6 +18,7 @@ export type SearchResult = {
 export type SearchFilter = {
   cameras?: string[];
   labels?: string[];
+  subLabels?: string[];
   zones?: string[];
   before?: number;
   after?: number;

--- a/web/src/types/search.ts
+++ b/web/src/types/search.ts
@@ -13,6 +13,16 @@ export type SearchResult = {
   zones: string[];
   search_source: SearchSource;
   search_distance: number;
+  data: {
+    top_score: number;
+    score: number;
+    sub_label_score?: number;
+    region: number[];
+    box: number[];
+    area: number;
+    ratio: number;
+    type: "object" | "audio" | "manual";
+  };
 };
 
 export type SearchFilter = {

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -16,15 +16,7 @@ import { Preview } from "@/types/preview";
 import { SearchFilter, SearchResult } from "@/types/search";
 import { useCallback, useMemo, useState } from "react";
 import { isMobileOnly } from "react-device-detect";
-import {
-  LuExternalLink,
-  LuImage,
-  LuSearchCheck,
-  LuSearchX,
-  LuText,
-  LuXCircle,
-} from "react-icons/lu";
-import { Link } from "react-router-dom";
+import { LuImage, LuSearchX, LuText, LuXCircle } from "react-icons/lu";
 import useSWR from "swr";
 
 type SearchViewProps = {
@@ -153,7 +145,7 @@ export default function SearchView({
 
         {hasExistingSearch && (
           <SearchFilterGroup
-            className={cn("", isMobileOnly && "w-full")}
+            className={cn("", isMobileOnly && "w-full justify-between")}
             filter={searchFilter}
             onUpdateFilter={onUpdateFilter}
           />

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -116,7 +116,7 @@ export default function SearchView({
           config?.semantic_search?.enabled
             ? "justify-between"
             : "justify-center",
-          isMobileOnly && "h-20 flex-wrap gap-2",
+          isMobileOnly && "h-[88px] flex-wrap gap-2",
         )}
       >
         {config?.semantic_search?.enabled && (

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -11,6 +11,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { FrigateConfig } from "@/types/frigateConfig";
 import { Preview } from "@/types/preview";
 import { SearchFilter, SearchResult } from "@/types/search";
 import { useCallback, useMemo, useState } from "react";
@@ -24,6 +25,7 @@ import {
   LuXCircle,
 } from "react-icons/lu";
 import { Link } from "react-router-dom";
+import useSWR from "swr";
 
 type SearchViewProps = {
   search: string;
@@ -51,6 +53,10 @@ export default function SearchView({
   onUpdateFilter,
   onOpenSearch,
 }: SearchViewProps) {
+  const { data: config } = useSWR<FrigateConfig>("config", {
+    revalidateOnFocus: false,
+  });
+
   // remove duplicate event ids
 
   const uniqueResults = useMemo(() => {
@@ -112,28 +118,37 @@ export default function SearchView({
         }
       />
 
-      <div className="relative mb-2 flex h-11 items-center justify-between pl-2 pr-2 md:pl-3">
-        <div
-          className={cn(
-            "relative w-full",
-            hasExistingSearch ? "mr-3 md:w-1/3" : "md:ml-[25%] md:w-1/2",
-          )}
-        >
-          <Input
-            className="text-md w-full bg-muted pr-10"
-            placeholder={
-              isMobileOnly ? "Search" : "Search for a detected object..."
-            }
-            value={similaritySearch ? "" : search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
-          {search && (
-            <LuXCircle
-              className="absolute right-2 top-1/2 h-5 w-5 -translate-y-1/2 cursor-pointer text-muted-foreground hover:text-primary"
-              onClick={() => setSearch("")}
+      <div
+        className={cn(
+          "relative mb-2 flex h-11 items-center pl-2 pr-2 md:pl-3",
+          config?.semantic_search?.enabled
+            ? "justify-between"
+            : "justify-center",
+        )}
+      >
+        {config?.semantic_search?.enabled && (
+          <div
+            className={cn(
+              "relative w-full",
+              hasExistingSearch ? "mr-3 md:w-1/3" : "md:ml-[25%] md:w-1/2",
+            )}
+          >
+            <Input
+              className="text-md w-full bg-muted pr-10"
+              placeholder={
+                isMobileOnly ? "Search" : "Search for a detected object..."
+              }
+              value={similaritySearch ? "" : search}
+              onChange={(e) => setSearch(e.target.value)}
             />
-          )}
-        </div>
+            {search && (
+              <LuXCircle
+                className="absolute right-2 top-1/2 h-5 w-5 -translate-y-1/2 cursor-pointer text-muted-foreground hover:text-primary"
+                onClick={() => setSearch("")}
+              />
+            )}
+          </div>
+        )}
 
         {hasExistingSearch && (
           <SearchFilterGroup

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -96,6 +96,11 @@ export default function SearchView({
     return Math.round(confidence * 100);
   };
 
+  const hasExistingSearch = useMemo(
+    () => searchResults != undefined || searchFilter != undefined,
+    [searchResults, searchFilter],
+  );
+
   return (
     <div className="flex size-full flex-col pt-2 md:py-2">
       <Toaster closeButton={true} />
@@ -108,7 +113,12 @@ export default function SearchView({
       />
 
       <div className="relative mb-2 flex h-11 items-center justify-between pl-2 pr-2 md:pl-3">
-        <div className="relative mr-3 w-full md:w-1/3">
+        <div
+          className={cn(
+            "relative w-full",
+            hasExistingSearch ? "mr-3 md:w-1/3" : "md:ml-[25%] md:w-1/2",
+          )}
+        >
           <Input
             className="text-md w-full bg-muted pr-10"
             placeholder={
@@ -125,10 +135,12 @@ export default function SearchView({
           )}
         </div>
 
-        <SearchFilterGroup
-          filter={searchFilter}
-          onUpdateFilter={onUpdateFilter}
-        />
+        {hasExistingSearch && (
+          <SearchFilterGroup
+            filter={searchFilter}
+            onUpdateFilter={onUpdateFilter}
+          />
+        )}
       </div>
 
       <div className="no-scrollbar flex flex-1 flex-wrap content-start gap-2 overflow-y-auto md:gap-4">
@@ -186,34 +198,36 @@ export default function SearchView({
                       scrollLock={false}
                       onClick={onSelectSearch}
                     />
-                    <div className={cn("absolute right-2 top-2 z-40")}>
-                      <Tooltip>
-                        <TooltipTrigger>
-                          <Chip
-                            className={`flex select-none items-center justify-between space-x-1 bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500 text-xs capitalize text-white`}
-                          >
-                            {value.search_source == "thumbnail" ? (
-                              <LuImage className="mr-1 size-3" />
-                            ) : (
-                              <LuText className="mr-1 size-3" />
-                            )}
+                    {searchTerm && (
+                      <div className={cn("absolute right-2 top-2 z-40")}>
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <Chip
+                              className={`flex select-none items-center justify-between space-x-1 bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500 text-xs capitalize text-white`}
+                            >
+                              {value.search_source == "thumbnail" ? (
+                                <LuImage className="mr-1 size-3" />
+                              ) : (
+                                <LuText className="mr-1 size-3" />
+                              )}
+                              {zScoreToConfidence(
+                                value.search_distance,
+                                value.search_source,
+                              )}
+                              %
+                            </Chip>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            Matched {value.search_source} at{" "}
                             {zScoreToConfidence(
                               value.search_distance,
                               value.search_source,
                             )}
                             %
-                          </Chip>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          Matched {value.search_source} at{" "}
-                          {zScoreToConfidence(
-                            value.search_distance,
-                            value.search_source,
-                          )}
-                          %
-                        </TooltipContent>
-                      </Tooltip>
-                    </div>
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                    )}
                   </div>
                   <div
                     className={`review-item-ring pointer-events-none absolute inset-0 z-10 size-full rounded-lg outline outline-[3px] -outline-offset-[2.8px] ${selected ? `shadow-severity_alert outline-severity_alert` : "outline-transparent duration-500"}`}

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -124,6 +124,7 @@ export default function SearchView({
           config?.semantic_search?.enabled
             ? "justify-between"
             : "justify-center",
+          isMobileOnly && "h-20 flex-wrap gap-2",
         )}
       >
         {config?.semantic_search?.enabled && (
@@ -152,6 +153,7 @@ export default function SearchView({
 
         {hasExistingSearch && (
           <SearchFilterGroup
+            className={cn("", isMobileOnly && "w-full")}
             filter={searchFilter}
             onUpdateFilter={onUpdateFilter}
           />

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -144,27 +144,6 @@ export default function SearchView({
       </div>
 
       <div className="no-scrollbar flex flex-1 flex-wrap content-start gap-2 overflow-y-auto md:gap-4">
-        {searchTerm.length == 0 && (
-          <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center text-center">
-            <LuSearchCheck className="size-16" />
-            Search
-            <div className="mt-2 max-w-64 text-sm text-secondary-foreground">
-              Frigate can find detected objects in your review items.
-            </div>
-            <div className="mt-2 flex items-center text-center text-sm text-primary">
-              <Link
-                to="https://docs.frigate.video/configuration/semantic_search"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline"
-              >
-                Read the Documentation{" "}
-                <LuExternalLink className="ml-2 inline-flex size-3" />
-              </Link>
-            </div>
-          </div>
-        )}
-
         {searchTerm.length > 0 && searchResults?.length == 0 && (
           <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center text-center">
             <LuSearchX className="size-16" />


### PR DESCRIPTION
This PR accomplishes the following:
- Refactor the search page to always be shown. The search bar will only be enabled when semantic search is enabled
- Show detected objects by default when opening and allow filtering to narrow down results
- Add filter for sub label and separate zone filter out from general filter
- Always expand filters (use second line on mobile)