### PR TITLE
Ensure config file naming is consistent throughout

### DIFF
--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -183,7 +183,7 @@ To do this:
 3. Give `go2rtc` execute permission.
 4. Restart Frigate and the custom version will be used, you can verify by checking go2rtc logs.
 
-## Validating your config.yaml file updates
+## Validating your config.yml file updates
 
 When frigate starts up, it checks whether your config file is valid, and if it is not, the process exits. To minimize interruptions when updating your config, you have three options -- you can edit the config via the WebUI which has built in validation, use the config API, or you can validate on the command line using the frigate docker container.
 

--- a/docs/docs/configuration/hardware_acceleration.md
+++ b/docs/docs/configuration/hardware_acceleration.md
@@ -370,7 +370,7 @@ Make sure to follow the [Rockchip specific installation instructions](/frigate/i
 
 ### Configuration
 
-Add one of the following FFmpeg presets to your `config.yaml` to enable hardware video processing:
+Add one of the following FFmpeg presets to your `config.yml` to enable hardware video processing:
 
 ```yaml
 # if you try to decode a h264 encoded stream


### PR DESCRIPTION
Rename just a few references of `config.yaml` to `config.yml`