### PR TITLE
Custom classes for Process and Metrics

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -4,6 +4,7 @@ from statistics import mean
 
 import numpy as np
 
+import frigate.util as util
 from frigate.config import DetectorTypeEnum
 from frigate.object_detection import (
     ObjectDetectProcess,
@@ -90,7 +91,7 @@ edgetpu_process_2 = ObjectDetectProcess(
 )
 
 for x in range(0, 10):
-    camera_process = mp.Process(
+    camera_process = util.Process(
         target=start, args=(x, 300, detection_queue, events[str(x)])
     )
     camera_process.daemon = True

--- a/frigate/__main__.py
+++ b/frigate/__main__.py
@@ -1,6 +1,5 @@
 import argparse
 import faulthandler
-import logging
 import signal
 import sys
 import threading
@@ -9,29 +8,20 @@ from pydantic import ValidationError
 
 from frigate.app import FrigateApp
 from frigate.config import FrigateConfig
-from frigate.log import log_thread
+from frigate.log import setup_logging
 
 
 def main() -> None:
     faulthandler.enable()
 
-    # Clear all existing handlers.
-    logging.basicConfig(
-        level=logging.INFO,
-        handlers=[],
-        force=True,
-    )
+    # Setup the logging thread
+    setup_logging()
 
     threading.current_thread().name = "frigate"
 
     # Make sure we exit cleanly on SIGTERM.
     signal.signal(signal.SIGTERM, lambda sig, frame: sys.exit())
 
-    run()
-
-
-@log_thread()
-def run() -> None:
     # Parse the cli arguments.
     parser = argparse.ArgumentParser(
         prog="Frigate",

--- a/frigate/camera/__init__.py
+++ b/frigate/camera/__init__.py
@@ -36,3 +36,33 @@ class CameraMetrics:
         self.capture_process = None
         self.ffmpeg_pid = mp.Value("i", 0)
 
+
+class PTZMetrics:
+    autotracker_enabled: Synchronized
+
+    start_time: Synchronized
+    stop_time: Synchronized
+    frame_time: Synchronized
+    zoom_level: Synchronized
+    max_zoom: Synchronized
+    min_zoom: Synchronized
+
+    tracking_active: Event
+    motor_stopped: Event
+    reset: Event
+
+    def __init__(self, *, autotracker_enabled: bool):
+        self.autotracker_enabled = mp.Value("i", autotracker_enabled)
+
+        self.start_time = mp.Value("d", 0)
+        self.stop_time = mp.Value("d", 0)
+        self.frame_time = mp.Value("d", 0)
+        self.zoom_level = mp.Value("d", 0)
+        self.max_zoom = mp.Value("d", 0)
+        self.min_zoom = mp.Value("d", 0)
+
+        self.tracking_active = mp.Event()
+        self.motor_stopped = mp.Event()
+        self.reset = mp.Event()
+
+        self.motor_stopped.set()

--- a/frigate/camera/__init__.py
+++ b/frigate/camera/__init__.py
@@ -1,0 +1,38 @@
+import multiprocessing as mp
+from multiprocessing.sharedctypes import Synchronized
+from multiprocessing.synchronize import Event
+from typing import Optional
+
+
+class CameraMetrics:
+    camera_fps: Synchronized
+    detection_fps: Synchronized
+    detection_frame: Synchronized
+    process_fps: Synchronized
+    skipped_fps: Synchronized
+    read_start: Synchronized
+    audio_rms: Synchronized
+    audio_dBFS: Synchronized
+
+    frame_queue: mp.Queue
+
+    process: Optional[mp.Process]
+    capture_process: Optional[mp.Process]
+    ffmpeg_pid: Synchronized
+
+    def __init__(self):
+        self.camera_fps = mp.Value("d", 0)
+        self.detection_fps = mp.Value("d", 0)
+        self.detection_frame = mp.Value("d", 0)
+        self.process_fps = mp.Value("d", 0)
+        self.skipped_fps = mp.Value("d", 0)
+        self.read_start = mp.Value("d", 0)
+        self.audio_rms = mp.Value("d", 0)
+        self.audio_dBFS = mp.Value("d", 0)
+
+        self.frame_queue = mp.Queue(maxsize=2)
+
+        self.process = None
+        self.capture_process = None
+        self.ffmpeg_pid = mp.Value("i", 0)
+

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -6,6 +6,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Optional
 
+from frigate.camera import PTZMetrics
 from frigate.comms.config_updater import ConfigPublisher
 from frigate.config import BirdseyeModeEnum, FrigateConfig
 from frigate.const import (
@@ -19,7 +20,6 @@ from frigate.const import (
 )
 from frigate.models import Event, Previews, Recordings, ReviewSegment
 from frigate.ptz.onvif import OnvifCommandEnum, OnvifController
-from frigate.types import PTZMetricsTypes
 from frigate.util.object import get_camera_regions_grid
 from frigate.util.services import restart_frigate
 
@@ -53,7 +53,7 @@ class Dispatcher:
         config: FrigateConfig,
         config_updater: ConfigPublisher,
         onvif: OnvifController,
-        ptz_metrics: dict[str, PTZMetricsTypes],
+        ptz_metrics: dict[str, PTZMetrics],
         communicators: list[Communicator],
     ) -> None:
         self.config = config
@@ -251,16 +251,16 @@ class Dispatcher:
                     "Autotracking must be enabled in the config to be turned on via MQTT."
                 )
                 return
-            if not self.ptz_metrics[camera_name]["ptz_autotracker_enabled"].value:
+            if not self.ptz_metrics[camera_name].autotracker_enabled.value:
                 logger.info(f"Turning on ptz autotracker for {camera_name}")
-                self.ptz_metrics[camera_name]["ptz_autotracker_enabled"].value = True
-                self.ptz_metrics[camera_name]["ptz_start_time"].value = 0
+                self.ptz_metrics[camera_name].autotracker_enabled.value = True
+                self.ptz_metrics[camera_name].start_time.value = 0
                 ptz_autotracker_settings.enabled = True
         elif payload == "OFF":
-            if self.ptz_metrics[camera_name]["ptz_autotracker_enabled"].value:
+            if self.ptz_metrics[camera_name].autotracker_enabled.value:
                 logger.info(f"Turning off ptz autotracker for {camera_name}")
-                self.ptz_metrics[camera_name]["ptz_autotracker_enabled"].value = False
-                self.ptz_metrics[camera_name]["ptz_start_time"].value = 0
+                self.ptz_metrics[camera_name].autotracker_enabled.value = False
+                self.ptz_metrics[camera_name].start_time.value = 0
                 ptz_autotracker_settings.enabled = False
 
         self.publish(f"{camera_name}/ptz_autotracker/state", payload, retain=True)

--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -2,7 +2,6 @@
 
 import datetime
 import logging
-import multiprocessing as mp
 import signal
 import sys
 import threading
@@ -12,6 +11,7 @@ from typing import Tuple
 import numpy as np
 import requests
 
+import frigate.util as util
 from frigate.comms.config_updater import ConfigSubscriber
 from frigate.comms.detections_updater import DetectionPublisher, DetectionTypeEnum
 from frigate.comms.inter_process import InterProcessRequestor
@@ -65,7 +65,7 @@ def get_ffmpeg_command(ffmpeg: FfmpegConfig) -> list[str]:
     )
 
 
-class AudioProcessor(mp.Process):
+class AudioProcessor(util.Process):
     def __init__(
         self,
         config: FrigateConfig,

--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -12,6 +12,7 @@ import numpy as np
 import requests
 
 import frigate.util as util
+from frigate.camera import CameraMetrics
 from frigate.comms.config_updater import ConfigSubscriber
 from frigate.comms.detections_updater import DetectionPublisher, DetectionTypeEnum
 from frigate.comms.inter_process import InterProcessRequestor
@@ -27,7 +28,6 @@ from frigate.const import (
 from frigate.ffmpeg_presets import parse_preset_input
 from frigate.log import LogPipe
 from frigate.object_detection import load_labels
-from frigate.types import CameraMetricsTypes
 from frigate.util.builtin import get_ffmpeg_arg_list
 from frigate.video import start_or_restart_ffmpeg, stop_ffmpeg
 
@@ -69,7 +69,7 @@ class AudioProcessor(util.Process):
     def __init__(
         self,
         config: FrigateConfig,
-        camera_metrics: dict[str, CameraMetricsTypes],
+        camera_metrics: dict[str, CameraMetrics],
     ):
         super().__init__(name="frigate.audio_manager", daemon=True)
 
@@ -123,7 +123,7 @@ class AudioEventMaintainer(threading.Thread):
     def __init__(
         self,
         camera: CameraConfig,
-        camera_metrics: dict[str, CameraMetricsTypes],
+        camera_metrics: dict[str, CameraMetrics],
         stop_event: threading.Event,
     ) -> None:
         super().__init__(name=f"{camera.name}_audio_event_processor")
@@ -152,8 +152,8 @@ class AudioEventMaintainer(threading.Thread):
         audio_as_float = audio.astype(np.float32)
         rms, dBFS = self.calculate_audio_levels(audio_as_float)
 
-        self.camera_metrics[self.config.name]["audio_rms"].value = rms
-        self.camera_metrics[self.config.name]["audio_dBFS"].value = dBFS
+        self.camera_metrics[self.config.name].audio_rms.value = rms
+        self.camera_metrics[self.config.name].audio_dBFS.value = dBFS
 
         # only run audio detection when volume is above min_volume
         if rms >= self.config.audio.min_volume:

--- a/frigate/object_detection.py
+++ b/frigate/object_detection.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 from setproctitle import setproctitle
 
+import frigate.util as util
 from frigate.detectors import create_detector
 from frigate.detectors.detector_config import InputTensorEnum
 from frigate.util.builtin import EventsPerSecond, load_labels
@@ -168,7 +169,7 @@ class ObjectDetectProcess:
         self.detection_start.value = 0.0
         if (self.detect_process is not None) and self.detect_process.is_alive():
             self.stop()
-        self.detect_process = mp.Process(
+        self.detect_process = util.Process(
             target=run_detector,
             name=f"detector:{self.name}",
             args=(

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -18,6 +18,7 @@ from norfair.camera_motion import (
     TranslationTransformationGetter,
 )
 
+from frigate.camera import PTZMetrics
 from frigate.comms.dispatcher import Dispatcher
 from frigate.config import CameraConfig, FrigateConfig, ZoomingModeEnum
 from frigate.const import (
@@ -31,7 +32,6 @@ from frigate.const import (
     CONFIG_DIR,
 )
 from frigate.ptz.onvif import OnvifController
-from frigate.types import PTZMetricsTypes
 from frigate.util.builtin import update_yaml_file
 from frigate.util.image import SharedMemoryFrameManager, intersection_over_union
 
@@ -50,23 +50,23 @@ def ptz_moving_at_frame_time(frame_time, ptz_start_time, ptz_stop_time):
 
 class PtzMotionEstimator:
     def __init__(
-        self, config: CameraConfig, ptz_metrics: dict[str, PTZMetricsTypes]
+        self, config: CameraConfig, ptz_metrics: dict[str, PTZMetrics]
     ) -> None:
         self.frame_manager = SharedMemoryFrameManager()
         self.norfair_motion_estimator = None
         self.camera_config = config
         self.coord_transformations = None
         self.ptz_metrics = ptz_metrics
-        self.ptz_start_time = self.ptz_metrics["ptz_start_time"]
-        self.ptz_stop_time = self.ptz_metrics["ptz_stop_time"]
+        self.ptz_start_time = self.ptz_metrics.start_time
+        self.ptz_stop_time = self.ptz_metrics.stop_time
 
-        self.ptz_metrics["ptz_reset"].set()
+        self.ptz_metrics.reset.set()
         logger.debug(f"{config.name}: Motion estimator init")
 
     def motion_estimator(self, detections, frame_time, camera):
         # If we've just started up or returned to our preset, reset motion estimator for new tracking session
-        if self.ptz_metrics["ptz_reset"].is_set():
-            self.ptz_metrics["ptz_reset"].clear()
+        if self.ptz_metrics.reset.is_set():
+            self.ptz_metrics.reset.clear()
 
             # homography is nice (zooming) but slow, translation is pan/tilt only but fast.
             if (
@@ -148,7 +148,7 @@ class PtzAutoTrackerThread(threading.Thread):
         self,
         config: FrigateConfig,
         onvif: OnvifController,
-        ptz_metrics: dict[str, PTZMetricsTypes],
+        ptz_metrics: dict[str, PTZMetrics],
         dispatcher: Dispatcher,
         stop_event: MpEvent,
     ) -> None:
@@ -182,7 +182,7 @@ class PtzAutoTracker:
         self,
         config: FrigateConfig,
         onvif: OnvifController,
-        ptz_metrics: PTZMetricsTypes,
+        ptz_metrics: PTZMetrics,
         dispatcher: Dispatcher,
         stop_event: MpEvent,
     ) -> None:
@@ -248,7 +248,7 @@ class PtzAutoTracker:
                 f"Disabling autotracking for {camera}: onvif connection failed"
             )
             camera_config.onvif.autotracking.enabled = False
-            self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
+            self.ptz_metrics[camera].autotracker_enabled.value = False
             return
 
         if not self.onvif.cams[camera]["init"]:
@@ -257,7 +257,7 @@ class PtzAutoTracker:
                     f"Disabling autotracking for {camera}: Unable to initialize onvif"
                 )
                 camera_config.onvif.autotracking.enabled = False
-                self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
+                self.ptz_metrics[camera].autotracker_enabled.value = False
                 return
 
             if "pt-r-fov" not in self.onvif.cams[camera]["features"]:
@@ -265,7 +265,7 @@ class PtzAutoTracker:
                     f"Disabling autotracking for {camera}: FOV relative movement not supported"
                 )
                 camera_config.onvif.autotracking.enabled = False
-                self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
+                self.ptz_metrics[camera].autotracker_enabled.value = False
                 return
 
             move_status_supported = self.onvif.get_service_capabilities(camera)
@@ -275,7 +275,7 @@ class PtzAutoTracker:
                     f"Disabling autotracking for {camera}: ONVIF MoveStatus not supported"
                 )
                 camera_config.onvif.autotracking.enabled = False
-                self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
+                self.ptz_metrics[camera].autotracker_enabled.value = False
                 return
 
         if self.onvif.cams[camera]["init"]:
@@ -295,12 +295,16 @@ class PtzAutoTracker:
                         float(val)
                         for val in camera_config.onvif.autotracking.movement_weights
                     ]
-                    self.ptz_metrics[camera][
-                        "ptz_min_zoom"
-                    ].value = camera_config.onvif.autotracking.movement_weights[0]
-                    self.ptz_metrics[camera][
-                        "ptz_max_zoom"
-                    ].value = camera_config.onvif.autotracking.movement_weights[1]
+                    self.ptz_metrics[
+                        camera
+                    ].min_zoom.value = (
+                        camera_config.onvif.autotracking.movement_weights[0]
+                    )
+                    self.ptz_metrics[
+                        camera
+                    ].max_zoom.value = (
+                        camera_config.onvif.autotracking.movement_weights[1]
+                    )
                     self.intercept[camera] = (
                         camera_config.onvif.autotracking.movement_weights[2]
                     )
@@ -309,7 +313,7 @@ class PtzAutoTracker:
                     )
                 else:
                     camera_config.onvif.autotracking.enabled = False
