### PR TITLE
GenAI: enable blurring detected faces if desired

### DIFF
--- a/docs/docs/configuration/genai.md
+++ b/docs/docs/configuration/genai.md
@@ -174,11 +174,14 @@ genai:
   object_prompts:
     person: "Examine the main person in these images. What are they doing and what might their actions suggest about their intent (e.g., approaching a door, leaving an area, standing still)? Do not describe the surroundings or static details."
     car: "Observe the primary vehicle in these images. Focus on its movement, direction, or purpose (e.g., parking, approaching, circling). If it's a delivery vehicle, mention the company."
+    blur_faces: False
 ```
 
 Prompts can also be overriden at the camera level to provide a more detailed prompt to the model about your specific camera, if you desire. By default, descriptions will be generated for all tracked objects and all zones. But you can also optionally specify `objects` and `required_zones` to only generate descriptions for certain tracked objects or zones.
 
 Optionally, you can generate the description using a snapshot (if enabled) by setting `use_snapshot` to `True`. By default, this is set to `False`, which sends the uncompressed images from the `detect` stream collected over the object's lifetime to the model. Once the object lifecycle ends, only a single compressed and cropped thumbnail is saved with the tracked object. Using a snapshot might be useful when you want to _regenerate_ a tracked object's description as it will provide the AI with a higher-quality image (typically downscaled by the AI itself) than the cropped/compressed thumbnail. Using a snapshot otherwise has a trade-off in that only a single image is sent to your provider, which will limit the model's ability to determine object movement or direction.
+
+If required for privacy purposes, Frigate can use OpenCV to attempt to detect faces in an image and blur them before sending to the provider. You can enable this by setting `blur_faces` to `True`.
 
 ```yaml
 cameras:

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -543,6 +543,8 @@ genai:
   # Format: {label}: {prompt}
   object_prompts:
     person: "My special person prompt."
+  # Optional: Attempt to detect faces in the image and blur for privacy before sending to provider (default: shown below)
+  blur_faces: False
 
 # Optional: Restream configuration
 # Uses https://github.com/AlexxIT/go2rtc (v1.9.2)

--- a/frigate/config/camera/genai.py
+++ b/frigate/config/camera/genai.py
@@ -68,3 +68,6 @@ class GenAIConfig(FrigateBaseModel):
     provider: GenAIProviderEnum = Field(
         default=GenAIProviderEnum.openai, title="GenAI provider."
     )
+    blur_faces: bool = Field(
+        default=False, title="Blur faces if detected in the image."
+    )

--- a/frigate/genai/__init__.py
+++ b/frigate/genai/__init__.py
@@ -83,12 +83,12 @@ class GenAIClient:
 
             for x, y, w, h in face_data:
                 roi = image[y : y + h, x : x + w]
-                roi = cv2.GaussianBlur(roi, (23, 23), 30)
+                roi = cv2.blur(roi, (30, 30), 0)
                 image[y : y + h, x : x + w] = roi
 
             for x, y, w, h in face_profile_data:
                 roi = image[y : y + h, x : x + w]
-                roi = cv2.GaussianBlur(roi, (23, 23), 30)
+                roi = cv2.blur(roi, (30, 30), 0)
                 image[y : y + h, x : x + w] = roi
 
 


### PR DESCRIPTION
## Proposed change
When enabled, this uses OpenCV to detect faces in images to be sent to GenAI, and applies blurring to them. This is desirable for anyone with legal or moral issues sending face data to AI (whether cloud or locally hosted).

In testing I have found OpenCV's face detection to be **reasonably** accurate. I've used two classifiers for frontal and side. This is best-endeavours rather than guaranteed.

I know this is arguably an additional feature targeted against the beta but given it's disabled by default hopefully it doesn't cause add any risk before a release candidate.

Happy to discuss the approach taken. I took a quick look at 0.16 for face recognition and it doesn't seem to use OpenCV to check for faces but there is a TODO for it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
