### PR TITLE
Add FAQ to explain why streams might work in VLC but not in Frigate

### DIFF
--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -174,7 +174,7 @@ NOTE: The folder that is set for the config needs to be the folder that contains
 
 ### Custom go2rtc version
 
-Frigate currently includes go2rtc v1.9.4, there may be certain cases where you want to run a different version of go2rtc.
+Frigate currently includes go2rtc v1.9.2, there may be certain cases where you want to run a different version of go2rtc.
 
 To do this:
 

--- a/docs/docs/troubleshooting/faqs.md
+++ b/docs/docs/troubleshooting/faqs.md
@@ -98,3 +98,9 @@ docker run -d \
   -p 8555:8555/udp \
   ghcr.io/blakeblackshear/frigate:stable
 ```
+
+### My RTSP stream works fine in VLC, but it does not work when I put the same URL in my Frigate config. Is this a bug?
+
+No. Frigate uses the TCP protocol to connect to your camera's RTSP URL. VLC automatically switches between UDP and TCP depending on network conditions and stream availability. So a stream that works in VLC but not in Frigate is likely due to VLC selecting UDP as the transfer protocol.
+
+TCP ensures that all data packets arrive in the correct order. This is crucial for video recording, which is why Frigate enforces a TCP connection. UDP is faster but less reliable, as it does not guarantee packet delivery or order.

--- a/docs/docs/troubleshooting/faqs.md
+++ b/docs/docs/troubleshooting/faqs.md
@@ -103,4 +103,4 @@ docker run -d \
 
 No. Frigate uses the TCP protocol to connect to your camera's RTSP URL. VLC automatically switches between UDP and TCP depending on network conditions and stream availability. So a stream that works in VLC but not in Frigate is likely due to VLC selecting UDP as the transfer protocol.
 
-TCP ensures that all data packets arrive in the correct order. This is crucial for video recording, which is why Frigate enforces a TCP connection. UDP is faster but less reliable, as it does not guarantee packet delivery or order.
+TCP ensures that all data packets arrive in the correct order. This is crucial for video recording, decoding, and stream processing, which is why Frigate enforces a TCP connection. UDP is faster but less reliable, as it does not guarantee packet delivery or order, and VLC does not have the same requirements as Frigate.

--- a/docs/docs/troubleshooting/faqs.md
+++ b/docs/docs/troubleshooting/faqs.md
@@ -104,3 +104,5 @@ docker run -d \
 No. Frigate uses the TCP protocol to connect to your camera's RTSP URL. VLC automatically switches between UDP and TCP depending on network conditions and stream availability. So a stream that works in VLC but not in Frigate is likely due to VLC selecting UDP as the transfer protocol.
 
 TCP ensures that all data packets arrive in the correct order. This is crucial for video recording, decoding, and stream processing, which is why Frigate enforces a TCP connection. UDP is faster but less reliable, as it does not guarantee packet delivery or order, and VLC does not have the same requirements as Frigate.
+
+You can still configure Frigate to use UDP by using ffmpeg input args or the preset `preset-rtsp-udp`. See the [ffmpeg presets](/configuration/ffmpeg_presets) documentation.


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Users often leave comments saying "my URL works fine when I put it in VLC but it doesn't work in Frigate, this must be a Frigate bug". This PR updates the docs with the primary reason why this occurs.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
