### PR TITLE
Fix config loading

### DIFF
--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 
 yaml = YAML()
 
-DEFAULT_CONFIG_FILES = ["/config/config.yaml", "/config/config.yml"]
+DEFAULT_CONFIG_FILE = "/config/config.yml"
 DEFAULT_CONFIG = """
 mqtt:
   enabled: False
@@ -634,20 +634,16 @@ class FrigateConfig(FrigateBaseModel):
 
     @classmethod
     def load(cls, **kwargs):
-        config_path = os.environ.get("CONFIG_FILE")
+        config_path = os.environ.get("CONFIG_FILE", DEFAULT_CONFIG_FILE)
 
-        # No explicit configuration file, try to find one in the default paths.
-        if config_path is None:
-            for path in DEFAULT_CONFIG_FILES:
-                if os.path.isfile(path):
-                    config_path = path
-                    break
+        if not os.path.isfile(config_path):
+            config_path = config_path.replace("yml", "yaml")
 
         # No configuration file found, create one.
         new_config = False
-        if config_path is None:
+        if not os.path.isfile(config_path):
             logger.info("No config file found, saving default config")
-            config_path = DEFAULT_CONFIG_FILES[-1]
+            config_path = DEFAULT_CONFIG_FILE
             new_config = True
         else:
             # Check if the config file needs to be migrated.


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

Fixes a bug introduced in https://github.com/blakeblackshear/frigate/pull/13897 which caused HA addon users with the config file `frigate.yaml` to not have their config loaded

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
