### PR TITLE
Fix audio event creation

### DIFF
--- a/frigate/events/external.py
+++ b/frigate/events/external.py
@@ -135,7 +135,7 @@ class ExternalEventProcessor:
         draw: dict[str, any],
         img_frame: Optional[ndarray],
     ) -> Optional[str]:
-        if not img_frame:
+        if img_frame is None:
             return None
 
         # write clean snapshot if enabled


### PR DESCRIPTION
## Proposed change
Fix issue with audio events creation. The numpy multi-d array check with `is not` fails and causes the issue because numpy doesn't know whether you want to check if all elements of the array are True or if any of them are as seen by error msg below. So Just check if is None.

 Latest dev build showed the following when audio event runs post:

```yaml
docker logs frigate  | grep -A2 audio

--
2024-12-01 19:47:08.832614559  [2024-12-01 19:47:08] audio.crib                     WARNING : Failed to create audio event with status code 500
2024-12-01 19:47:21.480054088  [2024-12-01 19:47:21] frigate.api.event              ERROR   : The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
2024-12-01 19:47:21.482088304  127.0.0.1 - - [01/Dec/2024:19:47:21 -0500] "POST /api/events/crib/crying/create HTTP/1.1" 500 55 "-" "python-requests/2.32.3" "-"
2024-12-01 19:47:21.484325971  [2024-12-01 19:47:21] audio.crib                     WARNING : Failed to create audio event with status code 500
2024-12-01 19:47:21.498257244  [2024-12-01 19:47:21] frigate.api.event              ERROR   : The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
2024-12-01 19:47:21.499582765  127.0.0.1 - - [01/Dec/2024:19:47:21 -0500] "POST /api/events/crib/crying/create HTTP/1.1" 500 55 "-" "python-requests/2.32.3" "-"
2024-12-01 19:47:21.500668425  [2024-12-01 19:47:21] audio.crib                     WARNING : Failed to create audio event with status code 500
```

Created a small reproducer:

```python
from frigate.const import (
    AUDIO_DURATION,
    AUDIO_FORMAT,
    AUDIO_MAX_BIT_RANGE,
    AUDIO_MIN_CONFIDENCE,
    AUDIO_SAMPLE_RATE,
    FRIGATE_LOCALHOST,
)
import requests
score=100
resp = requests.post(
        f"{FRIGATE_LOCALHOST}/api/events/crib/crying/create",
        json={"duration": None, "score": score, "source_type": "audio"},
)

print(resp)
```

Before this change:
```bash
python3 test.py
<Response [500]>
```

after the change in this PR:

```
python3 test.py
<Response [200]>
```

ref: https://github.com/blakeblackshear/frigate/discussions/15097#discussioncomment-11431271

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
