### PR TITLE
Fix substitution on genai prompts

### DIFF
--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -259,7 +259,7 @@ class EmbeddingMaintainer(threading.Thread):
         camera_config = self.config.cameras[event.camera]
 
         description = self.genai_client.generate_description(
-            camera_config, thumbnails, event.label
+            camera_config, thumbnails, event
         )
 
         if not description:

--- a/frigate/genai/__init__.py
+++ b/frigate/genai/__init__.py
@@ -5,6 +5,7 @@ import os
 from typing import Optional
 
 from frigate.config import CameraConfig, GenAIConfig, GenAIProviderEnum
+from frigate.models import Event
 
 PROVIDERS = {}
 
@@ -31,12 +32,12 @@ class GenAIClient:
         self,
         camera_config: CameraConfig,
         thumbnails: list[bytes],
-        label: str,
+        event: Event,
     ) -> Optional[str]:
         """Generate a description for the frame."""
         prompt = camera_config.genai.object_prompts.get(
-            label, camera_config.genai.prompt
-        ).format(label=label)
+            event.label, camera_config.genai.prompt
+        ).format(**event)
         return self._send(prompt, thumbnails)
 
     def _init_provider(self):


### PR DESCRIPTION
## Proposed change
Changes in https://github.com/blakeblackshear/frigate/pull/14256 only partially fixed the genai description substitution logic. This fix permits the documented fields like `{camera}` and `{sub_label}` to be correctly interpreted again.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- This PR is related to issue: https://github.com/blakeblackshear/frigate/discussions/14251

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
