### PR TITLE
Always display confidence chip on similarity searches

### DIFF
--- a/web/src/components/card/SearchThumbnail.tsx
+++ b/web/src/components/card/SearchThumbnail.tsx
@@ -79,19 +79,12 @@ export default function SearchThumbnail({
             <div className="flex">
               <TooltipTrigger asChild>
                 <div className="mx-3 pb-1 text-sm text-white">
-                  {
-                    <>
-                      <Chip
-                        className={`z-0 flex items-start justify-between space-x-1 bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500`}
-                        onClick={() => onClick(searchResult)}
-                      >
-                        {getIconForLabel(
-                          searchResult.label,
-                          "size-3 text-white",
-                        )}
-                      </Chip>
-                    </>
-                  }
+                  <Chip
+                    className={`z-0 flex items-start justify-between space-x-1 bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500`}
+                    onClick={() => onClick(searchResult)}
+                  >
+                    {getIconForLabel(searchResult.label, "size-3 text-white")}
+                  </Chip>
                 </div>
               </TooltipTrigger>
             </div>

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -390,7 +390,8 @@ export default function SearchView({
                         findSimilar={() => setSimilaritySearch(value)}
                         onClick={() => onSelectSearch(value, index)}
                       />
-                      {searchTerm && (
+                      {(searchTerm ||
+                        searchFilter?.search_type?.includes("similarity")) && (
                         <div className={cn("absolute right-2 top-2 z-40")}>
                           <Tooltip>
                             <TooltipTrigger>


### PR DESCRIPTION
## Proposed change
The confidence chip would only display on similarity searches after a text-based query. This PR ensures they show on every similarity search.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
