### PR TITLE
Preserve line numbers in config validation

### DIFF
--- a/frigate/__main__.py
+++ b/frigate/__main__.py
@@ -3,6 +3,7 @@ import faulthandler
 import signal
 import sys
 import threading
+from typing import Union
 
 import ruamel.yaml
 from pydantic import ValidationError
@@ -61,12 +62,15 @@ def main() -> None:
 
             try:
                 for i, part in enumerate(error_path):
-                    key = int(part) if part.isdigit() else part
+                    key: Union[int, str] = (
+                        int(part) if isinstance(part, str) and part.isdigit() else part
+                    )
 
                     if isinstance(current, ruamel.yaml.comments.CommentedMap):
                         current = current[key]
                     elif isinstance(current, list):
-                        current = current[key]
+                        if isinstance(key, int):
+                            current = current[key]
 
                     if hasattr(current, "lc"):
                         last_line_number = current.lc.line

--- a/frigate/__main__.py
+++ b/frigate/__main__.py
@@ -86,6 +86,7 @@ def main() -> None:
 
             print(f"Line #  : {line_number}")
             print(f"Key     : {' -> '.join(map(str, error_path))}")
+            print(f"Value   : {error.get('input','-')}")
             print(f"Message : {error.get('msg', error.get('type', 'Unknown'))}\n")
 
         print("*************************************************************")

--- a/frigate/__main__.py
+++ b/frigate/__main__.py
@@ -4,11 +4,13 @@ import signal
 import sys
 import threading
 
+import ruamel.yaml
 from pydantic import ValidationError
 
 from frigate.app import FrigateApp
 from frigate.config import FrigateConfig
 from frigate.log import setup_logging
+from frigate.util.config import find_config_file
 
 
 def main() -> None:
@@ -42,10 +44,46 @@ def main() -> None:
         print("*************************************************************")
         print("*************************************************************")
         print("***    Config Validation Errors                           ***")
-        print("*************************************************************")
+        print("*************************************************************\n")
+        # Attempt to get the original config file for line number tracking
+        config_path = find_config_file()
+        with open(config_path, "r") as f:
+            yaml_config = ruamel.yaml.YAML()
+            yaml_config.preserve_quotes = True
+            full_config = yaml_config.load(f)
+
         for error in e.errors():
-            location = ".".join(str(item) for item in error["loc"])
-            print(f"{location}: {error['msg']}")
+            error_path = error["loc"]
+
+            current = full_config
+            line_number = "Unknown"
+            last_line_number = "Unknown"
+
+            try:
+                for i, part in enumerate(error_path):
+                    key = int(part) if part.isdigit() else part
+
+                    if isinstance(current, ruamel.yaml.comments.CommentedMap):
+                        current = current[key]
+                    elif isinstance(current, list):
+                        current = current[key]
+
+                    if hasattr(current, "lc"):
+                        last_line_number = current.lc.line
+
+                    if i == len(error_path) - 1:
+                        if hasattr(current, "lc"):
+                            line_number = current.lc.line
+                        else:
+                            line_number = last_line_number
+
+            except Exception as traverse_error:
+                print(f"Could not determine exact line number: {traverse_error}")
+
+            print(f"Line #  : {line_number}")
+            print(f"Key     : {' -> '.join(map(str, error_path))}")
+            print(f"Message : {error.get('msg', error.get('type', 'Unknown'))}\n")
+
         print("*************************************************************")
         print("***    End Config Validation Errors                       ***")
         print("*************************************************************")

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -7,15 +7,17 @@ import os
 import traceback
 from datetime import datetime, timedelta
 from functools import reduce
+from io import StringIO
 from typing import Any, Optional
 
 import requests
+import ruamel.yaml
 from fastapi import APIRouter, Body, Path, Request, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.params import Depends
 from fastapi.responses import JSONResponse, PlainTextResponse
-from markupsafe import escape
 from peewee import operator
+from pydantic import ValidationError
 
 from frigate.api.defs.query.app_query_parameters import AppTimelineHourlyQueryParameters
 from frigate.api.defs.request.app_body import AppConfigSetBody
@@ -183,7 +185,6 @@ def config_raw():
 @router.post("/config/save")
 def config_save(save_option: str, body: Any = Body(media_type="text/plain")):
     new_config = body.decode()
-
     if not new_config:
         return JSONResponse(
             content=(
@@ -194,13 +195,53 @@ def config_save(save_option: str, body: Any = Body(media_type="text/plain")):
 
     # Validate the config schema
     try:
+        # Use ruamel to parse and preserve line numbers
+        yaml_config = ruamel.yaml.YAML()
+        yaml_config.preserve_quotes = True
+        full_config = yaml_config.load(StringIO(new_config))
+
         FrigateConfig.parse_yaml(new_config)
-    except Exception:
+
+    except ValidationError as e:
+        error_message = []
+
+        for error in e.errors():
+            error_path = error["loc"]
+            current = full_config
+            line_number = "Unknown"
+            last_line_number = "Unknown"
+
+            try:
+                for i, part in enumerate(error_path):
+                    key = int(part) if part.isdigit() else part
+
+                    if isinstance(current, ruamel.yaml.comments.CommentedMap):
+                        current = current[key]
+                    elif isinstance(current, list):
+                        current = current[key]
+
+                    if hasattr(current, "lc"):
+                        last_line_number = current.lc.line
+
+                    if i == len(error_path) - 1:
+                        if hasattr(current, "lc"):
+                            line_number = current.lc.line
+                        else:
+                            line_number = last_line_number
+
+            except Exception:
+                line_number = "Unable to determine"
+
+            error_message.append(
+                f"Line {line_number}: {' -> '.join(map(str, error_path))} - {error.get('msg', error.get('type', 'Unknown'))}"
+            )
+
         return JSONResponse(
             content=(
                 {
                     "success": False,
-                    "message": f"\nConfig Error:\n\n{escape(str(traceback.format_exc()))}",
+                    "message": "Your configuration is invalid.\nSee the official documentation at docs.frigate.video.\n\n"
+                    + "\n".join(error_message),
                 }
             ),
             status_code=400,

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Body, Path, Request, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.params import Depends
 from fastapi.responses import JSONResponse, PlainTextResponse
+from markupsafe import escape
 from peewee import operator
 from pydantic import ValidationError
 
@@ -242,6 +243,17 @@ def config_save(save_option: str, body: Any = Body(media_type="text/plain")):
                     "success": False,
                     "message": "Your configuration is invalid.\nSee the official documentation at docs.frigate.video.\n\n"
                     + "\n".join(error_message),
+                }
+            ),
+            status_code=400,
+        )
+
+    except Exception:
+        return JSONResponse(
+            content=(
+                {
+                    "success": False,
+                    "message": f"\nYour configuration is invalid.\nSee the official documentation at docs.frigate.video.\n\n{escape(str(traceback.format_exc()))}",
                 }
             ),
             status_code=400,


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR uses Ruamel to print line numbers for problematic configs in both the log and in the UI config editor error pane. This should alleviate some simpler support issues.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