-                    self.ptz_metrics[camera]["ptz_autotracker_enabled"].value = False
+                    self.ptz_metrics[camera].autotracker_enabled.value = False
                     logger.warning(
                         f"Autotracker recalibration is required for {camera}. Disabling autotracking."
                     )
@@ -317,7 +321,7 @@ class PtzAutoTracker:
             if camera_config.onvif.autotracking.calibrate_on_startup:
                 self._calibrate_camera(camera)
 
-        self.ptz_metrics[camera]["ptz_tracking_active"].clear()
+        self.ptz_metrics[camera].tracking_active.clear()
         self.dispatcher.publish(f"{camera}/ptz_autotracker/active", "OFF", retain=False)
         self.autotracker_init[camera] = True
 
@@ -363,10 +367,10 @@ class PtzAutoTracker:
                     1,
                 )
 
-                while not self.ptz_metrics[camera]["ptz_motor_stopped"].is_set():
+                while not self.ptz_metrics[camera].motor_stopped.is_set():
                     self.onvif.get_camera_status(camera)
 
-                zoom_out_values.append(self.ptz_metrics[camera]["ptz_zoom_level"].value)
+                zoom_out_values.append(self.ptz_metrics[camera].zoom_level.value)
 
                 self.onvif._zoom_absolute(
                     camera,
@@ -374,10 +378,10 @@ class PtzAutoTracker:
                     1,
                 )
 
