### PR TITLE
Fix alert thumbnails on iOS and Safari desktop

### DIFF
--- a/web/src/components/card/AnimatedEventCard.tsx
+++ b/web/src/components/card/AnimatedEventCard.tsx
@@ -17,6 +17,7 @@ import { usePersistence } from "@/hooks/use-persistence";
 import { Skeleton } from "../ui/skeleton";
 import { Button } from "../ui/button";
 import { FaCircleCheck } from "react-icons/fa6";
+import { cn } from "@/lib/utils";
 
 type AnimatedEventCardProps = {
   event: ReviewSegment;
@@ -145,7 +146,10 @@ export function AnimatedEventCard({
             >
               {!alertVideos ? (
                 <img
-                  className="max-h-full select-none"
+                  className={cn(
+                    "h-full w-auto min-w-10 select-none object-contain",
+                    isSafari && !isLoaded ? "hidden" : "visible",
+                  )}
                   src={`${apiHost}${event.thumb_path.replace("/media/frigate/", "")}`}
                   loading={isSafari ? "eager" : "lazy"}
                   onLoad={() => setIsLoaded(true)}
@@ -200,7 +204,14 @@ export function AnimatedEventCard({
               </div>
             </div>
           )}
-          {!isLoaded && <Skeleton className="absolute inset-0" />}
+          {!isLoaded && (
+            <Skeleton
+              style={{
+                aspectRatio: alertVideos ? aspectRatio : 16 / 9,
+              }}
+              className="size-full"
+            />
+          )}
         </div>
       </TooltipTrigger>
       <TooltipContent>


### PR DESCRIPTION
## Proposed change
When using alert thumbnails (rather than alert videos) in the filmstrip, Safari desktop and iOS devices would sometimes fail to display some/all of the thumbnails. Firefox and Chrome desktop are unaffected. This PR triggers a repaint by setting a `visible` class on the images after loading is complete.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
