### PR TITLE
Autotracking: don't set up onvif zoom space if zooming is disabled

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -207,7 +207,13 @@ class OnvifController:
                             "RelativeZoomTranslationSpace"
                         ][zoom_space_id]["URI"]
                 else:
-                    move_request.Translation.Zoom = []
+                    if "Zoom" in move_request["Translation"]:
+                        del move_request["Translation"]["Zoom"]
+                    if "Zoom" in move_request["Speed"]:
+                        del move_request["Speed"]["Zoom"]
+                    logger.debug(
+                        f"{camera_name}: Relative move request after deleting zoom: {move_request}"
+                    )
             except Exception:
                 self.config.cameras[
                     camera_name


### PR DESCRIPTION
Solves an issue with some Hikvision cameras when users set `zooming: disabled`. Closes https://github.com/blakeblackshear/frigate/discussions/13831