### PR TITLE
Removed usage of PyYAML for config parsing.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,7 +52,8 @@
         "csstools.postcss",
         "blanu.vscode-styled-jsx",
         "bradlc.vscode-tailwindcss",
-        "charliermarsh.ruff"
+        "charliermarsh.ruff",
+        "eamodio.gitlens"
       ],
       "settings": {
         "remote.autoForwardPorts": false,

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-*.pyc
+__pycache__
 *.swp
 debug
 .vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 __pycache__
+.mypy_cache
 *.swp
 debug
 .vscode/*

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -248,7 +248,7 @@ def config_save():
 
     # Validate the config schema
     try:
-        FrigateConfig.parse_raw(new_config)
+        FrigateConfig.parse_yaml(new_config)
     except Exception:
         return make_response(
             jsonify(
@@ -336,7 +336,7 @@ def config_set():
             f.close()
         # Validate the config schema
         try:
-            config_obj = FrigateConfig.parse_raw(new_raw_config)
+            config_obj = FrigateConfig.parse_yaml(new_raw_config)
         except Exception:
             with open(config_file, "w") as f:
                 f.write(old_raw_config)

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -361,8 +361,8 @@ def config_set():
     json = request.get_json(silent=True) or {}
 
     if json.get("requires_restart", 1) == 0:
-        current_app.frigate_config = FrigateConfig.runtime_config(
-            config_obj, current_app.plus_api
+        current_app.frigate_config = FrigateConfig.parse_object(
+            config_obj, plus_api=current_app.plus_api
         )
 
     return make_response(

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -129,8 +129,7 @@ class FrigateApp:
         # check if the config file needs to be migrated
         migrate_frigate_config(config_file)
 
-        user_config = FrigateConfig.parse_file(config_file)
-        self.config = user_config.runtime_config(self.plus_api)
+        self.config = FrigateConfig.parse_file(config_file, plus_api=self.plus_api)
 
         for camera_name in self.config.cameras.keys():
             # create camera_metrics

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -1359,17 +1359,15 @@ def verify_recording_segments_setup_with_reasonable_time(
     if record_args[0].startswith("preset"):
         return
 
-    seg_arg_index = record_args.index("-segment_time")
-
-    if seg_arg_index < 0:
-        raise ValueError(
-            f"Camera {camera_config.name} has no segment_time in recording output args, segment args are required for record."
-        )
+    try:
+        seg_arg_index = record_args.index("-segment_time")
+    except ValueError:
+        raise ValueError(f"Camera {camera_config.name} has no segment_time in \
+                         recording output args, segment args are required for record.")
 
     if int(record_args[seg_arg_index + 1]) > 60:
-        raise ValueError(
-            f"Camera {camera_config.name} has invalid segment_time output arg, segment_time must be 60 or less."
-        )
+        raise ValueError(f"Camera {camera_config.name} has invalid segment_time output arg, \
+                         segment_time must be 60 or less.")
 
 
 def verify_zone_objects_are_tracked(camera_config: CameraConfig) -> None:

--- a/frigate/config.py
+++ b/frigate/config.py
@@ -1743,12 +1743,12 @@ class FrigateConfig(FrigateBaseModel):
         return v
 
     @classmethod
-    def parse_file(cls, config_path, **kwargs) -> Self:
+    def parse_file(cls, config_path, **kwargs):
         with open(config_path) as f:
             return FrigateConfig.parse(f, **kwargs)
 
     @classmethod
-    def parse(cls, config, *, is_json=None, **context) -> Self:
+    def parse(cls, config, *, is_json=None, **context):
         # If config is a file, read its contents.
         if hasattr(config, "read"):
             fname = getattr(config, "name", None)
@@ -1780,5 +1780,5 @@ class FrigateConfig(FrigateBaseModel):
         return cls.model_validate(obj, context=context)
 
     @classmethod
-    def parse_yaml(cls, config_yaml, **context) -> Self:
+    def parse_yaml(cls, config_yaml, **context):
         return cls.parse(config_yaml, is_json=False, **context)

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -1,3 +1,5 @@
+import re
+
 CONFIG_DIR = "/config"
 DEFAULT_DB_PATH = f"{CONFIG_DIR}/frigate.db"
 MODEL_CACHE_DIR = f"{CONFIG_DIR}/model_cache"
@@ -7,7 +9,6 @@ RECORD_DIR = f"{BASE_DIR}/recordings"
 EXPORT_DIR = f"{BASE_DIR}/exports"
 BIRDSEYE_PIPE = "/tmp/cache/birdseye"
 CACHE_DIR = "/tmp/cache"
-YAML_EXT = (".yaml", ".yml")
 FRIGATE_LOCALHOST = "http://127.0.0.1:5000"
 PLUS_ENV_VAR = "PLUS_API_KEY"
 PLUS_API_HOST = "https://api.frigate.video"
@@ -56,6 +57,7 @@ FFMPEG_HWACCEL_VULKAN = "preset-vulkan"
 REGEX_CAMERA_NAME = r"^[a-zA-Z0-9_-]+$"
 REGEX_RTSP_CAMERA_USER_PASS = r":\/\/[a-zA-Z0-9_-]+:[\S]+@"
 REGEX_HTTP_CAMERA_USER_PASS = r"user=[a-zA-Z0-9_-]+&password=[\S]+"
+REGEX_JSON = re.compile(r"^\s*\{")
 
 # Known Driver Names
 

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -5,12 +5,13 @@ from unittest.mock import patch
 
 import numpy as np
 from pydantic import ValidationError
+from ruamel.yaml.constructor import DuplicateKeyError
 
 from frigate.config import BirdseyeModeEnum, FrigateConfig
 from frigate.const import MODEL_CACHE_DIR
 from frigate.detectors import DetectorTypeEnum
 from frigate.plus import PlusApi
-from frigate.util.builtin import deep_merge, load_config_with_no_duplicates
+from frigate.util.builtin import deep_merge
 
 
 class TestConfig(unittest.TestCase):
@@ -1537,7 +1538,7 @@ class TestConfig(unittest.TestCase):
         """
 
         self.assertRaises(
-            ValueError, lambda: load_config_with_no_duplicates(raw_config)
+            DuplicateKeyError, lambda: FrigateConfig.parse_yaml(raw_config)
         )
 
     def test_object_filter_ratios_work(self):

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -10,7 +10,6 @@ from ruamel.yaml.constructor import DuplicateKeyError
 from frigate.config import BirdseyeModeEnum, FrigateConfig
 from frigate.const import MODEL_CACHE_DIR
 from frigate.detectors import DetectorTypeEnum
-from frigate.plus import PlusApi
 from frigate.util.builtin import deep_merge
 
 
@@ -65,12 +64,9 @@ class TestConfig(unittest.TestCase):
 
     def test_config_class(self):
         frigate_config = FrigateConfig(**self.minimal)
-        assert self.minimal == frigate_config.model_dump(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        assert "cpu" in runtime_config.detectors.keys()
-        assert runtime_config.detectors["cpu"].type == DetectorTypeEnum.cpu
-        assert runtime_config.detectors["cpu"].model.width == 320
+        assert "cpu" in frigate_config.detectors.keys()
+        assert frigate_config.detectors["cpu"].type == DetectorTypeEnum.cpu
+        assert frigate_config.detectors["cpu"].model.width == 320
 
     @patch("frigate.detectors.detector_config.load_labels")
     def test_detector_custom_model_path(self, mock_labels):
@@ -94,24 +90,23 @@ class TestConfig(unittest.TestCase):
         }
 
         frigate_config = FrigateConfig(**(deep_merge(config, self.minimal)))
-        runtime_config = frigate_config.runtime_config()
 
-        assert "cpu" in runtime_config.detectors.keys()
-        assert "edgetpu" in runtime_config.detectors.keys()
-        assert "openvino" in runtime_config.detectors.keys()
+        assert "cpu" in frigate_config.detectors.keys()
+        assert "edgetpu" in frigate_config.detectors.keys()
+        assert "openvino" in frigate_config.detectors.keys()
 
-        assert runtime_config.detectors["cpu"].type == DetectorTypeEnum.cpu
-        assert runtime_config.detectors["edgetpu"].type == DetectorTypeEnum.edgetpu
-        assert runtime_config.detectors["openvino"].type == DetectorTypeEnum.openvino
+        assert frigate_config.detectors["cpu"].type == DetectorTypeEnum.cpu
+        assert frigate_config.detectors["edgetpu"].type == DetectorTypeEnum.edgetpu
+        assert frigate_config.detectors["openvino"].type == DetectorTypeEnum.openvino
 
-        assert runtime_config.detectors["cpu"].num_threads == 3
-        assert runtime_config.detectors["edgetpu"].device is None
-        assert runtime_config.detectors["openvino"].device is None
+        assert frigate_config.detectors["cpu"].num_threads == 3
+        assert frigate_config.detectors["edgetpu"].device is None
+        assert frigate_config.detectors["openvino"].device is None
 
-        assert runtime_config.model.path == "/etc/hosts"
-        assert runtime_config.detectors["cpu"].model.path == "/cpu_model.tflite"
-        assert runtime_config.detectors["edgetpu"].model.path == "/edgetpu_model.tflite"
-        assert runtime_config.detectors["openvino"].model.path == "/etc/hosts"
+        assert frigate_config.model.path == "/etc/hosts"
+        assert frigate_config.detectors["cpu"].model.path == "/cpu_model.tflite"
+        assert frigate_config.detectors["edgetpu"].model.path == "/edgetpu_model.tflite"
+        assert frigate_config.detectors["openvino"].model.path == "/etc/hosts"
 
     def test_invalid_mqtt_config(self):
         config = {
@@ -152,11 +147,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert "dog" in runtime_config.cameras["back"].objects.track
+        frigate_config = FrigateConfig(**config)
+        assert "dog" in frigate_config.cameras["back"].objects.track
 
     def test_override_birdseye(self):
         config = {
@@ -178,12 +171,10 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert not runtime_config.cameras["back"].birdseye.enabled
-        assert runtime_config.cameras["back"].birdseye.mode is BirdseyeModeEnum.motion
+        frigate_config = FrigateConfig(**config)
+        assert not frigate_config.cameras["back"].birdseye.enabled
+        assert frigate_config.cameras["back"].birdseye.mode is BirdseyeModeEnum.motion
 
     def test_override_birdseye_non_inheritable(self):
         config = {
@@ -204,11 +195,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].birdseye.enabled
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].birdseye.enabled
 
     def test_inherit_birdseye(self):
         config = {
@@ -229,13 +218,11 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].birdseye.enabled
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].birdseye.enabled
         assert (
-            runtime_config.cameras["back"].birdseye.mode is BirdseyeModeEnum.continuous
+            frigate_config.cameras["back"].birdseye.mode is BirdseyeModeEnum.continuous
         )
 
     def test_override_tracked_objects(self):
@@ -258,11 +245,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert "cat" in runtime_config.cameras["back"].objects.track
+        frigate_config = FrigateConfig(**config)
+        assert "cat" in frigate_config.cameras["back"].objects.track
 
     def test_default_object_filters(self):
         config = {
@@ -283,11 +268,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert "dog" in runtime_config.cameras["back"].objects.filters
+        frigate_config = FrigateConfig(**config)
+        assert "dog" in frigate_config.cameras["back"].objects.filters
 
     def test_inherit_object_filters(self):
         config = {
@@ -311,12 +294,10 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert "dog" in runtime_config.cameras["back"].objects.filters
-        assert runtime_config.cameras["back"].objects.filters["dog"].threshold == 0.7
+        frigate_config = FrigateConfig(**config)
+        assert "dog" in frigate_config.cameras["back"].objects.filters
+        assert frigate_config.cameras["back"].objects.filters["dog"].threshold == 0.7
 
     def test_override_object_filters(self):
         config = {
@@ -340,12 +321,10 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert "dog" in runtime_config.cameras["back"].objects.filters
-        assert runtime_config.cameras["back"].objects.filters["dog"].threshold == 0.7
+        frigate_config = FrigateConfig(**config)
+        assert "dog" in frigate_config.cameras["back"].objects.filters
+        assert frigate_config.cameras["back"].objects.filters["dog"].threshold == 0.7
 
     def test_global_object_mask(self):
         config = {
@@ -370,11 +349,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        back_camera = runtime_config.cameras["back"]
+        frigate_config = FrigateConfig(**config)
+        back_camera = frigate_config.cameras["back"]
         assert "dog" in back_camera.objects.filters
         assert len(back_camera.objects.filters["dog"].raw_mask) == 2
         assert len(back_camera.objects.filters["person"].raw_mask) == 1
@@ -420,7 +397,8 @@ class TestConfig(unittest.TestCase):
                 },
             },
         }
-        frigate_config = FrigateConfig(**config).runtime_config()
+
+        frigate_config = FrigateConfig(**config)
         assert np.array_equal(
             frigate_config.cameras["explicit"].motion.mask,
             frigate_config.cameras["relative"].motion.mask,
@@ -449,10 +427,7 @@ class TestConfig(unittest.TestCase):
         }
 
         frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        assert "-rtsp_transport" in runtime_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
+        assert "-rtsp_transport" in frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
 
     def test_ffmpeg_params_global(self):
         config = {
@@ -477,11 +452,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert "-re" in runtime_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
+        frigate_config = FrigateConfig(**config)
+        assert "-re" in frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
 
     def test_ffmpeg_params_camera(self):
         config = {
@@ -507,12 +480,10 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert "-re" in runtime_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
-        assert "test" not in runtime_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
+        frigate_config = FrigateConfig(**config)
+        assert "-re" in frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
+        assert "test" not in frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
 
     def test_ffmpeg_params_input(self):
         config = {
@@ -542,14 +513,12 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert "-re" in runtime_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
-        assert "test" in runtime_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
-        assert "test2" not in runtime_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
-        assert "test3" not in runtime_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
+        frigate_config = FrigateConfig(**config)
+        assert "-re" in frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
+        assert "test" in frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
+        assert "test2" not in frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
+        assert "test3" not in frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
 
     def test_inherit_clips_retention(self):
         config = {
@@ -570,11 +539,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].record.alerts.retain.days == 20
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].record.alerts.retain.days == 20
 
     def test_roles_listed_twice_throws_error(self):
         config = {
@@ -658,14 +625,12 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
+        frigate_config = FrigateConfig(**config)
         assert isinstance(
-            runtime_config.cameras["back"].zones["test"].contour, np.ndarray
+            frigate_config.cameras["back"].zones["test"].contour, np.ndarray
         )
-        assert runtime_config.cameras["back"].zones["test"].color != (0, 0, 0)
+        assert frigate_config.cameras["back"].zones["test"].color != (0, 0, 0)
 
     def test_zone_relative_matches_explicit(self):
         config = {
@@ -700,7 +665,8 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config).runtime_config()
+
+        frigate_config = FrigateConfig(**config)
         assert np.array_equal(
             frigate_config.cameras["back"].zones["explicit"].contour,
             frigate_config.cameras["back"].zones["relative"].contour,
@@ -730,10 +696,7 @@ class TestConfig(unittest.TestCase):
         }
 
         frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        ffmpeg_cmds = runtime_config.cameras["back"].ffmpeg_cmds
+        ffmpeg_cmds = frigate_config.cameras["back"].ffmpeg_cmds
         assert len(ffmpeg_cmds) == 1
         assert "clips" not in ffmpeg_cmds[0]["roles"]
 
@@ -761,10 +724,7 @@ class TestConfig(unittest.TestCase):
         }
 
         frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].detect.max_disappeared == 5 * 5
+        assert frigate_config.cameras["back"].detect.max_disappeared == 5 * 5
 
     def test_motion_frame_height_wont_go_below_120(self):
         config = {
@@ -789,10 +749,7 @@ class TestConfig(unittest.TestCase):
         }
 
         frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].motion.frame_height == 100
+        assert frigate_config.cameras["back"].motion.frame_height == 100
 
     def test_motion_contour_area_dynamic(self):
         config = {
@@ -817,10 +774,7 @@ class TestConfig(unittest.TestCase):
         }
 
         frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        assert round(runtime_config.cameras["back"].motion.contour_area) == 10
+        assert round(frigate_config.cameras["back"].motion.contour_area) == 10
 
     def test_merge_labelmap(self):
         config = {
@@ -846,10 +800,7 @@ class TestConfig(unittest.TestCase):
         }
 
         frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.model.merged_labelmap[7] == "truck"
+        assert frigate_config.model.merged_labelmap[7] == "truck"
 
     def test_default_labelmap_empty(self):
         config = {
@@ -874,10 +825,7 @@ class TestConfig(unittest.TestCase):
         }
 
         frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.model.merged_labelmap[0] == "person"
+        assert frigate_config.model.merged_labelmap[0] == "person"
 
     def test_default_labelmap(self):
         config = {
@@ -903,10 +851,7 @@ class TestConfig(unittest.TestCase):
         }
 
         frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.model.merged_labelmap[0] == "person"
+        assert frigate_config.model.merged_labelmap[0] == "person"
 
     def test_plus_labelmap(self):
         with open("/config/model_cache/test", "w") as f:
@@ -937,10 +882,7 @@ class TestConfig(unittest.TestCase):
         }
 
         frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
-
-        runtime_config = frigate_config.runtime_config(PlusApi())
-        assert runtime_config.model.merged_labelmap[0] == "amazon"
+        assert frigate_config.model.merged_labelmap[0] == "amazon"
 
     def test_fails_on_invalid_role(self):
         config = {
@@ -997,8 +939,7 @@ class TestConfig(unittest.TestCase):
             },
         }
 
-        frigate_config = FrigateConfig(**config)
-        self.assertRaises(ValueError, lambda: frigate_config.runtime_config())
+        self.assertRaises(ValueError, lambda: FrigateConfig(**config))
 
     def test_works_on_missing_role_multiple_cams(self):
         config = {
@@ -1045,8 +986,7 @@ class TestConfig(unittest.TestCase):
             },
         }
 
-        frigate_config = FrigateConfig(**config)
-        frigate_config.runtime_config()
+        FrigateConfig(**config)
 
     def test_global_detect(self):
         config = {
@@ -1070,12 +1010,10 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].detect.max_disappeared == 1
-        assert runtime_config.cameras["back"].detect.height == 1080
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].detect.max_disappeared == 1
+        assert frigate_config.cameras["back"].detect.height == 1080
 
     def test_default_detect(self):
         config = {
@@ -1098,12 +1036,10 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].detect.max_disappeared == 25
-        assert runtime_config.cameras["back"].detect.height == 720
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].detect.max_disappeared == 25
+        assert frigate_config.cameras["back"].detect.height == 720
 
     def test_global_detect_merge(self):
         config = {
@@ -1127,13 +1063,11 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].detect.max_disappeared == 1
-        assert runtime_config.cameras["back"].detect.height == 1080
-        assert runtime_config.cameras["back"].detect.width == 1920
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].detect.max_disappeared == 1
+        assert frigate_config.cameras["back"].detect.height == 1080
+        assert frigate_config.cameras["back"].detect.width == 1920
 
     def test_global_snapshots(self):
         config = {
@@ -1160,12 +1094,10 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].snapshots.enabled
-        assert runtime_config.cameras["back"].snapshots.height == 100
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].snapshots.enabled
+        assert frigate_config.cameras["back"].snapshots.height == 100
 
     def test_default_snapshots(self):
         config = {
@@ -1188,12 +1120,10 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].snapshots.bounding_box
-        assert runtime_config.cameras["back"].snapshots.quality == 70
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].snapshots.bounding_box
+        assert frigate_config.cameras["back"].snapshots.quality == 70
 
     def test_global_snapshots_merge(self):
         config = {
@@ -1221,13 +1151,11 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].snapshots.bounding_box is False
-        assert runtime_config.cameras["back"].snapshots.height == 150
-        assert runtime_config.cameras["back"].snapshots.enabled
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].snapshots.bounding_box is False
+        assert frigate_config.cameras["back"].snapshots.height == 150
+        assert frigate_config.cameras["back"].snapshots.enabled
 
     def test_global_jsmpeg(self):
         config = {
@@ -1251,11 +1179,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].live.quality == 4
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].live.quality == 4
 
     def test_default_live(self):
         config = {
@@ -1278,11 +1204,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].live.quality == 8
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].live.quality == 8
 
     def test_global_live_merge(self):
         config = {
@@ -1309,12 +1233,10 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].live.quality == 7
-        assert runtime_config.cameras["back"].live.height == 480
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].live.quality == 7
+        assert frigate_config.cameras["back"].live.height == 480
 
     def test_global_timestamp_style(self):
         config = {
@@ -1338,11 +1260,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].timestamp_style.position == "bl"
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].timestamp_style.position == "bl"
 
     def test_default_timestamp_style(self):
         config = {
@@ -1365,11 +1285,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].timestamp_style.position == "tl"
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].timestamp_style.position == "tl"
 
     def test_global_timestamp_style_merge(self):
         config = {
@@ -1394,12 +1312,10 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].timestamp_style.position == "bl"
-        assert runtime_config.cameras["back"].timestamp_style.thickness == 4
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].timestamp_style.position == "bl"
+        assert frigate_config.cameras["back"].timestamp_style.thickness == 4
 
     def test_allow_retain_to_be_a_decimal(self):
         config = {
@@ -1423,11 +1339,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].snapshots.retain.default == 1.5
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].snapshots.retain.default == 1.5
 
     def test_fails_on_bad_camera_name(self):
         config = {
@@ -1452,11 +1366,7 @@ class TestConfig(unittest.TestCase):
             },
         }
 
-        frigate_config = FrigateConfig(**config)
-
-        self.assertRaises(
-            ValidationError, lambda: frigate_config.runtime_config().cameras
-        )
+        self.assertRaises(ValidationError, lambda: FrigateConfig(**config).cameras)
 
     def test_fails_on_bad_segment_time(self):
         config = {
@@ -1484,11 +1394,9 @@ class TestConfig(unittest.TestCase):
             },
         }
 
-        frigate_config = FrigateConfig(**config)
-
         self.assertRaises(
             ValueError,
-            lambda: frigate_config.runtime_config().ffmpeg.output_args.record,
+            lambda: FrigateConfig(**config).ffmpeg.output_args.record,
         )
 
     def test_fails_zone_defines_untracked_object(self):
@@ -1520,9 +1428,7 @@ class TestConfig(unittest.TestCase):
             },
         }
 
-        frigate_config = FrigateConfig(**config)
-
-        self.assertRaises(ValueError, lambda: frigate_config.runtime_config().cameras)
+        self.assertRaises(ValueError, lambda: FrigateConfig(**config).cameras)
 
     def test_fails_duplicate_keys(self):
         raw_config = """
@@ -1563,13 +1469,11 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
-        assert config == frigate_config.model_dump(exclude_unset=True)
 
-        runtime_config = frigate_config.runtime_config()
-        assert "dog" in runtime_config.cameras["back"].objects.filters
-        assert runtime_config.cameras["back"].objects.filters["dog"].min_ratio == 0.2
-        assert runtime_config.cameras["back"].objects.filters["dog"].max_ratio == 10.1
+        frigate_config = FrigateConfig(**config)
+        assert "dog" in frigate_config.cameras["back"].objects.filters
+        assert frigate_config.cameras["back"].objects.filters["dog"].min_ratio == 0.2
+        assert frigate_config.cameras["back"].objects.filters["dog"].max_ratio == 10.1
 
     def test_valid_movement_weights(self):
         config = {
@@ -1592,10 +1496,9 @@ class TestConfig(unittest.TestCase):
                 }
             },
         }
-        frigate_config = FrigateConfig(**config)
 
-        runtime_config = frigate_config.runtime_config()
-        assert runtime_config.cameras["back"].onvif.autotracking.movement_weights == [
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.cameras["back"].onvif.autotracking.movement_weights == [
             "0.0",
             "1.0",
             "1.23",

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -134,7 +134,7 @@ class TestFfmpegPresets(unittest.TestCase):
 
     def test_ffmpeg_output_record_not_preset(self):
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["output_args"]["record"] = (
-            "-some output"
+            "-some output -segment_time 10"
         )
         frigate_config = FrigateConfig(**self.default_ffmpeg)
         assert "-some output" in (

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -36,16 +36,13 @@ class TestFfmpegPresets(unittest.TestCase):
         }
 
     def test_default_ffmpeg(self):
-        frigate_config = FrigateConfig(**self.default_ffmpeg)
-        frigate_config.cameras["back"].create_ffmpeg_cmds()
-        assert self.default_ffmpeg == frigate_config.dict(exclude_unset=True)
+        FrigateConfig(**self.default_ffmpeg)
 
     def test_ffmpeg_hwaccel_preset(self):
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["hwaccel_args"] = (
             "preset-rpi-64-h264"
         )
         frigate_config = FrigateConfig(**self.default_ffmpeg)
-        frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-rpi-64-h264" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
@@ -58,7 +55,6 @@ class TestFfmpegPresets(unittest.TestCase):
             "-other-hwaccel args"
         )
         frigate_config = FrigateConfig(**self.default_ffmpeg)
-        frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "-other-hwaccel args" in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
@@ -73,7 +69,6 @@ class TestFfmpegPresets(unittest.TestCase):
             "fps": 10,
         }
         frigate_config = FrigateConfig(**self.default_ffmpeg)
-        frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-nvidia-h264" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
@@ -89,8 +84,6 @@ class TestFfmpegPresets(unittest.TestCase):
             "preset-rtsp-generic"
         )
         frigate_preset_config = FrigateConfig(**self.default_ffmpeg)
-        frigate_config.cameras["back"].create_ffmpeg_cmds()
-        frigate_preset_config.cameras["back"].create_ffmpeg_cmds()
         assert (
             # Ignore global and user_agent args in comparison
             frigate_preset_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
@@ -102,7 +95,6 @@ class TestFfmpegPresets(unittest.TestCase):
             "preset-rtmp-generic"
         )
         frigate_config = FrigateConfig(**self.default_ffmpeg)
-        frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-rtmp-generic" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
@@ -117,7 +109,6 @@ class TestFfmpegPresets(unittest.TestCase):
         argsList = defaultArgsList + ["-some", "arg with space"]
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["input_args"] = argsString
         frigate_config = FrigateConfig(**self.default_ffmpeg)
-        frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert set(argsList).issubset(
             frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]
         )
@@ -125,7 +116,6 @@ class TestFfmpegPresets(unittest.TestCase):
     def test_ffmpeg_input_not_preset(self):
         self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["input_args"] = "-some inputs"
         frigate_config = FrigateConfig(**self.default_ffmpeg)
-        frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "-some inputs" in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
@@ -135,7 +125,6 @@ class TestFfmpegPresets(unittest.TestCase):
             "preset-record-generic-audio-aac"
         )
         frigate_config = FrigateConfig(**self.default_ffmpeg)
-        frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "preset-record-generic-audio-aac" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
@@ -148,7 +137,6 @@ class TestFfmpegPresets(unittest.TestCase):
             "-some output"
         )
         frigate_config = FrigateConfig(**self.default_ffmpeg)
-        frigate_config.cameras["back"].create_ffmpeg_cmds()
         assert "-some output" in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )

--- a/frigate/test/test_http.py
+++ b/frigate/test/test_http.py
@@ -345,7 +345,7 @@ class TestHttp(unittest.TestCase):
 
     def test_config(self):
         app = create_app(
-            FrigateConfig(**self.minimal_config).runtime_config(),
+            FrigateConfig(**self.minimal_config),
             self.db,
             None,
             None,
@@ -363,7 +363,7 @@ class TestHttp(unittest.TestCase):
 
     def test_recordings(self):
         app = create_app(
-            FrigateConfig(**self.minimal_config).runtime_config(),
+            FrigateConfig(**self.minimal_config),
             self.db,
             None,
             None,
@@ -385,7 +385,7 @@ class TestHttp(unittest.TestCase):
         stats = Mock(spec=StatsEmitter)
         stats.get_latest_stats.return_value = self.test_stats
         app = create_app(
-            FrigateConfig(**self.minimal_config).runtime_config(),
+            FrigateConfig(**self.minimal_config),
             self.db,
             None,
             None,

--- a/frigate/util/builtin.py
+++ b/frigate/util/builtin.py
@@ -9,14 +9,12 @@ import queue
 import re
 import shlex
 import urllib.parse
-from collections import Counter
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Optional, Tuple
 
 import numpy as np
 import pytz
-import yaml
 from ruamel.yaml import YAML
 from tzlocal import get_localzone
 from zoneinfo import ZoneInfoNotFoundError
@@ -87,34 +85,6 @@ def deep_merge(dct1: dict, dct2: dict, override=False, merge_lists=False) -> dic
         else:
             merged[k] = copy.deepcopy(v2)
     return merged
-
-
-def load_config_with_no_duplicates(raw_config) -> dict:
-    """Get config ensuring duplicate keys are not allowed."""
-
-    # https://stackoverflow.com/a/71751051
-    # important to use SafeLoader here to avoid RCE
-    class PreserveDuplicatesLoader(yaml.loader.SafeLoader):
-        pass
-
-    def map_constructor(loader, node, deep=False):
-        keys = [loader.construct_object(node, deep=deep) for node, _ in node.value]
-        vals = [loader.construct_object(node, deep=deep) for _, node in node.value]
-        key_count = Counter(keys)
-        data = {}
-        for key, val in zip(keys, vals):
-            if key_count[key] > 1:
-                raise ValueError(
-                    f"Config input {key} is defined multiple times for the same field, this is not allowed."
-                )
-            else:
-                data[key] = val
-        return data
-
-    PreserveDuplicatesLoader.add_constructor(
-        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, map_constructor
-    )
-    return yaml.load(raw_config, PreserveDuplicatesLoader)
 
 
 def clean_camera_user_pass(line: str) -> str:

--- a/process_clip.py
+++ b/process_clip.py
@@ -280,10 +280,7 @@ def process(path, label, output, debug_path):
         json_config["cameras"]["camera"]["ffmpeg"]["inputs"][0]["path"] = c
 
         frigate_config = FrigateConfig(**json_config)
-        runtime_config = frigate_config.runtime_config()
-        runtime_config.cameras["camera"].create_ffmpeg_cmds()
-
-        process_clip = ProcessClip(c, frame_shape, runtime_config)
+        process_clip = ProcessClip(c, frame_shape, frigate_config)
         process_clip.load_frames()
         process_clip.process_frames(object_detector, objects_to_track=[label])
 


### PR DESCRIPTION
Continuation of #13809.

- Ignore `__pycache__` folders instead of `*.pyc* files.
- Ignore `.mypy_cache` (It is created by mypy when testing inside the devcontainer).
- Use `ruamel.yaml` instead of `PyYAML` for config parsing.
- Moved handling of `FRIGATE_*` env vars to a dedicated pydantic annotation.
- Added gitlens to dev container.
- Properly handled missing `-segment_time` in post config validation.

---

In the process I had added some more type annotations to `FrigateConfig.parse_*()`, but then mypy started complaining because throughout the code base, some fields are marked as optional in pydantic, but they are then used as if they are not. Take `BaseDetectorConfig.model` for example: It is marked optional, but then in post_validation (What used to be runtime_config), it is filled in from FrigateConfig.model.

This is really difficult to encode in pydantic. It is possible by doing pre-validation, but that would then make FrigateConfig's json schema no longer match the actually expected schema. At this point I figured this question was out of scope for what I originally set out to do. It might be possible to make this work, but that seems like a lot of work.

Besides, I'd like to eventually migrate most, if not all, of config.yaml to the sqlite database (to get proper ui management of frigate's configuration). Is that something we want? Should I put time into this? Or do we want to maintain the existing config.yml file? Possibly, we might want to have a switch between config.yaml backed config vs sqlite backed config? Is that something worth supporting?

Personally I'd rather we completely ditch config.yaml and move most of the configuration to the db, possibly with the ability to import/export settings for users who want to do configuration through yaml.