### PR TITLE
Fix crash when streams are undefined in go2rtc config password cleaning

### DIFF
--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -139,6 +139,8 @@ def config(request: Request):
         mode="json", warnings="none", exclude_none=True
     )
     for stream_name, stream in go2rtc.get("streams", {}).items():
+        if stream is None:
+            continue
         if isinstance(stream, str):
             cleaned = clean_camera_user_pass(stream)
         else:


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Fix a bug introduced in https://github.com/blakeblackshear/frigate/pull/15524 where a user could have a stream name defined in their go2rtc config without any streams. Seen by a user in https://github.com/blakeblackshear/frigate/discussions/15694


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/15694
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
