### PR TITLE
Don't run CI builds on docs-only change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - dev
       - master
+    paths-ignore:
+      - 'docs/**'      
 
 # only run the latest commit to avoid cache overwrites
 concurrency:


### PR DESCRIPTION
Same as https://github.com/blakeblackshear/frigate/pull/14485, but for CI builds which look to take *up to 3 hours*.