### PR TITLE
Clarify storage metrics values with a popover

### DIFF
--- a/web/src/components/graph/CombinedStorageGraph.tsx
+++ b/web/src/components/graph/CombinedStorageGraph.tsx
@@ -10,7 +10,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { getUnitSize } from "@/utils/storageUtil";
+import { LuAlertCircle } from "react-icons/lu";
 
 type CameraStorage = {
   [key: string]: {
@@ -50,7 +56,7 @@ export function CombinedStorageGraph({
 
   // Add the unused percentage to the series
   series.push({
-    name: "Unused Free Space",
+    name: "Unused",
     data: [
       ((totalStorage.total - totalStorage.used) / totalStorage.total) * 100,
     ],
@@ -186,11 +192,34 @@ export function CombinedStorageGraph({
                     style={{ backgroundColor: item.color }}
                   ></div>
                   {item.name.replaceAll("_", " ")}
+                  {item.name === "Unused" && (
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <button
+                          className="focus:outline-none"
+                          aria-label="Unused Storage Information"
+                        >
+                          <LuAlertCircle
+                            className="size-5"
+                            aria-label="Unused Storage Information"
+                          />
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-80">
+                        <div className="space-y-2">
+                          This value may not accurately represent the free space
+                          available to Frigate if you have other files stored on
+                          your drive beyond Frigate's recordings. Frigate does
+                          not track storage usage outside of its recordings.
+                        </div>
+                      </PopoverContent>
+                    </Popover>
+                  )}
                 </TableCell>
                 <TableCell>{getUnitSize(item.usage)}</TableCell>
                 <TableCell>{item.data[0].toFixed(2)}%</TableCell>
                 <TableCell>
-                  {item.name === "Unused Free Space"
+                  {item.name === "Unused"
                     ? "—"
                     : `${getUnitSize(item.bandwidth)} / hour`}
                 </TableCell>

--- a/web/src/views/system/StorageMetrics.tsx
+++ b/web/src/views/system/StorageMetrics.tsx
@@ -2,7 +2,13 @@ import { CombinedStorageGraph } from "@/components/graph/CombinedStorageGraph";
 import { StorageGraph } from "@/components/graph/StorageGraph";
 import { FrigateStats } from "@/types/stats";
 import { useMemo } from "react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import useSWR from "swr";
+import { LuAlertCircle } from "react-icons/lu";
 
 type CameraStorage = {
   [key: string]: {
@@ -47,7 +53,29 @@ export default function StorageMetrics({
       <div className="text-sm font-medium text-muted-foreground">Overview</div>
       <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-3">
         <div className="flex-col rounded-lg bg-background_alt p-2.5 md:rounded-2xl">
-          <div className="mb-5">Recordings</div>
+          <div className="mb-5 flex flex-row items-center justify-between">
+            Recordings
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  className="focus:outline-none"
+                  aria-label="Unused Storage Information"
+                >
+                  <LuAlertCircle
+                    className="size-5"
+                    aria-label="Unused Storage Information"
+                  />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent className="w-80">
+                <div className="space-y-2">
+                  This value represents the total storage used by the recordings
+                  in Frigate's database. Frigate does not track storage usage
+                  for all files on your disk.
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
           <StorageGraph
             graphId="general-recordings"
             used={totalStorage.used}


### PR DESCRIPTION
## Proposed change
Users have been confused about the storage metrics page in the UI, often times highlighting the discrepancy between a `df -h` on their drive and the values displayed in Frigate. For example, https://github.com/blakeblackshear/frigate/discussions/14030 https://github.com/blakeblackshear/frigate/discussions/13892

This PR adds a popover to the storage metrics page to clarify that Frigate only tracks storage for its own recordings.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
