### PR TITLE
Don't crop by region for genai snapshot for manual events

### DIFF
--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -335,8 +335,10 @@ class EmbeddingMaintainer(threading.Thread):
                 )
 
                 # crop snapshot based on region before sending off to genai
+                # provide full image if region doesn't exist (manual events)
+                region = event.data.get("region", [0, 0, 1, 1])
                 height, width = img.shape[:2]
-                x1_rel, y1_rel, width_rel, height_rel = event.data["region"]
+                x1_rel, y1_rel, width_rel, height_rel = region
 
                 x1, y1 = int(x1_rel * width), int(y1_rel * height)
                 cropped_image = img[


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Provide a default region (the whole frame) for events that don't define one (eg. manual events). Fixes the issue seen by a user here: https://github.com/blakeblackshear/frigate/discussions/15443#discussioncomment-11574921


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
