### PR TITLE
Don't assume single render device is D128

### DIFF
--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -32,7 +32,7 @@ class LibvaGpuSelector:
         devices = list(filter(lambda d: d.startswith("render"), os.listdir("/dev/dri")))
 
         if len(devices) < 2:
-            self._selected_gpu = "/dev/dri/renderD128"
+            self._selected_gpu = devices[0]
             return self._selected_gpu
 
         for device in devices:


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

Seems there are some edge cases where there is a single render device and it is D129

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
