### PR TITLE
Catch OS error when checking storage utilization

### DIFF
--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -293,7 +293,7 @@ def stats_snapshot(
     for path in [RECORD_DIR, CLIPS_DIR, CACHE_DIR, "/dev/shm"]:
         try:
             storage_stats = shutil.disk_usage(path)
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             stats["service"]["storage"][path] = {}
             continue
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

If a folder is not available an OS error can also be thrown

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes # https://github.com/blakeblackshear/frigate/discussions/15589
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