-                while not self.ptz_metrics[camera]["ptz_motor_stopped"].is_set():
+                while not self.ptz_metrics[camera].motor_stopped.is_set():
                     self.onvif.get_camera_status(camera)
 
-                zoom_in_values.append(self.ptz_metrics[camera]["ptz_zoom_level"].value)
+                zoom_in_values.append(self.ptz_metrics[camera].zoom_level.value)
 
                 if (
                     self.config.cameras[camera].onvif.autotracking.zooming
@@ -392,12 +396,10 @@ class PtzAutoTracker:
                         1,
                     )
 
-                    while not self.ptz_metrics[camera]["ptz_motor_stopped"].is_set():
+                    while not self.ptz_metrics[camera].motor_stopped.is_set():
                         self.onvif.get_camera_status(camera)
 
-                    zoom_out_values.append(
-                        self.ptz_metrics[camera]["ptz_zoom_level"].value
-                    )
+                    zoom_out_values.append(self.ptz_metrics[camera].zoom_level.value)
 
                     # relative move to 0.01
                     self.onvif._move_relative(
@@ -408,33 +410,31 @@ class PtzAutoTracker:
                         1,
                     )
 
-                    while not self.ptz_metrics[camera]["ptz_motor_stopped"].is_set():
+                    while not self.ptz_metrics[camera].motor_stopped.is_set():
                         self.onvif.get_camera_status(camera)
 
