### PR TITLE
Log correct tensorRT version when debugging

### DIFF
--- a/frigate/detectors/plugins/tensorrt.py
+++ b/frigate/detectors/plugins/tensorrt.py
@@ -255,7 +255,7 @@ class TensorRtDetector(DetectionApi):
             raise RuntimeError("fail to allocate CUDA resources") from e
 
         logger.debug("TensorRT loaded. Input shape is %s", self.input_shape)
-        logger.debug("TensorRT version is %s", trt.__version__[0])
+        logger.debug("TensorRT version is %s", TRT_VERSION)
 
     def __del__(self):
         """Free CUDA memories."""


### PR DESCRIPTION
## Proposed change
When debugging, tensorRT will output the correct version if version is greater or equal than 10

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
