### PR TITLE
Updated supported cameras: Speco O8P32X

### DIFF
--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -98,6 +98,7 @@ This list of working and non-working PTZ cameras is based on user feedback.
 | Reolink E1 Pro           |      ✅      |      ❌      |                                                                                                                                                 |
 | Reolink E1 Zoom          |      ✅      |      ❌      |                                                                                                                                                 |
 | Reolink RLC-823A 16x     |      ✅      |      ❌      |                                                                                                                                                 |
+| Speco O8P32X             |      ✅      |      ❌      |                                                                                                                                                 |
 | Sunba 405-D20X           |      ✅      |      ❌      |                                                                                                                                                 |
 | Tapo                     |      ✅      |      ❌      | Many models supported, ONVIF Service Port: 2020                                                                                                 |
 | Uniview IPC672LR-AX4DUPK |      ✅      |      ❌      | Firmware says FOV relative movement is supported, but camera doesn't actually move when sending ONVIF commands                                  |


### PR DESCRIPTION
Added Speco Technologies O8P32X camera to cameras list.

https://www.specotech.com/product/o8p32x/