### PR TITLE
Use number keys on keyboard to move ptz camera to presets

### DIFF
--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -531,9 +531,37 @@ function PtzControlPanel({
   );
 
   useKeyboardListener(
-    ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "+", "-"],
+    [
+      "ArrowLeft",
+      "ArrowRight",
+      "ArrowUp",
+      "ArrowDown",
+      "+",
+      "-",
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+    ],
     (key, modifiers) => {
-      if (modifiers.repeat) {
+      if (modifiers.repeat || !key) {
+        return;
+      }
+
+      if (["1", "2", "3", "4", "5", "6", "7", "8", "9"].includes(key)) {
+        const presetNumber = parseInt(key);
+        if (
+          ptz &&
+          (ptz?.presets?.length ?? 0) > 0 &&
+          presetNumber <= ptz.presets.length
+        ) {
+          sendPtz(`preset_${ptz.presets[presetNumber - 1]}`);
+        }
         return;
       }
 

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -557,7 +557,7 @@ function PtzControlPanel({
         const presetNumber = parseInt(key);
         if (
           ptz &&
-          (ptz?.presets?.length ?? 0) > 0 &&
+          (ptz.presets?.length ?? 0) > 0 &&
           presetNumber <= ptz.presets.length
         ) {
           sendPtz(`preset_${ptz.presets[presetNumber - 1]}`);


### PR DESCRIPTION
## Proposed change
Add ability to use the number keys on the keyboard to select ptz presets from the single camera Live view.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: closes https://github.com/blakeblackshear/frigate/issues/12959
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
