### PR TITLE
Reduce onnx memory usage

### DIFF
--- a/frigate/util/model.py
+++ b/frigate/util/model.py
@@ -16,7 +16,14 @@ def get_ort_providers(
     force_cpu: bool = False, openvino_device: str = "AUTO", requires_fp16: bool = False
 ) -> tuple[list[str], list[dict[str, any]]]:
     if force_cpu:
-        return (["CPUExecutionProvider"], [{}])
+        return (
+            ["CPUExecutionProvider"],
+            [
+                {
+                    "arena_extend_strategy": "kSameAsRequested",
+                }
+            ],
+        )
 
     providers = ort.get_available_providers()
     options = []
@@ -28,6 +35,7 @@ def get_ort_providers(
             if not requires_fp16 or os.environ.get("USE_FP_16", "True") != "False":
                 options.append(
                     {
+                        "arena_extend_strategy": "kSameAsRequested",
                         "trt_fp16_enable": requires_fp16,
                         "trt_timing_cache_enable": True,
                         "trt_engine_cache_enable": True,
@@ -41,8 +49,15 @@ def get_ort_providers(
             os.makedirs("/config/model_cache/openvino/ort", exist_ok=True)
             options.append(
                 {
+                    "arena_extend_strategy": "kSameAsRequested",
                     "cache_dir": "/config/model_cache/openvino/ort",
                     "device_type": openvino_device,
+                }
+            )
+        elif provider == "CPUExecutionProvider":
+            options.append(
+                {
+                    "arena_extend_strategy": "kSameAsRequested",
                 }
             )
         else:


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

This PR changes the onnx config to only pre-allocate as much memory to the heap as the first inference requires. This greatly reduces memory usage of running onnx models. 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