-                    zoom_in_values.append(
-                        self.ptz_metrics[camera]["ptz_zoom_level"].value
-                    )
+                    zoom_in_values.append(self.ptz_metrics[camera].zoom_level.value)
 
-            self.ptz_metrics[camera]["ptz_max_zoom"].value = max(zoom_in_values)
-            self.ptz_metrics[camera]["ptz_min_zoom"].value = min(zoom_out_values)
+            self.ptz_metrics[camera].max_zoom.value = max(zoom_in_values)
+            self.ptz_metrics[camera].min_zoom.value = min(zoom_out_values)
 
             logger.debug(
-                f'{camera}: Calibration values: max zoom: {self.ptz_metrics[camera]["ptz_max_zoom"].value}, min zoom: {self.ptz_metrics[camera]["ptz_min_zoom"].value}'
+                f"{camera}: Calibration values: max zoom: {self.ptz_metrics[camera].max_zoom.value}, min zoom: {self.ptz_metrics[camera].min_zoom.value}"
             )
 
         else:
-            self.ptz_metrics[camera]["ptz_max_zoom"].value = 1
-            self.ptz_metrics[camera]["ptz_min_zoom"].value = 0
+            self.ptz_metrics[camera].max_zoom.value = 1
+            self.ptz_metrics[camera].min_zoom.value = 0
 
         self.onvif._move_to_preset(
             camera,
             self.config.cameras[camera].onvif.autotracking.return_preset.lower(),
         )
-        self.ptz_metrics[camera]["ptz_reset"].set()
-        self.ptz_metrics[camera]["ptz_motor_stopped"].clear()
+        self.ptz_metrics[camera].reset.set()
+        self.ptz_metrics[camera].motor_stopped.clear()
 
         # Wait until the camera finishes moving
-        while not self.ptz_metrics[camera]["ptz_motor_stopped"].is_set():
+        while not self.ptz_metrics[camera].motor_stopped.is_set():
             self.onvif.get_camera_status(camera)
 
         for step in range(num_steps):
@@ -445,7 +445,7 @@ class PtzAutoTracker:
             self.onvif._move_relative(camera, pan, tilt, 0, 1)
 
             # Wait until the camera finishes moving
-            while not self.ptz_metrics[camera]["ptz_motor_stopped"].is_set():
+            while not self.ptz_metrics[camera].motor_stopped.is_set():
                 self.onvif.get_camera_status(camera)
             stop_time = time.time()
 
