### PR TITLE
Revamp object snapshot tab

### DIFF
--- a/web/src/components/overlay/detail/ReviewDetailDialog.tsx
+++ b/web/src/components/overlay/detail/ReviewDetailDialog.tsx
@@ -279,7 +279,7 @@ function EventItem({
     <>
       <div
         className={cn(
-          "relative",
+          "relative mr-auto",
           !event.has_snapshot && "flex flex-row items-center justify-center",
         )}
         onMouseEnter={isDesktop ? () => setHovered(true) : undefined}


### PR DESCRIPTION
## Proposed change
Rather than using the Frigate+ dialog for the object snapshot pane in the search detail dialog, revamp it so that it optionally displays the Frigate+ submission card below the snapshot.

Also, left-justify the snapshots and thumbnails in the review item pane.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
