### PR TITLE
Initialize path before calling super()

### DIFF
--- a/frigate/db/sqlitevecq.py
+++ b/frigate/db/sqlitevecq.py
@@ -6,10 +6,9 @@ from playhouse.sqliteq import SqliteQueueDatabase
 class SqliteVecQueueDatabase(SqliteQueueDatabase):
     def __init__(self, *args, load_vec_extension: bool = False, **kwargs) -> None:
         self.load_vec_extension: bool = load_vec_extension
-        super().__init__(*args, **kwargs)
-
         # no extension necessary, sqlite will load correctly for each platform
         self.sqlite_vec_path = "/usr/local/lib/vec0"
+        super().__init__(*args, **kwargs)
 
     def _connect(self, *args, **kwargs) -> sqlite3.Connection:
         conn: sqlite3.Connection = super()._connect(*args, **kwargs)


### PR DESCRIPTION
## Proposed change
Fix a race condition introduced by https://github.com/blakeblackshear/frigate/pull/14163 - sqlite-vec parameters need to be initialized before calling `super()` because `_connect` may be called first.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
