### PR TITLE
Chroma fixes

### DIFF
--- a/frigate/embeddings/embeddings.py
+++ b/frigate/embeddings/embeddings.py
@@ -126,9 +126,9 @@ class Embeddings:
                 thumbnails["ids"].append(event.id)
                 thumbnails["images"].append(img)
                 thumbnails["metadatas"].append(metadata)
-                if event.data.get("description") is not None:
+                if description := event.data.get("description", "").strip():
                     descriptions["ids"].append(event.id)
-                    descriptions["documents"].append(event.data["description"])
+                    descriptions["documents"].append(description)
                     descriptions["metadatas"].append(metadata)
 
             if len(thumbnails["ids"]) > 0:

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -177,7 +177,7 @@ class EmbeddingMaintainer(threading.Thread):
             camera_config, thumbnails, metadata
         )
 
-        if description is None:
+        if not description:
             logger.debug("Failed to generate description for %s", event.id)
             return
 

--- a/frigate/events/cleanup.py
+++ b/frigate/events/cleanup.py
@@ -230,7 +230,12 @@ class EventCleanup(threading.Thread):
                     Event.delete().where(Event.id << chunk).execute()
 
                     if self.config.semantic_search.enabled:
-                        self.embeddings.thumbnail.delete(ids=chunk)
-                        self.embeddings.description.delete(ids=chunk)
+                        for collection in [
+                            self.embeddings.thumbnail,
+                            self.embeddings.description,
+                        ]:
+                            existing_ids = collection.get(ids=chunk, include=[])["ids"]
+                            if existing_ids:
+                                collection.delete(ids=existing_ids)
 
         logger.info("Exiting event cleanup...")

--- a/frigate/events/cleanup.py
+++ b/frigate/events/cleanup.py
@@ -237,5 +237,8 @@ class EventCleanup(threading.Thread):
                             existing_ids = collection.get(ids=chunk, include=[])["ids"]
                             if existing_ids:
                                 collection.delete(ids=existing_ids)
+                                logger.debug(
+                                    f"Deleted {len(existing_ids)} embeddings from {collection.__class__.__name__}"
+                                )
 
         logger.info("Exiting event cleanup...")


### PR DESCRIPTION
- Ensure only non-empty description embeddings are saved in Chroma. In testing, if Ollama is running slowly or is offline, a blank description embedding ends up being saved and then wrongly shows up in search results.
- Only delete embeddings that actually exist in event cleanup. This prevents the log from printing errors during event cleanup for event ids that don't have embeddings saved in Chroma.