### PR TITLE
Fix audio events in explore section

### DIFF
--- a/docs/static/frigate-api.yaml
+++ b/docs/static/frigate-api.yaml
@@ -3225,7 +3225,7 @@ components:
           title: Sub Label
         score:
           anyOf:
-            - type: integer
+            - type: number
             - type: 'null'
           title: Score
           default: 0
@@ -3264,7 +3264,7 @@ components:
       properties:
         end_time:
           anyOf:
-            - type: integer
+            - type: number
             - type: 'null'
           title: End Time
       type: object

--- a/frigate/api/defs/events_body.py
+++ b/frigate/api/defs/events_body.py
@@ -17,14 +17,14 @@ class EventsDescriptionBody(BaseModel):
 class EventsCreateBody(BaseModel):
     source_type: Optional[str] = "api"
     sub_label: Optional[str] = None
-    score: Optional[int] = 0
+    score: Optional[float] = 0
     duration: Optional[int] = 30
     include_recording: Optional[bool] = True
     draw: Optional[dict] = {}
 
 
 class EventsEndBody(BaseModel):
-    end_time: Optional[int] = None
+    end_time: Optional[float] = None
 
 
 class SubmitPlusBody(BaseModel):

--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -216,6 +216,7 @@ class AudioEventMaintainer(threading.Thread):
                     "label": label,
                     "last_detection": datetime.datetime.now().timestamp(),
                 }
+            else:
                 self.logger.warning(
                     f"Failed to create audio event with status code {resp.status_code}"
                 )

--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -216,6 +216,9 @@ class AudioEventMaintainer(threading.Thread):
                     "label": label,
                     "last_detection": datetime.datetime.now().timestamp(),
                 }
+                self.logger.warning(
+                    f"Failed to create audio event with status code {resp.status_code}"
+                )
 
     def expire_detections(self) -> None:
         now = datetime.datetime.now().timestamp()

--- a/frigate/events/external.py
+++ b/frigate/events/external.py
@@ -108,6 +108,7 @@ class ExternalEventProcessor:
                 EventTypeEnum.api,
                 EventStateEnum.end,
                 None,
+                "",
                 {"id": event_id, "end_time": end_time},
             )
         )

--- a/web/src/components/menu/SearchResultActions.tsx
+++ b/web/src/components/menu/SearchResultActions.tsx
@@ -128,6 +128,7 @@ export default function SearchResultActions({
         config?.plus?.enabled &&
         searchResult.has_snapshot &&
         searchResult.end_time &&
+        searchResult.data.type == "object" &&
         !searchResult.plus_id && (
           <MenuItem aria-label="Submit to Frigate Plus" onClick={showSnapshot}>
             <FrigatePlusIcon className="mr-2 size-4 cursor-pointer text-primary" />
@@ -197,6 +198,7 @@ export default function SearchResultActions({
             config?.plus?.enabled &&
             searchResult.has_snapshot &&
             searchResult.end_time &&
+            searchResult.data.type == "object" &&
             !searchResult.plus_id && (
               <Tooltip>
                 <TooltipTrigger>

--- a/web/src/components/overlay/detail/ReviewDetailDialog.tsx
+++ b/web/src/components/overlay/detail/ReviewDetailDialog.tsx
@@ -379,6 +379,7 @@ function EventItem({
 
               {event.has_snapshot &&
                 event.plus_id == undefined &&
+                event.data.type == "object" &&
                 config?.plus.enabled && (
                   <Tooltip>
                     <TooltipTrigger>

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -626,7 +626,7 @@ export function ObjectSnapshotTab({
                 </div>
               )}
             </TransformComponent>
-            {search.plus_id !== "not_enabled" && search.end_time && (
+            {search.data.type == "object" && search.plus_id !== "not_enabled" && search.end_time && (
               <Card className="p-1 text-sm md:p-2">
                 <CardContent className="flex flex-col items-center justify-between gap-3 p-2 md:flex-row">
                   <div className={cn("flex flex-col space-y-3")}>


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

Current code does not show audio events in the explore section. Old events created with 0.14.1 are still shown, but new events created with 0.15.0 beta 1 and 2 were not visible.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
