### PR TITLE
Cleanup batching

### DIFF
--- a/frigate/events/cleanup.py
+++ b/frigate/events/cleanup.py
@@ -9,7 +9,7 @@ from multiprocessing.synchronize import Event as MpEvent
 from pathlib import Path
 
 from frigate.config import FrigateConfig
-from frigate.const import CHUNK_SIZE, CLIPS_DIR
+from frigate.const import CLIPS_DIR
 from frigate.db.sqlitevecq import SqliteVecQueueDatabase
 from frigate.models import Event, Timeline
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Implement batching for event cleanup when large numbers of events need to be updated to avoid "too many SQL variables" errors.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
