### PR TITLE
Fix frontend bug when consecutive underscores are used in camera names

### DIFF
--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -62,6 +62,7 @@ function Live() {
     if (selectedCameraName) {
       const capitalized = selectedCameraName
         .split("_")
+        .filter((text) => text)
         .map((text) => text[0].toUpperCase() + text.substring(1));
       document.title = `${capitalized.join(" ")} - Live - Frigate`;
     } else if (cameraGroup && cameraGroup != "default") {


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Fix frontend crash when consecutive underscores are used in camera names.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/15253
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
