### PR TITLE
Improve message for detected objects in review items

### DIFF
--- a/web/src/components/overlay/detail/ReviewDetailDialog.tsx
+++ b/web/src/components/overlay/detail/ReviewDetailDialog.tsx
@@ -74,6 +74,23 @@ export default function ReviewDetailDialog({
     return events.length != review?.data.detections.length;
   }, [review, events]);
 
+  const missingObjects = useMemo(() => {
+    if (!review || !events) {
+      return [];
+    }
+
+    const detectedIds = review.data.detections;
+    const missing = Array.from(
+      new Set(
+        events
+          .filter((event) => !detectedIds.includes(event.id))
+          .map((event) => event.label),
+      ),
+    );
+
+    return missing;
+  }, [review, events]);
+
   const formattedDate = useFormattedTimestamp(
     review?.start_time ?? 0,
     config?.ui.time_format == "24hour"
@@ -263,8 +280,13 @@ export default function ReviewDetailDialog({
               </div>
               {hasMismatch && (
                 <div className="p-4 text-center text-sm">
-                  Some objects that were detected are not included in this list
-                  because the object does not have a snapshot
+                  Some objects may have been detected in this review item that
+                  did not qualify as an alert or detection. Adjust your
+                  configuration if you want Frigate to save tracked objects for
+                  any missing labels.
+                  {missingObjects.length > 0 && (
+                    <div className="mt-2">{missingObjects.join(", ")}</div>
+                  )}
                 </div>
               )}
               <div className="relative flex size-full flex-col gap-2">


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Depending on a user's configuration, some detected objects may not qualify as an alert or detection, and thus won't be saved as part of a review item. This PR improves the message and lists the labels that have no associated tracked object.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
