### PR TITLE
Better review sub-labels

### DIFF
--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -347,7 +347,7 @@ class ReviewSegmentMaintainer(threading.Thread):
 
         if len(active_objects) > 0:
             detections: dict[str, str] = {}
-            sub_labels = set()
+            sub_labels = dict[str, str] = {}
             zones: list[str] = []
             severity = None
 
@@ -358,7 +358,7 @@ class ReviewSegmentMaintainer(threading.Thread):
                     detections[object["id"]] = object["sub_label"][0]
                 else:
                     detections[object["id"]] = f'{object["label"]}-verified'
-                    sub_labels.add(object["sub_label"][0])
+                    sub_labels[object["id"]] = object["sub_label"][0]
 
                 # if object is alert label
                 # and has entered required zones or required zones is not set
@@ -566,7 +566,7 @@ class ReviewSegmentMaintainer(threading.Thread):
                             frame_time,
                             severity,
                             {},
-                            set(),
+                            {},
                             [],
                             detections,
                         )
@@ -576,7 +576,7 @@ class ReviewSegmentMaintainer(threading.Thread):
                         frame_time,
                         SeverityEnum.alert,
                         {manual_info["event_id"]: manual_info["label"]},
-                        set(),
+                        {},
                         [],
                         set(),
                     )

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -51,7 +51,7 @@ class PendingReviewSegment:
         frame_time: float,
         severity: SeverityEnum,
         detections: dict[str, str],
-        sub_labels: set[str],
+        sub_labels: dict[str, str],
         zones: list[str],
         audio: set[str],
     ):
@@ -135,7 +135,7 @@ class PendingReviewSegment:
             ReviewSegment.data.name: {
                 "detections": list(set(self.detections.keys())),
                 "objects": list(set(self.detections.values())),
-                "sub_labels": list(self.sub_labels),
+                "sub_labels": list(self.sub_labels.values()),
                 "zones": self.zones,
                 "audio": list(self.audio),
             },
@@ -261,7 +261,7 @@ class ReviewSegmentMaintainer(threading.Thread):
                     segment.detections[object["id"]] = object["sub_label"][0]
                 else:
                     segment.detections[object["id"]] = f'{object["label"]}-verified'
-                    segment.sub_labels.add(object["sub_label"][0])
+                    segment.sub_labels[object["id"]] = object["sub_label"][0]
 
                 # if object is alert label
                 # and has entered required zones or required zones is not set


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

There are some cases where an object might have one sub label set but then be recognized as something else later. Currently using a set means both sub labels would show in review despite only one belonging to the object. This ensures that the sub labels are kept up to date for each object.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
