### PR TITLE
Script to migrate masks to new camera resolutions

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,65 @@
+# Mask Rescaler Script
+
+This script is designed to scale the coordinates of a mask when the resolution of the camera is changed. It adjusts the mask coordinates to fit a new resolution based on the old resolution and the scaling factors.
+
+## Features
+- Accepts user input for mask coordinates, old resolution, and new resolution.
+- Calculates the scaling factors based on the resolutions and applies them to the mask coordinates.
+- Displays the scaled mask coordinates.
+- Optionally copies the scaled mask to the clipboard, making it easy to use in your configuration.
+
+## Prerequisites
+
+This script requires the following tools:
+- **bash**: The script is written in bash and should run in any bash-compatible shell.
+- **xclip** (Linux), **xsel** (Linux), **pbcopy** (macOS), or **clip** (Windows) for clipboard functionality.
+
+You can install the clipboard tools with the following commands:
+
+### Linux:
+- Install `xclip`:  
+  ```bash
+  sudo apt install xclip
+  
+- Or install `xsel`:  
+  ```bash
+  sudo apt install xsel
+  
+### macOS:
+- pbcopy is pre-installed, so no installation is needed.
+
+### Windows:
+- Use Git Bash, WSL, or Cygwin for Unix-like commands, including printf and echo -n.
+- Alternatively, if using Windows command prompt (cmd), clip should be available.
+
+## Usage
+
+1. **Run the script**:
+   ```bash
+   ./mask_rescaler.sh
+   ```
+
+2. **Provide input** when prompted:
+   - The script will ask for the mask coordinates (comma-separated), the old resolution (default: `1280,720`), and the new resolution (default: `640,360`).
+
+   Example input:
+   ```bash
+   Enter the mask (comma-separated values): 682,98,716,284,469,284,442,103
+   Enter the old resolution (width,height) [1280,720]: 1280,720
+   Enter the new resolution (width,height) [640,360]: 640,360
+   ```
+
+3. **Result**:
+   - The script will calculate the scaled mask and display it in the terminal.
+   - The scaled mask is also copied to the clipboard, ready to be pasted into your Frigate or other video surveillance configuration.
+
+## Example Output
+
+```bash
+Enter the mask (comma-separated values): 682,98,716,284,469,284,442,103
+Enter the old resolution (width,height) [1280,720]: 1280,720
+Enter the new resolution (width,height) [640,360]: 640,360
+Scaled mask:
+341,49,358,142,234,142,221,51
+Scaled mask copied to clipboard!
+```

--- a/scripts/mask_rescaler.sh
+++ b/scripts/mask_rescaler.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set_clipboard_command() {
+    case "$(uname)" in
+        Linux)
+            if command -v xclip &>/dev/null; then
+                clipboard_cmd="xclip -selection clipboard"
+            elif command -v xsel &>/dev/null; then
+                clipboard_cmd="xsel --clipboard --input"
+            else
+                clipboard_cmd=""
+                echo "Clipboard tool (xclip or xsel) not found. Clipboard functionality will be disabled."
+            fi
+            ;;
+        Darwin) # macOS
+            if command -v pbcopy &>/dev/null; then
+                clipboard_cmd="pbcopy"
+            else
+                clipboard_cmd=""
+                echo "Clipboard tool (pbcopy) not found. Clipboard functionality will be disabled."
+            fi
+            ;;
+        MINGW* | CYGWIN* | MSYS*) # Windows
+            if command -v clip &>/dev/null; then
+                clipboard_cmd="clip"
+            else
+                clipboard_cmd=""
+                echo "Clipboard tool (clip) not found. Clipboard functionality will be disabled."
+            fi
+            ;;
+        *)
+            clipboard_cmd=""
+            echo "Unsupported operating system. Clipboard functionality will be disabled."
+            ;;
+    esac
+}
+
+get_user_input() {
+    read -p "Enter the mask (comma-separated values): " mask_input
+    read -p "Enter the old resolution (width,height) [1280,720]: " old_resolution
+    read -p "Enter the new resolution (width,height) [640,360]: " new_resolution
+
+    old_resolution=${old_resolution:-1280,720}
+    new_resolution=${new_resolution:-640,360}
+}
+
+calculate_scaling_factors() {
+    IFS=',' read -r old_width old_height <<< "$old_resolution"
+    IFS=',' read -r new_width new_height <<< "$new_resolution"
+
+    width_scale=$(awk "BEGIN {print $new_width / $old_width}")
+    height_scale=$(awk "BEGIN {print $new_height / $old_height}")
+}
+
+scale_mask() {
+    IFS=',' read -ra mask_coords <<< "$mask_input"
+    scaled_mask=()
+
+    for ((i=0; i<${#mask_coords[@]}; i+=2)); do
+        x=$(awk "BEGIN {printf \"%d\", ${mask_coords[i]} * $width_scale}")
+        y=$(awk "BEGIN {printf \"%d\", ${mask_coords[i+1]} * $height_scale}")
+        scaled_mask+=("$x" "$y")
+    done
+}
+
+display_output() {
+    output=$(echo "${scaled_mask[*]}" | tr ' ' ',')
+    echo "Scaled mask:"
+    echo "$output"
+}
+
+copy_to_clipboard() {
+    if [[ -n $clipboard_cmd ]]; then
+        # Use printf to avoid a newline, or echo -n
+        printf "%s" "$output" | $clipboard_cmd
+        echo "Scaled mask copied to clipboard!"
+    else
+        echo "Clipboard functionality not available."
+    fi
+}
+
+main() {
+    set_clipboard_command
+    get_user_input
+    calculate_scaling_factors
+    scale_mask
+    display_output
+    copy_to_clipboard
+}
+
+main


### PR DESCRIPTION
## Proposed change
**Background**:  
As discussed in issue #8321, Frigate is moving towards using relative coordinates for masks, which will eventually make resolution-related migrations obsolete. However, until relative coordinates are implemented, users may face issues with their mask coordinates when changing camera resolutions. This is particularly important for users who have previously created masks using fixed resolution coordinates (e.g., `1280x720`) and need a way to migrate them to newer resolutions.

**Summary of Change**:  
This PR introduces a bash script designed to help Frigate users easily migrate their mask coordinates when the camera resolution is changed. The script does the following:
1. **User Input**: Prompts the user for the old resolution (default `1280x720`), the new resolution (default `640x360`), and the mask coordinates.
2. **Calculation**: Scales the mask coordinates according to the resolution change.
3. **Clipboard Support**: Optionally copies the scaled mask to the clipboard for easy use in configuration files.
4. **Practical Use**: Until relative coordinates are supported, this script provides an essential workaround for users who need to update their masks and zones after changing camera resolutions.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #8321

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
