### PR TITLE
fix string comparison on mqtt error message for Server unavailable

### DIFF
--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -133,7 +133,7 @@ class MqttClient(Communicator):  # type: ignore[misc]
         """Mqtt connection callback."""
         threading.current_thread().name = "mqtt"
         if reason_code != 0:
-            if reason_code == "Server Unavailable":
+            if reason_code == "Server unavailable":
                 logger.error(
                     "Unable to connect to MQTT server: MQTT Server unavailable"
                 )


### PR DESCRIPTION
## Proposed change

Fix case of reason_code to match what is specified in paho.mqtt
https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/reasoncodes.py#L77

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
