### PR TITLE
Search functionality and UI tweaks

### DIFF
--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -32,7 +32,7 @@ unidecode == 1.3.*
 # OpenVino (ONNX installed in wheels-post)
 openvino == 2024.3.*
 # Embeddings
-chromadb == 0.5.0
+chromadb == 0.5.*
 onnx_clip == 4.0.*
 # Generative AI
 google-generativeai == 0.6.*

--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -32,7 +32,7 @@ unidecode == 1.3.*
 # OpenVino (ONNX installed in wheels-post)
 openvino == 2024.3.*
 # Embeddings
-chromadb == 0.5.*
+chromadb == 0.5.7
 onnx_clip == 4.0.*
 # Generative AI
 google-generativeai == 0.6.*

--- a/frigate/api/defs/events_query_parameters.py
+++ b/frigate/api/defs/events_query_parameters.py
@@ -43,6 +43,7 @@ class EventsSearchQueryParams(BaseModel):
     zones: Optional[str] = "all"
     after: Optional[float] = None
     before: Optional[float] = None
+    time_range: Optional[str] = DEFAULT_TIME_RANGE
     timezone: Optional[str] = "utc"
 
 

--- a/frigate/embeddings/embeddings.py
+++ b/frigate/embeddings/embeddings.py
@@ -43,7 +43,7 @@ def get_metadata(event: Event) -> dict:
         {
             k: v
             for k, v in event_dict.items()
-            if k not in ["id", "thumbnail"]
+            if k not in ["thumbnail"]
             and v is not None
             and isinstance(v, (str, int, float, bool))
         }

--- a/web/src/components/card/SearchThumbnail.tsx
+++ b/web/src/components/card/SearchThumbnail.tsx
@@ -15,6 +15,7 @@ import { capitalizeFirstLetter } from "@/utils/stringUtil";
 import { SearchResult } from "@/types/search";
 import useContextMenu from "@/hooks/use-contextmenu";
 import { cn } from "@/lib/utils";
