### PR TITLE
Add missing use_snapshot config field for GenAIConfig

### DIFF
--- a/frigate/config/camera/genai.py
+++ b/frigate/config/camera/genai.py
@@ -50,6 +50,9 @@ class GenAICameraConfig(BaseModel):
 
 class GenAIConfig(FrigateBaseModel):
     enabled: bool = Field(default=False, title="Enable GenAI.")
+    use_snapshot: bool = Field(
+        default=False, title="Use snapshots for generating descriptions."
+    )
     prompt: str = Field(
         default="Analyze the sequence of images containing the {label}. Focus on the likely intent or behavior of the {label} based on its actions and movement, rather than describing its appearance or the surroundings. Consider what the {label} is doing, why, and what it might do next.",
         title="Default caption prompt.",


### PR DESCRIPTION
## Proposed change
Add missing `use_snapshot` config field for GenAIConfig, it already exists in GenAICameraConfig but missing in the global config for GenAI.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
