### PR TITLE
Handle hwaccel_args not being set for birdseye restream

### DIFF
--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -165,7 +165,7 @@ if config.get("birdseye", {}).get("restream", False):
     birdseye: dict[str, any] = config.get("birdseye")
 
     input = f"-f rawvideo -pix_fmt yuv420p -video_size {birdseye.get('width', 1280)}x{birdseye.get('height', 720)} -r 10 -i {BIRDSEYE_PIPE}"
-    ffmpeg_cmd = f"exec:{parse_preset_hardware_acceleration_encode(ffmpeg_path, config.get('ffmpeg', {}).get('hwaccel_args'), input, '-rtsp_transport tcp -f rtsp {output}')}"
+    ffmpeg_cmd = f"exec:{parse_preset_hardware_acceleration_encode(ffmpeg_path, config.get('ffmpeg', {}).get('hwaccel_args', ''), input, '-rtsp_transport tcp -f rtsp {output}')}"
 
     if go2rtc_config.get("streams"):
         go2rtc_config["streams"]["birdseye"] = ffmpeg_cmd


### PR DESCRIPTION
## Proposed change
When the following conditions are met, go2rtc will fail to start and cause an error:
- Birdseye enabled with restream
- ffmpeg>hwaccel_args is not set 

The issue occurs because `config.get('ffmpeg', {}).get('hwaccel_args')` in [create_config.py](https://github.com/blakeblackshear/frigate/blob/33825f6d96911656b10ac6bae03c857997968460/docker/main/rootfs/usr/local/go2rtc/create_config.py#L168) evaluates as None. This change sets the default to an empty string.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- Initial discussion in [0.15.0 Beta 1 release discussion](https://github.com/blakeblackshear/frigate/discussions/14653#discussioncomment-11086973)

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
