### PR TITLE
Avoid divide by zero in shm_frame_count

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -514,7 +514,7 @@ class FrigateApp:
 
         if cam_total_frame_size == 0.0:
             return 0
-        
+
         shm_frame_count = min(50, int(available_shm / (cam_total_frame_size)))
 
         logger.debug(

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -512,6 +512,9 @@ class FrigateApp:
                     1,
                 )
 
+        if cam_total_frame_size == 0.0:
+            return 0
+        
         shm_frame_count = min(50, int(available_shm / (cam_total_frame_size)))
 
         logger.debug(


### PR DESCRIPTION
## Proposed change
If all my cameras are `enabled: false`, Frigate will start up but the UI breaks, because all API calls (e.g. `/api/config`, `/api/stats` etc) break. This looks to be because `shm_frame_count()` expects to be > 0.0.

I appreciate most people won't disable all their cameras (or have none configured) all that often, but breaking the UI is inconvenient. If in future it becomes possible to enable/disable cameras in realtime this would also be necessary. Hopefully the 

```
2024-11-03 10:46:36.029689690  Traceback (most recent call last):
2024-11-03 10:46:36.029695057    File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
2024-11-03 10:46:36.029698348      return _run_code(code, main_globals, None,
2024-11-03 10:46:36.029702974    File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
2024-11-03 10:46:36.029705977      exec(code, run_globals)
2024-11-03 10:46:36.029708194    File "/opt/frigate/frigate/__main__.py", line 64, in <module>
2024-11-03 10:46:36.029729009      main()
2024-11-03 10:46:36.029731310    File "/opt/frigate/frigate/__main__.py", line 60, in main
2024-11-03 10:46:36.029733877      FrigateApp(config).start()
2024-11-03 10:46:36.029735774    File "/opt/frigate/frigate/app.py", line 595, in start
2024-11-03 10:46:36.029737805      self.start_camera_capture_processes()
2024-11-03 10:46:36.029739953    File "/opt/frigate/frigate/app.py", line 427, in start_camera_capture_processes
2024-11-03 10:46:36.029762151      shm_frame_count = self.shm_frame_count()
2024-11-03 10:46:36.029764358    File "/opt/frigate/frigate/app.py", line 515, in shm_frame_count
2024-11-03 10:46:36.029766624      shm_frame_count = min(50, int(available_shm / (cam_total_frame_size)))
2024-11-03 10:46:36.029768472  ZeroDivisionError: float division by zero
```


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
