### PR TITLE
Do not migrate db to new config path

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -35,7 +35,6 @@ from frigate.const import (
     CACHE_DIR,
     CLIPS_DIR,
     CONFIG_DIR,
-    DEFAULT_DB_PATH,
     EXPORT_DIR,
     MODEL_CACHE_DIR,
     RECORD_DIR,
@@ -150,13 +149,6 @@ class FrigateApp:
                     f.write(str(datetime.datetime.now().timestamp()))
             except PermissionError:
                 logger.error("Unable to write to /config to save DB state")
-
-        # Migrate DB location
-        old_db_path = DEFAULT_DB_PATH
-        if not os.path.isfile(self.config.database.path) and os.path.isfile(
-            old_db_path
-        ):
-            os.rename(old_db_path, self.config.database.path)
 
         # Migrate DB schema
         migrate_db = SqliteExtDatabase(self.config.database.path)


### PR DESCRIPTION
## Proposed change
I would be very surprised by that behaviour as a user. Changing the db path would randomly move the database, and changing it back (or to anything, really) would not. These kinds of advanced settings are generally expected to do one thing: Change the path frigate opens the database from. The end.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
