### PR TITLE
Explore fixes

### DIFF
--- a/web/src/pages/Explore.tsx
+++ b/web/src/pages/Explore.tsx
@@ -18,6 +18,7 @@ import { isMobileOnly } from "react-device-detect";
 import { LuCheck, LuExternalLink, LuX } from "react-icons/lu";
 import { TbExclamationCircle } from "react-icons/tb";
 import { Link } from "react-router-dom";
+import { toast } from "sonner";
 import useSWR from "swr";
 import useSWRInfinite from "swr/infinite";
 
@@ -180,6 +181,18 @@ export default function Explore() {
     revalidateFirstPage: true,
     revalidateOnFocus: true,
     revalidateAll: false,
+    onError: (error) => {
+      toast.error(
+        `Error fetching tracked objects: ${error.response.data.message}`,
+        {
+          position: "top-center",
+        },
+      );
+      if (error.response.status === 404) {
+        // reset all filters if 404
+        setSearchFilter({});
+      }
+    },
   });
 
   const searchResults = useMemo(


### PR DESCRIPTION
## Proposed change
- Employ the onError handler with useSWRInfinite and add a toast message with the error
- When the first tracked object in a similarity search (which is the original thumbnail itself) is deleted, the filters don't reset even though the API (rightly) returns a 404.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
