### PR TITLE
Allow empty description for tracked objects

### DIFF
--- a/frigate/api/defs/events_body.py
+++ b/frigate/api/defs/events_body.py
@@ -11,9 +11,7 @@ class EventsSubLabelBody(BaseModel):
 
 
 class EventsDescriptionBody(BaseModel):
-    description: Union[str, None] = Field(
-        title="The description of the event", min_length=1
-    )
+    description: Union[str, None] = Field(title="The description of the event")
 
 
 class EventsCreateBody(BaseModel):

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -939,7 +939,7 @@ def set_description(
                 new_description,
             )
         else:
-            context.db.delete_embeddings_description(event_id)
+            context.db.delete_embeddings_description(event_ids=[event_id])
 
     response_message = (
         f"Event {event_id} description is now blank"
@@ -1025,8 +1025,8 @@ def delete_event(request: Request, event_id: str):
     # If semantic search is enabled, update the index
     if request.app.frigate_config.semantic_search.enabled:
         context: EmbeddingsContext = request.app.embeddings
-        context.db.delete_embeddings_thumbnail(id=[event_id])
-        context.db.delete_embeddings_description(id=[event_id])
+        context.db.delete_embeddings_thumbnail(event_ids=[event_id])
+        context.db.delete_embeddings_description(event_ids=[event_id])
     return JSONResponse(
         content=({"success": True, "message": "Event " + event_id + " deleted"}),
         status_code=200,

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -927,27 +927,19 @@ def set_description(
 
     new_description = body.description
 
-    if new_description is None or len(new_description) == 0:
-        return JSONResponse(
-            content=(
-                {
-                    "success": False,
-                    "message": "description cannot be empty",
-                }
-            ),
-            status_code=400,
-        )
-
     event.data["description"] = new_description
     event.save()
 
     # If semantic search is enabled, update the index
     if request.app.frigate_config.semantic_search.enabled:
         context: EmbeddingsContext = request.app.embeddings
-        context.update_description(
-            event_id,
-            new_description,
-        )
+        if len(new_description) > 0:
+            context.update_description(
+                event_id,
+                new_description,
+            )
+        else:
+            context.db.delete_embeddings_description(event_id)
 
     response_message = (
         f"Event {event_id} description is now blank"

--- a/frigate/events/cleanup.py
+++ b/frigate/events/cleanup.py
@@ -229,8 +229,8 @@ class EventCleanup(threading.Thread):
                     Event.delete().where(Event.id << chunk).execute()
 
                     if self.config.semantic_search.enabled:
-                        self.db.delete_embeddings_description(chunk)
-                        self.db.delete_embeddings_thumbnail(chunk)
+                        self.db.delete_embeddings_description(event_ids=[chunk])
+                        self.db.delete_embeddings_thumbnail(event_ids=[chunk])
                         logger.debug(f"Deleted {len(events_to_delete)} embeddings")
 
         logger.info("Exiting event cleanup...")


### PR DESCRIPTION
## Proposed change
The Fast API changes set a min length for a string to be 1. This PR allows a blank description to be set for a tracked object. Also fixes a bug where embeddings would not be removed when when deleting events via the API.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
