### PR TITLE
Improve error message when semantic search is not enabled with genai

### DIFF
--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -1015,7 +1015,7 @@ def regenerate_description(
         content=(
             {
                 "success": False,
-                "message": "Semantic search and generative AI are not enabled",
+                "message": "Semantic Search and Generative AI must be enabled to regenerate a description",
             }
         ),
         status_code=400,

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -368,9 +368,9 @@ function ObjectDetailsTab({
             );
           }
         })
-        .catch(() => {
+        .catch((error) => {
           toast.error(
-            `Failed to call ${capitalizeAll(config?.genai.provider.replaceAll("_", " ") ?? "Generative AI")} for a new description`,
+            `Failed to call ${capitalizeAll(config?.genai.provider.replaceAll("_", " ") ?? "Generative AI")} for a new description: ${error.response.data.message}`,
             {
               position: "top-center",
             },


### PR DESCRIPTION
## Proposed change
Users must enable semantic search to use genai. This PR improves the error message provided when users attempt to regenerate a description from the Explore page with semantic search disabled.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/blakeblackshear/frigate/discussions/14526

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
