### PR TITLE
Auto-unmute inbound audio when enabling two way audio

### DIFF
--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -437,12 +437,7 @@ export default function LiveCameraView({
                   onClick={() => {
                     setMic(!mic);
                     // Turn on audio when enabling the mic if audio is currently off
-                    if (
-                      !mic &&
-                      !audio &&
-                      supportsAudioOutput &&
-                      preferredLiveMode !== "jsmpeg"
-                    ) {
+                    if (!mic && !audio) {
                       setAudio(true);
                     }
                   }}

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -434,7 +434,18 @@ export default function LiveCameraView({
                   Icon={mic ? FaMicrophone : FaMicrophoneSlash}
                   isActive={mic}
                   title={`${mic ? "Disable" : "Enable"} Two Way Talk`}
-                  onClick={() => setMic(!mic)}
+                  onClick={() => {
+                    setMic(!mic);
+                    // Turn on audio when enabling the mic if audio is currently off
+                    if (
+                      !mic &&
+                      !audio &&
+                      supportsAudioOutput &&
+                      preferredLiveMode !== "jsmpeg"
+                    ) {
+                      setAudio(true);
+                    }
+                  }}
                 />
               )}
               {supportsAudioOutput && preferredLiveMode != "jsmpeg" && (


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Auto-unmute inbound audio when enabling two way audio in Live camera view. Audio will not re-mute when disabling mic.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: closes https://github.com/blakeblackshear/frigate/issues/14852
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
