### PR TITLE
Set the loglevel for OpenCV ffmpeg messages to fatal

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -211,6 +211,9 @@ ENV TOKENIZERS_PARALLELISM=true
 # https://github.com/huggingface/transformers/issues/27214
 ENV TRANSFORMERS_NO_ADVISORY_WARNINGS=1
 
+# Set OpenCV ffmpeg loglevel to fatal: https://ffmpeg.org/doxygen/trunk/log_8h.html
+ENV OPENCV_FFMPEG_LOGLEVEL=8
+
 ENV PATH="/usr/local/go2rtc/bin:/usr/local/tempio/bin:/usr/local/nginx/sbin:${PATH}"
 ENV LIBAVFORMAT_VERSION_MAJOR=60
 

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -585,8 +585,6 @@ async def get_video_properties(
 
     try:
         # Open the video stream using OpenCV
-        # Only print fatal or worse output: https://ffmpeg.org/doxygen/trunk/log_8h.html
-        os.environ["OPENCV_FFMPEG_LOGLEVEL"] = "8"
         video = cv2.VideoCapture(url)
 
         # Check if the video stream was opened successfully

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -584,7 +584,9 @@ async def get_video_properties(
     width = height = 0
 
     try:
-        # Open the video stream
+        # Open the video stream using OpenCV
+        # Only print fatal or worse output: https://ffmpeg.org/doxygen/trunk/log_8h.html
+        os.environ["OPENCV_FFMPEG_LOGLEVEL"] = "8"
         video = cv2.VideoCapture(url)
 
         # Check if the video stream was opened successfully


### PR DESCRIPTION
## Proposed change
Messages from ffmpeg were making their way to Frigate's pipe, without being handled by Frigate's logger.  This change sets the loglevel for OpenCV/ffmpeg to Fatal, so that only warranted messages make it through.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #8829
- This PR is related to issue: https://github.com/blakeblackshear/frigate/issues/8829

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
