### PR TITLE
Improve docs on exports API endpoints

### DIFF
--- a/docs/docs/integrations/api.md
+++ b/docs/docs/integrations/api.md
@@ -411,6 +411,25 @@ HTTP Live Streaming Video on Demand URL for the specified event. Can be viewed i
 
 HTTP Live Streaming Video on Demand URL for the camera with the specified time range. Can be viewed in an application like VLC.
 
+### `GET /api/exports`
+
+Fetch a list of all export recordings
+
+Sample response:
+```json
+[
+  {
+    "camera": "doorbell",
+    "date": 12800057,
+    "id": "doorbell_pjis54",
+    "in_progress": false,
+    "name": "2024-10-04 fox visit",
+    "thumb_path": "/media/frigate/clips/export/doorbell_pjis54.webp",
+    "video_path": "/media/frigate/exports/doorbell_pjis54.mp4"
+  }
+]
+```
+
 ### `POST /api/export/<camera>/start/<start-timestamp>/end/<end-timestamp>`
 
 Export recordings from `start-timestamp` to `end-timestamp` for `camera` as a single mp4 file. These recordings will be exported to the `/media/frigate/exports` folder.

--- a/docs/docs/integrations/api.md
+++ b/docs/docs/integrations/api.md
@@ -415,13 +415,14 @@ HTTP Live Streaming Video on Demand URL for the camera with the specified time r
 
 Export recordings from `start-timestamp` to `end-timestamp` for `camera` as a single mp4 file. These recordings will be exported to the `/media/frigate/exports` folder.
 
-It is also possible to export this recording as a time-lapse.
+It is also possible to export this recording as a time-lapse using the "playback" key in the json body, or specify a custom export filename, using the "name" key.
 
 **Optional Body:**
 
 ```json
 {
-  "playback": "realtime" // playback factor: realtime or timelapse_25x
+  "playback": "realtime", // playback factor: realtime or timelapse_25x
+  "name": "custom export name" // override the default export filename with a custom name
 }
 ```
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
- Adding comments about the optional "name" parameter for the API endpoint to create a new export.
- Adding an entry in the documentation about the /api/exports endpoint


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code (docs)
(Not sure if docs should be a separate type here, or whether this counts as new feature, for documenting features without docs, or bugfix for adding docs where they perhaps should have existed)

## Additional information

I was unsure whether this merges into dev or master, but I saw other PRs merged into master when updating docs (for example #14202) and dev branch will be headed towards post-0.14 changes now I suppose.
Originally I was planning to add an issue asking why these features weren't available in the API, but then I checked the API source and found they do exist.

One question I do have is that it seems like the /api/exports endpoint lists the video path relative to the container root, rather than relative to the web root. Is that intended? Should a user of that API strip "/media/frigate" from the video path, or that they should just use the export ID as `{frigate_url}/exports/{export_id}.mp4`

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`ruff format frigate`) 
  (Not applicable for the docs directory?)

Screenshot:
![image](https://github.com/user-attachments/assets/b3f489a6-a991-40f1-ad8f-58b9de1a858f)


