### PR TITLE
UI changes and bugfixes

### DIFF
--- a/web/src/components/input/InputWithTags.tsx
+++ b/web/src/components/input/InputWithTags.tsx
@@ -523,17 +523,29 @@ export default function InputWithTags({
 
   const handleInputKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
+      const event = e.target as HTMLInputElement;
+
+      if (!currentFilterType && (e.key === "Home" || e.key === "End")) {
+        const position = e.key === "Home" ? 0 : event.value.length;
+        event.setSelectionRange(position, position);
+      }
+
       if (
         e.key === "Enter" &&
         inputValue.trim() !== "" &&
         filterSuggestions(suggestions).length == 0
       ) {
         e.preventDefault();
-
         handleSearch(inputValue);
       }
     },
-    [inputValue, handleSearch, filterSuggestions, suggestions],
+    [
+      inputValue,
+      handleSearch,
+      filterSuggestions,
+      suggestions,
+      currentFilterType,
+    ],
   );
 
   // effects

--- a/web/src/components/overlay/detail/ObjectLifecycle.tsx
+++ b/web/src/components/overlay/detail/ObjectLifecycle.tsx
@@ -621,7 +621,7 @@ function getLifecycleItemDescription(lifecycleItem: ObjectLifecycleSequence) {
         )} detected for ${label}`;
       } else {
         title = `${
-          lifecycleItem.data.sub_label
+          lifecycleItem.data.label
         } recognized as ${lifecycleItem.data.attribute.replaceAll("_", " ")}`;
       }
       return title;

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -146,7 +146,7 @@ export default function SearchDetailDialog({
       views.splice(index, 1);
     }
 
-    if (search.data.type != "object") {
+    if (search.data.type != "object" || !search.has_clip) {
       const index = views.indexOf("object lifecycle");
       views.splice(index, 1);
     }

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -141,6 +141,11 @@ export default function SearchDetailDialog({
       views.splice(index, 1);
     }
 
+    if (!search.has_clip) {
+      const index = views.indexOf("video");
+      views.splice(index, 1);
+    }
+
     if (search.data.type != "object") {
       const index = views.indexOf("object lifecycle");
       views.splice(index, 1);

--- a/web/src/components/settings/SearchSettings.tsx
+++ b/web/src/components/settings/SearchSettings.tsx
@@ -99,7 +99,7 @@ export default function SearchSettings({
               <Slider
                 value={[columns]}
                 onValueChange={([value]) => setColumns(value)}
-                max={6}
+                max={8}
                 min={2}
                 step={1}
                 className="flex-grow"

--- a/web/src/hooks/use-api-filter.ts
+++ b/web/src/hooks/use-api-filter.ts
@@ -65,7 +65,11 @@ export function useApiFilterArgs<
     const filter: { [key: string]: unknown } = {};
 
     rawParams.forEach((value, key) => {
-      if (value != "true" && value != "false" && isNaN(parseFloat(value))) {
+      if (
+        value != "true" &&
+        value != "false" &&
+        (/[^0-9,]/.test(value) || isNaN(parseFloat(value)))
+      ) {
         filter[key] = value.includes(",") ? value.split(",") : [value];
       } else {
         if (value != undefined) {

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -83,6 +83,8 @@ export default function SearchView({
       "sm:grid-cols-4": columns === 4,
       "sm:grid-cols-5": columns === 5,
       "sm:grid-cols-6": columns === 6,
+      "sm:grid-cols-7": columns === 7,
+      "sm:grid-cols-8": columns === 8,
     },
   );
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
- Allow up to 8 columns in the search results grid (up from 6)
- Add ability to use Home/End keys in search input field when a search term is being entered (keys still will scroll to start/end of suggestions list when active)
- Fix lifecycle label for "recognized as" case
- Hide video tab and object lifecycle tab in tracked object details pane when `has_clip` is false
- Fix api filter args hook to only allow fully numeric values to pass as non-arrays. `sub_label`s that looked like `123-4567` would actually cause `parseFloat` to return everything up to the first invalid character, so it would end up incorrectly returning as a non-array.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