@@ -462,11 +462,11 @@ class PtzAutoTracker:
                 camera,
                 self.config.cameras[camera].onvif.autotracking.return_preset.lower(),
             )
-            self.ptz_metrics[camera]["ptz_reset"].set()
-            self.ptz_metrics[camera]["ptz_motor_stopped"].clear()
+            self.ptz_metrics[camera].reset.set()
+            self.ptz_metrics[camera].motor_stopped.clear()
 
             # Wait until the camera finishes moving
-            while not self.ptz_metrics[camera]["ptz_motor_stopped"].is_set():
+            while not self.ptz_metrics[camera].motor_stopped.is_set():
                 self.onvif.get_camera_status(camera)
 
             logger.info(
@@ -512,8 +512,8 @@ class PtzAutoTracker:
             self.config.cameras[camera].onvif.autotracking.movement_weights = ", ".join(
                 str(v)
                 for v in [
-                    self.ptz_metrics[camera]["ptz_min_zoom"].value,
-                    self.ptz_metrics[camera]["ptz_max_zoom"].value,
+                    self.ptz_metrics[camera].min_zoom.value,
+                    self.ptz_metrics[camera].max_zoom.value,
                     self.intercept[camera],
                     *self.move_coefficients[camera],
                 ]
@@ -649,8 +649,8 @@ class PtzAutoTracker:
                 # if we're receiving move requests during a PTZ move, ignore them
                 if ptz_moving_at_frame_time(
                     frame_time,
-                    self.ptz_metrics[camera]["ptz_start_time"].value,
-                    self.ptz_metrics[camera]["ptz_stop_time"].value,
+                    self.ptz_metrics[camera].start_time.value,
+                    self.ptz_metrics[camera].stop_time.value,
                 ):
                     # instead of dequeueing this might be a good place to preemptively move based
                     # on an estimate - for fast moving objects, etc.
@@ -671,19 +671,17 @@ class PtzAutoTracker:
                             self.onvif._move_relative(camera, pan, tilt, 0, 1)
 
                             # Wait until the camera finishes moving
-                            while not self.ptz_metrics[camera][
-                                "ptz_motor_stopped"
-                            ].is_set():
+                            while not self.ptz_metrics[camera].motor_stopped.is_set():
                                 self.onvif.get_camera_status(camera)
 
                         if (
                             zoom > 0
-                            and self.ptz_metrics[camera]["ptz_zoom_level"].value != zoom
+                            and self.ptz_metrics[camera].zoom_level.value != zoom
                         ):
                             self.onvif._zoom_absolute(camera, zoom, 1)
 
                     # Wait until the camera finishes moving
-                    while not self.ptz_metrics[camera]["ptz_motor_stopped"].is_set():
+                    while not self.ptz_metrics[camera].motor_stopped.is_set():
                         self.onvif.get_camera_status(camera)
 
                     if self.config.cameras[camera].onvif.autotracking.movement_weights:
@@ -691,7 +689,7 @@ class PtzAutoTracker:
                             f"{camera}: Predicted movement time: {self._predict_movement_time(camera, pan, tilt)}"
                         )
                         logger.debug(
-                            f'{camera}: Actual movement time: {self.ptz_metrics[camera]["ptz_stop_time"].value-self.ptz_metrics[camera]["ptz_start_time"].value}'
+                            f"{camera}: Actual movement time: {self.ptz_metrics[camera].stop_time.value-self.ptz_metrics[camera].start_time.value}"
                         )
 
                     # save metrics for better estimate calculations
@@ -709,12 +707,12 @@ class PtzAutoTracker:
                             {
                                 "pan": pan,
                                 "tilt": tilt,
-                                "start_timestamp": self.ptz_metrics[camera][
-                                    "ptz_start_time"
-                                ].value,
-                                "end_timestamp": self.ptz_metrics[camera][
-                                    "ptz_stop_time"
-                                ].value,
+                                "start_timestamp": self.ptz_metrics[
+                                    camera
+                                ].start_time.value,
+                                "end_timestamp": self.ptz_metrics[
+                                    camera
+                                ].stop_time.value,
                             }
                         )
 
@@ -734,8 +732,8 @@ class PtzAutoTracker:
             return clipped, diff
 
         if (
-            frame_time > self.ptz_metrics[camera]["ptz_start_time"].value
-            and frame_time > self.ptz_metrics[camera]["ptz_stop_time"].value
+            frame_time > self.ptz_metrics[camera].start_time.value
+            and frame_time > self.ptz_metrics[camera].stop_time.value
             and not self.move_queue_locks[camera].locked()
         ):
             # we can split up any large moves caused by velocity estimated movements if necessary
@@ -954,12 +952,12 @@ class PtzAutoTracker:
         )
 
         at_max_zoom = (
-            self.ptz_metrics[camera]["ptz_zoom_level"].value
-            == self.ptz_metrics[camera]["ptz_max_zoom"].value
+            self.ptz_metrics[camera].zoom_level.value
+            == self.ptz_metrics[camera].max_zoom.value
         )
         at_min_zoom = (
-            self.ptz_metrics[camera]["ptz_zoom_level"].value
-            == self.ptz_metrics[camera]["ptz_min_zoom"].value
+            self.ptz_metrics[camera].zoom_level.value
+            == self.ptz_metrics[camera].min_zoom.value
         )
 
         # debug zooming
