### PR TITLE
Let the docker container spend more time to clean up and shut down (docs)

### DIFF
--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -193,6 +193,7 @@ services:
     container_name: frigate
     privileged: true # this may not be necessary for all setups
     restart: unless-stopped
+    stop_grace_period: 30s # allow enough time to shut down the various services
     image: ghcr.io/blakeblackshear/frigate:stable
     shm_size: "512mb" # update for your cameras based on calculation above
     devices:
@@ -224,6 +225,7 @@ If you can't use docker compose, you can run the container with something simila
 docker run -d \
   --name frigate \
   --restart=unless-stopped \
+  --stop-timeout 30 \
   --mount type=tmpfs,target=/tmp/cache,tmpfs-size=1000000000 \
   --device /dev/bus/usb:/dev/bus/usb \
   --device /dev/dri/renderD128 \

--- a/docs/docs/guides/getting_started.md
+++ b/docs/docs/guides/getting_started.md
@@ -115,6 +115,7 @@ services:
   frigate:
     container_name: frigate
     restart: unless-stopped
+    stop_grace_period: 30s
     image: ghcr.io/blakeblackshear/frigate:stable
     volumes:
       - ./config:/config


### PR DESCRIPTION

## Proposed change
After running frigate for a while, I realized that using the restart feature within the app (for example save and restart) was broken.
I also noticed that when executing `docker compose down` the container would exit with an error code (137 if I remember correctly).

I think both issues are related to the fact that frigate needs more time to properly shut down than the default 10 seconds allowed by docker by default, before a `SIGKILL` is sent.

This PR changes to documentation, to guide users to allow a little more time to shut down (I arbitrarily picked 30s, which works for me).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
