### PR TITLE
Fix always the same image is sent to GenAI

### DIFF
--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -221,7 +221,7 @@ class EmbeddingMaintainer(threading.Thread):
                         [snapshot_image]
                         if event.has_snapshot and camera_config.genai.use_snapshot
                         else (
-                            [thumbnail for data in self.tracked_events[event_id]]
+                            [data["thumbnail"] for data in self.tracked_events[event_id]]
                             if len(self.tracked_events.get(event_id, [])) > 0
                             else [thumbnail]
                         )

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -221,7 +221,10 @@ class EmbeddingMaintainer(threading.Thread):
                         [snapshot_image]
                         if event.has_snapshot and camera_config.genai.use_snapshot
                         else (
-                            [data["thumbnail"] for data in self.tracked_events[event_id]]
+                            [
+                                data["thumbnail"]
+                                for data in self.tracked_events[event_id]
+                            ]
                             if len(self.tracked_events.get(event_id, [])) > 0
                             else [thumbnail]
                         )

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -357,7 +357,7 @@ class EmbeddingMaintainer(threading.Thread):
             [snapshot_image]
             if event.has_snapshot and source == "snapshot"
             else (
-                [thumbnail for data in self.tracked_events[event_id]]
+                [data["thumbnail"] for data in self.tracked_events[event_id]]
                 if len(self.tracked_events.get(event_id, [])) > 0
                 else [thumbnail]
             )


### PR DESCRIPTION
## Proposed change
This bugfix is needed because the actual code sends always the same image to GenAI provider, while on the documentation it says that different images should be sent to GenAI during "key moments".
See: https://github.com/blakeblackshear/frigate/discussions/15549
It is just a bugfix.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/15549
- This PR is related to issue: https://github.com/blakeblackshear/frigate/discussions/15549

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
