### PR TITLE
fix regex for cookie_name to be general snake case

### DIFF
--- a/frigate/config/auth.py
+++ b/frigate/config/auth.py
@@ -13,7 +13,7 @@ class AuthConfig(FrigateBaseModel):
         default=False, title="Reset the admin password on startup"
     )
     cookie_name: str = Field(
-        default="frigate_token", title="Name for jwt token cookie", pattern=r"^[a-z]_*$"
+        default="frigate_token", title="Name for jwt token cookie", pattern=r"^[a-z]+(_[a-z]+)*$"
     )
     cookie_secure: bool = Field(default=False, title="Set secure flag on cookie")
     session_length: int = Field(

--- a/frigate/config/auth.py
+++ b/frigate/config/auth.py
@@ -13,7 +13,7 @@ class AuthConfig(FrigateBaseModel):
         default=False, title="Reset the admin password on startup"
     )
     cookie_name: str = Field(
-        default="frigate_token", title="Name for jwt token cookie", pattern=r"^[a-z]+(_[a-z]+)*$"
+        default="frigate_token", title="Name for jwt token cookie", pattern=r"^[a-z_]+$"
     )
     cookie_secure: bool = Field(default=False, title="Set secure flag on cookie")
     session_length: int = Field(


### PR DESCRIPTION
## Proposed change

cookie_name doesn't work as expected. Even when using the one supplied in the full reference config I got config errors. The new pattern is general snakecase

Fixes https://github.com/blakeblackshear/frigate/issues/14644

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
