### PR TITLE
Ensure that go2rtc streams are cleaned

### DIFF
--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -135,9 +135,10 @@ def config(request: Request):
             camera_dict["zones"][zone_name]["color"] = zone.color
 
     # remove go2rtc stream passwords
-    for stream_name, stream in request.app.frigate_config.go2rtc.get(
-        "streams", {}
-    ).items():
+    go2rtc = config_obj.go2rtc.model_dump(
+        mode="json", warnings="none", exclude_none=True
+    )
+    for stream_name, stream in go2rtc.get("streams", {}).items():
         if isinstance(stream, str):
             cleaned = clean_camera_user_pass(stream)
         else:

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -135,7 +135,7 @@ def config(request: Request):
             camera_dict["zones"][zone_name]["color"] = zone.color
 
     # remove go2rtc stream passwords
-    go2rtc = config_obj.go2rtc.model_dump(
+    go2rtc: dict[str, any] = config_obj.go2rtc.model_dump(
         mode="json", warnings="none", exclude_none=True
     )
     for stream_name, stream in go2rtc.get("streams", {}).items():

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -135,7 +135,9 @@ def config(request: Request):
             camera_dict["zones"][zone_name]["color"] = zone.color
 
     # remove go2rtc stream passwords
-    for stream_name, stream in request.app.frigate_config.go2rtc.get("streams", {}).items():
+    for stream_name, stream in request.app.frigate_config.go2rtc.get(
+        "streams", {}
+    ).items():
         if isinstance(stream, str):
             cleaned = clean_camera_user_pass(stream)
         else:


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

go2rtc streams did not have credentials cleaned before returning the config

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/issues/15522
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
