### PR TITLE
Properly call super() in subclasses

### DIFF
--- a/frigate/comms/zmq_proxy.py
+++ b/frigate/comms/zmq_proxy.py
@@ -12,8 +12,7 @@ SOCKET_SUB = "ipc:///tmp/cache/proxy_sub"
 
 class ZmqProxyRunner(threading.Thread):
     def __init__(self, context: zmq.Context[zmq.Socket]) -> None:
-        threading.Thread.__init__(self)
-        self.name = "detection_proxy"
+        super().__init__(name="detection_proxy")
         self.context = context
 
     def run(self) -> None:

--- a/frigate/detectors/plugins/tensorrt.py
+++ b/frigate/detectors/plugins/tensorrt.py
@@ -26,9 +26,6 @@ DETECTOR_KEY = "tensorrt"
 if TRT_SUPPORT:
 
     class TrtLogger(trt.ILogger):
-        def __init__(self):
-            trt.ILogger.__init__(self)
-
         def log(self, severity, msg):
             logger.log(self.getSeverity(severity), msg)
 

--- a/frigate/events/cleanup.py
+++ b/frigate/events/cleanup.py
@@ -23,8 +23,7 @@ class EventCleanupType(str, Enum):
 
 class EventCleanup(threading.Thread):
     def __init__(self, config: FrigateConfig, stop_event: MpEvent):
-        threading.Thread.__init__(self)
-        self.name = "event_cleanup"
+        super().__init__(name="event_cleanup")
         self.config = config
         self.stop_event = stop_event
         self.camera_keys = list(self.config.cameras.keys())

--- a/frigate/events/maintainer.py
+++ b/frigate/events/maintainer.py
@@ -54,8 +54,7 @@ class EventProcessor(threading.Thread):
         timeline_queue: Queue,
         stop_event: MpEvent,
     ):
-        threading.Thread.__init__(self)
-        self.name = "event_processor"
+        super().__init__(name="event_processor")
         self.config = config
         self.timeline_queue = timeline_queue
         self.events_in_process: Dict[str, Event] = {}

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -70,8 +70,7 @@ os.register_at_fork(after_in_child=reopen_std_streams)
 class LogPipe(threading.Thread):
     def __init__(self, log_name: str):
         """Setup the object with a logger and start the thread"""
-        threading.Thread.__init__(self)
-        self.daemon = False
+        super().__init__(daemon=False)
         self.logger = logging.getLogger(log_name)
         self.level = logging.ERROR
         self.deque: Deque[str] = deque(maxlen=100)

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -932,8 +932,7 @@ class TrackedObjectProcessor(threading.Thread):
         ptz_autotracker_thread,
         stop_event,
     ):
-        threading.Thread.__init__(self)
-        self.name = "detected_frames_processor"
+        super().__init__(name="detected_frames_processor")
         self.config = config
         self.dispatcher = dispatcher
         self.tracked_objects_queue = tracked_objects_queue

--- a/frigate/output/birdseye.py
+++ b/frigate/output/birdseye.py
@@ -122,8 +122,7 @@ class FFMpegConverter(threading.Thread):
         quality: int,
         birdseye_rtsp: bool = False,
     ):
-        threading.Thread.__init__(self)
-        self.name = "birdseye_output_converter"
+        super().__init__(name="birdseye_output_converter")
         self.camera = "birdseye"
         self.input_queue = input_queue
         self.stop_event = stop_event
@@ -235,7 +234,7 @@ class BroadcastThread(threading.Thread):
         websocket_server,
         stop_event: mp.Event,
     ):
-        super(BroadcastThread, self).__init__()
+        super().__init__()
         self.camera = camera
         self.converter = converter
         self.websocket_server = websocket_server

--- a/frigate/output/camera.py
+++ b/frigate/output/camera.py
@@ -24,8 +24,7 @@ class FFMpegConverter(threading.Thread):
         out_height: int,
         quality: int,
     ):
-        threading.Thread.__init__(self)
-        self.name = f"{camera}_output_converter"
+        super().__init__(name=f"{camera}_output_converter")
         self.camera = camera
         self.input_queue = input_queue
         self.stop_event = stop_event
@@ -102,7 +101,7 @@ class BroadcastThread(threading.Thread):
         websocket_server,
         stop_event: mp.Event,
     ):
-        super(BroadcastThread, self).__init__()
+        super().__init__()
         self.camera = camera
         self.converter = converter
         self.websocket_server = websocket_server

