### PR TITLE
Cap storage bandwidth

### DIFF
--- a/frigate/storage.py
+++ b/frigate/storage.py
@@ -17,6 +17,8 @@ bandwidth_equation = Recordings.segment_size / (
     Recordings.end_time - Recordings.start_time
 )
 
+MAX_CALCULATED_BANDWIDTH = 10000  # 10Gb/hr
+
 
 class StorageMaintainer(threading.Thread):
     """Maintain frigates recording storage."""
@@ -52,6 +54,12 @@ class StorageMaintainer(threading.Thread):
                         * 3600,
                         2,
                     )
+
+                    if bandwidth > MAX_CALCULATED_BANDWIDTH:
+                        logger.warning(
+                            f"{camera} has a bandwidth of {bandwidth} MB/hr which exceeds the expected maximum. This typically indicates an issue with the cameras recordings."
+                        )
+                        bandwidth = MAX_CALCULATED_BANDWIDTH
                 except TypeError:
                     bandwidth = 0
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

Some users have cameras that record very short recording segments, this causes the bandwidth calculation to exceed typical values and cause storage to be deleted unexpectedly. This bandwidth is now capped at a logical maximum and then a log is printed if it is exceeded. 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
