### PR TITLE
Increase healthcheck start period to 5 minutes

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -239,7 +239,7 @@ ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
 ENTRYPOINT ["/init"]
 CMD []
 
-HEALTHCHECK --start-period=120s --start-interval=5s --interval=15s --timeout=5s --retries=3 \
+HEALTHCHECK --start-period=300s --start-interval=5s --interval=15s --timeout=5s --retries=3 \
     CMD curl --fail --silent --show-error http://127.0.0.1:5000/api/version || exit 1
 
 # Frigate deps with Node.js and NPM for devcontainer


### PR DESCRIPTION
Some users have autotracking cameras that take longer than 2 minutes for calibration. 

Solves https://github.com/blakeblackshear/frigate/discussions/13967