### PR TITLE
Regenerate genai tracked object descriptions 

### DIFF
--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -23,6 +23,7 @@ from frigate.api.media import MediaBp
 from frigate.api.notification import NotificationBp
 from frigate.api.preview import PreviewBp
 from frigate.api.review import ReviewBp
+from frigate.comms.event_metadata_updater import EventMetadataPublisher
 from frigate.config import FrigateConfig
 from frigate.const import CONFIG_DIR
 from frigate.embeddings import EmbeddingsContext
@@ -63,6 +64,7 @@ def create_app(
     external_processor: ExternalEventProcessor,
     plus_api: PlusApi,
     stats_emitter: StatsEmitter,
+    event_metadata_updater: EventMetadataPublisher,
 ):
     app = Flask(__name__)
 
@@ -92,6 +94,7 @@ def create_app(
     app.plus_api = plus_api
     app.camera_error_image = None
     app.stats_emitter = stats_emitter
+    app.event_metadata_updater = event_metadata_updater
     app.jwt_token = get_jwt_secret() if frigate_config.auth.enabled else None
     # update the request_address with the x-forwarded-for header from nginx
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1)

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -926,6 +926,12 @@ def set_description(
             ids=[id],
         )
 
+    response_message = (
+        f"Event {id} description is now blank"
+        if new_description is None or len(new_description) == 0
+        else f"Event {id} description set to {new_description}"
+    )
+
     return JSONResponse(
         content=(
             {

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -962,20 +962,24 @@ def regenerate_description(request: Request, event_id: str):
         request.app.event_metadata_updater.publish(event.id)
 
         return JSONResponse(
-            {
-                "success": True,
-                "message": "Event "
-                + event_id
-                + " description regeneration has been requested.",
-            },
+            content=(
+                {
+                    "success": True,
+                    "message": "Event "
+                    + event_id
+                    + " description regeneration has been requested.",
+                }
+            ),
             status_code=200,
         )
 
     return JSONResponse(
-        {
-            "success": False,
-            "message": "Semantic search and generative AI are not enabled",
-        },
+        content=(
+            {
+                "success": False,
+                "message": "Semantic search and generative AI are not enabled",
+            }
+        ),
         status_code=400,
     )
 

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -911,7 +911,11 @@ def set_description(id):
     json: dict[str, any] = request.get_json(silent=True) or {}
     new_description = json.get("description")
 
-    event.data["description"] = new_description or None
+    # ensure we can save an empty description
+    if new_description:
+        event.data["description"] = new_description
+    else:
+        event.data.pop("description", None)
     event.save()
 
     # If semantic search is enabled, update the index

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -923,13 +923,13 @@ def set_description(
         context.embeddings.description.upsert(
             documents=[new_description],
             metadatas=[get_metadata(event)],
-            ids=[id],
+            ids=[event_id],
         )
 
     response_message = (
-        f"Event {id} description is now blank"
+        f"Event {event_id} description is now blank"
         if new_description is None or len(new_description) == 0
-        else f"Event {id} description set to {new_description}"
+        else f"Event {event_id} description set to {new_description}"
     )
 
     return JSONResponse(

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -963,7 +963,7 @@ def regenerate_description(request: Request, event_id: str):
             {
                 "success": True,
                 "message": "Event "
-                + id
+                + event_id
                 + " description regeneration has been requested.",
             },
             status_code=200,

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -22,10 +22,6 @@ from peewee import JOIN, DoesNotExist, fn, operator
 from PIL import Image
 from playhouse.shortcuts import model_to_dict
 
-from frigate.comms.event_metadata_updater import (
-    EventMetadataPublisher,
-    EventMetadataTypeEnum,
-)
 from frigate.const import (
     CLIPS_DIR,
 )
@@ -951,10 +947,6 @@ def set_description(id):
 
 @EventBp.route("/events/<id>/description/regenerate", methods=["PUT"])
 def regenerate_description(id):
-    current_app.event_metadata_updater = EventMetadataPublisher(
-        EventMetadataTypeEnum.regenerate_description
-    )
-
     # try:
     #     event: Event = Event.get(Event.id == id)
     # except DoesNotExist:

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -907,10 +907,12 @@ def set_description(
 
     if new_description is None or len(new_description) == 0:
         return JSONResponse(
-            content={
-                "success": False,
-                "message": "description cannot be empty",
-            },
+            content=(
+                {
+                    "success": False,
+                    "message": "description cannot be empty",
+                }
+            ),
             status_code=400,
         )
 

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -947,31 +947,30 @@ def set_description(id):
 
 @EventBp.route("/events/<id>/description/regenerate", methods=["PUT"])
 def regenerate_description(id):
-    # try:
-    #     event: Event = Event.get(Event.id == id)
-    # except DoesNotExist:
-    #     return make_response(
-    #         jsonify({"success": False, "message": "Event " + id + " not found"}), 404
-    #     )
+    try:
+        event: Event = Event.get(Event.id == id)
+    except DoesNotExist:
+        return make_response(
+            jsonify({"success": False, "message": "Event " + id + " not found"}), 404
+        )
 
-    # if (
-    #     current_app.frigate_config.semantic_search.enabled
-    #     and current_app.frigate_config.genai.enabled
-    # ):
-    logger.info(id)
-    current_app.event_metadata_updater.publish(id)
+    if (
+        current_app.frigate_config.semantic_search.enabled
+        and current_app.frigate_config.genai.enabled
+    ):
+        current_app.event_metadata_updater.publish(event.id)
 
-    return make_response(
-        jsonify(
-            {
-                "success": True,
-                "message": "Event "
-                + id
-                + " description regeneration has been requested.",
-            }
-        ),
-        200,
-    )
+        return make_response(
+            jsonify(
+                {
+                    "success": True,
+                    "message": "Event "
+                    + id
+                    + " description regeneration has been requested.",
+                }
+            ),
+            200,
+        )
 
     return make_response(
         jsonify(

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -22,6 +22,10 @@ from peewee import JOIN, DoesNotExist, fn, operator
 from PIL import Image
 from playhouse.shortcuts import model_to_dict
 
+from frigate.comms.event_metadata_updater import (
+    EventMetadataPublisher,
+    EventMetadataTypeEnum,
+)
 from frigate.const import (
     CLIPS_DIR,
 )
@@ -942,6 +946,49 @@ def set_description(id):
             }
         ),
         200,
+    )
+
+
+@EventBp.route("/events/<id>/description/regenerate", methods=["PUT"])
+def regenerate_description(id):
+    event_metadata_updater = EventMetadataPublisher(
+        EventMetadataTypeEnum.regenerate_description
+    )
+
+    # try:
+    #     event: Event = Event.get(Event.id == id)
+    # except DoesNotExist:
+    #     return make_response(
+    #         jsonify({"success": False, "message": "Event " + id + " not found"}), 404
+    #     )
+
+    # if (
+    #     current_app.frigate_config.semantic_search.enabled
+    #     and current_app.frigate_config.genai.enabled
+    # ):
+    logger.info(id)
+    event_metadata_updater.publish(id)
+
+    return make_response(
+        jsonify(
+            {
+                "success": True,
+                "message": "Event "
+                + id
+                + " description regeneration has been requested.",
+            }
+        ),
+        200,
+    )
+
+    return make_response(
+        jsonify(
+            {
+                "success": False,
+                "message": "Semantic search and generative AI are not enabled",
+            }
+        ),
+        400,
     )
 
 

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -951,7 +951,7 @@ def set_description(id):
 
 @EventBp.route("/events/<id>/description/regenerate", methods=["PUT"])
 def regenerate_description(id):
-    event_metadata_updater = EventMetadataPublisher(
+    current_app.event_metadata_updater = EventMetadataPublisher(
         EventMetadataTypeEnum.regenerate_description
     )
 
@@ -967,7 +967,7 @@ def regenerate_description(id):
     #     and current_app.frigate_config.genai.enabled
     # ):
     logger.info(id)
-    event_metadata_updater.publish(id)
+    current_app.event_metadata_updater.publish(id)
 
     return make_response(
         jsonify(

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -907,7 +907,7 @@ def set_description(
 
     if new_description is None or len(new_description) == 0:
         return JSONResponse(
-            {
+            content={
                 "success": False,
                 "message": "description cannot be empty",
             },

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -951,7 +951,7 @@ def regenerate_description(request: Request, event_id: str):
         event: Event = Event.get(Event.id == event_id)
     except DoesNotExist:
         return JSONResponse(
-            content={"success": False, "message": "Event " + event_id + " not found"},
+            content=({"success": False, "message": "Event " + event_id + " not found"}),
             status_code=404,
         )
 

--- a/frigate/api/fastapi_app.py
+++ b/frigate/api/fastapi_app.py
@@ -13,6 +13,9 @@ from starlette_context.plugins import Plugin
 from frigate.api import app as main_app
 from frigate.api import auth, event, export, media, notification, preview, review
 from frigate.api.auth import get_jwt_secret, limiter
+from frigate.comms.event_metadata_updater import (
+    EventMetadataPublisher,
+)
 from frigate.config import FrigateConfig
 from frigate.embeddings import EmbeddingsContext
 from frigate.events.external import ExternalEventProcessor
@@ -47,6 +50,7 @@ def create_fastapi_app(
     onvif: OnvifController,
     external_processor: ExternalEventProcessor,
     stats_emitter: StatsEmitter,
+    event_metadata_updater: EventMetadataPublisher,
 ):
     logger.info("Starting FastAPI app")
     app = FastAPI(
@@ -102,6 +106,7 @@ def create_fastapi_app(
     app.camera_error_image = None
     app.onvif = onvif
     app.stats_emitter = stats_emitter
+    app.event_metadata_updater = event_metadata_updater
     app.external_processor = external_processor
     app.jwt_token = get_jwt_secret() if frigate_config.auth.enabled else None
 

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -663,6 +663,7 @@ class FrigateApp:
                     self.onvif_controller,
                     self.external_event_processor,
                     self.stats_emitter,
+                    self.event_metadata_updater,
                 ),
                 host="127.0.0.1",
                 port=5001,

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -661,6 +661,7 @@ class FrigateApp:
                 self.onvif_controller,
                 self.external_event_processor,
                 self.stats_emitter,
+                self.event_metadata_updater,
             ).run(host="127.0.0.1", port=5001, debug=False, threaded=True)
         finally:
             self.stop()

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -23,6 +23,10 @@ from frigate.api.app import create_app
 from frigate.api.auth import hash_password
 from frigate.comms.config_updater import ConfigPublisher
 from frigate.comms.dispatcher import Communicator, Dispatcher
+from frigate.comms.event_metadata_updater import (
+    EventMetadataPublisher,
+    EventMetadataTypeEnum,
+)
 from frigate.comms.inter_process import InterProcessCommunicator
 from frigate.comms.mqtt import MqttClient
 from frigate.comms.webpush import WebPushClient
@@ -372,6 +376,7 @@ class FrigateApp:
     def init_inter_process_communicator(self) -> None:
         self.inter_process_communicator = InterProcessCommunicator()
         self.inter_config_updater = ConfigPublisher()
+        self.event_metadata_updater = EventMetadataPublisher(EventMetadataTypeEnum.all)
         self.inter_zmq_proxy = ZmqProxy()
 
     def init_web_server(self) -> None:
@@ -385,6 +390,7 @@ class FrigateApp:
             self.external_event_processor,
             self.plus_api,
             self.stats_emitter,
+            self.event_metadata_updater,
         )
 
     def init_onvif(self) -> None:
@@ -828,6 +834,7 @@ class FrigateApp:
         # Stop Communicators
         self.inter_process_communicator.stop()
         self.inter_config_updater.stop()
+        self.event_metadata_updater.stop()
         self.inter_zmq_proxy.stop()
 
         while len(self.detection_shms) > 0:

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -376,7 +376,9 @@ class FrigateApp:
     def init_inter_process_communicator(self) -> None:
         self.inter_process_communicator = InterProcessCommunicator()
         self.inter_config_updater = ConfigPublisher()
-        self.event_metadata_updater = EventMetadataPublisher(EventMetadataTypeEnum.all)
+        self.event_metadata_updater = EventMetadataPublisher(
+            EventMetadataTypeEnum.regenerate_description
+        )
         self.inter_zmq_proxy = ZmqProxy()
 
     def init_web_server(self) -> None:

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -140,6 +140,10 @@ class Dispatcher:
             event: Event = Event.get(Event.id == payload["id"])
             event.data["description"] = payload["description"]
             event.save()
+            self.publish(
+                "event_update",
+                json.dumps({"id": event.id, "description": event.data["description"]}),
+            )
         elif topic == "onConnect":
             camera_status = self.camera_activity.copy()
 

--- a/frigate/comms/event_metadata_updater.py
+++ b/frigate/comms/event_metadata_updater.py
@@ -23,10 +23,6 @@ class EventMetadataPublisher(Publisher):
         topic = topic.value
         super().__init__(topic)
 
-    def publish(self, payload: str) -> None:
-        logger.info(f"publishing payload: {payload}")
-        super().publish(payload)
-
 
 class EventMetadataSubscriber(Subscriber):
     """Simplifies receiving event metadata."""
@@ -35,7 +31,7 @@ class EventMetadataSubscriber(Subscriber):
 
     def __init__(self, topic: EventMetadataTypeEnum) -> None:
         topic = topic.value
-        logger.info(f"subscribing to: {topic.value}")
+        logger.info(f"subscribing to: {topic}")
         super().__init__(topic)
 
     def check_for_update(

--- a/frigate/comms/event_metadata_updater.py
+++ b/frigate/comms/event_metadata_updater.py
@@ -1,0 +1,48 @@
+"""Facilitates communication between processes."""
+
+import logging
+from enum import Enum
+from typing import Optional
+
+from .zmq_proxy import Publisher, Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+class EventMetadataTypeEnum(str, Enum):
+    regenerate_description = "regenerate_description"
+
+
+class EventMetadataPublisher(Publisher):
+    """Simplifies receiving event metadata."""
+
+    topic_base = "event_metadata/"
+
+    def __init__(self, topic: EventMetadataTypeEnum) -> None:
+        topic = topic.value
+        super().__init__(topic)
+
+    def publish(self, payload: str) -> None:
+        logger.info(f"publishing payload: {payload}")
+        super().publish(payload)
+
+
+class EventMetadataSubscriber(Subscriber):
+    """Simplifies receiving event metadata."""
+
+    topic_base = "event_metadata/"
+
+    def __init__(self, topic: EventMetadataTypeEnum) -> None:
+        topic = topic.value
+        logger.info(f"subscribing to: {topic.value}")
+        super().__init__(topic)
+
+    def check_for_update(
+        self, timeout: float = None
+    ) -> Optional[tuple[EventMetadataTypeEnum, any]]:
+        return super().check_for_update(timeout)
+
+    def _return_object(self, topic: str, payload: any) -> any:
+        if payload is None:
+            return (None, None)
+        return (EventMetadataTypeEnum[topic[len(self.topic_base) :]], payload)

--- a/frigate/comms/event_metadata_updater.py
+++ b/frigate/comms/event_metadata_updater.py
@@ -37,9 +37,11 @@ class EventMetadataSubscriber(Subscriber):
     def check_for_update(
         self, timeout: float = None
     ) -> Optional[tuple[EventMetadataTypeEnum, any]]:
+        print(f"checking for update, timeout {timeout}")
         return super().check_for_update(timeout)
 
     def _return_object(self, topic: str, payload: any) -> any:
+        print(topic, payload)
         if payload is None:
             return (None, None)
         return (EventMetadataTypeEnum[topic[len(self.topic_base) :]], payload)

--- a/frigate/comms/event_metadata_updater.py
+++ b/frigate/comms/event_metadata_updater.py
@@ -37,11 +37,9 @@ class EventMetadataSubscriber(Subscriber):
     def check_for_update(
         self, timeout: float = None
     ) -> Optional[tuple[EventMetadataTypeEnum, any]]:
-        print(f"checking for update, timeout {timeout}")
         return super().check_for_update(timeout)
 
     def _return_object(self, topic: str, payload: any) -> any:
-        print(topic, payload)
         if payload is None:
             return (None, None)
         return (EventMetadataTypeEnum[topic[len(self.topic_base) :]], payload)

--- a/frigate/comms/event_metadata_updater.py
+++ b/frigate/comms/event_metadata_updater.py
@@ -31,7 +31,6 @@ class EventMetadataSubscriber(Subscriber):
 
     def __init__(self, topic: EventMetadataTypeEnum) -> None:
         topic = topic.value
-        logger.info(f"subscribing to: {topic}")
         super().__init__(topic)
 
     def check_for_update(

--- a/frigate/comms/event_metadata_updater.py
+++ b/frigate/comms/event_metadata_updater.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class EventMetadataTypeEnum(str, Enum):
+    all = ""
     regenerate_description = "regenerate_description"
 
 

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -56,6 +56,7 @@ class EmbeddingMaintainer(threading.Thread):
 
     def run(self) -> None:
         """Maintain a Chroma vector database for semantic search."""
+        logger.info("in maintainer run()")
         while not self.stop_event.is_set():
             self._process_updates()
             self._process_finalized()
@@ -149,12 +150,13 @@ class EmbeddingMaintainer(threading.Thread):
             if event_id in self.tracked_events:
                 del self.tracked_events[event_id]
 
-    def _process_event_metadata(self, event_id):
+    def _process_event_metadata(self):
         # Check for regenerate description requests
+        logger.info("processing event metadata")
         (topic, event_id) = self.event_metadata_subscriber.check_for_update()
         logger.info(f"in init in maintainer, {topic} {event_id}")
 
-        if not topic:
+        if topic is None:
             return
 
         if event_id:

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -70,10 +70,13 @@ class EmbeddingMaintainer(threading.Thread):
 
     def _process_updates(self) -> None:
         """Process event updates"""
-        update = self.event_subscriber.check_for_update()
+        logger.info("processing event updates")
+        update = self.event_subscriber.check_for_update(timeout=1)
 
         if update is None:
             return
+
+        logger.info("not returning from _process_updates")
 
         source_type, _, camera, data = update
 
@@ -98,66 +101,67 @@ class EmbeddingMaintainer(threading.Thread):
 
     def _process_finalized(self) -> None:
         """Process the end of an event."""
-        while True:
-            ended = self.event_end_subscriber.check_for_update()
 
-            if ended == None:
-                break
+        logger.info("processing finalized")
+        ended = self.event_end_subscriber.check_for_update(timeout=1)
 
-            event_id, camera, updated_db = ended
-            camera_config = self.config.cameras[camera]
+        if ended is None:
+            return
 
-            if updated_db:
-                try:
-                    event: Event = Event.get(Event.id == event_id)
-                except DoesNotExist:
-                    continue
+        logger.info("not returning from _process_finalized")
+        event_id, camera, updated_db = ended
+        camera_config = self.config.cameras[camera]
 
-                # Skip the event if not an object
-                if event.data.get("type") != "object":
-                    continue
+        if updated_db:
+            try:
+                event: Event = Event.get(Event.id == event_id)
+            except DoesNotExist:
+                return
 
-                # Extract valid event metadata
-                metadata = get_metadata(event)
-                thumbnail = base64.b64decode(event.thumbnail)
+            # Skip the event if not an object
+            if event.data.get("type") != "object":
+                return
 
-                # Embed the thumbnail
-                self._embed_thumbnail(event_id, thumbnail, metadata)
+            # Extract valid event metadata
+            metadata = get_metadata(event)
+            thumbnail = base64.b64decode(event.thumbnail)
 
-                if (
-                    camera_config.genai.enabled
-                    and self.genai_client is not None
-                    and event.data.get("description") is None
-                ):
-                    # Generate the description. Call happens in a thread since it is network bound.
-                    threading.Thread(
-                        target=self._embed_description,
-                        name=f"_embed_description_{event.id}",
-                        daemon=True,
-                        args=(
-                            event,
-                            [
-                                data["thumbnail"]
-                                for data in self.tracked_events[event_id]
-                            ]
-                            if len(self.tracked_events.get(event_id, [])) > 0
-                            else [thumbnail],
-                            metadata,
-                        ),
-                    ).start()
+            # Embed the thumbnail
+            self._embed_thumbnail(event_id, thumbnail, metadata)
 
-            # Delete tracked events based on the event_id
-            if event_id in self.tracked_events:
-                del self.tracked_events[event_id]
+            if (
+                camera_config.genai.enabled
+                and self.genai_client is not None
+                and event.data.get("description") is None
+            ):
+                # Generate the description. Call happens in a thread since it is network bound.
+                threading.Thread(
+                    target=self._embed_description,
+                    name=f"_embed_description_{event.id}",
+                    daemon=True,
+                    args=(
+                        event,
+                        [data["thumbnail"] for data in self.tracked_events[event_id]]
+                        if len(self.tracked_events.get(event_id, [])) > 0
+                        else [thumbnail],
+                        metadata,
+                    ),
+                ).start()
+
+        # Delete tracked events based on the event_id
+        if event_id in self.tracked_events:
+            del self.tracked_events[event_id]
 
     def _process_event_metadata(self):
         # Check for regenerate description requests
         logger.info("processing event metadata")
-        (topic, event_id) = self.event_metadata_subscriber.check_for_update()
+        (topic, event_id) = self.event_metadata_subscriber.check_for_update(timeout=1)
         logger.info(f"in init in maintainer, {topic} {event_id}")
 
         if topic is None:
             return
+
+        logger.info("not returning from _process_event_metadata")
 
         if event_id:
             logger.info(f"in maintainer: {event_id}")

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -56,7 +56,6 @@ class EmbeddingMaintainer(threading.Thread):
 
     def run(self) -> None:
         """Maintain a Chroma vector database for semantic search."""
-        logger.info("in maintainer run()")
         while not self.stop_event.is_set():
             self._process_updates()
             self._process_finalized()

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -12,6 +12,10 @@ import numpy as np
 from peewee import DoesNotExist
 from PIL import Image
 
+from frigate.comms.event_metadata_updater import (
+    EventMetadataSubscriber,
+    EventMetadataTypeEnum,
+)
 from frigate.comms.events_updater import EventEndSubscriber, EventUpdateSubscriber
 from frigate.comms.inter_process import InterProcessRequestor
 from frigate.config import FrigateConfig
@@ -40,6 +44,9 @@ class EmbeddingMaintainer(threading.Thread):
         self.embeddings = Embeddings()
         self.event_subscriber = EventUpdateSubscriber()
         self.event_end_subscriber = EventEndSubscriber()
+        self.event_metadata_subscriber = EventMetadataSubscriber(
+            EventMetadataTypeEnum.regenerate_description
+        )
         self.frame_manager = SharedMemoryFrameManager()
         # create communication for updating event descriptions
         self.requestor = InterProcessRequestor()
@@ -52,9 +59,11 @@ class EmbeddingMaintainer(threading.Thread):
         while not self.stop_event.is_set():
             self._process_updates()
             self._process_finalized()
+            self._process_event_metadata()
 
         self.event_subscriber.stop()
         self.event_end_subscriber.stop()
+        self.event_metadata_subscriber.stop()
         self.requestor.stop()
         logger.info("Exiting embeddings maintenance...")
 
@@ -140,6 +149,18 @@ class EmbeddingMaintainer(threading.Thread):
             if event_id in self.tracked_events:
                 del self.tracked_events[event_id]
 
+    def _process_event_metadata(self, event_id):
+        # Check for regenerate description requests
+        (topic, event_id) = self.event_metadata_subscriber.check_for_update()
+        logger.info(f"in init in maintainer, {topic} {event_id}")
+
+        if not topic:
+            return
+
+        if event_id:
+            logger.info(f"in maintainer: {event_id}")
+            # self.handle_regenerate_description(event_id)
+
     def _create_thumbnail(self, yuv_frame, box, height=500) -> Optional[bytes]:
         """Return jpg thumbnail of a region of the frame."""
         frame = cv2.cvtColor(yuv_frame, cv2.COLOR_YUV2BGR_I420)
@@ -200,3 +221,20 @@ class EmbeddingMaintainer(threading.Thread):
             len(thumbnails),
             description,
         )
+
+    def handle_regenerate_description(self, event_id: str) -> None:
+        try:
+            event: Event = Event.get(Event.id == event_id)
+        except DoesNotExist:
+            logger.error(f"Event {event_id} not found for description regeneration")
+            return
+
+        camera_config = self.config.cameras[event.camera]
+        if not camera_config.genai.enabled or self.genai_client is None:
+            logger.error(f"GenAI not enabled for camera {event.camera}")
+            return
+
+        metadata = get_metadata(event)
+        thumbnail = base64.b64decode(event.thumbnail)
+
+        self._embed_description(event, [thumbnail], metadata)

--- a/frigate/test/test_http.py
+++ b/frigate/test/test_http.py
@@ -121,6 +121,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
+            None,
         )
         id = "123456.random"
         id2 = "7890.random"
@@ -157,6 +158,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
+            None,
         )
         id = "123456.random"
 
@@ -178,6 +180,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
+            None,
         )
         id = "123456.random"
         bad_id = "654321.other"
@@ -192,6 +195,7 @@ class TestHttp(unittest.TestCase):
         app = create_app(
             FrigateConfig(**self.minimal_config),
             self.db,
+            None,
             None,
             None,
             None,
@@ -220,6 +224,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
+            None,
         )
         id = "123456.random"
 
@@ -240,6 +245,7 @@ class TestHttp(unittest.TestCase):
         app = create_app(
             FrigateConfig(**self.minimal_config),
             self.db,
+            None,
             None,
             None,
             None,
@@ -284,6 +290,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
+            None,
         )
         id = "123456.random"
         sub_label = "sub"
@@ -319,6 +326,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
+            None,
         )
         id = "123456.random"
         sub_label = "sub"
@@ -344,6 +352,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             None,
+            None,
         )
 
         with app.test_client() as client:
@@ -355,6 +364,7 @@ class TestHttp(unittest.TestCase):
         app = create_app(
             FrigateConfig(**self.minimal_config),
             self.db,
+            None,
             None,
             None,
             None,
@@ -382,6 +392,7 @@ class TestHttp(unittest.TestCase):
             None,
             None,
             stats,
+            None,
         )
 
         with app.test_client() as client:

--- a/frigate/test/test_http.py
+++ b/frigate/test/test_http.py
@@ -1,18 +1,18 @@
 import datetime
-import json
 import logging
 import os
 import unittest
 from unittest.mock import Mock
 
+from fastapi.testclient import TestClient
 from peewee_migrate import Router
 from playhouse.shortcuts import model_to_dict
 from playhouse.sqlite_ext import SqliteExtDatabase
 from playhouse.sqliteq import SqliteQueueDatabase
 
-from frigate.api.app import create_app
+from frigate.api.fastapi_app import create_fastapi_app
 from frigate.config import FrigateConfig
-from frigate.models import Event, Recordings
+from frigate.models import Event, Recordings, Timeline
 from frigate.stats.emitter import StatsEmitter
 from frigate.test.const import TEST_DB, TEST_DB_CLEANUPS
 
@@ -26,7 +26,7 @@ class TestHttp(unittest.TestCase):
         router.run()
         migrate_db.close()
         self.db = SqliteQueueDatabase(TEST_DB)
-        models = [Event, Recordings]
+        models = [Event, Recordings, Timeline]
         self.db.bind(models)
 
         self.minimal_config = {
@@ -112,7 +112,7 @@ class TestHttp(unittest.TestCase):
             pass
 
     def test_get_event_list(self):
-        app = create_app(
+        app = create_fastapi_app(
             FrigateConfig(**self.minimal_config),
             self.db,
             None,
@@ -126,30 +126,30 @@ class TestHttp(unittest.TestCase):
         id = "123456.random"
         id2 = "7890.random"
 
-        with app.test_client() as client:
+        with TestClient(app) as client:
             _insert_mock_event(id)
-            events = client.get("/events").json
+            events = client.get("/events").json()
             assert events
             assert len(events) == 1
             assert events[0]["id"] == id
             _insert_mock_event(id2)
-            events = client.get("/events").json
+            events = client.get("/events").json()
             assert events
             assert len(events) == 2
             events = client.get(
                 "/events",
-                query_string={"limit": 1},
-            ).json
+                params={"limit": 1},
+            ).json()
             assert events
             assert len(events) == 1
             events = client.get(
                 "/events",
-                query_string={"has_clip": 0},
-            ).json
+                params={"has_clip": 0},
+            ).json()
             assert not events
 
     def test_get_good_event(self):
-        app = create_app(
+        app = create_fastapi_app(
             FrigateConfig(**self.minimal_config),
             self.db,
             None,
@@ -162,16 +162,16 @@ class TestHttp(unittest.TestCase):
         )
         id = "123456.random"
 
-        with app.test_client() as client:
+        with TestClient(app) as client:
             _insert_mock_event(id)
-            event = client.get(f"/events/{id}").json
+            event = client.get(f"/events/{id}").json()
 
         assert event
         assert event["id"] == id
         assert event == model_to_dict(Event.get(Event.id == id))
 
     def test_get_bad_event(self):
-        app = create_app(
+        app = create_fastapi_app(
             FrigateConfig(**self.minimal_config),
             self.db,
             None,
@@ -185,14 +185,14 @@ class TestHttp(unittest.TestCase):
         id = "123456.random"
         bad_id = "654321.other"
 
-        with app.test_client() as client:
+        with TestClient(app) as client:
             _insert_mock_event(id)
-            event = client.get(f"/events/{bad_id}").json
-
-        assert not event
+            event_response = client.get(f"/events/{bad_id}")
+            assert event_response.status_code == 404
+            assert event_response.json() == "Event not found"
 
     def test_delete_event(self):
-        app = create_app(
+        app = create_fastapi_app(
             FrigateConfig(**self.minimal_config),
             self.db,
             None,
@@ -205,17 +205,17 @@ class TestHttp(unittest.TestCase):
         )
         id = "123456.random"
 
-        with app.test_client() as client:
+        with TestClient(app) as client:
             _insert_mock_event(id)
-            event = client.get(f"/events/{id}").json
+            event = client.get(f"/events/{id}").json()
             assert event
             assert event["id"] == id
             client.delete(f"/events/{id}")
-            event = client.get(f"/events/{id}").json
-            assert not event
+            event = client.get(f"/events/{id}").json()
+            assert event == "Event not found"
 
     def test_event_retention(self):
-        app = create_app(
+        app = create_fastapi_app(
             FrigateConfig(**self.minimal_config),
             self.db,
             None,
@@ -228,21 +228,21 @@ class TestHttp(unittest.TestCase):
         )
         id = "123456.random"
 
-        with app.test_client() as client:
+        with TestClient(app) as client:
             _insert_mock_event(id)
             client.post(f"/events/{id}/retain")
-            event = client.get(f"/events/{id}").json
+            event = client.get(f"/events/{id}").json()
             assert event
             assert event["id"] == id
             assert event["retain_indefinitely"] is True
             client.delete(f"/events/{id}/retain")
-            event = client.get(f"/events/{id}").json
+            event = client.get(f"/events/{id}").json()
             assert event
             assert event["id"] == id
             assert event["retain_indefinitely"] is False
 
     def test_event_time_filtering(self):
-        app = create_app(
+        app = create_fastapi_app(
             FrigateConfig(**self.minimal_config),
             self.db,
             None,
@@ -258,30 +258,30 @@ class TestHttp(unittest.TestCase):
         morning = 1656590400  # 06/30/2022 6 am (GMT)
         evening = 1656633600  # 06/30/2022 6 pm (GMT)
 
-        with app.test_client() as client:
+        with TestClient(app) as client:
             _insert_mock_event(morning_id, morning)
             _insert_mock_event(evening_id, evening)
             # both events come back
-            events = client.get("/events").json
+            events = client.get("/events").json()
             assert events
             assert len(events) == 2
             # morning event is excluded
             events = client.get(
                 "/events",
-                query_string={"time_range": "07:00,24:00"},
-            ).json
+                params={"time_range": "07:00,24:00"},
+            ).json()
             assert events
             # assert len(events) == 1
             # evening event is excluded
             events = client.get(
                 "/events",
-                query_string={"time_range": "00:00,18:00"},
-            ).json
+                params={"time_range": "00:00,18:00"},
+            ).json()
             assert events
             assert len(events) == 1
 
     def test_set_delete_sub_label(self):
-        app = create_app(
+        app = create_fastapi_app(
             FrigateConfig(**self.minimal_config),
             self.db,
             None,
@@ -295,29 +295,29 @@ class TestHttp(unittest.TestCase):
         id = "123456.random"
         sub_label = "sub"
 
-        with app.test_client() as client:
+        with TestClient(app) as client:
             _insert_mock_event(id)
-            client.post(
+            new_sub_label_response = client.post(
                 f"/events/{id}/sub_label",
-                data=json.dumps({"subLabel": sub_label}),
-                content_type="application/json",
+                json={"subLabel": sub_label},
             )
-            event = client.get(f"/events/{id}").json
+            assert new_sub_label_response.status_code == 200
+            event = client.get(f"/events/{id}").json()
             assert event
             assert event["id"] == id
             assert event["sub_label"] == sub_label
-            client.post(
+            empty_sub_label_response = client.post(
                 f"/events/{id}/sub_label",
-                data=json.dumps({"subLabel": ""}),
-                content_type="application/json",
+                json={"subLabel": ""},
             )
-            event = client.get(f"/events/{id}").json
+            assert empty_sub_label_response.status_code == 200
+            event = client.get(f"/events/{id}").json()
             assert event
             assert event["id"] == id
             assert event["sub_label"] == ""
 
     def test_sub_label_list(self):
-        app = create_app(
+        app = create_fastapi_app(
             FrigateConfig(**self.minimal_config),
             self.db,
             None,
@@ -331,19 +331,18 @@ class TestHttp(unittest.TestCase):
         id = "123456.random"
         sub_label = "sub"
 
-        with app.test_client() as client:
+        with TestClient(app) as client:
             _insert_mock_event(id)
             client.post(
                 f"/events/{id}/sub_label",
-                data=json.dumps({"subLabel": sub_label}),
-                content_type="application/json",
+                json={"subLabel": sub_label},
             )
-            sub_labels = client.get("/sub_labels").json
+            sub_labels = client.get("/sub_labels").json()
             assert sub_labels
             assert sub_labels == [sub_label]
 
     def test_config(self):
-        app = create_app(
+        app = create_fastapi_app(
             FrigateConfig(**self.minimal_config),
             self.db,
             None,
@@ -355,13 +354,13 @@ class TestHttp(unittest.TestCase):
             None,
         )
 
-        with app.test_client() as client:
-            config = client.get("/config").json
+        with TestClient(app) as client:
+            config = client.get("/config").json()
             assert config
             assert config["cameras"]["front_door"]
 
     def test_recordings(self):
-        app = create_app(
+        app = create_fastapi_app(
             FrigateConfig(**self.minimal_config),
             self.db,
             None,
@@ -374,16 +373,18 @@ class TestHttp(unittest.TestCase):
         )
         id = "123456.random"
 
-        with app.test_client() as client:
+        with TestClient(app) as client:
             _insert_mock_recording(id)
-            recording = client.get("/front_door/recordings").json
+            response = client.get("/front_door/recordings")
+            assert response.status_code == 200
+            recording = response.json()
             assert recording
             assert recording[0]["id"] == id
 
     def test_stats(self):
         stats = Mock(spec=StatsEmitter)
         stats.get_latest_stats.return_value = self.test_stats
-        app = create_app(
+        app = create_fastapi_app(
             FrigateConfig(**self.minimal_config),
             self.db,
             None,
@@ -395,8 +396,8 @@ class TestHttp(unittest.TestCase):
             None,
         )
 
-        with app.test_client() as client:
-            full_stats = client.get("/stats").json
+        with TestClient(app) as client:
+            full_stats = client.get("/stats").json()
             assert full_stats == self.test_stats
 
 
@@ -429,8 +430,8 @@ def _insert_mock_recording(id: str) -> Event:
         id=id,
         camera="front_door",
         path=f"/recordings/{id}",
-        start_time=datetime.datetime.now().timestamp() - 50,
-        end_time=datetime.datetime.now().timestamp() - 60,
+        start_time=datetime.datetime.now().timestamp() - 60,
+        end_time=datetime.datetime.now().timestamp() - 50,
         duration=10,
         motion=True,
         objects=True,

--- a/web/src/api/ws.tsx
+++ b/web/src/api/ws.tsx
@@ -321,3 +321,10 @@ export function useImproveContrast(camera: string): {
   );
   return { payload: payload as ToggleableSetting, send };
 }
+
+export function useEventUpdate(): { payload: string } {
+  const {
+    value: { payload },
+  } = useWs("event_update", "");
+  return useDeepMemo(JSON.parse(payload as string));
+}

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -291,6 +291,28 @@ function ObjectDetailsTab({
       });
   }, [desc, search]);
 
+  const regenerateDescription = useCallback(() => {
+    if (!search) {
+      return;
+    }
+
+    axios
+      .put(`events/${search.id}/description/regenerate`)
+      .then((resp) => {
+        if (resp.status == 200) {
+          toast.success("Description regeneration requested.", {
+            position: "top-center",
+          });
+        }
+      })
+      .catch(() => {
+        toast.error("Failed to call generative AI for a new description", {
+          position: "top-center",
+        });
+        setDesc(search.data.description);
+      });
+  }, [search]);
+
   return (
     <div className="flex flex-col gap-5">
       <div className="flex w-full flex-row">
@@ -355,7 +377,10 @@ function ObjectDetailsTab({
           value={desc}
           onChange={(e) => setDesc(e.target.value)}
         />
-        <div className="flex w-full flex-row justify-end">
+        <div className="flex w-full flex-row justify-end gap-2">
+          {config?.genai.enabled && (
+            <Button onClick={regenerateDescription}>Regenerate</Button>
+          )}
           <Button variant="select" onClick={updateDescription}>
             Save
           </Button>

--- a/web/src/hooks/use-global-mutate.ts
+++ b/web/src/hooks/use-global-mutate.ts
@@ -1,0 +1,16 @@
+// https://github.com/vercel/swr/issues/1670#issuecomment-1844114401
+import { useCallback } from "react";
+import { cache, mutate } from "swr/_internal";
+
+const useGlobalMutation = () => {
+  return useCallback((swrKey: string | ((key: string) => boolean), ...args) => {
+    if (typeof swrKey === "function") {
+      const keys = Array.from(cache.keys()).filter(swrKey);
+      keys.forEach((key) => mutate(key, ...args));
+    } else {
+      mutate(swrKey, ...args);
+    }
+  }, []) as typeof mutate;
+};
+
+export default useGlobalMutation;

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -298,6 +298,16 @@ export interface FrigateConfig {
     retry_interval: number;
   };
 
+  genai: {
+    enabled: boolean;
+    provider: string;
+    base_url?: string;
+    api_key?: string;
+    model: string;
+    prompt: string;
+    object_prompts: { [key: string]: string };
+  };
+
   go2rtc: {
     streams: string[];
     webrtc: {

--- a/web/src/views/explore/ExploreView.tsx
+++ b/web/src/views/explore/ExploreView.tsx
@@ -37,7 +37,7 @@ export default function ExploreView({ onSelectSearch }: ExploreViewProps) {
       },
     ],
     {
-      revalidateOnFocus: false,
+      revalidateOnFocus: true,
     },
   );
 

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -23,6 +23,7 @@ import useKeyboardListener, {
 import scrollIntoView from "scroll-into-view-if-needed";
 import InputWithTags from "@/components/input/InputWithTags";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { isEqual } from "lodash";
 
 type SearchViewProps = {
   search: string;
@@ -139,6 +140,21 @@ export default function SearchView({
     setSearchDetail(item);
     setSelectedIndex(index);
   }, []);
+
+  // update search detail when results change
+
+  useEffect(() => {
+    if (searchDetail && searchResults) {
+      const flattenedResults = searchResults.flat();
+      const updatedSearchDetail = flattenedResults.find(
+        (result) => result.id === searchDetail.id,
+      );
+
+      if (updatedSearchDetail && !isEqual(updatedSearchDetail, searchDetail)) {
+        setSearchDetail(updatedSearchDetail);
+      }
+    }
+  }, [searchResults, searchDetail]);
 
   // confidence score - probably needs tweaking
 


### PR DESCRIPTION
- Add button in object details pane to regenerate new genai description for tracked objects
- Add new pub/sub model `event_metadata` as a foundational framework for future improvements for time-delayed tracked object updates
- Add new comms/publisher topic, `event_update`, that publishes description updates over websocket and mqtt
- Add global mutation custom hook to mutate swr and infinite swr objects without having to pass a mutation function around as a prop