### PR TITLE
Removed os._exit call that bypasses finalization

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -725,5 +725,3 @@ class FrigateApp:
             shm = self.detection_shms.pop()
             shm.close()
             shm.unlink()
-
-        os._exit(os.EX_OK)


### PR DESCRIPTION

## Proposed change
Title.

If you're having to os._exit at the end of the program, you've done something wrong. Fix what you did wrong instead.

## Additional information

This is the last of the no-brainer changes from #14045. I'll do the rest when 0.15 comes out.

<details>
<summary>Rant</summary>

FYI, when you want to release, you branch from dev into a branch for the new release and keep developing on dev. Otherwise, do what the linux kernel does and have a merge window. Pick your poison. But a 0.16 branch you randomly rebase to dev is 110% the wrong choice. Unless you love merge conflicts, in which case its great.

</details>

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code

## Pointless checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
