### PR TITLE
Add ability to rename camera groups

### DIFF
--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -645,7 +645,7 @@ export function CameraGroupEdit({
 
       let renamingQuery = "";
       if (editingGroup && editingGroup[0] !== values.name) {
-        renamingQuery = `&camera_groups.${editingGroup?.[0]}`;
+        renamingQuery = `&camera_groups.${editingGroup[0]}`;
       }
 
       const order =

--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -643,6 +643,11 @@ export function CameraGroupEdit({
 
       setIsLoading(true);
 
+      let renamingQuery = "";
+      if (editingGroup && editingGroup[0] !== values.name) {
+        renamingQuery = `&camera_groups.${editingGroup?.[0]}`;
+      }
+
       const order =
         editingGroup === undefined
           ? currentGroups.length + 1
@@ -655,9 +660,12 @@ export function CameraGroupEdit({
         .join("");
 
       axios
-        .put(`config/set?${orderQuery}&${iconQuery}${cameraQueries}`, {
-          requires_restart: 0,
-        })
+        .put(
+          `config/set?${renamingQuery}&${orderQuery}&${iconQuery}${cameraQueries}`,
+          {
+            requires_restart: 0,
+          },
+        )
         .then((res) => {
           if (res.status === 200) {
             toast.success(`Camera group (${values.name}) has been saved.`, {
@@ -712,7 +720,6 @@ export function CameraGroupEdit({
                 <Input
                   className="text-md w-full border border-input bg-background p-2 hover:bg-accent hover:text-accent-foreground dark:[color-scheme:dark]"
                   placeholder="Enter a name..."
-                  disabled={editingGroup !== undefined}
                   {...field}
                 />
               </FormControl>

--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -645,7 +645,7 @@ export function CameraGroupEdit({
 
       let renamingQuery = "";
       if (editingGroup && editingGroup[0] !== values.name) {
-        renamingQuery = `&camera_groups.${editingGroup[0]}`;
+        renamingQuery = `camera_groups.${editingGroup[0]}&`;
       }
 
       const order =
@@ -661,7 +661,7 @@ export function CameraGroupEdit({
 
       axios
         .put(
-          `config/set?${renamingQuery}&${orderQuery}&${iconQuery}${cameraQueries}`,
+          `config/set?${renamingQuery}${orderQuery}&${iconQuery}${cameraQueries}`,
           {
             requires_restart: 0,
           },


### PR DESCRIPTION
## Proposed change
This PR adds the ability to rename camera groups from the edit camera group pane.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
