### PR TITLE
Re-send camera states after websocket disconnects and reconnects

### DIFF
--- a/web/src/api/ws.tsx
+++ b/web/src/api/ws.tsx
@@ -69,7 +69,10 @@ function useValue(): useValueReturn {
       ...prevState,
       ...cameraStates,
     }));
-    setHasCameraState(true);
+
+    if (Object.keys(cameraStates).length > 0) {
+      setHasCameraState(true);
+    }
     // we only want this to run initially when the config is loaded
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wsState]);
@@ -92,6 +95,9 @@ function useValue(): useValueReturn {
         message: "",
         retain: false,
       });
+    },
+    onClose: () => {
+      setHasCameraState(false);
     },
     shouldReconnect: () => true,
     retryOnError: true,


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Backend improvements need to happen for this to be reliable and consistent, but this PR will cause the camera states to be re-sent after the websocket disconnects and reconnects (when a user keeps their browser open and restarts Frigate, for example).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/blakeblackshear/frigate/discussions/14801

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
