### PR TITLE
Revert audio detection as service manager process

### DIFF
--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -9,6 +9,7 @@ from typing import Tuple
 import numpy as np
 import requests
 
+import frigate.util as util
 from frigate.camera import CameraMetrics
 from frigate.comms.config_updater import ConfigSubscriber
 from frigate.comms.detections_updater import DetectionPublisher, DetectionTypeEnum
@@ -25,7 +26,6 @@ from frigate.const import (
 from frigate.ffmpeg_presets import parse_preset_input
 from frigate.log import LogPipe
 from frigate.object_detection import load_labels
-from frigate.service_manager import ServiceProcess
 from frigate.util.builtin import get_ffmpeg_arg_list
 from frigate.video import start_or_restart_ffmpeg, stop_ffmpeg
 
@@ -63,7 +63,7 @@ def get_ffmpeg_command(ffmpeg: FfmpegConfig) -> list[str]:
     )
 
 
-class AudioProcessor(ServiceProcess):
+class AudioProcessor(util.Process):
     name = "frigate.audio_manager"
 
     def __init__(
@@ -71,7 +71,7 @@ class AudioProcessor(ServiceProcess):
         cameras: list[CameraConfig],
         camera_metrics: dict[str, CameraMetrics],
     ):
-        super().__init__()
+        super().__init__(name="frigate.audio_manager", daemon=True)
 
         self.camera_metrics = camera_metrics
         self.cameras = cameras


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Users (myself included) were seeing shutdown hangs when using audio detection (https://github.com/blakeblackshear/frigate/discussions/14653#discussioncomment-11171155). This was only consistently reproducible in the built docker/s6 environment, not in a devcontainer. This PR reverts some of the changes made in https://github.com/blakeblackshear/frigate/pull/14150 and moves audio detection back to its own process, fixing the shutdown hang.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/blakeblackshear/frigate/pull/14150

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
