### PR TITLE
LPR improvements

### DIFF
--- a/frigate/embeddings/alpr/alpr.py
+++ b/frigate/embeddings/alpr/alpr.py
@@ -13,6 +13,8 @@ from frigate.embeddings.embeddings import Embeddings
 
 logger = logging.getLogger(__name__)
 
+MIN_PLATE_LENGTH = 3
+
 
 class LicensePlateRecognition:
     def __init__(
@@ -197,7 +199,22 @@ class LicensePlateRecognition:
                 average_confidences[original_idx] = average_confidence
                 areas[original_idx] = area
 
-            return license_plates, average_confidences, areas
+            # Filter out plates that have a length of less than 3 characters
+            # Sort by area, then by plate length, then by confidence all desc
+            sorted_data = sorted(
+                [
+                    (plate, conf, area)
+                    for plate, conf, area in zip(
+                        license_plates, average_confidences, areas
+                    )
+                    if len(plate) >= MIN_PLATE_LENGTH
+                ],
+                key=lambda x: (x[2], len(x[0]), x[1]),
+                reverse=True,
+            )
+
+            if sorted_data:
+                return map(list, zip(*sorted_data))
 
         return [], [], []
 


### PR DESCRIPTION
## Proposed change
- Only recognize 3 or more characters as a potentially valid plate.
- Always assume the largest area of detected text is the plate value (as opposed to a state or country name, even if it comes back at a higher confidence).
- Throw out recognized potential plate values if it's shorter than previous or has a smaller area, and it has lower average confidence and worse character confidences.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
