### PR TITLE
Ffmpeg 6

### DIFF
--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -40,25 +40,25 @@ apt-get -qq install --no-install-recommends --no-install-suggests -y \
 # btbn-ffmpeg -> amd64
 if [[ "${TARGETARCH}" == "amd64" ]]; then
     mkdir -p /usr/lib/ffmpeg/5.0
-    mkdir -p /usr/lib/ffmpeg/7.0
+    mkdir -p /usr/lib/ffmpeg/6.0
     wget -qO btbn-ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linux64-gpl-5.1.tar.xz"
     tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1
     rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/5.0/doc /usr/lib/ffmpeg/5.0/bin/ffplay
-    wget -qO btbn-ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-09-13-12-57/ffmpeg-n7.0.2-17-gf705bc5b73-linux64-gpl-7.0.tar.xz"
-    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1
-    rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/7.0/doc /usr/lib/ffmpeg/7.0/bin/ffplay
+    wget -qO btbn-ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-08-31-12-50/ffmpeg-n6.1.2-2-gb534cc666e-linux64-gpl-6.1.tar.xz"
+    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/6.0 --strip-components 1
+    rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/6.0/doc /usr/lib/ffmpeg/6.0/bin/ffplay
 fi
 
 # ffmpeg -> arm64
 if [[ "${TARGETARCH}" == "arm64" ]]; then
     mkdir -p /usr/lib/ffmpeg/5.0
-    mkdir -p /usr/lib/ffmpeg/7.0
+    mkdir -p /usr/lib/ffmpeg/6.0
     wget -qO btbn-ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linuxarm64-gpl-5.1.tar.xz"
     tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1
     rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/5.0/doc /usr/lib/ffmpeg/5.0/bin/ffplay
-    wget -qO btbn-ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-09-13-12-57/ffmpeg-n7.0.2-17-gf705bc5b73-linuxarm64-gpl-7.0.tar.xz"
-    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1
-    rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/7.0/doc /usr/lib/ffmpeg/7.0/bin/ffplay
+    wget -qO btbn-ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-08-31-12-50/ffmpeg-n6.1.2-2-gb534cc666e-linuxarm64-gpl-6.1.tar.xz"
+    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/6.0 --strip-components 1
+    rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/6.0/doc /usr/lib/ffmpeg/6.0/bin/ffplay
 fi
 
 # arch specific packages

--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -110,11 +110,11 @@ else:
 path = config.get("ffmpeg", {}).get("path", "default")
 if path == "default":
     if shutil.which("ffmpeg") is None:
-        ffmpeg_path = "/usr/lib/ffmpeg/7.0/bin/ffmpeg"
+        ffmpeg_path = "/usr/lib/ffmpeg/6.0/bin/ffmpeg"
     else:
         ffmpeg_path = "ffmpeg"
-elif path == "7.0":
-    ffmpeg_path = "/usr/lib/ffmpeg/7.0/bin/ffmpeg"
+elif path == "6.0":
+    ffmpeg_path = "/usr/lib/ffmpeg/6.0/bin/ffmpeg"
 elif path == "5.0":
     ffmpeg_path = "/usr/lib/ffmpeg/5.0/bin/ffmpeg"
 else:

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -890,11 +890,11 @@ class FfmpegConfig(FrigateBaseModel):
     def ffmpeg_path(self) -> str:
         if self.path == "default":
             if shutil.which("ffmpeg") is None:
-                return "/usr/lib/ffmpeg/7.0/bin/ffmpeg"
+                return "/usr/lib/ffmpeg/6.0/bin/ffmpeg"
             else:
                 return "ffmpeg"
-        elif self.path == "7.0":
-            return "/usr/lib/ffmpeg/7.0/bin/ffmpeg"
+        elif self.path == "6.0":
+            return "/usr/lib/ffmpeg/6.0/bin/ffmpeg"
         elif self.path == "5.0":
             return "/usr/lib/ffmpeg/5.0/bin/ffmpeg"
         else:
@@ -904,11 +904,11 @@ class FfmpegConfig(FrigateBaseModel):
     def ffprobe_path(self) -> str:
         if self.path == "default":
             if int(os.getenv("LIBAVFORMAT_VERSION_MAJOR", "59")) >= 59:
-                return "/usr/lib/ffmpeg/7.0/bin/ffprobe"
+                return "/usr/lib/ffmpeg/6.0/bin/ffprobe"
             else:
                 return "ffprobe"
-        elif self.path == "7.0":
-            return "/usr/lib/ffmpeg/7.0/bin/ffprobe"
+        elif self.path == "6.0":
+            return "/usr/lib/ffmpeg/6.0/bin/ffprobe"
         elif self.path == "5.0":
             return "/usr/lib/ffmpeg/5.0/bin/ffprobe"
         else:

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -91,7 +91,7 @@ PRESETS_HW_ACCEL_DECODE["preset-nvidia-mjpeg"] = PRESETS_HW_ACCEL_DECODE[
 PRESETS_HW_ACCEL_SCALE = {
     "preset-rpi-64-h264": "-r {0} -vf fps={0},scale={1}:{2}",
     "preset-rpi-64-h265": "-r {0} -vf fps={0},scale={1}:{2}",
-    FFMPEG_HWACCEL_VAAPI: "-r {0} -vf fps={0},scale_vaapi=w={1}:h={2},hwdownload,eq=gamma=1.05",
+    FFMPEG_HWACCEL_VAAPI: "-r {0} -vf fps={0},scale_vaapi=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
     "preset-intel-qsv-h264": "-r {0} -vf vpp_qsv=framerate={0}:w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
     "preset-intel-qsv-h265": "-r {0} -vf vpp_qsv=framerate={0}:w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
     FFMPEG_HWACCEL_NVIDIA: "-r {0} -vf fps={0},scale_cuda=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",


### PR DESCRIPTION
Ffmpeg 7 is too new and there are many issues with qsv. This PR pushes the default ffmpeg back to 6 which still maintains many benefits like using libvpl instead of msdk for intel qsv