### PR TITLE
Add option to export Timelapses from History view

### DIFF
--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -154,7 +154,7 @@ Footage can be exported from Frigate by right-clicking (desktop) or long pressin
 
 ### Time-lapse export
 
-Time lapse exporting is available only via the [HTTP API](../integrations/api/export-recording-export-camera-name-start-start-time-end-end-time-post.api.mdx).
+Time lapse exporting is available while exporting from the History view, or via the [HTTP API](../integrations/api/export-recording-export-camera-name-start-start-time-end-end-time-post.api.mdx).
 
 When exporting a time-lapse the default speed-up is 25x with 30 FPS. This means that every 25 seconds of (real-time) recording is condensed into 1 second of time-lapse video (always without audio) with a smoothness of 30 FPS.
 

--- a/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
+++ b/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
@@ -62,6 +62,7 @@ export default function MobileReviewSettingsDrawer({
   setShowExportPreview,
 }: MobileReviewSettingsDrawerProps) {
   const [drawerMode, setDrawerMode] = useState<DrawerMode>("none");
+  const [isTimelapse, setIsTimelapse] = useState(false);
 
   // exports
 
@@ -83,7 +84,7 @@ export default function MobileReviewSettingsDrawer({
       .post(
         `export/${camera}/start/${Math.round(range.after)}/end/${Math.round(range.before)}`,
         {
-          playback: "realtime",
+          playback: isTimelapse ? "timelapse_25x" : "realtime",
           name,
         },
       )
@@ -96,6 +97,7 @@ export default function MobileReviewSettingsDrawer({
           setName("");
           setRange(undefined);
           setMode("none");
+          setIsTimelapse(false);
         }
       })
       .catch((error) => {
@@ -110,7 +112,7 @@ export default function MobileReviewSettingsDrawer({
           });
         }
       });
-  }, [camera, name, range, setRange, setName, setMode]);
+  }, [camera, name, range, isTimelapse, setRange, setName, setMode]);
 
   // filters
 
@@ -177,6 +179,7 @@ export default function MobileReviewSettingsDrawer({
         currentTime={currentTime}
         range={range}
         name={name}
+        isTimelapse={isTimelapse}
         onStartExport={onStartExport}
         setName={setName}
         setRange={setRange}
@@ -187,10 +190,12 @@ export default function MobileReviewSettingsDrawer({
             setDrawerMode("none");
           }
         }}
+        setIsTimelapse={setIsTimelapse}
         onCancel={() => {
           setMode("none");
           setRange(undefined);
           setDrawerMode("select");
+          setIsTimelapse(false);
         }}
       />
     );
@@ -289,7 +294,10 @@ export default function MobileReviewSettingsDrawer({
         className="pointer-events-none absolute left-1/2 top-8 z-50 -translate-x-1/2"
         show={mode == "timeline"}
         onSave={() => onStartExport()}
-        onCancel={() => setMode("none")}
+        onCancel={() => {
+          setMode("none");
+          setIsTimelapse(false);
+        }}
         onPreview={() => setShowExportPreview(true)}
       />
       <ExportPreviewDialog


### PR DESCRIPTION
## Proposed change

Add a timelapse checkbox to the Export overlay, allowing users to export timelapses from the UI while in the History view. Currently this function is only available via the HTTP API.

Let me know if this is a wanted addition, or if there is anything in the UI that you would like to get changed. See screenshots below.

#### Desktop

<img width="568" alt="Screenshot 2024-11-04 at 17 59 32" src="https://github.com/user-attachments/assets/f01942e0-0891-4f3b-a944-5d6b6bc6bef8">

#### Mobile

<img width="459" alt="Screenshot 2024-11-04 at 18 01 19" src="https://github.com/user-attachments/assets/ce623c31-fcee-4c4e-a564-d0c0e5edda63">

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
