### PR TITLE
Connect Review item details to Explore

### DIFF
--- a/frigate/api/defs/events_query_parameters.py
+++ b/frigate/api/defs/events_query_parameters.py
@@ -28,6 +28,7 @@ class EventsQueryParams(BaseModel):
     is_submitted: Optional[int] = None
     min_length: Optional[float] = None
     max_length: Optional[float] = None
+    event_id: Optional[str] = None
     sort: Optional[str] = None
     timezone: Optional[str] = "utc"
 

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -88,6 +88,7 @@ def events(params: EventsQueryParams = Depends()):
     is_submitted = params.is_submitted
     min_length = params.min_length
     max_length = params.max_length
+    event_id = params.event_id
 
     sort = params.sort
 
@@ -229,6 +230,9 @@ def events(params: EventsQueryParams = Depends()):
             clauses.append((Event.plus_id.is_null()))
         elif is_submitted > 0:
             clauses.append((Event.plus_id != ""))
+
+    if event_id is not None:
+        clauses.append((Event.id == event_id))
 
     if len(clauses) == 0:
         clauses.append((True))

--- a/web/src/components/overlay/detail/ReviewDetailDialog.tsx
+++ b/web/src/components/overlay/detail/ReviewDetailDialog.tsx
@@ -40,6 +40,7 @@ import {
 import { useOverlayState } from "@/hooks/use-overlay-state";
 import { DownloadVideoButton } from "@/components/button/DownloadVideoButton";
 import { TooltipPortal } from "@radix-ui/react-tooltip";
+import { LuSearch } from "react-icons/lu";
 
 type ReviewDetailDialogProps = {
   review?: ReviewSegment;
@@ -52,6 +53,8 @@ export default function ReviewDetailDialog({
   const { data: config } = useSWR<FrigateConfig>("config", {
     revalidateOnFocus: false,
   });
+
+  const navigate = useNavigate();
 
   // upload
 
@@ -219,6 +222,21 @@ export default function ReviewDetailDialog({
                             )}
                             {event.sub_label ?? event.label} (
                             {Math.round(event.data.top_score * 100)}%)
+                            <Tooltip>
+                              <TooltipTrigger>
+                                <div
+                                  className="cursor-pointer"
+                                  onClick={() => {
+                                    navigate(`/explore?event_id=${event.id}`);
+                                  }}
+                                >
+                                  <LuSearch className="size-4 text-muted-foreground" />
+                                </div>
+                              </TooltipTrigger>
+                              <TooltipPortal>
+                                <TooltipContent>View in Explore</TooltipContent>
+                              </TooltipPortal>
+                            </Tooltip>
                           </div>
                         );
                       })}

--- a/web/src/pages/Explore.tsx
+++ b/web/src/pages/Explore.tsx
@@ -114,6 +114,7 @@ export default function Explore() {
           max_score: searchSearchParams["max_score"],
           has_snapshot: searchSearchParams["has_snapshot"],
           has_clip: searchSearchParams["has_clip"],
+          event_id: searchSearchParams["event_id"],
           limit:
             Object.keys(searchSearchParams).length == 0 ? API_LIMIT : undefined,
           timezone,


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
- Add ability to navigate to specific tracked objects in Explore from the review item details pane. Users can click on the magnifying glass icon next to the object in the objects list to view that specific tracked object in Explore.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
