### PR TITLE
Embeddings normalization fixes

### DIFF
--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -473,12 +473,7 @@ def events_search(request: Request, params: EventsSearchQueryParams = Depends())
             )
 
         thumb_result = context.search_thumbnail(search_event)
-        thumb_ids = dict(
-            zip(
-                [result[0] for result in thumb_result],
-                context.thumb_stats.normalize([result[1] for result in thumb_result]),
-            )
-        )
+        thumb_ids = {result[0]: result[1] for result in thumb_result}
         search_results = {
             event_id: {"distance": distance, "source": "thumbnail"}
             for event_id, distance in thumb_ids.items()
@@ -486,15 +481,23 @@ def events_search(request: Request, params: EventsSearchQueryParams = Depends())
     else:
         search_types = search_type.split(",")
 
+        # only normalize multi-modal searches
+        apply_normalization = (
+            "thumbnail" in search_types and "description" in search_types
+        )
+
         if "thumbnail" in search_types:
             thumb_result = context.search_thumbnail(query)
-            thumb_ids = dict(
-                zip(
-                    [result[0] for result in thumb_result],
-                    context.thumb_stats.normalize(
-                        [result[1] for result in thumb_result]
-                    ),
+
+            if apply_normalization:
+                thumb_distances = context.thumb_stats.normalize(
+                    [result[1] for result in thumb_result]
                 )
+            else:
+                thumb_distances = [result[1] for result in thumb_result]
+
+            thumb_ids = dict(
+                zip([result[0] for result in thumb_result], thumb_distances)
             )
             search_results.update(
                 {
@@ -505,12 +508,17 @@ def events_search(request: Request, params: EventsSearchQueryParams = Depends())
 
         if "description" in search_types:
             desc_result = context.search_description(query)
-            desc_ids = dict(
-                zip(
-                    [result[0] for result in desc_result],
-                    context.desc_stats.normalize([result[1] for result in desc_result]),
+            if apply_normalization:
+                desc_distances = context.desc_stats.normalize(
+                    [result[1] for result in desc_result]
                 )
-            )
+            else:
+                desc_distances = [
+                    result[1] for result in desc_result
+                ]  # Use raw distances
+
+            desc_ids = dict(zip([result[0] for result in desc_result], desc_distances))
+
             for event_id, distance in desc_ids.items():
                 if (
                     event_id not in search_results

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -481,20 +481,15 @@ def events_search(request: Request, params: EventsSearchQueryParams = Depends())
     else:
         search_types = search_type.split(",")
 
-        # only normalize multi-modal searches
-        apply_normalization = (
-            "thumbnail" in search_types and "description" in search_types
-        )
+        # only save stats for multi-modal searches
+        save_stats = "thumbnail" in search_types and "description" in search_types
 
         if "thumbnail" in search_types:
             thumb_result = context.search_thumbnail(query)
 
-            if apply_normalization:
-                thumb_distances = context.thumb_stats.normalize(
-                    [result[1] for result in thumb_result]
-                )
-            else:
-                thumb_distances = [result[1] for result in thumb_result]
+            thumb_distances = context.thumb_stats.normalize(
+                [result[1] for result in thumb_result], save_stats
+            )
 
             thumb_ids = dict(
                 zip([result[0] for result in thumb_result], thumb_distances)
@@ -508,14 +503,10 @@ def events_search(request: Request, params: EventsSearchQueryParams = Depends())
 
         if "description" in search_types:
             desc_result = context.search_description(query)
-            if apply_normalization:
-                desc_distances = context.desc_stats.normalize(
-                    [result[1] for result in desc_result]
-                )
-            else:
-                desc_distances = [
-                    result[1] for result in desc_result
-                ]  # Use raw distances
+
+            desc_distances = context.desc_stats.normalize(
+                [result[1] for result in desc_result], save_stats
+            )
 
             desc_ids = dict(zip([result[0] for result in desc_result], desc_distances))
 

--- a/frigate/db/sqlitevecq.py
+++ b/frigate/db/sqlitevecq.py
@@ -42,12 +42,12 @@ class SqliteVecQueueDatabase(SqliteQueueDatabase):
         self.execute_sql("""
             CREATE VIRTUAL TABLE IF NOT EXISTS vec_thumbnails USING vec0(
                 id TEXT PRIMARY KEY,
-                thumbnail_embedding FLOAT[768]
+                thumbnail_embedding FLOAT[768] distance_metric=cosine
             );
         """)
         self.execute_sql("""
             CREATE VIRTUAL TABLE IF NOT EXISTS vec_descriptions USING vec0(
                 id TEXT PRIMARY KEY,
-                description_embedding FLOAT[768]
+                description_embedding FLOAT[768] distance_metric=cosine
             );
         """)

--- a/frigate/embeddings/util.py
+++ b/frigate/embeddings/util.py
@@ -20,7 +20,7 @@ class ZScoreNormalization:
 
     @property
     def stddev(self):
-        return math.sqrt(self.variance)
+        return math.sqrt(self.variance) if self.variance > 0 else 0.0
 
     def normalize(self, distances: list[float]):
         self._update(distances)

--- a/frigate/embeddings/util.py
+++ b/frigate/embeddings/util.py
@@ -22,8 +22,9 @@ class ZScoreNormalization:
     def stddev(self):
         return math.sqrt(self.variance) if self.variance > 0 else 0.0
 
-    def normalize(self, distances: list[float]):
-        self._update(distances)
+    def normalize(self, distances: list[float], save_stats: bool):
+        if save_stats:
+            self._update(distances)
         if self.stddev == 0:
             return distances
         return [

--- a/web/src/pages/Explore.tsx
+++ b/web/src/pages/Explore.tsx
@@ -2,6 +2,7 @@ import {
   useEmbeddingsReindexProgress,
   useEventUpdate,
   useModelState,
+  useWs,
 } from "@/api/ws";
 import ActivityIndicator from "@/components/indicators/activity-indicator";
 import AnimatedCircularProgressBar from "@/components/ui/circular-progress-bar";
@@ -201,6 +202,14 @@ export default function Explore() {
   );
 
   // model states
+
+  const { send: sendCommand } = useWs("model_state", "modelState");
+
+  useEffect(() => {
+    sendCommand("modelState");
+    // only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { payload: textModelState } = useModelState(
     "jinaai/jina-clip-v1-text_model_fp16.onnx",

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -187,13 +187,23 @@ export default function SearchView({
     }
   }, [searchResults, searchDetail]);
 
-  // confidence score - probably needs tweaking
+  // confidence score
 
   const zScoreToConfidence = (score: number) => {
-    // Sigmoid function: 1 / (1 + e^x)
-    const confidence = 1 / (1 + Math.exp(score));
+    // Normalizing is needed for multi-modal searches only
+    // Sigmoid function for normalized: 1 / (1 + e^x)
+    // Cosine for non-normalized
+    if (searchFilter) {
+      const normalized =
+        !searchFilter.search_type ||
+        (Array.isArray(searchFilter.search_type) &&
+          searchFilter.search_type.length === 2 &&
+          searchFilter.search_type.includes("thumbnail") &&
+          searchFilter.search_type.includes("description"));
+      const confidence = normalized ? 1 / (1 + Math.exp(score)) : 1 - score;
 
-    return Math.round(confidence * 100);
+      return Math.round(confidence * 100);
+    }
   };
 
   const hasExistingSearch = useMemo(

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -190,17 +190,13 @@ export default function SearchView({
   // confidence score
 
   const zScoreToConfidence = (score: number) => {
-    // Normalizing is needed for multi-modal searches only
+    // Normalizing is not needed for similarity searches
     // Sigmoid function for normalized: 1 / (1 + e^x)
-    // Cosine for non-normalized
+    // Cosine for similarity
     if (searchFilter) {
-      const normalized =
-        !searchFilter.search_type ||
-        (Array.isArray(searchFilter.search_type) &&
-          searchFilter.search_type.length === 2 &&
-          searchFilter.search_type.includes("thumbnail") &&
-          searchFilter.search_type.includes("description"));
-      const confidence = normalized ? 1 / (1 + Math.exp(score)) : 1 - score;
+      const notNormalized = searchFilter?.search_type?.includes("similarity");
+
+      const confidence = notNormalized ? 1 - score : 1 / (1 + Math.exp(score));
 
       return Math.round(confidence * 100);
     }


### PR DESCRIPTION
## Proposed change
For the Jina AI models, text-text cosine similarity is normally larger than text-image cosine similarity. This PR applies normalization for all vector based searches, uses cosine similarity on image-image searches, and only saves Z score normalization stats for multi-modal searches.

- Use cosine distance instead of euclidean distance for vector tables (requires users to reindex embeddings)
- Ensure we fetch model state on Explore page load


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

**Users running the dev builds will have to set `reindex: True` in their config to regenerate their embeddings as distance function has now been changed to cosine.**


## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
