### PR TITLE
Fix #7944: Adds tls_insecure to the onvif configuration

### DIFF
--- a/docs/docs/configuration/autotracking.md
+++ b/docs/docs/configuration/autotracking.md
@@ -41,6 +41,7 @@ cameras:
     ...
     onvif:
       # Required: host of the camera being connected to.
+      # NOTE: HTTP is assumed by default; HTTPS is supported if you specify the scheme, ex: "https://0.0.0.0".
       host: 0.0.0.0
       # Optional: ONVIF port for device (default: shown below).
       port: 8000
@@ -49,6 +50,8 @@ cameras:
       user: admin
       # Optional: password for login.
       password: admin
+      # Optional: Skip TLS verification from the ONVIF server (default: shown below)
+      tls_insecure: False
       # Optional: PTZ camera object autotracking. Keeps a moving object in
       # the center of the frame by automatically moving the PTZ camera.
       autotracking:

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -686,6 +686,7 @@ cameras:
     # to enable PTZ controls.
     onvif:
       # Required: host of the camera being connected to.
+      # NOTE: HTTP is assumed by default; HTTPS is supported if you specify the scheme, ex: "https://0.0.0.0".
       host: 0.0.0.0
       # Optional: ONVIF port for device (default: shown below).
       port: 8000
@@ -694,6 +695,8 @@ cameras:
       user: admin
       # Optional: password for login.
       password: admin
+      # Optional: Skip TLS verification from the ONVIF server (default: shown below)
+      tls_insecure: False
       # Optional: Ignores time synchronization mismatches between the camera and the server during authentication.
       # Using NTP on both ends is recommended and this should only be set to True in a "safe" environment due to the security risk it represents.
       ignore_time_mismatch: False

--- a/frigate/config/camera/onvif.py
+++ b/frigate/config/camera/onvif.py
@@ -74,6 +74,10 @@ class OnvifConfig(FrigateBaseModel):
     port: int = Field(default=8000, title="Onvif Port")
     user: Optional[EnvString] = Field(default=None, title="Onvif Username")
     password: Optional[EnvString] = Field(default=None, title="Onvif Password")
+    tls_insecure: bool = Field(
+        default=False,
+        title="Onvif Disable TLS verification"
+    )
     autotracking: PtzAutotrackConfig = Field(
         default_factory=PtzAutotrackConfig,
         title="PTZ auto tracking config.",

--- a/frigate/config/camera/onvif.py
+++ b/frigate/config/camera/onvif.py
@@ -74,10 +74,7 @@ class OnvifConfig(FrigateBaseModel):
     port: int = Field(default=8000, title="Onvif Port")
     user: Optional[EnvString] = Field(default=None, title="Onvif Username")
     password: Optional[EnvString] = Field(default=None, title="Onvif Password")
-    tls_insecure: bool = Field(
-        default=False,
-        title="Onvif Disable TLS verification"
-    )
+    tls_insecure: bool = Field(default=False, title="Onvif Disable TLS verification")
     autotracking: PtzAutotrackConfig = Field(
         default_factory=PtzAutotrackConfig,
         title="PTZ auto tracking config.",

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -6,6 +6,7 @@ from importlib.util import find_spec
 from pathlib import Path
 
 import numpy
+import requests
 from onvif import ONVIFCamera, ONVIFError
 from zeep.exceptions import Fault, TransportError
 from zeep.transports import Transport
@@ -48,7 +49,9 @@ class OnvifController:
 
             if cam.onvif.host:
                 try:
-                    transport = Transport(timeout=10, operation_timeout=10)
+                    session = requests.Session()
+                    session.verify = not cam.onvif.tls_insecure
+                    transport = Transport(timeout=10, operation_timeout=10, session=session)
                     self.cams[cam_name] = {
                         "onvif": ONVIFCamera(
                             cam.onvif.host,

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -51,7 +51,9 @@ class OnvifController:
                 try:
                     session = requests.Session()
                     session.verify = not cam.onvif.tls_insecure
-                    transport = Transport(timeout=10, operation_timeout=10, session=session)
+                    transport = Transport(
+                        timeout=10, operation_timeout=10, session=session
+                    )
                     self.cams[cam_name] = {
                         "onvif": ONVIFCamera(
                             cam.onvif.host,

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -142,6 +142,7 @@ export interface CameraConfig {
     password: string | null;
     port: number;
     user: string | null;
+    tls_insecure: boolean;
   };
   record: {
     enabled: boolean;


### PR DESCRIPTION
## Proposed change
This change adds a new boolean configuration called `tls_insecure` to `cameras.*.onvif` allowing the TLS verification to be skipped when connecting to the ONVIF server within the camera device.

Some cameras have weird requirements and only expose an HTTPS server using a self-signed certificate for the web service. This change will fix the request on #7944, helping folks with this kind of requirement.

This value will be `False` by default, which means that TLS **will be verified**, but users can opt to disable this verification by setting `tls_insecure: True`.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #7944

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
