### PR TITLE
Explore view fixes

### DIFF
--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -302,8 +302,21 @@ def events_explore():
         .dicts()
     )
 
-    events = query.iterator()
-    return jsonify(list(events))
+    events = list(query.iterator())
+
+    processed_events = [
+        {k: v for k, v in event.items() if k != "data"}
+        | {
+            "data": {
+                k: v
+                for k, v in event["data"].items()
+                if k in ["type", "score", "top_score", "description"]
+            }
+        }
+        for event in events
+    ]
+
+    return jsonify(processed_events)
 
 
 @EventBp.route("/event_ids")
@@ -507,9 +520,11 @@ def events_search():
     events = [
         {k: v for k, v in event.items() if k != "data"}
         | {
-            k: v
-            for k, v in event["data"].items()
-            if k in ["type", "score", "top_score", "description"]
+            "data": {
+                k: v
+                for k, v in event["data"].items()
+                if k in ["type", "score", "top_score", "description"]
+            }
         }
         | {
             "search_distance": results[event["id"]]["distance"],

--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -94,6 +94,18 @@ def review():
     return jsonify([r for r in review])
 
 
+@ReviewBp.route("/review/event/<id>")
+def get_review_from_event(id: str):
+    try:
+        return model_to_dict(
+            ReviewSegment.get(
+                ReviewSegment.data["detections"].cast("text") % f'*"{id}"*'
+            )
+        )
+    except DoesNotExist:
+        return "Review item not found", 404
+
+
 @ReviewBp.route("/review/<id>")
 def get_review(id: str):
     try:

--- a/web/src/types/search.ts
+++ b/web/src/types/search.ts
@@ -3,7 +3,6 @@ export type SearchSource = "similarity" | "thumbnail" | "description";
 export type SearchResult = {
   id: string;
   camera: string;
-  description?: string;
   start_time: number;
   end_time?: number;
   score: number;
@@ -25,6 +24,7 @@ export type SearchResult = {
     area: number;
     ratio: number;
     type: "object" | "audio" | "manual";
+    description?: string;
   };
 };
 


### PR DESCRIPTION
- Ensure description is returned consistently (`Event` object has it under `data`, but semantic search returned it at the root level)
- Add ability to navigate to History view from Explore view's video details tab