### PR TITLE
Tracked object details pane bugfix

### DIFF
--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -505,54 +505,51 @@ function ObjectDetailsTab({
 
         <div className="flex w-full flex-row justify-end gap-2">
           {config?.cameras[search.camera].genai.enabled && search.end_time && (
-            <>
-              <div className="flex items-start">
-                <Button
-                  className="rounded-r-none border-r-0"
-                  aria-label="Regenerate tracked object description"
-                  onClick={() => regenerateDescription("thumbnails")}
-                >
-                  Regenerate
-                </Button>
-                {search.has_snapshot && (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        className="rounded-l-none border-l-0 px-2"
-                        aria-label="Expand regeneration menu"
-                      >
-                        <FaChevronDown className="size-3" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent>
-                      <DropdownMenuItem
-                        className="cursor-pointer"
-                        aria-label="Regenerate from snapshot"
-                        onClick={() => regenerateDescription("snapshot")}
-                      >
-                        Regenerate from Snapshot
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        className="cursor-pointer"
-                        aria-label="Regenerate from thumbnails"
-                        onClick={() => regenerateDescription("thumbnails")}
-                      >
-                        Regenerate from Thumbnails
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
-              </div>
-
+            <div className="flex items-start">
               <Button
-                variant="select"
-                aria-label="Save"
-                onClick={updateDescription}
+                className="rounded-r-none border-r-0"
+                aria-label="Regenerate tracked object description"
+                onClick={() => regenerateDescription("thumbnails")}
               >
-                Save
+                Regenerate
               </Button>
-            </>
+              {search.has_snapshot && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      className="rounded-l-none border-l-0 px-2"
+                      aria-label="Expand regeneration menu"
+                    >
+                      <FaChevronDown className="size-3" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <DropdownMenuItem
+                      className="cursor-pointer"
+                      aria-label="Regenerate from snapshot"
+                      onClick={() => regenerateDescription("snapshot")}
+                    >
+                      Regenerate from Snapshot
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="cursor-pointer"
+                      aria-label="Regenerate from thumbnails"
+                      onClick={() => regenerateDescription("thumbnails")}
+                    >
+                      Regenerate from Thumbnails
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+            </div>
           )}
+          <Button
+            variant="select"
+            aria-label="Save"
+            onClick={updateDescription}
+          >
+            Save
+          </Button>
         </div>
       </div>
     </div>

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -543,13 +543,16 @@ function ObjectDetailsTab({
               )}
             </div>
           )}
-          <Button
-            variant="select"
-            aria-label="Save"
-            onClick={updateDescription}
-          >
-            Save
-          </Button>
+          {(config?.cameras[search.camera].genai.enabled && search.end_time) ||
+            (!config?.cameras[search.camera].genai.enabled && (
+              <Button
+                variant="select"
+                aria-label="Save"
+                onClick={updateDescription}
+              >
+                Save
+              </Button>
+            ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Fix a bug introduced in https://github.com/blakeblackshear/frigate/pull/15561 that caused the Save button in the Tracked Object Details pane to always be hidden if GenAI is disabled.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
