### PR TITLE
Bumping rocm to the version 6.1.2

### DIFF
--- a/docker/rocm/Dockerfile
+++ b/docker/rocm/Dockerfile
@@ -2,7 +2,7 @@
 
 # https://askubuntu.com/questions/972516/debian-frontend-environment-variable
 ARG DEBIAN_FRONTEND=noninteractive
-ARG ROCM=5.7.3
+ARG ROCM=6.1.2
 ARG AMDGPU=gfx900
 ARG HSA_OVERRIDE_GFX_VERSION
 ARG HSA_OVERRIDE
@@ -23,11 +23,11 @@ COPY docker/rocm/rocm-pin-600 /etc/apt/preferences.d/
 
 RUN apt-get update
 
-RUN apt-get -y install --no-install-recommends migraphx hipfft roctracer
+RUN apt-get -y install --no-install-recommends migraphx hipfft roctracer rocprofiler-register miopen-hip
 RUN apt-get -y install --no-install-recommends migraphx-dev
 
 RUN mkdir -p /opt/rocm-dist/opt/rocm-$ROCM/lib
-RUN cd /opt/rocm-$ROCM/lib && cp -dpr libMIOpen*.so* libamd*.so* libhip*.so* libhsa*.so* libmigraphx*.so* librocm*.so* librocblas*.so* libroctracer*.so* librocfft*.so* /opt/rocm-dist/opt/rocm-$ROCM/lib/
+RUN cd /opt/rocm-$ROCM/lib && cp -dpr libMIOpen*.so* libamd*.so* libhip*.so* libhsa*.so* libmigraphx*.so* librocm*.so* librocblas*.so* libroctracer*.so* librocfft*.so* librocprofiler-register*.so* libroctx64*.so* /opt/rocm-dist/opt/rocm-$ROCM/lib/
 RUN cd /opt/rocm-dist/opt/ && ln -s rocm-$ROCM rocm
 
 RUN mkdir -p /opt/rocm-dist/etc/ld.so.conf.d/
@@ -82,7 +82,7 @@ ARG ROCM
 ARG AMDGPU
 
 COPY --from=rocm /opt/rocm-$ROCM/bin/rocminfo /opt/rocm-$ROCM/bin/migraphx-driver /opt/rocm-$ROCM/bin/
-COPY --from=rocm /opt/rocm-$ROCM/share/miopen/db/*$AMDGPU* /opt/rocm-$ROCM/share/miopen/db/
+COPY --from=rocm /opt/rocm-$ROCM/share/miopen/db/ /opt/rocm-$ROCM/share/miopen/db/
 COPY --from=rocm /opt/rocm-$ROCM/lib/rocblas/library/*$AMDGPU* /opt/rocm-$ROCM/lib/rocblas/library/
 COPY --from=rocm /opt/rocm-dist/ /
 COPY --from=debian-build /opt/rocm/lib/migraphx.cpython-39-x86_64-linux-gnu.so /opt/rocm-$ROCM/lib/

--- a/docker/rocm/rocm.hcl
+++ b/docker/rocm/rocm.hcl
@@ -2,7 +2,7 @@ variable "AMDGPU" {
   default = "gfx900"
 }
 variable "ROCM" {
-  default = "5.7.3"
+  default = "6.1.2"
 }
 variable "HSA_OVERRIDE_GFX_VERSION" {
   default = ""

--- a/docker/rocm/rocm.list
+++ b/docker/rocm/rocm.list
@@ -1,1 +1,1 @@
-deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/5.7.3 focal main
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.1.2 focal main


### PR DESCRIPTION
I also needed to copy the whole `opt/rocm-$ROCM/share/miopen/db/ ` as I was getting an error when using gfx1100 overwise

Current Problem:
```
devcontainer-1  | 2024-09-26 14:22:14.399519815    what():  Thread 0x/long_pathname_so_that_rpms_can_package_the_debug_info/src/extlibs/AMDMIGraphX/src/targets/gpu/mlir.cpp:723: run_high_level_pipeline: Invalid MLIR created: Error: Disjointed yx or hw!
devcontainer-1  | 2024-09-26 14:22:14.399522309  Note: see current operation: %5 = "rock.conv2d"(%3, %2, %4) <{arch = "gfx1100", dilations = [1 : i32, 1 : i32], features = #rock<GemmFeatures dot|atomic_add|atomic_fmax_f32>, numCU = 6 : i32, padding = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]}> {filter_layout = ["g", "k", "c", "y", "x"], input_layout = ["ni", "wi", "gi", "ci", "hi"], output_layout = ["no", "wo", "go", "ko", "ho"]} : (tensor<1x1x17x1x1xf32>, tensor<1x4x1x17x100xf32>, tensor<1x4x1x1x100xf32>) -> tensor<1x4x1x1x100xf32>
```