### PR TITLE
UI fixes

### DIFF
--- a/web/src/components/overlay/ExportDialog.tsx
+++ b/web/src/components/overlay/ExportDialog.tsx
@@ -22,7 +22,7 @@ import { FrigateConfig } from "@/types/frigateConfig";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { TimezoneAwareCalendar } from "./ReviewActivityCalendar";
 import { SelectSeparator } from "../ui/select";
-import { isDesktop } from "react-device-detect";
+import { isDesktop, isIOS } from "react-device-detect";
 import { Drawer, DrawerContent, DrawerTrigger } from "../ui/drawer";
 import SaveExportOverlay from "./SaveExportOverlay";
 import { getUTCOffset } from "@/utils/dateUtil";
@@ -435,15 +435,18 @@ function CustomTimeSelector({
             id="startTime"
             type="time"
             value={startClock}
-            step="1"
+            step={isIOS ? "60" : "1"}
             onChange={(e) => {
               const clock = e.target.value;
-              const [hour, minute, second] = clock.split(":");
+              const [hour, minute, second] = isIOS
+                ? [...clock.split(":"), "00"]
+                : clock.split(":");
+
               const start = new Date(startTime * 1000);
               start.setHours(
                 parseInt(hour),
                 parseInt(minute),
-                parseInt(second),
+                parseInt(second ?? 0),
                 0,
               );
               setRange({
@@ -497,15 +500,18 @@ function CustomTimeSelector({
             id="startTime"
             type="time"
             value={endClock}
-            step="1"
+            step={isIOS ? "60" : "1"}
             onChange={(e) => {
               const clock = e.target.value;
-              const [hour, minute, second] = clock.split(":");
-              const end = new Date(endTime * 1000);
+              const [hour, minute, second] = isIOS
+                ? [...clock.split(":"), "00"]
+                : clock.split(":");
+
+              const end = new Date(startTime * 1000);
               end.setHours(
                 parseInt(hour),
                 parseInt(minute),
-                parseInt(second),
+                parseInt(second ?? 0),
                 0,
               );
               setRange({

--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -46,6 +46,7 @@ const DrawerContent = React.forwardRef<
         "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
         className,
         isIOS && isPWA && "pb-5",
+        isIOS && !isPWA && "md:pb-5",
       )}
       {...props}
     >


### PR DESCRIPTION
- Fix export time picker on iOS - iOS only supports hour/minute resolution
- Add padding to dialog on iPads to prevent buttons from being cut off