### PR TITLE
Fix autotracking absolute zoom interpolation logic

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -406,19 +406,19 @@ class OnvifController:
         # The onvif spec says this can report as +INF and -INF, so this may need to be modified
         pan = numpy.interp(
             pan,
-            [-1, 1],
             [
                 self.cams[camera_name]["relative_fov_range"]["XRange"]["Min"],
                 self.cams[camera_name]["relative_fov_range"]["XRange"]["Max"],
             ],
+            [-1, 1],
         )
         tilt = numpy.interp(
             tilt,
-            [-1, 1],
             [
                 self.cams[camera_name]["relative_fov_range"]["YRange"]["Min"],
                 self.cams[camera_name]["relative_fov_range"]["YRange"]["Max"],
             ],
+            [-1, 1],
         )
 
         move_request.Speed = {
@@ -531,11 +531,11 @@ class OnvifController:
         # function takes in 0 to 1 for zoom, interpolate to the values of the camera.
         zoom = numpy.interp(
             zoom,
-            [0, 1],
             [
                 self.cams[camera_name]["absolute_zoom_range"]["XRange"]["Min"],
                 self.cams[camera_name]["absolute_zoom_range"]["XRange"]["Max"],
             ],
+            [0, 1],
         )
 
         move_request.Speed = {"Zoom": speed}
@@ -686,11 +686,11 @@ class OnvifController:
             # store absolute zoom level as 0 to 1 interpolated from the values of the camera
             self.ptz_metrics[camera_name].zoom_level.value = numpy.interp(
                 round(status.Position.Zoom.x, 2),
-                [0, 1],
                 [
                     self.cams[camera_name]["absolute_zoom_range"]["XRange"]["Min"],
                     self.cams[camera_name]["absolute_zoom_range"]["XRange"]["Max"],
                 ],
+                [0, 1],
             )
             logger.debug(
                 f"{camera_name}: Camera zoom level: {self.ptz_metrics[camera_name].zoom_level.value}"


### PR DESCRIPTION
## Proposed change
The interpolation logic for tracking the zoom level when using absolute zooming with autotracking was reversed.

Panning/tilting interpolation was also corrected, but these values are -1 to 1 in the onvif spec already.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/issues/10184

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
