### PR TITLE
Disable keepalive for Safari in nginx vod location

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -104,6 +104,8 @@ http {
 
             add_header Cache-Control "no-store";
             expires off;
+
+            keepalive_disable safari;
         }
 
         location /stream/ {


### PR DESCRIPTION
This change disables keepalive for Safari browsers in nginx solely for vod. This fixes an issue where lower-speed connections would hang while trying to load video segments in recording history/reviews. Fixes #13862.