### PR TITLE
Explore bulk actions

### DIFF
--- a/frigate/api/defs/events_body.py
+++ b/frigate/api/defs/events_body.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -25,6 +25,10 @@ class EventsCreateBody(BaseModel):
 
 class EventsEndBody(BaseModel):
     end_time: Optional[float] = None
+
+
+class EventsDeleteBody(BaseModel):
+    event_ids: List[str] = Field(title="The event IDs to delete")
 
 
 class SubmitPlusBody(BaseModel):

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -72,6 +72,7 @@
         "tailwind-merge": "^2.4.0",
         "tailwind-scrollbar": "^3.1.0",
         "tailwindcss-animate": "^1.0.7",
+        "use-long-press": "^3.2.0",
         "vaul": "^0.9.1",
         "vite-plugin-monaco-editor": "^1.1.0",
         "zod": "^3.23.8"
@@ -8707,6 +8708,15 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "scheduler": ">=0.19.0"
+      }
+    },
+    "node_modules/use-long-press": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/use-long-press/-/use-long-press-3.2.0.tgz",
+      "integrity": "sha512-uq5o2qFR1VRjHn8Of7Fl344/AGvgk7C5Mcb4aSb1ZRVp6PkgdXJJLdRrlSTJQVkkQcDuqFbFc3mDX4COg7mRTA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/web/package.json
+++ b/web/package.json
@@ -78,6 +78,7 @@
     "tailwind-merge": "^2.4.0",
     "tailwind-scrollbar": "^3.1.0",
     "tailwindcss-animate": "^1.0.7",
+    "use-long-press": "^3.2.0",
     "vaul": "^0.9.1",
     "vite-plugin-monaco-editor": "^1.1.0",
     "zod": "^3.23.8"

--- a/web/src/components/card/SearchThumbnail.tsx
+++ b/web/src/components/card/SearchThumbnail.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { useApiHost } from "@/api";
 import { getIconForLabel } from "@/utils/iconUtil";
 import useSWR from "swr";