--- a/frigate/output/preview.py
+++ b/frigate/output/preview.py
@@ -66,8 +66,7 @@ class FFMpegConverter(threading.Thread):
         frame_times: list[float],
         requestor: InterProcessRequestor,
     ):
-        threading.Thread.__init__(self)
-        self.name = f"{config.name}_preview_converter"
+        super().__init__(name=f"{config.name}_preview_converter")
         self.config = config
         self.frame_times = frame_times
         self.requestor = requestor

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -149,8 +149,7 @@ class PtzAutoTrackerThread(threading.Thread):
         dispatcher: Dispatcher,
         stop_event: MpEvent,
     ) -> None:
-        threading.Thread.__init__(self)
-        self.name = "ptz_autotracker"
+        super().__init__(name="ptz_autotracker")
         self.ptz_autotracker = PtzAutoTracker(
             config, onvif, ptz_metrics, dispatcher, stop_event
         )

--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -23,8 +23,7 @@ class RecordingCleanup(threading.Thread):
     """Cleanup existing recordings based on retention config."""
 
     def __init__(self, config: FrigateConfig, stop_event: MpEvent) -> None:
-        threading.Thread.__init__(self)
-        self.name = "recording_cleanup"
+        super().__init__(name="recording_cleanup")
         self.config = config
         self.stop_event = stop_event
 

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -57,7 +57,7 @@ class RecordingExporter(threading.Thread):
         end_time: int,
         playback_factor: PlaybackFactorEnum,
     ) -> None:
-        threading.Thread.__init__(self)
+        super().__init__()
         self.config = config
         self.export_id = id
         self.camera = camera

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -62,8 +62,7 @@ class SegmentInfo:
 
 class RecordingMaintainer(threading.Thread):
     def __init__(self, config: FrigateConfig, stop_event: MpEvent):
-        threading.Thread.__init__(self)
-        self.name = "recording_maintainer"
+        super().__init__(name="recording_maintainer")
         self.config = config
 
         # create communication for retained recordings

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -146,8 +146,7 @@ class ReviewSegmentMaintainer(threading.Thread):
     """Maintain review segments."""
 
     def __init__(self, config: FrigateConfig, stop_event: MpEvent):
-        threading.Thread.__init__(self)
-        self.name = "review_segment_maintainer"
+        super().__init__(name="review_segment_maintainer")
         self.config = config
         self.active_review_segments: dict[str, Optional[PendingReviewSegment]] = {}
         self.frame_manager = SharedMemoryFrameManager()

--- a/frigate/stats/emitter.py
+++ b/frigate/stats/emitter.py
@@ -27,8 +27,7 @@ class StatsEmitter(threading.Thread):
         stats_tracking: StatsTrackingTypes,
         stop_event: MpEvent,
     ):
-        threading.Thread.__init__(self)
-        self.name = "frigate_stats_emitter"
+        super().__init__(name="frigate_stats_emitter")
         self.config = config
         self.stats_tracking = stats_tracking
         self.stop_event = stop_event

--- a/frigate/storage.py
+++ b/frigate/storage.py
@@ -22,8 +22,7 @@ class StorageMaintainer(threading.Thread):
     """Maintain frigates recording storage."""
 
     def __init__(self, config: FrigateConfig, stop_event) -> None:
-        threading.Thread.__init__(self)
-        self.name = "storage_maintainer"
+        super().__init__(name="storage_maintainer")
         self.config = config
         self.stop_event = stop_event
         self.camera_storage_stats: dict[str, dict] = {}

--- a/frigate/timeline.py
+++ b/frigate/timeline.py
@@ -23,8 +23,7 @@ class TimelineProcessor(threading.Thread):
         queue: Queue,
         stop_event: MpEvent,
     ) -> None:
-        threading.Thread.__init__(self)
-        self.name = "timeline_processor"
+        super().__init__(name="timeline_processor")
         self.config = config
         self.queue = queue
         self.stop_event = stop_event

--- a/frigate/watchdog.py
+++ b/frigate/watchdog.py
@@ -12,8 +12,7 @@ logger = logging.getLogger(__name__)
 
 class FrigateWatchdog(threading.Thread):
     def __init__(self, detectors: dict[str, ObjectDetectProcess], stop_event: MpEvent):
-        threading.Thread.__init__(self)
-        self.name = "frigate_watchdog"
+        super().__init__(name="frigate_watchdog")
         self.detectors = detectors
         self.stop_event = stop_event
 


### PR DESCRIPTION
## Proposed change
Do not call python super functions directly from the base class. It breaks MRO on multiple inheritance, but more importantly, it breaks convention.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)