### PR TITLE
Fix event cleanup debug logging crash

### DIFF
--- a/frigate/events/cleanup.py
+++ b/frigate/events/cleanup.py
@@ -110,7 +110,7 @@ class EventCleanup(threading.Thread):
                 .namedtuples()
                 .iterator()
             )
-            logger.debug(f"{len(expired_events)} events can be expired")
+            logger.debug(f"{len(list(expired_events))} events can be expired")
             # delete the media from disk
             for expired in expired_events:
                 media_name = f"{expired.camera}-{expired.id}"


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
In an [unrelated issue](https://github.com/blakeblackshear/frigate/discussions/15225), a user was seeing a crash in the events cleanup thread when debugging was enabled. This PR ensures the generator is a list before logging the length.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/15225
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