@@ -1100,7 +1098,7 @@ class PtzAutoTracker:
 
         zoom = 0
         result = None
-        current_zoom_level = self.ptz_metrics[camera]["ptz_zoom_level"].value
+        current_zoom_level = self.ptz_metrics[camera].zoom_level.value
         target_box = max(
             obj.obj_data["box"][2] - obj.obj_data["box"][0],
             obj.obj_data["box"][3] - obj.obj_data["box"][1],
@@ -1123,8 +1121,8 @@ class PtzAutoTracker:
                 ) is not None:
                     # divide zoom in 10 increments and always zoom out more than in
                     level = (
-                        self.ptz_metrics[camera]["ptz_max_zoom"].value
-                        - self.ptz_metrics[camera]["ptz_min_zoom"].value
+                        self.ptz_metrics[camera].max_zoom.value
+                        - self.ptz_metrics[camera].min_zoom.value
                     ) / 20
                     if result:
                         zoom = min(1.0, current_zoom_level + level)
@@ -1219,7 +1217,7 @@ class PtzAutoTracker:
                 logger.debug(
                     f"{camera}: New object: {obj.obj_data['id']} {obj.obj_data['box']} {obj.obj_data['frame_time']}"
                 )
-                self.ptz_metrics[camera]["ptz_tracking_active"].set()
+                self.ptz_metrics[camera].tracking_active.set()
                 self.dispatcher.publish(
                     f"{camera}/ptz_autotracker/active", "ON", retain=False
                 )