@@ -27,10 +27,11 @@ export default function SearchThumbnail({
   const apiHost = useApiHost();
   const { data: config } = useSWR<FrigateConfig>("config");
   const [imgRef, imgLoaded, onImgLoad] = useImageLoaded();
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   // interactions
 
-  useContextMenu(imgRef, () => {
+  useContextMenu(containerRef, () => {
     onClick(searchResult, true, false);
   });
 
@@ -53,6 +54,7 @@ export default function SearchThumbnail({
 
   return (
     <div
+      ref={containerRef}
       className="relative size-full cursor-pointer"
       {...bindClickAndLongPress}
     >

--- a/web/src/components/card/SearchThumbnail.tsx
+++ b/web/src/components/card/SearchThumbnail.tsx
@@ -17,7 +17,7 @@ import useContextMenu from "@/hooks/use-contextmenu";
 
 type SearchThumbnailProps = {
   searchResult: SearchResult;
-  onClick: (searchResult: SearchResult, ctrl: boolean) => void;
+  onClick: (searchResult: SearchResult, ctrl: boolean, detail: boolean) => void;
 };
 
 export default function SearchThumbnail({
@@ -31,12 +31,12 @@ export default function SearchThumbnail({
   // interactions
 
   useContextMenu(imgRef, () => {
-    onClick(searchResult, true);
+    onClick(searchResult, true, false);
   });
 
   const bindClickAndLongPress = usePress({
-    onLongPress: () => onClick(searchResult, true),
-    onPress: () => onClick(searchResult, false),
+    onLongPress: () => onClick(searchResult, true, false),
+    onPress: () => onClick(searchResult, false, true),
   })();
 
   const objectLabel = useMemo(() => {
@@ -89,7 +89,7 @@ export default function SearchThumbnail({
                 <div className="mx-3 pb-1 text-sm text-white">
                   <Chip
                     className={`z-0 flex items-center justify-between gap-1 space-x-1 bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500 text-xs`}
-                    onClick={() => onClick(searchResult, false)}
+                    onClick={() => onClick(searchResult, false, true)}
                   >
                     {getIconForLabel(objectLabel, "size-3 text-white")}
                     {Math.round(

--- a/web/src/components/card/SearchThumbnail.tsx
+++ b/web/src/components/card/SearchThumbnail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import { useApiHost } from "@/api";
 import { getIconForLabel } from "@/utils/iconUtil";
 import useSWR from "swr";
@@ -12,10 +12,12 @@ import { capitalizeFirstLetter } from "@/utils/stringUtil";
 import { SearchResult } from "@/types/search";
 import { cn } from "@/lib/utils";
 import { TooltipPortal } from "@radix-ui/react-tooltip";
+import usePress from "@/hooks/use-press";
+import useContextMenu from "@/hooks/use-contextmenu";
 
 type SearchThumbnailProps = {
   searchResult: SearchResult;
-  onClick: (searchResult: SearchResult) => void;
+  onClick: (searchResult: SearchResult, ctrl: boolean) => void;
 };
 
 export default function SearchThumbnail({
@@ -28,9 +30,14 @@ export default function SearchThumbnail({
 
   // interactions
 
-  const handleOnClick = useCallback(() => {
-    onClick(searchResult);
-  }, [searchResult, onClick]);
+  useContextMenu(imgRef, () => {
+    onClick(searchResult, true);
+  });
+
+  const bindClickAndLongPress = usePress({
+    onLongPress: () => onClick(searchResult, true),
+    onPress: () => onClick(searchResult, false),
+  })();
 
   const objectLabel = useMemo(() => {
     if (
@@ -45,7 +52,10 @@ export default function SearchThumbnail({
   }, [config, searchResult]);
 
   return (
-    <div className="relative size-full cursor-pointer" onClick={handleOnClick}>
+    <div
+      className="relative size-full cursor-pointer"
+      {...bindClickAndLongPress}
+    >
       <ImageLoadingIndicator
         className="absolute inset-0"
         imgLoaded={imgLoaded}
@@ -79,7 +89,7 @@ export default function SearchThumbnail({
                 <div className="mx-3 pb-1 text-sm text-white">
                   <Chip
                     className={`z-0 flex items-center justify-between gap-1 space-x-1 bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500 text-xs`}
-                    onClick={() => onClick(searchResult)}
+                    onClick={() => onClick(searchResult, false)}
                   >
                     {getIconForLabel(objectLabel, "size-3 text-white")}
                     {Math.round(

--- a/web/src/components/card/SearchThumbnail.tsx
+++ b/web/src/components/card/SearchThumbnail.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { useApiHost } from "@/api";
 import { getIconForLabel } from "@/utils/iconUtil";
 import useSWR from "swr";
@@ -12,7 +12,6 @@ import { capitalizeFirstLetter } from "@/utils/stringUtil";
 import { SearchResult } from "@/types/search";
 import { cn } from "@/lib/utils";
 import { TooltipPortal } from "@radix-ui/react-tooltip";
-import usePress from "@/hooks/use-press";
 import useContextMenu from "@/hooks/use-contextmenu";
 
 type SearchThumbnailProps = {
@@ -27,18 +26,12 @@ export default function SearchThumbnail({
   const apiHost = useApiHost();
   const { data: config } = useSWR<FrigateConfig>("config");
   const [imgRef, imgLoaded, onImgLoad] = useImageLoaded();
-  const containerRef = useRef<HTMLDivElement | null>(null);
 
   // interactions
 
-  useContextMenu(containerRef, () => {
+  useContextMenu(imgRef, () => {
     onClick(searchResult, true, false);
   });
-
-  const bindClickAndLongPress = usePress({
-    onLongPress: () => onClick(searchResult, true, false),
-    onPress: () => onClick(searchResult, false, true),
-  })();
 
   const objectLabel = useMemo(() => {
     if (
@@ -54,9 +47,8 @@ export default function SearchThumbnail({
 
   return (
     <div
-      ref={containerRef}
       className="relative size-full cursor-pointer"
-      {...bindClickAndLongPress}
+      onClick={() => onClick(searchResult, false, true)}
     >
       <ImageLoadingIndicator
         className="absolute inset-0"

--- a/web/src/components/filter/SearchActionGroup.tsx
+++ b/web/src/components/filter/SearchActionGroup.tsx
@@ -32,8 +32,9 @@ export default function SearchActionGroup({
 
   const onDelete = useCallback(async () => {
     await axios
-      // TODO: fix for multiple event deletion
-      .delete(`events/${selectedObjects.id}`)
+      .delete(`events/`, {
+        data: { event_ids: selectedObjects },
+      })
       .then((resp) => {
         if (resp.status == 200) {
           toast.success("Tracked objects deleted successfully.", {

--- a/web/src/components/filter/SearchActionGroup.tsx
+++ b/web/src/components/filter/SearchActionGroup.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useState } from "react";
+import axios from "axios";
+import { Button, buttonVariants } from "../ui/button";
+import { isDesktop } from "react-device-detect";
+import { HiTrash } from "react-icons/hi";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../ui/alert-dialog";
+import useKeyboardListener from "@/hooks/use-keyboard-listener";
+import { toast } from "sonner";
+
+type SearchActionGroupProps = {
+  selectedObjects: string[];
+  setSelectedObjects: (ids: string[]) => void;
+  pullLatestData: () => void;
+};
+export default function SearchActionGroup({
+  selectedObjects,
+  setSelectedObjects,
+  pullLatestData,
+}: SearchActionGroupProps) {
+  const onClearSelected = useCallback(() => {
+    setSelectedObjects([]);
+  }, [setSelectedObjects]);
+
+  const onDelete = useCallback(async () => {
+    await axios
+      // TODO: fix for multiple event deletion
+      .delete(`events/${selectedObjects.id}`)
+      .then((resp) => {
+        if (resp.status == 200) {
+          toast.success("Tracked objects deleted successfully.", {
+            position: "top-center",
+          });
+          setSelectedObjects([]);
+          pullLatestData();
+        }
+      })
+      .catch(() => {
+        toast.error("Failed to delete tracked objects.", {
+          position: "top-center",
+        });
+      });
+  }, [selectedObjects, setSelectedObjects, pullLatestData]);
+
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [bypassDialog, setBypassDialog] = useState(false);
+
+  useKeyboardListener(["Shift"], (_, modifiers) => {
+    setBypassDialog(modifiers.shift);
+  });
+
+  const handleDelete = useCallback(() => {
+    if (bypassDialog) {
+      onDelete();
+    } else {
+      setDeleteDialogOpen(true);
+    }
+  }, [bypassDialog, onDelete]);
+
+  return (
+    <>
+      <AlertDialog
+        open={deleteDialogOpen}
+        onOpenChange={() => setDeleteDialogOpen(!deleteDialogOpen)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm Delete</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogDescription>
+            Deleting these {selectedObjects.length} tracked objects removes the
+            snapshot, any saved embeddings, and any associated object lifecycle
+            entries. Recorded footage of these tracked objects in History view
+            will <em>NOT</em> be deleted.
+            <br />
+            <br />
+            Are you sure you want to proceed?
+            <br />
+            <br />
+            Hold the <em>Shift</em> key to bypass this dialog in the future.
+          </AlertDialogDescription>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              onClick={onDelete}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <div className="absolute inset-x-2 inset-y-0 flex items-center justify-between gap-2 bg-background py-2 md:left-auto">
+        <div className="mx-1 flex items-center justify-center text-sm text-muted-foreground">
+          <div className="p-1">{`${selectedObjects.length} selected`}</div>
+          <div className="p-1">{"|"}</div>
+          <div
+            className="cursor-pointer p-2 text-primary hover:rounded-lg hover:bg-secondary"
+            onClick={onClearSelected}
+          >
+            Unselect
+          </div>
+        </div>
+        <div className="flex items-center gap-1 md:gap-2">
+          <Button
+            className="flex items-center gap-2 p-2"
+            aria-label="Delete"
+            size="sm"
+            onClick={handleDelete}
+          >
+            <HiTrash className="text-secondary-foreground" />
+            {isDesktop && (
+              <div className="text-primary">
+                {bypassDialog ? "Delete Now" : "Delete"}
+              </div>
+            )}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/src/components/player/PreviewThumbnailPlayer.tsx
+++ b/web/src/components/player/PreviewThumbnailPlayer.tsx
@@ -21,6 +21,8 @@ import { cn } from "@/lib/utils";
 import { InProgressPreview, VideoPreview } from "../preview/ScrubbablePreview";
 import { Preview } from "@/types/preview";
 import { baseUrl } from "@/api/baseUrl";
+import usePress from "@/hooks/use-press";
+import { LongPressReactEvents } from "use-long-press";
 
 type PreviewPlayerProps = {
   review: ReviewSegment;
@@ -49,7 +51,7 @@ export default function PreviewThumbnailPlayer({
 
   const [ignoreClick, setIgnoreClick] = useState(false);
   const handleOnClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+    (e: LongPressReactEvents<Element>) => {
       if (!ignoreClick) {
         onClick(review, e.metaKey, false);
       }
@@ -76,6 +78,11 @@ export default function PreviewThumbnailPlayer({
   useContextMenu(imgRef, () => {
     onClick(review, true, false);
   });
+
+  const bindClickAndLongPress = usePress({
+    onLongPress: () => onClick(review, true, false),
+    onPress: (e) => handleOnClick(e),
+  })();
 
   // playback
 
@@ -176,7 +183,7 @@ export default function PreviewThumbnailPlayer({
       className="relative size-full cursor-pointer"
       onMouseOver={isMobile ? undefined : () => setIsHovered(true)}
       onMouseLeave={isMobile ? undefined : () => setIsHovered(false)}
-      onClick={handleOnClick}
+      {...bindClickAndLongPress}
       onAuxClick={(e) => {
         if (e.button === 1) {
           window.open(`${baseUrl}review?id=${review.id}`, "_blank")?.focus();

--- a/web/src/components/player/PreviewThumbnailPlayer.tsx
+++ b/web/src/components/player/PreviewThumbnailPlayer.tsx
@@ -21,8 +21,6 @@ import { cn } from "@/lib/utils";
 import { InProgressPreview, VideoPreview } from "../preview/ScrubbablePreview";
 import { Preview } from "@/types/preview";
 import { baseUrl } from "@/api/baseUrl";
-import usePress from "@/hooks/use-press";
-import { LongPressReactEvents } from "use-long-press";
 
 type PreviewPlayerProps = {
   review: ReviewSegment;
@@ -51,7 +49,7 @@ export default function PreviewThumbnailPlayer({
 
   const [ignoreClick, setIgnoreClick] = useState(false);
   const handleOnClick = useCallback(
-    (e: LongPressReactEvents<Element>) => {
+    (e: React.MouseEvent<HTMLDivElement>) => {
       if (!ignoreClick) {
         onClick(review, e.metaKey, false);
       }
@@ -78,11 +76,6 @@ export default function PreviewThumbnailPlayer({
   useContextMenu(imgRef, () => {
     onClick(review, true, false);
   });
-
-  const bindClickAndLongPress = usePress({
-    onLongPress: () => onClick(review, true, false),
-    onPress: (e) => handleOnClick(e),
-  })();
 
   // playback
 
@@ -183,7 +176,7 @@ export default function PreviewThumbnailPlayer({
       className="relative size-full cursor-pointer"
       onMouseOver={isMobile ? undefined : () => setIsHovered(true)}
       onMouseLeave={isMobile ? undefined : () => setIsHovered(false)}
-      {...bindClickAndLongPress}
+      onClick={handleOnClick}
       onAuxClick={(e) => {
         if (e.button === 1) {
           window.open(`${baseUrl}review?id=${review.id}`, "_blank")?.focus();

--- a/web/src/components/player/PreviewThumbnailPlayer.tsx
+++ b/web/src/components/player/PreviewThumbnailPlayer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useApiHost } from "@/api";
 import { isCurrentHour } from "@/utils/dateUtil";
 import { ReviewSegment } from "@/types/review";

--- a/web/src/components/player/PreviewThumbnailPlayer.tsx
+++ b/web/src/components/player/PreviewThumbnailPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useApiHost } from "@/api";
 import { isCurrentHour } from "@/utils/dateUtil";
 import { ReviewSegment } from "@/types/review";

--- a/web/src/hooks/use-press.ts
+++ b/web/src/hooks/use-press.ts
@@ -10,7 +10,7 @@ import {
 export default function usePress(
   options: Omit<Parameters<typeof useLongPress>[1], "onCancel" | "onStart"> & {
     onLongPress: NonNullable<Parameters<typeof useLongPress>[0]>;
-    onPress: () => void;
+    onPress: (event: LongPressReactEvents<Element>) => void;
   },
 ) {
   const { onLongPress, onPress, ...actualOptions } = options;
@@ -43,9 +43,9 @@ export default function usePress(
   return useCallback(
     () => ({
       ...bind(),
-      onClick: () => {
+      onClick: (event: LongPressReactEvents<HTMLDivElement>) => {
         if (!hasLongPress) {
-          onPress();
+          onPress(event);
         }
       },
     }),

--- a/web/src/hooks/use-press.ts
+++ b/web/src/hooks/use-press.ts
@@ -1,0 +1,54 @@
+// https://gist.github.com/cpojer/641bf305e6185006ea453e7631b80f95
+
+import { useCallback, useState } from "react";
+import {
+  LongPressCallbackMeta,
+  LongPressReactEvents,
+  useLongPress,
+} from "use-long-press";
+
+export default function usePress(
+  options: Omit<Parameters<typeof useLongPress>[1], "onCancel" | "onStart"> & {
+    onLongPress: NonNullable<Parameters<typeof useLongPress>[0]>;
+    onPress: () => void;
+  },
+) {
+  const { onLongPress, onPress, ...actualOptions } = options;
+  const [hasLongPress, setHasLongPress] = useState(false);
+
+  const onCancel = useCallback(() => {
+    if (hasLongPress) {
+      setHasLongPress(false);
+    }
+  }, [hasLongPress]);
+
+  const bind = useLongPress(
+    useCallback(
+      (
+        event: LongPressReactEvents<Element>,
+        meta: LongPressCallbackMeta<unknown>,
+      ) => {
+        setHasLongPress(true);
+        onLongPress(event, meta);
+      },
+      [onLongPress],
+    ),
+    {
+      ...actualOptions,
+      onCancel,
+      onStart: onCancel,
+    },
+  );
+
+  return useCallback(
+    () => ({
+      ...bind(),
+      onClick: () => {
+        if (!hasLongPress) {
+          onPress();
+        }
+      },
+    }),
+    [bind, hasLongPress, onPress],
+  );
+}

--- a/web/src/views/explore/ExploreView.tsx
+++ b/web/src/views/explore/ExploreView.tsx
@@ -26,7 +26,7 @@ type ExploreViewProps = {
   searchDetail: SearchResult | undefined;
   setSearchDetail: (search: SearchResult | undefined) => void;
   setSimilaritySearch: (search: SearchResult) => void;
-  onSelectSearch: (item: SearchResult, index: number, page?: SearchTab) => void;
+  onSelectSearch: (item: SearchResult, page?: SearchTab) => void;
 };
 
 export default function ExploreView({
@@ -125,7 +125,7 @@ type ThumbnailRowType = {
   setSearchDetail: (search: SearchResult | undefined) => void;
   mutate: () => void;
   setSimilaritySearch: (search: SearchResult) => void;
-  onSelectSearch: (item: SearchResult, index: number, page?: SearchTab) => void;
+  onSelectSearch: (item: SearchResult, page?: SearchTab) => void;
 };
 
 function ThumbnailRow({
@@ -205,7 +205,7 @@ type ExploreThumbnailImageProps = {
   setSearchDetail: (search: SearchResult | undefined) => void;
   mutate: () => void;
   setSimilaritySearch: (search: SearchResult) => void;
-  onSelectSearch: (item: SearchResult, index: number, page?: SearchTab) => void;
+  onSelectSearch: (item: SearchResult, page?: SearchTab) => void;
 };
 function ExploreThumbnailImage({
   event,
@@ -225,11 +225,11 @@ function ExploreThumbnailImage({
   };
 
   const handleShowObjectLifecycle = () => {
-    onSelectSearch(event, 0, "object lifecycle");
+    onSelectSearch(event, "object lifecycle");
   };
 
   const handleShowSnapshot = () => {
-    onSelectSearch(event, 0, "snapshot");
+    onSelectSearch(event, "snapshot");
   };
 
   return (

--- a/web/src/views/explore/ExploreView.tsx
+++ b/web/src/views/explore/ExploreView.tsx
@@ -26,7 +26,7 @@ type ExploreViewProps = {
   searchDetail: SearchResult | undefined;
   setSearchDetail: (search: SearchResult | undefined) => void;
   setSimilaritySearch: (search: SearchResult) => void;
-  onSelectSearch: (item: SearchResult, page?: SearchTab) => void;
+  onSelectSearch: (item: SearchResult, ctrl: boolean, page?: SearchTab) => void;
 };
 
 export default function ExploreView({
@@ -125,7 +125,7 @@ type ThumbnailRowType = {
   setSearchDetail: (search: SearchResult | undefined) => void;
   mutate: () => void;
   setSimilaritySearch: (search: SearchResult) => void;
-  onSelectSearch: (item: SearchResult, page?: SearchTab) => void;
+  onSelectSearch: (item: SearchResult, ctrl: boolean, page?: SearchTab) => void;
 };
 
 function ThumbnailRow({
@@ -205,7 +205,7 @@ type ExploreThumbnailImageProps = {
   setSearchDetail: (search: SearchResult | undefined) => void;
   mutate: () => void;
   setSimilaritySearch: (search: SearchResult) => void;
-  onSelectSearch: (item: SearchResult, page?: SearchTab) => void;
+  onSelectSearch: (item: SearchResult, ctrl: boolean, page?: SearchTab) => void;
 };
 function ExploreThumbnailImage({
   event,
@@ -225,11 +225,11 @@ function ExploreThumbnailImage({
   };
 
   const handleShowObjectLifecycle = () => {
-    onSelectSearch(event, "object lifecycle");
+    onSelectSearch(event, false, "object lifecycle");
   };
 
   const handleShowSnapshot = () => {
-    onSelectSearch(event, "snapshot");
+    onSelectSearch(event, false, "snapshot");
   };
 
   return (

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -187,7 +187,7 @@ export default function SearchView({
 
   const onSelectSearch = useCallback(
     (item: SearchResult, ctrl: boolean, page: SearchTab = "details") => {
-      if (selectedObjects.length > 0 || ctrl) {
+      if (selectedObjects.length > 1 || ctrl) {
         const index = selectedObjects.indexOf(item.id);
 
         if (index != -1) {
@@ -205,12 +205,9 @@ export default function SearchView({
           copy.push(item.id);
           setSelectedObjects(copy);
         }
-      }
-      if (!ctrl) {
+      } else {
         setPage(page);
         setSearchDetail(item);
-      } else {
-        setSearchDetail(undefined);
       }
     },
     [selectedObjects],
@@ -556,10 +553,13 @@ export default function SearchView({
                           ctrl: boolean,
                           detail: boolean,
                         ) => {
-                          if (detail) {
+                          if (detail && selectedObjects.length == 0) {
                             setSearchDetail(value);
                           } else {
-                            onSelectSearch(value, ctrl);
+                            onSelectSearch(
+                              value,
+                              ctrl || selectedObjects.length > 0,
+                            );
                           }
                         }}
                       />


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
- Add the ability to select multiple tracked objects in Explore in order to perform bulk actions on them, initiated by a right click / long press on a thumbnail from the grid. This mimics the way bulk actions already work in Review. 
- Add a new API endpoint for multiple event_id deletion.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
