### PR TITLE
Bugfix: Update tracked object description optimistically

### DIFF
--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -321,6 +321,28 @@ function ObjectDetailsTab({
             (key.includes("events") ||
               key.includes("events/search") ||
               key.includes("events/explore")),
+          (currentData: SearchResult[][] | undefined) => {
+            if (!currentData) return currentData;
+            // optimistic update
+            return currentData.map((page) =>
+              page.map((event) =>
+                event.id === search.id
+                  ? {
+                      ...event,
+                      data: {
+                        ...event.data,
+                        description: desc,
+                      },
+                    }
+                  : event,
+              ),
+            );
+          },
+          {
+            optimisticData: true,
+            rollbackOnError: true,
+            revalidate: false,
+          },
         );
       })
       .catch(() => {


### PR DESCRIPTION
## Proposed change
When manually editing a tracked object description, mutation would sometimes not cause a refetch/revalidation. So this would cause a description to have stale data after closing/reopening the dialog.

This PR just calls `mutate()` with an optimistic state.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
