### PR TITLE
Add support for specifying tensorrt device

### DIFF
--- a/frigate/util/model.py
+++ b/frigate/util/model.py
@@ -33,10 +33,12 @@ def get_ort_providers(
 
     for provider in ort.get_available_providers():
         if provider == "CUDAExecutionProvider":
+            device_id = 0 if not device.isdigit() else int(device)
             providers.append(provider)
             options.append(
                 {
                     "arena_extend_strategy": "kSameAsRequested",
+                    "device_id": device_id,
                 }
             )
         elif provider == "TensorrtExecutionProvider":
@@ -46,10 +48,11 @@ def get_ort_providers(
                 os.makedirs(
                     "/config/model_cache/tensorrt/ort/trt-engines", exist_ok=True
                 )
+                device_id = 0 if not device.isdigit() else int(device)
                 providers.append(provider)
                 options.append(
                     {
-                        "arena_extend_strategy": "kSameAsRequested",
+                        "device_id": device_id,
                         "trt_fp16_enable": requires_fp16
                         and os.environ.get("USE_FP_16", "True") != "False",
                         "trt_timing_cache_enable": True,


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

This makes it so when device is set to an integer and cuda or tensorrt is used for onnx then the device id is set

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
