### PR TITLE
Misc bugfixes and improvements

### DIFF
--- a/frigate/util/model.py
+++ b/frigate/util/model.py
@@ -85,8 +85,14 @@ class ONNXModelRunner:
         else:
             # Use ONNXRuntime
             self.type = "ort"
+            options = ort.SessionOptions()
+            if device == "CPU":
+                options.enable_cpu_mem_arena = False
             self.ort = ort.InferenceSession(
-                model_path, providers=providers, provider_options=options
+                model_path,
+                sess_options=options,
+                providers=providers,
+                provider_options=options,
             )
 
     def get_input_names(self) -> list[str]:

--- a/web/src/views/settings/SearchSettingsView.tsx
+++ b/web/src/views/settings/SearchSettingsView.tsx
@@ -84,7 +84,10 @@ export default function SearchSettingsView({
 
     axios
       .put(
-        `config/set?semantic_search.enabled=${searchSettings.enabled}&semantic_search.reindex=${searchSettings.reindex}&semantic_search.model_size=${searchSettings.model_size}`,
+        `config/set?semantic_search.enabled=${searchSettings.enabled ? "True" : "False"}&semantic_search.reindex=${searchSettings.reindex ? "True" : "False"}&semantic_search.model_size=${searchSettings.model_size}`,
+        {
+          requires_restart: 0,
+        },
       )
       .then((res) => {
         if (res.status === 200) {


### PR DESCRIPTION
## Proposed change
This PR fixes several bugs and makes some optimizations for decreased RAM usage.

- Only save a fixed number of thumbnails in the embeddings mantainer, and only save them if genai is actually enabled. For stationary or long-running tracked objects, memory usage would grow with thumbnails until tracking ended. This PR always saves the first, and at most 10 of the most recent, thumbnails to use for genai.
- Disable memory arena usage when using CPU with onnxruntime. For a small penalty in inference speed on CPU, disabling this option prevents allocation of more RAM than needed. Resident usage dropped from 1.2gb to 800mb on my system. https://onnxruntime.ai/docs/api/python/api_summary.html#onnxruntime.SessionOptions.enable_cpu_mem_arena
- Fix the Search Settings pane so that it actually saves the correct values back to the config. 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