+import { TooltipPortal } from "@radix-ui/react-tooltip";
 
 type SearchThumbnailProps = {
   searchResult: SearchResult;
@@ -95,16 +96,18 @@ export default function SearchThumbnail({
                 </div>
               </TooltipTrigger>
             </div>
-            <TooltipContent className="capitalize">
-              {[...new Set([searchResult.label])]
-                .filter(
-                  (item) => item !== undefined && !item.includes("-verified"),
-                )
-                .map((text) => capitalizeFirstLetter(text))
-                .sort()
-                .join(", ")
-                .replaceAll("-verified", "")}
-            </TooltipContent>
+            <TooltipPortal>
+              <TooltipContent className="capitalize">
+                {[...new Set([searchResult.label])]
+                  .filter(
+                    (item) => item !== undefined && !item.includes("-verified"),
+                  )
+                  .map((text) => capitalizeFirstLetter(text))
+                  .sort()
+                  .join(", ")
+                  .replaceAll("-verified", "")}
+              </TooltipContent>
+            </TooltipPortal>
           </Tooltip>
         </div>
         <div className="rounded-t-l pointer-events-none absolute inset-x-0 top-0 z-10 h-[30%] w-full bg-gradient-to-b from-black/60 to-transparent"></div>

--- a/web/src/components/filter/CamerasFilterButton.tsx
+++ b/web/src/components/filter/CamerasFilterButton.tsx
@@ -112,7 +112,10 @@ export function CamerasFilterButton({
                 <div
                   key={name}
                   className="w-full cursor-pointer rounded-lg px-2 py-0.5 text-sm capitalize text-primary hover:bg-muted"
-                  onClick={() => setCurrentCameras([...conf.cameras])}
+                  onClick={() => {
+                    setAllCamerasSelected(false);
+                    setCurrentCameras([...conf.cameras]);
+                  }}
                 >
                   {name}
                 </div>

--- a/web/src/components/navigation/Bottombar.tsx
+++ b/web/src/components/navigation/Bottombar.tsx
@@ -27,7 +27,7 @@ function Bottombar() {
         isPWA && isIOS
           ? "portrait:items-start portrait:pt-1 landscape:items-center"
           : "items-center",
-        isMobile && !isPWA && "h-12 landscape:md:h-16",
+        isMobile && !isPWA && "h-12 md:h-16",
       )}
     >
       {navItems.map((item) => (

--- a/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
+++ b/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
@@ -201,21 +201,24 @@ export default function MobileReviewSettingsDrawer({
             Calendar
           </div>
         </div>
-        <ReviewActivityCalendar
-          reviewSummary={reviewSummary}
-          selectedDay={
-            filter?.after == undefined
-              ? undefined
-              : new Date(filter.after * 1000)
-          }
-          onSelect={(day) => {
-            onUpdateFilter({
-              ...filter,
-              after: day == undefined ? undefined : day.getTime() / 1000,
-              before: day == undefined ? undefined : getEndOfDayTimestamp(day),
-            });
-          }}
-        />
+        <div className="flex w-full flex-row justify-center">
+          <ReviewActivityCalendar
+            reviewSummary={reviewSummary}
+            selectedDay={
+              filter?.after == undefined
+                ? undefined
+                : new Date(filter.after * 1000)
+            }
+            onSelect={(day) => {
+              onUpdateFilter({
+                ...filter,
+                after: day == undefined ? undefined : day.getTime() / 1000,
+                before:
+                  day == undefined ? undefined : getEndOfDayTimestamp(day),
+              });
+            }}
+          />
+        </div>
         <SelectSeparator />
         <div className="flex items-center justify-center p-2">
           <Button

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -95,6 +95,11 @@ export default function SearchDetailDialog({
       views.splice(index, 1);
     }
 
+    if (search.data.type != "object") {
+      const index = views.indexOf("object lifecycle");
+      views.splice(index, 1);
+    }
+
     // TODO implement
     //if (!config.semantic_search.enabled) {
     //  const index = views.indexOf("similar-calendar");

--- a/web/src/components/overlay/dialog/PlatformAwareDialog.tsx
+++ b/web/src/components/overlay/dialog/PlatformAwareDialog.tsx
@@ -26,7 +26,7 @@ export default function PlatformAwareDialog({
     return (
       <Drawer open={open} onOpenChange={onOpenChange}>
         <DrawerTrigger asChild>{trigger}</DrawerTrigger>
-        <DrawerContent className="max-h-[75dvh] overflow-hidden p-4">
+        <DrawerContent className="max-h-[75dvh] overflow-hidden px-4">
           {content}
         </DrawerContent>
       </Drawer>

--- a/web/src/hooks/use-date-utils.ts
+++ b/web/src/hooks/use-date-utils.ts
@@ -82,14 +82,9 @@ export function useFormattedHour(
     const [hour, minute] = time.includes(":") ? time.split(":") : [time, "00"];
     const hourNum = parseInt(hour);
 
-    if (hourNum < 12) {
-      if (hourNum == 0) {
-        return `12:${minute} AM`;
-      }
+    const adjustedHour = hourNum % 12 || 12;
+    const period = hourNum < 12 ? "AM" : "PM";
 
-      return `${hourNum}:${minute} AM`;
-    } else {
-      return `${hourNum - 12}:${minute} PM`;
-    }
+    return `${adjustedHour}:${minute} ${period}`;
   }, [hour24, time]);
 }

--- a/web/src/pages/Explore.tsx
+++ b/web/src/pages/Explore.tsx
@@ -103,6 +103,7 @@ export default function Explore() {
         time_range: searchSearchParams["time_range"],
         search_type: searchSearchParams["search_type"],
         event_id: searchSearchParams["event_id"],
+        timezone,
         include_thumbnails: 0,
       },
     ];

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -31,6 +31,7 @@ import InputWithTags from "@/components/input/InputWithTags";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { isEqual } from "lodash";
 import { formatDateToLocaleString } from "@/utils/dateUtil";
+import { TooltipPortal } from "@radix-ui/react-tooltip";
 
 type SearchViewProps = {
   search: string;
@@ -401,14 +402,16 @@ export default function SearchView({
                                 %
                               </Chip>
                             </TooltipTrigger>
-                            <TooltipContent>
-                              Matched {value.search_source} at{" "}
-                              {zScoreToConfidence(
-                                value.search_distance,
-                                value.search_source,
-                              )}
-                              %
-                            </TooltipContent>
+                            <TooltipPortal>
+                              <TooltipContent>
+                                Matched {value.search_source} at{" "}
+                                {zScoreToConfidence(
+                                  value.search_distance,
+                                  value.search_source,
+                                )}
+                                %
+                              </TooltipContent>
+                            </TooltipPortal>
                           </Tooltip>
                         </div>
                       )}

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -11,13 +11,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { FrigateConfig } from "@/types/frigateConfig";
-import {
-  DEFAULT_SEARCH_FILTERS,
-  SearchFilter,
-  SearchFilters,
-  SearchResult,
-  SearchSource,
-} from "@/types/search";
+import { SearchFilter, SearchResult, SearchSource } from "@/types/search";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isMobileOnly } from "react-device-detect";
 import { LuImage, LuSearchX, LuText } from "react-icons/lu";
@@ -144,20 +138,6 @@ export default function SearchView({
   // detail
 
   const [searchDetail, setSearchDetail] = useState<SearchResult>();
-
-  const selectedFilters = useMemo<SearchFilters[]>(() => {
-    const filters = [...DEFAULT_SEARCH_FILTERS];
-
-    if (
-      searchFilter &&
-      (searchFilter?.query?.length || searchFilter?.event_id?.length)
-    ) {
-      const index = filters.indexOf("time");
-      filters.splice(index, 1);
-    }
-
-    return filters;
-  }, [searchFilter]);
 
   // search interaction
 
@@ -336,7 +316,6 @@ export default function SearchView({
                   "w-full justify-between md:justify-start lg:justify-end",
                 )}
                 filter={searchFilter}
-                filters={selectedFilters as SearchFilters[]}
                 onUpdateFilter={onUpdateFilter}
               />
               <ScrollBar orientation="horizontal" className="h-0" />


### PR DESCRIPTION
- Add ability to use time range for Chroma based searches
- Add event_id back to Chroma metadata for filtering
- Portal tooltips on search pages
- Remove object lifecycle from search details for non-object events
- Small tweaks for spacing consistency on mobile
- Bump `chromadb` to 0.5.7

Users on the dev builds running semantic search will need to reindex their embeddings (`reindex: True`) in order to use filters for thumbnail/description searches. A text query search with no filters will work without issue. Additionally, users may want to vaccum their Chroma database as a one-time optimization due to the upgrade from 0.5.0 to 0.5.7 by logging into the container and running `/usr/local/chroma utils vacuum --path /config/chroma`
