### PR TITLE
Decrease number of X ticks on system and camera graphs

### DIFF
--- a/web/src/components/graph/CameraGraph.tsx
+++ b/web/src/components/graph/CameraGraph.tsx
@@ -86,7 +86,7 @@ export function CameraLineGraph({
         size: 0,
       },
       xaxis: {
-        tickAmount: isMobileOnly ? 3 : 4,
+        tickAmount: isMobileOnly ? 2 : 3,
         tickPlacement: "on",
         labels: {
           rotate: 0,

--- a/web/src/components/graph/SystemGraph.tsx
+++ b/web/src/components/graph/SystemGraph.tsx
@@ -121,7 +121,7 @@ export function ThresholdBarGraph({
         size: 0,
       },
       xaxis: {
-        tickAmount: isMobileOnly ? 3 : 4,
+        tickAmount: isMobileOnly ? 2 : 3,
         tickPlacement: "on",
         labels: {
           rotate: 0,


### PR DESCRIPTION
This has been bugging me (minorly) again recently, I have no idea when it regressed. This seems like the simplest fix that doesn't have too many downsides 🤷 

Old reference with a screenshot:

https://github.com/blakeblackshear/frigate/pull/11148

Either the tick count changed how it works in apex charts (couldn't find anything about this in the release notes) or the change from between->on or something changed, but on smaller screens there are too many ticks to render nicely for the axis. I can do more investigation to bisect it if you care, but it also seems like an inconsequential change.

Before:

![image](https://github.com/user-attachments/assets/da626517-f540-4aa4-a18b-24b63258f909)

With this MR:

![image](https://github.com/user-attachments/assets/2c4b0fef-6e33-472a-92a9-2b55830f400f)
