### PR TITLE
Reenable revalidation of first page

### DIFF
--- a/web/src/pages/Explore.tsx
+++ b/web/src/pages/Explore.tsx
@@ -177,7 +177,7 @@ export default function Explore() {
   const { data, size, setSize, isValidating, mutate } = useSWRInfinite<
     SearchResult[]
   >(getKey, {
-    revalidateFirstPage: false,
+    revalidateFirstPage: true,
     revalidateOnFocus: true,
     revalidateAll: false,
   });


### PR DESCRIPTION
## Proposed change
Disabling it showed stale data when navigating from Explore summary to search results.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
