### PR TITLE
Move more things out of FrigateApp

### DIFF
--- a/frigate/__main__.py
+++ b/frigate/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import faulthandler
 import logging
+import signal
 import sys
 import threading
 
@@ -23,6 +24,9 @@ def main() -> None:
 
     threading.current_thread().name = "frigate"
     cli.show_server_banner = lambda *x: None
+
+    # Make sure we exit cleanly on SIGTERM.
+    signal.signal(signal.SIGTERM, lambda sig, frame: sys.exit())
 
     # Parse the cli arguments.
     parser = argparse.ArgumentParser(

--- a/frigate/__main__.py
+++ b/frigate/__main__.py
@@ -9,7 +9,6 @@ from pydantic import ValidationError
 
 from frigate.app import FrigateApp
 from frigate.config import FrigateConfig
-from frigate.plus import PlusApi
 
 
 def main() -> None:
@@ -33,11 +32,9 @@ def main() -> None:
     parser.add_argument("--validate-config", action="store_true")
     args = parser.parse_args()
 
-    plus_api = PlusApi()
-
     # Load the configuration.
     try:
-        config = FrigateConfig.load(plus_api=plus_api)
+        config = FrigateConfig.load()
     except ValidationError as e:
         print("*************************************************************")
         print("*************************************************************")
@@ -62,7 +59,7 @@ def main() -> None:
         sys.exit(0)
 
     # Run the main application.
-    FrigateApp(config, plus_api).start()
+    FrigateApp(config).start()
 
 
 if __name__ == "__main__":

--- a/frigate/__main__.py
+++ b/frigate/__main__.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from frigate.app import FrigateApp
 from frigate.config import FrigateConfig
+from frigate.log import log_thread
 
 
 def main() -> None:
@@ -28,6 +29,11 @@ def main() -> None:
     # Make sure we exit cleanly on SIGTERM.
     signal.signal(signal.SIGTERM, lambda sig, frame: sys.exit())
 
+    run()
+
+
+@log_thread()
+def run() -> None:
     # Parse the cli arguments.
     parser = argparse.ArgumentParser(
         prog="Frigate",

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -612,7 +612,7 @@ def set_retain(id):
 
 @EventBp.route("/events/<id>/plus", methods=("POST",))
 def send_to_plus(id):
-    if not current_app.plus_api.is_active():
+    if not current_app.frigate_config.plus_api.is_active():
         message = "PLUS_API_KEY environment variable is not set"
         logger.error(message)
         return make_response(
@@ -680,7 +680,7 @@ def send_to_plus(id):
         )
 
     try:
-        plus_id = current_app.plus_api.upload_image(image, event.camera)
+        plus_id = current_app.frigate_config.plus_api.upload_image(image, event.camera)
     except Exception as ex:
         logger.exception(ex)
         return make_response(
@@ -696,7 +696,7 @@ def send_to_plus(id):
         box = event.data["box"]
 
         try:
-            current_app.plus_api.add_annotation(
+            current_app.frigate_config.plus_api.add_annotation(
                 event.plus_id,
                 box,
                 event.label,
@@ -720,7 +720,7 @@ def send_to_plus(id):
 
 @EventBp.route("/events/<id>/false_positive", methods=("PUT",))
 def false_positive(id):
-    if not current_app.plus_api.is_active():
+    if not current_app.frigate_config.plus_api.is_active():
         message = "PLUS_API_KEY environment variable is not set"
         logger.error(message)
         return make_response(
@@ -769,7 +769,7 @@ def false_positive(id):
     )
 
     try:
-        current_app.plus_api.add_false_positive(
+        current_app.frigate_config.plus_api.add_false_positive(
             event.plus_id,
             region,
             box,

--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -294,7 +294,7 @@ def submit_recording_snapshot_to_plus(camera_name: str, frame_time: str):
             )
 
         nd = cv2.imdecode(np.frombuffer(image_data, dtype=np.int8), cv2.IMREAD_COLOR)
-        current_app.plus_api.upload_image(nd, camera_name)
+        current_app.frigate_config.plus_api.upload_image(nd, camera_name)
 
         return make_response(
             jsonify(

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -37,7 +37,6 @@ from frigate.events.audio import listen_to_audio
 from frigate.events.cleanup import EventCleanup
 from frigate.events.external import ExternalEventProcessor
 from frigate.events.maintainer import EventProcessor
-from frigate.log import log_thread
 from frigate.models import (
     Event,
     Export,
@@ -632,7 +631,6 @@ class FrigateApp:
                 logger.info("********************************************************")
                 logger.info("********************************************************")
 
-    @log_thread()
     def start(self) -> None:
         logger.info(f"Starting Frigate ({VERSION})")
 

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -4,7 +4,6 @@ import multiprocessing as mp
 import os
 import secrets
 import shutil
-import sys
 from multiprocessing import Queue
 from multiprocessing.synchronize import Event as MpEvent
 from typing import Any
@@ -634,25 +633,21 @@ class FrigateApp:
     def start(self) -> None:
         logger.info(f"Starting Frigate ({VERSION})")
 
-        try:
-            self.ensure_dirs()
-            self.init_camera_metrics()
-            self.set_environment_vars()
-            self.set_log_levels()
-            self.init_queues()
-            self.init_database()
-            self.init_onvif()
-            self.init_recording_manager()
-            self.init_review_segment_manager()
-            self.init_embeddings_manager()
-            self.init_go2rtc()
-            self.bind_database()
-            self.check_db_data_migrations()
-            self.init_inter_process_communicator()
-            self.init_dispatcher()
-        except Exception as e:
-            print(e)
-            sys.exit(1)
+        self.ensure_dirs()
+        self.init_camera_metrics()
+        self.set_environment_vars()
+        self.set_log_levels()
+        self.init_queues()
+        self.init_database()
+        self.init_onvif()
+        self.init_recording_manager()
+        self.init_review_segment_manager()
+        self.init_embeddings_manager()
+        self.init_go2rtc()
+        self.bind_database()
+        self.check_db_data_migrations()
+        self.init_inter_process_communicator()
+        self.init_dispatcher()
 
         self.start_detectors()
         self.start_video_output_processor()

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -4,12 +4,10 @@ import multiprocessing as mp
 import os
 import secrets
 import shutil
-import signal
 import sys
 from multiprocessing import Queue
 from multiprocessing.synchronize import Event as MpEvent
-from types import FrameType
-from typing import Any, Optional
+from typing import Any
 
 import psutil
 from peewee_migrate import Router
@@ -677,12 +675,6 @@ class FrigateApp:
         self.start_record_cleanup()
         self.start_watchdog()
         self.init_auth()
-
-        # Flask only listens for SIGINT, so we need to catch SIGTERM and send SIGINT
-        def receiveSignal(signalNumber: int, frame: Optional[FrameType]) -> None:
-            os.kill(os.getpid(), signal.SIGINT)
-
-        signal.signal(signal.SIGTERM, receiveSignal)
 
         try:
             self.flask_app.run(host="127.0.0.1", port=5001, debug=False, threaded=True)

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -9,7 +9,7 @@ import sys
 from multiprocessing import Queue
 from multiprocessing.synchronize import Event as MpEvent
 from types import FrameType
-from typing import Optional
+from typing import Any, Optional
 
 import psutil
 from peewee_migrate import Router
@@ -75,14 +75,14 @@ logger = logging.getLogger(__name__)
 
 
 class FrigateApp:
-    def __init__(self, config, plus_api) -> None:
+    # TODO: Fix FrigateConfig usage, so we can properly annotate it here without mypy erroring out.
+    def __init__(self, config: Any) -> None:
         self.stop_event: MpEvent = mp.Event()
         self.detection_queue: Queue = mp.Queue()
         self.detectors: dict[str, ObjectDetectProcess] = {}
         self.detection_out_events: dict[str, MpEvent] = {}
         self.detection_shms: list[mp.shared_memory.SharedMemory] = []
         self.log_queue: Queue = mp.Queue()
-        self.plus_api = plus_api
         self.camera_metrics: dict[str, CameraMetricsTypes] = {}
         self.ptz_metrics: dict[str, PTZMetricsTypes] = {}
         self.processes: dict[str, int] = {}
@@ -361,7 +361,6 @@ class FrigateApp:
             self.storage_maintainer,
             self.onvif_controller,
             self.external_event_processor,
-            self.plus_api,
             self.stats_emitter,
         )
 

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -655,12 +655,8 @@ class FrigateApp:
                 self.external_event_processor,
                 self.stats_emitter,
             ).run(host="127.0.0.1", port=5001, debug=False, threaded=True)
-        except KeyboardInterrupt:
-            pass
-
-        logger.info("Flask has exited...")
-
-        self.stop()
+        finally:
+            self.stop()
 
     def stop(self) -> None:
         logger.info("Stopping...")

--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -76,16 +76,8 @@ def listen_to_audio(
     stop_event = mp.Event()
     audio_threads: list[threading.Thread] = []
 
-    def exit_process() -> None:
-        for thread in audio_threads:
-            thread.join()
-
-        logger.info("Exiting audio detector...")
-
     def receiveSignal(signalNumber: int, frame: Optional[FrameType]) -> None:
-        logger.debug(f"Audio process received signal {signalNumber}")
         stop_event.set()
-        exit_process()
 
     signal.signal(signal.SIGTERM, receiveSignal)
     signal.signal(signal.SIGINT, receiveSignal)
@@ -103,6 +95,11 @@ def listen_to_audio(
             )
             audio_threads.append(audio)
             audio.start()
+
+    for thread in audio_threads:
+        thread.join()
+
+    logger.info("Exiting audio detector...")
 
 
 class AudioTfl:

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -74,7 +74,7 @@ class log_thread(AbstractContextManager, ContextDecorator):
 # happens while an internal lock is held, the stdout/err flush can cause a deadlock.
 #
 # https://github.com/python/cpython/issues/91776
-def reopen_std_streams():
+def reopen_std_streams() -> None:
     sys.stdout = os.fdopen(1, "w")
     sys.stderr = os.fdopen(2, "w")
 

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -2,6 +2,7 @@ import atexit
 import logging
 import multiprocessing as mp
 import os
+import sys
 import threading
 from collections import deque
 from contextlib import AbstractContextManager, ContextDecorator
@@ -66,6 +67,19 @@ class log_thread(AbstractContextManager, ContextDecorator):
 
         atexit.unregister(self._stop_thread)
         self._stop_thread()
+
+
+# When a multiprocessing.Process exits, python tries to flush stdout and stderr. However, if the
+# process is created after a thread (for example a logging thread) is created and the process fork
+# happens while an internal lock is held, the stdout/err flush can cause a deadlock.
+#
+# https://github.com/python/cpython/issues/91776
+def reopen_std_streams():
+    sys.stdout = os.fdopen(1, "w")
+    sys.stderr = os.fdopen(2, "w")
+
+
+os.register_at_fork(after_in_child=reopen_std_streams)
 
 
 # based on https://codereview.stackexchange.com/a/17959

--- a/frigate/object_detection.py
+++ b/frigate/object_detection.py
@@ -92,7 +92,6 @@ def run_detector(
     stop_event = mp.Event()
 
     def receiveSignal(signalNumber, frame):
-        logger.info("Signal to exit detection process...")
         stop_event.set()
 
     signal.signal(signal.SIGTERM, receiveSignal)

--- a/frigate/output/output.py
+++ b/frigate/output/output.py
@@ -38,7 +38,6 @@ def output_frames(
     stop_event = mp.Event()
 
     def receiveSignal(signalNumber, frame):
-        logger.debug(f"Output frames process received signal {signalNumber}")
         stop_event.set()
 
     signal.signal(signal.SIGTERM, receiveSignal)

--- a/frigate/record/record.py
+++ b/frigate/record/record.py
@@ -22,7 +22,6 @@ def manage_recordings(config: FrigateConfig) -> None:
     stop_event = mp.Event()
 
     def receiveSignal(signalNumber: int, frame: Optional[FrameType]) -> None:
-        logger.debug(f"Recording manager process received signal {signalNumber}")
         stop_event.set()
 
     signal.signal(signal.SIGTERM, receiveSignal)

--- a/frigate/review/review.py
+++ b/frigate/review/review.py
@@ -20,7 +20,6 @@ def manage_review_segments(config: FrigateConfig) -> None:
     stop_event = mp.Event()
 
     def receiveSignal(signalNumber: int, frame: Optional[FrameType]) -> None:
-        logger.debug(f"Manage review segments process received signal {signalNumber}")
         stop_event.set()
 
     signal.signal(signal.SIGTERM, receiveSignal)

--- a/frigate/test/test_http.py
+++ b/frigate/test/test_http.py
@@ -13,7 +13,6 @@ from playhouse.sqliteq import SqliteQueueDatabase
 from frigate.api.app import create_app
 from frigate.config import FrigateConfig
 from frigate.models import Event, Recordings
-from frigate.plus import PlusApi
 from frigate.stats.emitter import StatsEmitter
 from frigate.test.const import TEST_DB, TEST_DB_CLEANUPS
 
@@ -121,7 +120,6 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            PlusApi(),
             None,
         )
         id = "123456.random"
@@ -158,7 +156,6 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            PlusApi(),
             None,
         )
         id = "123456.random"
@@ -180,7 +177,6 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            PlusApi(),
             None,
         )
         id = "123456.random"
@@ -201,7 +197,6 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            PlusApi(),
             None,
         )
         id = "123456.random"
@@ -224,7 +219,6 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            PlusApi(),
             None,
         )
         id = "123456.random"
@@ -251,7 +245,6 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            PlusApi(),
             None,
         )
         morning_id = "123456.random"
@@ -290,7 +283,6 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            PlusApi(),
             None,
         )
         id = "123456.random"
@@ -326,7 +318,6 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            PlusApi(),
             None,
         )
         id = "123456.random"
@@ -352,7 +343,6 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            PlusApi(),
             None,
         )
 
@@ -370,7 +360,6 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            PlusApi(),
             None,
         )
         id = "123456.random"
