### PR TITLE
Only revalidate if event update is valid

### DIFF
--- a/web/src/pages/Explore.tsx
+++ b/web/src/pages/Explore.tsx
@@ -184,7 +184,9 @@ export default function Explore() {
   const eventUpdate = useEventUpdate();
 
   useEffect(() => {
-    mutate();
+    if (eventUpdate) {
+      mutate();
+    }
     // mutate / revalidate when event description updates come in
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [eventUpdate]);


### PR DESCRIPTION
## Proposed change
useSWRInfinite was making multiple requests on the search page when reloading. This was because `mutate()` was being called too many times. This PR just ensures eventUpdate is valid before calling mutate.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
