### PR TITLE
Logs: Remove vertical padding on log items

### DIFF
--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -458,7 +458,7 @@ function LogLineData({
     <div
       ref={startRef}
       className={cn(
-        "grid w-full cursor-pointer grid-cols-5 gap-2 border-t border-secondary py-2 hover:bg-muted sm:grid-cols-8 md:grid-cols-12",
+        "grid w-full cursor-pointer grid-cols-5 gap-2 border-t border-secondary hover:bg-muted sm:grid-cols-8 md:grid-cols-12",
         className,
         "*:text-sm",
       )}


### PR DESCRIPTION
This trivial change removes IMHO unnecessary vertical padding on log entries. Personally, I find it less easy to scan and it requires more scrolling/paging.

Appreciate there might be a style guide somewhere that is against this; if so I'd be interested in the logic. I have done a spot check of a variety of applications/appliances I use that have log viewers, and have yet to find an example of added vertical spacing.

Many desktop applications output logs to flat text files; spacing is never added there. Similarly on any form of *nix terminal where people frequently parse logs for information (e.g. `dmesg` and other logs) it's rarely with any added spacing.

**Before:**

![image](https://github.com/user-attachments/assets/b62779ce-470e-499e-8005-b5c5f283e76d)

**After:**

![image](https://github.com/user-attachments/assets/ab932d40-504f-44c8-aeb8-f85287d52a26)
