### PR TITLE
Add ability to filter Explore by Frigate+ submission status

### DIFF
--- a/frigate/api/defs/events_query_parameters.py
+++ b/frigate/api/defs/events_query_parameters.py
@@ -47,6 +47,7 @@ class EventsSearchQueryParams(BaseModel):
     time_range: Optional[str] = DEFAULT_TIME_RANGE
     has_clip: Optional[bool] = None
     has_snapshot: Optional[bool] = None
+    is_submitted: Optional[bool] = None
     timezone: Optional[str] = "utc"
     min_score: Optional[float] = None
     max_score: Optional[float] = None

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -360,6 +360,7 @@ def events_search(request: Request, params: EventsSearchQueryParams = Depends())
     time_range = params.time_range
     has_clip = params.has_clip
     has_snapshot = params.has_snapshot
+    is_submitted = params.is_submitted
 
     # for similarity search
     event_id = params.event_id
@@ -440,6 +441,12 @@ def events_search(request: Request, params: EventsSearchQueryParams = Depends())
 
     if has_snapshot is not None:
         event_filters.append((Event.has_snapshot == has_snapshot))
+
+    if is_submitted is not None:
+        if is_submitted == 0:
+            event_filters.append((Event.plus_id.is_null()))
+        elif is_submitted > 0:
+            event_filters.append((Event.plus_id != ""))
 
     if min_score is not None and max_score is not None:
         event_filters.append((Event.data["score"].between(min_score, max_score)))

--- a/web/src/components/input/InputWithTags.tsx
+++ b/web/src/components/input/InputWithTags.tsx
@@ -194,6 +194,11 @@ export default function InputWithTags({
         if (newFilters[filterType] === filterValue) {
           delete newFilters[filterType];
         }
+      } else if (filterType === "has_snapshot") {
+        if (newFilters[filterType] === filterValue) {
+          delete newFilters[filterType];
+          delete newFilters["is_submitted"];
+        }
       } else {
         delete newFilters[filterType];
       }
@@ -307,6 +312,10 @@ export default function InputWithTags({
             if (!newFilters.has_snapshot) newFilters.has_snapshot = undefined;
             newFilters.has_snapshot = value == "yes" ? 1 : 0;
             break;
+          case "is_submitted":
+            if (!newFilters.is_submitted) newFilters.is_submitted = undefined;
+            newFilters.is_submitted = value == "yes" ? 1 : 0;
+            break;
           case "has_clip":
             if (!newFilters.has_clip) newFilters.has_clip = undefined;
             newFilters.has_clip = value == "yes" ? 1 : 0;
@@ -356,7 +365,11 @@ export default function InputWithTags({
       }`;
     } else if (filterType === "min_score" || filterType === "max_score") {
       return Math.round(Number(filterValues) * 100).toString() + "%";
-    } else if (filterType === "has_clip" || filterType === "has_snapshot") {
+    } else if (
+      filterType === "has_clip" ||
+      filterType === "has_snapshot" ||
+      filterType === "is_submitted"
+    ) {
       return filterValues ? "Yes" : "No";
     } else {
       return filterValues as string;
@@ -774,7 +787,9 @@ export default function InputWithTags({
                         >
                           {filterType === "event_id"
                             ? "Tracked Object ID"
-                            : filterType.replaceAll("_", " ")}
+                            : filterType === "is_submitted"
+                              ? "Submitted to Frigate+"
+                              : filterType.replaceAll("_", " ")}
                           : {formatFilterValues(filterType, filterValues)}
                           <button
                             onClick={() =>

--- a/web/src/pages/Explore.tsx
+++ b/web/src/pages/Explore.tsx
@@ -113,6 +113,7 @@ export default function Explore() {
           min_score: searchSearchParams["min_score"],
           max_score: searchSearchParams["max_score"],
           has_snapshot: searchSearchParams["has_snapshot"],
+          is_submitted: searchSearchParams["is_submitted"],
           has_clip: searchSearchParams["has_clip"],
           event_id: searchSearchParams["event_id"],
           limit:
@@ -144,6 +145,7 @@ export default function Explore() {
         min_score: searchSearchParams["min_score"],
         max_score: searchSearchParams["max_score"],
         has_snapshot: searchSearchParams["has_snapshot"],
+        is_submitted: searchSearchParams["is_submitted"],
         has_clip: searchSearchParams["has_clip"],
         event_id: searchSearchParams["event_id"],
         timezone,

--- a/web/src/types/search.ts
+++ b/web/src/types/search.ts
@@ -61,6 +61,7 @@ export type SearchFilter = {
   max_score?: number;
   has_snapshot?: number;
   has_clip?: number;
+  is_submitted?: number;
   time_range?: string;
   search_type?: SearchSource[];
   event_id?: string;

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -159,8 +159,10 @@ export default function SearchView({
       max_score: ["100"],
       has_clip: ["yes", "no"],
       has_snapshot: ["yes", "no"],
+      ...(config?.plus?.enabled &&
+        searchFilter?.has_snapshot && { is_submitted: ["yes", "no"] }),
     }),
-    [config, allLabels, allZones, allSubLabels],
+    [config, allLabels, allZones, allSubLabels, searchFilter],
   );
 
   // remove duplicate event ids


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR adds the ability to filter the Explore view and search results by snapshots that have been/have not been submitted to Frigate+. Users must have Frigate+ enabled in order to see and use the option.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes: closes https://github.com/blakeblackshear/frigate/issues/14769
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
