### PR TITLE
Fix extraction of Hailo userspace libs

### DIFF
--- a/docker/hailo8l/Dockerfile
+++ b/docker/hailo8l/Dockerfile
@@ -36,8 +36,5 @@ RUN pip3 install -U /deps/hailo-wheels/*.whl
 # Copy base files from the rootfs stage
 COPY --from=rootfs / /
 
-# Set Library path for hailo driver
-ENV LD_LIBRARY_PATH=/rootfs/usr/local/lib/
-
 # Set workdir
 WORKDIR /opt/frigate/

--- a/docker/hailo8l/install_hailort.sh
+++ b/docker/hailo8l/install_hailort.sh
@@ -10,10 +10,8 @@ elif [[ "${TARGETARCH}" == "arm64" ]]; then
     arch="aarch64"
 fi
 
-mkdir -p /rootfs
-
 wget -qO- "https://github.com/frigate-nvr/hailort/releases/download/v${hailo_version}/hailort-${TARGETARCH}.tar.gz" |
-    tar -C /rootfs/ -xzf -
+    tar -C / -xzf -
 
 mkdir -p /hailo-wheels
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

The archive already has everything contained in a rootfs folder, extract it as-is to the root folder. This also reverts changes from 33957e53600afd0e1a677d6575917955d156dd4a which addressed the same issue in a less optimal way.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #15167 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
