### PR TITLE
fix: hailo driver wrong version name

### DIFF
--- a/docker/hailo8l/user_installation.sh
+++ b/docker/hailo8l/user_installation.sh
@@ -38,7 +38,7 @@ cd ../../
 if [ ! -d /lib/firmware/hailo ]; then
   sudo mkdir /lib/firmware/hailo
 fi
-sudo mv hailo8_fw.4.17.0.bin /lib/firmware/hailo/hailo8_fw.bin
+sudo mv hailo8_fw.4.18.0.bin /lib/firmware/hailo/hailo8_fw.bin
 
 # Install udev rules
 sudo cp ./linux/pcie/51-hailo-udev.rules /etc/udev/rules.d/


### PR DESCRIPTION
## Proposed change

Fixes bug on hailort using the wrong version for the file name

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
