### PR TITLE
Fix vscode launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,10 +3,9 @@
   "configurations": [
     {
       "name": "Python: Launch Frigate",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
-      "module": "frigate",
-      "justMyCode": true
+      "module": "frigate"
     }
   ]
 }


### PR DESCRIPTION
Use debugpy. The old debugger module will apparently be deprecated soon.

Also, it doesn't work. No idea why, don't really care to figure out. This works.