### PR TITLE
Don't run pull_request builds on docs-only change

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,9 @@
 name: On pull request
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 env:
   DEFAULT_PYTHON: 3.9


### PR DESCRIPTION
This might be deliberate but as far as I can tell, there's no reason to run all the Python / Web linting checks, build a devcontainer if a change only touches the `docs/` directory. Only Netlify really needs to run and that looks to be controlled outside of here.

My recent two-sentence change to a single file in docs/ seems to have generated 8 minutes of code checking (https://github.com/blakeblackshear/frigate/actions/runs/11443888358).

Not sure whether this project has to pay for Github action runtime, but either way it would save a few watts!

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#example-excluding-paths

Also, my PR seems to have generated a CI deploy which has been running for over an hour - if this change is valid, assume it can also be applied to ci.yml?