@@ -392,7 +381,6 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
-            PlusApi(),
             stats,
         )
 

--- a/frigate/util/builtin.py
+++ b/frigate/util/builtin.py
@@ -258,37 +258,6 @@ def find_by_key(dictionary, target_key):
     return None
 
 
-def save_default_config(location: str) -> None:
-    try:
-        with open(location, "w") as f:
-            f.write(
-                """
-mqtt:
-  enabled: False
-
-cameras:
-  name_of_your_camera: # <------ Name the camera
-    enabled: True
-    ffmpeg:
-      inputs:
-        - path: rtsp://10.0.10.10:554/rtsp # <----- The stream you want to use for detection
-          roles:
-            - detect
-    detect:
-      enabled: False # <---- disable detection until you have a working camera feed
-      width: 1280
-      height: 720
-                    """
-            )
-    except PermissionError:
-        logger.error("Unable to write default config to /config")
-        return
-
-    logger.info(
-        "Created default config file, see the getting started docs for configuration https://docs.frigate.video/guides/getting_started"
-    )
-
-
 def get_tomorrow_at_time(hour: int) -> datetime.datetime:
     """Returns the datetime of the following day at 2am."""
     try:

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -390,7 +390,6 @@ def capture_camera(name, config: CameraConfig, shm_frame_count: int, process_inf
     stop_event = mp.Event()
 
     def receiveSignal(signalNumber, frame):
-        logger.debug(f"Capture camera received signal {signalNumber}")
         stop_event.set()
 
     signal.signal(signal.SIGTERM, receiveSignal)


### PR DESCRIPTION
This should (hopefully) be the last tangent to rewriting `FrigateApp` to properly manage all its subprocesses. I moved all the `FrigateConfig` parsing out of `FrigateApp` so that it ~~only~~ mainly deals with all the subprocesses it spawns.

**Changes:**

- Moved functionality of `FrigateApp.init_config()` into `FrigateConfig.load()`
- `main()` is now responsible for loading the config (and potentially verifying it, if cli says to do so).
- Moved `PlusApi` to a private attr in `FrigateConfig`.
- Moved `SIGTERM` registration to `main()`.
- Set the log thread up earlier, since `FrigateConfig.load()` is now called in main.

---

**Changes (2):**
- Removed logging from signal handlers, since python's logging module functions tend to not be [re-entrant](https://docs.python.org/3/library/logging.html#thread-safety).
- Added code to reopen stdout & stderr on fork. This helps prevent a deadlock I was encountering.