@@ -1243,8 +1241,8 @@ class PtzAutoTracker:
 
                 if not ptz_moving_at_frame_time(
                     obj.obj_data["frame_time"],
-                    self.ptz_metrics[camera]["ptz_start_time"].value,
-                    self.ptz_metrics[camera]["ptz_stop_time"].value,
+                    self.ptz_metrics[camera].start_time.value,
+                    self.ptz_metrics[camera].stop_time.value,
                 ):
                     if self.tracked_object_metrics[camera]["below_distance_threshold"]:
                         logger.debug(
@@ -1325,7 +1323,7 @@ class PtzAutoTracker:
         if not self.autotracker_init[camera]:
             self._autotracker_setup(self.config.cameras[camera], camera)
         # regularly update camera status
-        if not self.ptz_metrics[camera]["ptz_motor_stopped"].is_set():
+        if not self.ptz_metrics[camera].motor_stopped.is_set():
             self.onvif.get_camera_status(camera)
 
         # return to preset if tracking is over
@@ -1334,7 +1332,7 @@ class PtzAutoTracker:
             and self.tracked_object_history[camera]
             and (
                 # might want to use a different timestamp here?
-                self.ptz_metrics[camera]["ptz_frame_time"].value
+                self.ptz_metrics[camera].frame_time.value
                 - self.tracked_object_history[camera][-1]["frame_time"]
                 >= autotracker_config.timeout
             )
@@ -1348,9 +1346,9 @@ class PtzAutoTracker:
             while not self.move_queues[camera].empty():
                 self.move_queues[camera].get()
 
-            self.ptz_metrics[camera]["ptz_motor_stopped"].wait()
+            self.ptz_metrics[camera].motor_stopped.wait()
             logger.debug(
-                f"{camera}: Time is {self.ptz_metrics[camera]['ptz_frame_time'].value}, returning to preset: {autotracker_config.return_preset}"
+                f"{camera}: Time is {self.ptz_metrics[camera].frame_time.value}, returning to preset: {autotracker_config.return_preset}"
             )
             self.onvif._move_to_preset(
                 camera,
@@ -1358,11 +1356,11 @@ class PtzAutoTracker:
             )
 
             # update stored zoom level from preset
-            if not self.ptz_metrics[camera]["ptz_motor_stopped"].is_set():
+            if not self.ptz_metrics[camera].motor_stopped.is_set():
                 self.onvif.get_camera_status(camera)
 
-            self.ptz_metrics[camera]["ptz_tracking_active"].clear()
+            self.ptz_metrics[camera].tracking_active.clear()
             self.dispatcher.publish(
                 f"{camera}/ptz_autotracker/active", "OFF", retain=False
             )
-            self.ptz_metrics[camera]["ptz_reset"].set()
+            self.ptz_metrics[camera].reset.set()

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -55,9 +55,6 @@ class PtzMotionEstimator:
         self.camera_config = config
         self.coord_transformations = None
         self.ptz_metrics = ptz_metrics
-        self.ptz_start_time = self.ptz_metrics.start_time
-        self.ptz_stop_time = self.ptz_metrics.stop_time
-
         self.ptz_metrics.reset.set()
         logger.debug(f"{config.name}: Motion estimator init")
 
@@ -86,7 +83,9 @@ class PtzMotionEstimator:
             self.coord_transformations = None
 
         if ptz_moving_at_frame_time(
-            frame_time, self.ptz_start_time.value, self.ptz_stop_time.value
+            frame_time,
+            self.ptz_metrics.start_time.value,
+            self.ptz_metrics.stop_time.value,
         ):
             logger.debug(
                 f"{camera}: Motion estimator running - frame time: {frame_time}"

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -49,9 +49,7 @@ def ptz_moving_at_frame_time(frame_time, ptz_start_time, ptz_stop_time):
 
 
 class PtzMotionEstimator:
-    def __init__(
-        self, config: CameraConfig, ptz_metrics: dict[str, PTZMetrics]
-    ) -> None:
+    def __init__(self, config: CameraConfig, ptz_metrics: PTZMetrics) -> None:
         self.frame_manager = SharedMemoryFrameManager()
         self.norfair_motion_estimator = None
         self.camera_config = config

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -11,10 +11,11 @@ import psutil
 import requests
 from requests.exceptions import RequestException
 
+from frigate.camera import CameraMetrics
 from frigate.config import FrigateConfig
 from frigate.const import CACHE_DIR, CLIPS_DIR, RECORD_DIR
 from frigate.object_detection import ObjectDetectProcess
-from frigate.types import CameraMetricsTypes, StatsTrackingTypes
+from frigate.types import StatsTrackingTypes
 from frigate.util.services import (
     get_amd_gpu_stats,
     get_bandwidth_stats,
@@ -49,7 +50,7 @@ def get_latest_version(config: FrigateConfig) -> str:
 
 def stats_init(
     config: FrigateConfig,
-    camera_metrics: dict[str, CameraMetricsTypes],
+    camera_metrics: dict[str, CameraMetrics],
     detectors: dict[str, ObjectDetectProcess],
     processes: dict[str, int],
 ) -> StatsTrackingTypes:
@@ -245,27 +246,23 @@ def stats_snapshot(
 
     stats["cameras"] = {}
     for name, camera_stats in camera_metrics.items():
-        total_detection_fps += camera_stats["detection_fps"].value
-        pid = camera_stats["process"].pid if camera_stats["process"] else None
-        ffmpeg_pid = (
-            camera_stats["ffmpeg_pid"].value if camera_stats["ffmpeg_pid"] else None
-        )
+        total_detection_fps += camera_stats.detection_fps.value
+        pid = camera_stats.process.pid if camera_stats.process else None
+        ffmpeg_pid = camera_stats.ffmpeg_pid.value if camera_stats.ffmpeg_pid else None
         capture_pid = (
-            camera_stats["capture_process"].pid
-            if camera_stats["capture_process"]
-            else None
+            camera_stats.capture_process.pid if camera_stats.capture_process else None
         )
         stats["cameras"][name] = {
-            "camera_fps": round(camera_stats["camera_fps"].value, 2),
-            "process_fps": round(camera_stats["process_fps"].value, 2),
-            "skipped_fps": round(camera_stats["skipped_fps"].value, 2),
-            "detection_fps": round(camera_stats["detection_fps"].value, 2),
+            "camera_fps": round(camera_stats.camera_fps.value, 2),
+            "process_fps": round(camera_stats.process_fps.value, 2),
+            "skipped_fps": round(camera_stats.skipped_fps.value, 2),
+            "detection_fps": round(camera_stats.detection_fps.value, 2),
             "detection_enabled": config.cameras[name].detect.enabled,
             "pid": pid,
             "capture_pid": capture_pid,
             "ffmpeg_pid": ffmpeg_pid,
-            "audio_rms": round(camera_stats["audio_rms"].value, 4),
-            "audio_dBFS": round(camera_stats["audio_dBFS"].value, 4),
+            "audio_rms": round(camera_stats.audio_rms.value, 4),
+            "audio_dBFS": round(camera_stats.audio_dBFS.value, 4),
         }
 
     stats["detectors"] = {}

--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -85,7 +85,6 @@ class NorfairTracker(ObjectTracker):
         self.camera_config = config
         self.detect_config = config.detect
         self.ptz_metrics = ptz_metrics
-        self.ptz_autotracker_enabled = ptz_metrics.autotracker_enabled
         self.ptz_motion_estimator = {}
         self.camera_name = config.name
         self.track_id_map = {}
@@ -104,7 +103,7 @@ class NorfairTracker(ObjectTracker):
             #       the different tracker per object class
             filter_factory=OptimizedKalmanFilterFactory(R=3.4),
         )
-        if self.ptz_autotracker_enabled.value:
+        if self.ptz_metrics.autotracker_enabled.value:
             self.ptz_motion_estimator = PtzMotionEstimator(
                 self.camera_config, self.ptz_metrics
             )
@@ -315,7 +314,7 @@ class NorfairTracker(ObjectTracker):
 
         coord_transformations = None
 
-        if self.ptz_autotracker_enabled.value:
+        if self.ptz_metrics.autotracker_enabled.value:
             # we must have been enabled by mqtt, so set up the estimator
             if not self.ptz_motion_estimator:
                 self.ptz_motion_estimator = PtzMotionEstimator(

--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -12,10 +12,10 @@ from norfair import (
 )
 from norfair.drawing.drawer import Drawer
 
+from frigate.camera import PTZMetrics
 from frigate.config import CameraConfig
 from frigate.ptz.autotrack import PtzMotionEstimator
 from frigate.track import ObjectTracker
-from frigate.types import PTZMetricsTypes
 from frigate.util.image import intersection_over_union
 from frigate.util.object import average_boxes, median_of_boxes
 
@@ -75,7 +75,7 @@ class NorfairTracker(ObjectTracker):
     def __init__(
         self,
         config: CameraConfig,
-        ptz_metrics: PTZMetricsTypes,
+        ptz_metrics: PTZMetrics,
     ):
         self.tracked_objects = {}
         self.untracked_object_boxes: list[list[int]] = []
@@ -85,7 +85,7 @@ class NorfairTracker(ObjectTracker):
         self.camera_config = config
         self.detect_config = config.detect
         self.ptz_metrics = ptz_metrics
-        self.ptz_autotracker_enabled = ptz_metrics["ptz_autotracker_enabled"]
+        self.ptz_autotracker_enabled = ptz_metrics.autotracker_enabled
         self.ptz_motion_estimator = {}
         self.camera_name = config.name
         self.track_id_map = {}

--- a/frigate/types.py
+++ b/frigate/types.py
@@ -1,25 +1,9 @@
-from multiprocessing import Queue
-from multiprocessing.context import Process
 from multiprocessing.sharedctypes import Synchronized
 from multiprocessing.synchronize import Event
-from typing import Optional, TypedDict
+from typing import TypedDict
 
+from frigate.camera import CameraMetrics
 from frigate.object_detection import ObjectDetectProcess
-
-
-class CameraMetricsTypes(TypedDict):
-    camera_fps: Synchronized
-    capture_process: Optional[Process]
-    detection_fps: Synchronized
-    detection_frame: Synchronized
-    ffmpeg_pid: Synchronized
-    frame_queue: Queue
-    process: Optional[Process]
-    process_fps: Synchronized
-    read_start: Synchronized
-    skipped_fps: Synchronized
-    audio_rms: Synchronized
-    audio_dBFS: Synchronized
 
 
 class PTZMetricsTypes(TypedDict):
@@ -36,7 +20,7 @@ class PTZMetricsTypes(TypedDict):
 
 
 class StatsTrackingTypes(TypedDict):
-    camera_metrics: dict[str, CameraMetricsTypes]
+    camera_metrics: dict[str, CameraMetrics]
     detectors: dict[str, ObjectDetectProcess]
     started: int
     latest_frigate_version: str

--- a/frigate/types.py
+++ b/frigate/types.py
@@ -1,22 +1,7 @@
-from multiprocessing.sharedctypes import Synchronized
-from multiprocessing.synchronize import Event
 from typing import TypedDict
 
 from frigate.camera import CameraMetrics
 from frigate.object_detection import ObjectDetectProcess
-
-
-class PTZMetricsTypes(TypedDict):
-    ptz_autotracker_enabled: Synchronized
-    ptz_tracking_active: Event
-    ptz_motor_stopped: Event
-    ptz_reset: Event
-    ptz_start_time: Synchronized
-    ptz_stop_time: Synchronized
-    ptz_frame_time: Synchronized
-    ptz_zoom_level: Synchronized
-    ptz_max_zoom: Synchronized
-    ptz_min_zoom: Synchronized
 
 
 class StatsTrackingTypes(TypedDict):

--- a/frigate/util/__init__.py
+++ b/frigate/util/__init__.py
@@ -1,0 +1,3 @@
+from .process import Process
+
+__all__ = ["Process"]

--- a/frigate/util/process.py
+++ b/frigate/util/process.py
@@ -1,0 +1,55 @@
+import logging
+import multiprocessing as mp
+from functools import wraps
+from logging.handlers import QueueHandler
+from typing import Any
+
+import frigate.log
+
+
+class BaseProcess(mp.Process):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def start(self, *args, **kwargs):
+        self.before_start()
+        super().start(*args, **kwargs)
+        self.after_start()
+
+    def __getattribute__(self, name: str) -> Any:
+        if name == "run":
+            run = super().__getattribute__("run")
+
+            @wraps(run)
+            def run_wrapper(*args, **kwargs):
+                try:
+                    self.before_run()
+                    return run(*args, **kwargs)
+                finally:
+                    self.after_run()
+
+            return run_wrapper
+
+        return super().__getattribute__(name)
+
+    def before_start(self) -> None:
+        pass
+
+    def after_start(self) -> None:
+        pass
+
+    def before_run(self) -> None:
+        pass
+
+    def after_run(self) -> None:
+        pass
+
+
+class Process(BaseProcess):
+    def before_start(self) -> None:
+        self.__log_queue = frigate.log.log_listener.queue
+
+    def before_run(self) -> None:
+        if self.__log_queue:
+            logging.basicConfig(handlers=[], force=True)
+            logging.getLogger().addHandler(QueueHandler(self.__log_queue))


### PR DESCRIPTION
**Changes:**
- Converted `listen_to_audio` Process to subclass `mp.Process`.
- Added a base class for future processes that sets up the logging queue. This doesn't do much currently, but its a step towards making it possible to switch away from the fork multiprocessing start method.
- Converted `CameraMetricsType` and `PTZMetricsType` typed dicts into proper classes.
- Fixed `ptz_metrics` type annotation in `PtzMotionEstimator.__init__`.
- Removed some pointless variables that just copied over `ptz_metrics` to instance variables.

Note: I don't have any ptz cameras. If someone can test I didn't accidentally break anything in autotracking, it would be much appreciated.