### PR TITLE
Restructure embeddings

### DIFF
--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -472,7 +472,7 @@ def events_search(request: Request, params: EventsSearchQueryParams = Depends())
                 status_code=404,
             )
 
-        thumb_result = context.embeddings.search_thumbnail(search_event)
+        thumb_result = context.search_thumbnail(search_event)
         thumb_ids = dict(
             zip(
                 [result[0] for result in thumb_result],
@@ -487,7 +487,7 @@ def events_search(request: Request, params: EventsSearchQueryParams = Depends())
         search_types = search_type.split(",")
 
         if "thumbnail" in search_types:
-            thumb_result = context.embeddings.search_thumbnail(query)
+            thumb_result = context.search_thumbnail(query)
             thumb_ids = dict(
                 zip(
                     [result[0] for result in thumb_result],
@@ -504,7 +504,7 @@ def events_search(request: Request, params: EventsSearchQueryParams = Depends())
             )
 
         if "description" in search_types:
-            desc_result = context.embeddings.search_description(query)
+            desc_result = context.search_description(query)
             desc_ids = dict(
                 zip(
                     [result[0] for result in desc_result],
@@ -1033,8 +1033,8 @@ def delete_event(request: Request, event_id: str):
     # If semantic search is enabled, update the index
     if request.app.frigate_config.semantic_search.enabled:
         context: EmbeddingsContext = request.app.embeddings
-        context.embeddings.delete_thumbnail(id=[event_id])
-        context.embeddings.delete_description(id=[event_id])
+        context.db.delete_embeddings_thumbnail(id=[event_id])
+        context.db.delete_embeddings_description(id=[event_id])
     return JSONResponse(
         content=({"success": True, "message": "Event " + event_id + " deleted"}),
         status_code=200,

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -944,9 +944,9 @@ def set_description(
     # If semantic search is enabled, update the index
     if request.app.frigate_config.semantic_search.enabled:
         context: EmbeddingsContext = request.app.embeddings
-        context.embeddings.upsert_description(
-            event_id=event_id,
-            description=new_description,
+        context.update_description(
+            event_id,
+            new_description,
         )
 
     response_message = (

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -276,7 +276,7 @@ class FrigateApp:
     def init_embeddings_client(self) -> None:
         if self.config.semantic_search.enabled:
             # Create a client for other processes to use
-            self.embeddings = EmbeddingsContext(self.config, self.db)
+            self.embeddings = EmbeddingsContext(self.db)
 
     def init_external_event_processor(self) -> None:
         self.external_event_processor = ExternalEventProcessor(self.config)
@@ -699,7 +699,7 @@ class FrigateApp:
 
         # Save embeddings stats to disk
         if self.embeddings:
-            self.embeddings.save_stats()
+            self.embeddings.stop()
 
         # Stop Communicators
         self.inter_process_communicator.stop()

--- a/frigate/comms/embeddings_updater.py
+++ b/frigate/comms/embeddings_updater.py
@@ -1,0 +1,62 @@
+"""Facilitates communication between processes."""
+
+from enum import Enum
+from typing import Callable
+
+import zmq
+
+SOCKET_REP_REQ = "ipc:///tmp/cache/embeddings"
+
+
+class EmbeddingsRequestEnum(Enum):
+    embed_description = "embed_description"
+    embed_thumbnail = "embed_thumbnail"
+    generate_search = "generate_search"
+
+
+class EmbeddingsResponder:
+    def __init__(self) -> None:
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.REP)
+        self.socket.bind(SOCKET_REP_REQ)
+
+    def check_for_request(self, process: Callable) -> None:
+        while True:  # load all messages that are queued
+            has_message, _, _ = zmq.select([self.socket], [], [], 1)
+
+            if not has_message:
+                break
+
+            try:
+                (topic, value) = self.socket.recv_json(flags=zmq.NOBLOCK)
+
+                response = process(topic, value)
+
+                if response is not None:
+                    self.socket.send_json(response)
+                else:
+                    self.socket.send_json([])
+            except zmq.ZMQError:
+                break
+
+    def stop(self) -> None:
+        self.socket.close()
+        self.context.destroy()
+
+
+class EmbeddingsRequestor:
+    """Simplifies sending data to EmbeddingsResponder and getting a reply."""
+
+    def __init__(self) -> None:
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.REQ)
+        self.socket.connect(SOCKET_REP_REQ)
+
+    def send_data(self, topic: str, data: any) -> any:
+        """Sends data and then waits for reply."""
+        self.socket.send_json((topic, data))
+        return self.socket.recv_json()
+
+    def stop(self) -> None:
+        self.socket.close()
+        self.context.destroy()

--- a/frigate/comms/embeddings_updater.py
+++ b/frigate/comms/embeddings_updater.py
@@ -52,7 +52,7 @@ class EmbeddingsRequestor:
         self.socket = self.context.socket(zmq.REQ)
         self.socket.connect(SOCKET_REP_REQ)
 
-    def send_data(self, topic: str, data: any) -> any:
+    def send_data(self, topic: str, data: any) -> str:
         """Sends data and then waits for reply."""
         self.socket.send_json((topic, data))
         return self.socket.recv_json()

--- a/frigate/db/sqlitevecq.py
+++ b/frigate/db/sqlitevecq.py
@@ -20,3 +20,15 @@ class SqliteVecQueueDatabase(SqliteQueueDatabase):
         conn.enable_load_extension(True)
         conn.load_extension(self.sqlite_vec_path)
         conn.enable_load_extension(False)
+
+    def delete_embeddings_thumbnail(self, event_ids: list[str]) -> None:
+        ids = ",".join(["?" for _ in event_ids])
+        self.execute_sql(
+            f"DELETE FROM vec_thumbnails WHERE id IN ({ids})", event_ids
+        )
+
+    def delete_embeddings_description(self, event_ids: list[str]) -> None:
+        ids = ",".join(["?" for _ in event_ids])
+        self.execute_sql(
+            f"DELETE FROM vec_descriptions WHERE id IN ({ids})", event_ids
+        )

--- a/frigate/db/sqlitevecq.py
+++ b/frigate/db/sqlitevecq.py
@@ -23,12 +23,8 @@ class SqliteVecQueueDatabase(SqliteQueueDatabase):
 
     def delete_embeddings_thumbnail(self, event_ids: list[str]) -> None:
         ids = ",".join(["?" for _ in event_ids])
-        self.execute_sql(
-            f"DELETE FROM vec_thumbnails WHERE id IN ({ids})", event_ids
-        )
+        self.execute_sql(f"DELETE FROM vec_thumbnails WHERE id IN ({ids})", event_ids)
 
     def delete_embeddings_description(self, event_ids: list[str]) -> None:
         ids = ",".join(["?" for _ in event_ids])
-        self.execute_sql(
-            f"DELETE FROM vec_descriptions WHERE id IN ({ids})", event_ids
-        )
+        self.execute_sql(f"DELETE FROM vec_descriptions WHERE id IN ({ids})", event_ids)

--- a/frigate/embeddings/__init__.py
+++ b/frigate/embeddings/__init__.py
@@ -16,7 +16,7 @@ from frigate.config import FrigateConfig
 from frigate.const import CONFIG_DIR
 from frigate.db.sqlitevecq import SqliteVecQueueDatabase
 from frigate.models import Event
-from frigate.util.builtin import deserialize, serialize
+from frigate.util.builtin import serialize
 from frigate.util.services import listen
 
 from .embeddings import Embeddings

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -12,6 +12,7 @@ import numpy as np
 from peewee import DoesNotExist
 from playhouse.sqliteq import SqliteQueueDatabase
 
+from frigate.comms.embeddings_updater import EmbeddingsRequestEnum, EmbeddingsResponder
 from frigate.comms.event_metadata_updater import (
     EventMetadataSubscriber,
     EventMetadataTypeEnum,
@@ -48,6 +49,7 @@ class EmbeddingMaintainer(threading.Thread):
         self.event_metadata_subscriber = EventMetadataSubscriber(
             EventMetadataTypeEnum.regenerate_description
         )
+        self.embeddings_responder = EmbeddingsResponder()
         self.frame_manager = SharedMemoryFrameManager()
         # create communication for updating event descriptions
         self.requestor = InterProcessRequestor()
@@ -58,6 +60,7 @@ class EmbeddingMaintainer(threading.Thread):
     def run(self) -> None:
         """Maintain a SQLite-vec database for semantic search."""
         while not self.stop_event.is_set():
+            self._process_requests()
             self._process_updates()
             self._process_finalized()
             self._process_event_metadata()
@@ -65,8 +68,25 @@ class EmbeddingMaintainer(threading.Thread):
         self.event_subscriber.stop()
         self.event_end_subscriber.stop()
         self.event_metadata_subscriber.stop()
+        self.embeddings_responder.stop()
         self.requestor.stop()
         logger.info("Exiting embeddings maintenance...")
+
+    def _process_requests(self) -> None:
+        """Process embeddings requests"""
+
+        def handle_request(topic: str, data: str) -> any:
+            if topic == EmbeddingsRequestEnum.embed_description:
+                return self.embeddings.upsert_description(
+                    data["id"], data["description"]
+                )
+            elif topic == EmbeddingsRequestEnum.embed_thumbnail:
+                thumbnail = base64.b64decode(data["thumbnail"])
+                return self.embeddings.upsert_thumbnail(data["id"], thumbnail)
+            elif topic == EmbeddingsRequestEnum.generate_search:
+                return self.embeddings.text_embedding([data])[0]
+
+        self.embeddings_responder.check_for_request(handle_request)
 
     def _process_updates(self) -> None:
         """Process event updates"""

--- a/frigate/util/builtin.py
+++ b/frigate/util/builtin.py
@@ -345,7 +345,7 @@ def generate_color_palette(n):
     return colors
 
 
-def serialize(vector: Union[list[float], np.ndarray, float]) -> bytes:
+def serialize(vector: Union[list[float], np.ndarray, float], pack: bool = True) -> bytes:
     """Serializes a list of floats, numpy array, or single float into a compact "raw bytes" format"""
     if isinstance(vector, np.ndarray):
         # Convert numpy array to list of floats
@@ -359,7 +359,10 @@ def serialize(vector: Union[list[float], np.ndarray, float]) -> bytes:
         )
 
     try:
-        return struct.pack("%sf" % len(vector), *vector)
+        if pack:
+            return struct.pack("%sf" % len(vector), *vector)
+        else:
+            return vector
     except struct.error as e:
         raise ValueError(f"Failed to pack vector: {e}. Vector: {vector}")
 

--- a/frigate/util/builtin.py
+++ b/frigate/util/builtin.py
@@ -8,10 +8,11 @@ import multiprocessing as mp
 import queue
 import re
 import shlex
+import struct
 import urllib.parse
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, Union
 
 import numpy as np
 import pytz
@@ -342,3 +343,27 @@ def generate_color_palette(n):
         colors.append(interpolate(color1, color2, factor))
 
     return colors
+
+
+def serialize(vector: Union[list[float], np.ndarray, float]) -> bytes:
+    """Serializes a list of floats, numpy array, or single float into a compact "raw bytes" format"""
+    if isinstance(vector, np.ndarray):
+        # Convert numpy array to list of floats
+        vector = vector.flatten().tolist()
+    elif isinstance(vector, (float, np.float32, np.float64)):
+        # Handle single float values
+        vector = [vector]
+    elif not isinstance(vector, list):
+        raise TypeError(
+            f"Input must be a list of floats, a numpy array, or a single float. Got {type(vector)}"
+        )
+
+    try:
+        return struct.pack("%sf" % len(vector), *vector)
+    except struct.error as e:
+        raise ValueError(f"Failed to pack vector: {e}. Vector: {vector}")
+
+
+def deserialize(bytes_data: bytes) -> list[float]:
+    """Deserializes a compact "raw bytes" format into a list of floats"""
+    return list(struct.unpack("%sf" % (len(bytes_data) // 4), bytes_data))

--- a/frigate/util/builtin.py
+++ b/frigate/util/builtin.py
@@ -345,7 +345,9 @@ def generate_color_palette(n):
     return colors
 
 
-def serialize(vector: Union[list[float], np.ndarray, float], pack: bool = True) -> bytes:
+def serialize(
+    vector: Union[list[float], np.ndarray, float], pack: bool = True
+) -> bytes:
     """Serializes a list of floats, numpy array, or single float into a compact "raw bytes" format"""
     if isinstance(vector, np.ndarray):
         # Convert numpy array to list of floats


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

This PR removes the embeddings encapsulation from embeddings context and replaces it with a ZMQ proxy. This ensures that only one process interacts with the model so the model is not loaded multiple times. 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
