### PR TITLE
Search fixes

### DIFF
--- a/web/src/components/input/InputWithTags.tsx
+++ b/web/src/components/input/InputWithTags.tsx
@@ -397,6 +397,11 @@ export default function InputWithTags({
     setIsSimilaritySearch(false);
   }, [setFilters, resetSuggestions, setSearch, setInputFocused]);
 
+  const handleClearSimilarity = useCallback(() => {
+    removeFilter("event_id", filters.event_id!);
+    removeFilter("search_type", "similarity");
+  }, [removeFilter, filters]);
+
   const handleInputBlur = useCallback(
     (e: React.FocusEvent) => {
       if (
@@ -638,7 +643,7 @@ export default function InputWithTags({
                   <span className="inline-flex items-center whitespace-nowrap rounded-full bg-blue-100 px-2 py-0.5 text-sm text-blue-800">
                     Similarity Search
                     <button
-                      onClick={handleClearInput}
+                      onClick={handleClearSimilarity}
                       className="ml-1 focus:outline-none"
                       aria-label="Clear similarity search"
                     >

--- a/web/src/pages/Explore.tsx
+++ b/web/src/pages/Explore.tsx
@@ -225,10 +225,11 @@ export default function Explore() {
   };
 
   if (
-    !minilmModelState ||
-    !minilmTokenizerState ||
-    !clipImageModelState ||
-    !clipTextModelState
+    config?.semantic_search.enabled &&
+    (!minilmModelState ||
+      !minilmTokenizerState ||
+      !clipImageModelState ||
+      !clipTextModelState)
   ) {
     return (
       <ActivityIndicator className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2" />
@@ -237,7 +238,7 @@ export default function Explore() {
 
   return (
     <>
-      {!allModelsLoaded ? (
+      {config?.semantic_search.enabled && !allModelsLoaded ? (
         <div className="absolute inset-0 left-1/2 top-1/2 flex h-96 w-96 -translate-x-1/2 -translate-y-1/2">
           <div className="flex flex-col items-center justify-center space-y-3 rounded-lg bg-background/50 p-5">
             <div className="my-5 flex flex-col items-center gap-2 text-xl">


### PR DESCRIPTION
## Proposed change
- Ensure semantic search is enabled before checking model download state. Users without semantic search enabled would see an endless spinner on the Explore page.
- Only clear similarity search filters when clicking the "x" in the Similarity Search pill. The old behavior cleared all the filters.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
