### PR TITLE
Add UI for managing face recognitions

### DIFF
--- a/frigate/config/semantic_search.py
+++ b/frigate/config/semantic_search.py
@@ -23,17 +23,23 @@ class SemanticSearchConfig(FrigateBaseModel):
 
 class FaceRecognitionConfig(FrigateBaseModel):
     enabled: bool = Field(default=False, title="Enable face recognition.")
+    min_score: float = Field(
+        title="Minimum face distance score required to save the attempt.",
+        default=0.8,
+        gt=0.0,
+        le=1.0,
+    )
     threshold: float = Field(
-        default=170,
-        title="minimum face distance score required to be considered a match.",
+        default=0.9,
+        title="Minimum face distance score required to be considered a match.",
         gt=0.0,
         le=1.0,
     )
     min_area: int = Field(
         default=500, title="Min area of face box to consider running face recognition."
     )
-    debug_save_images: bool = Field(
-        default=False, title="Save images of face detections for debugging."
+    save_attempts: bool = Field(
+        default=True, title="Save images of face detections for training."
     )
 
 

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -515,12 +515,18 @@ class EmbeddingMaintainer(threading.Thread):
             f"Detected best face for person as: {sub_label} with probability {score} and overall face score {face_score}"
         )
 
-        if self.config.face_recognition.debug_save_images:
+        if self.config.face_recognition.save_attempts:
             # write face to library
             folder = os.path.join(FACE_DIR, "debug")
             file = os.path.join(folder, f"{id}-{sub_label}-{score}-{face_score}.webp")
             os.makedirs(folder, exist_ok=True)
             cv2.imwrite(file, face_frame)
+
+        if score < self.config.face_recognition.threshold:
+            logger.debug(
+                f"Recognized face distance {score} is less than threshold {self.config.face_recognition.threshold}"
+            )
+            return
 
         if id in self.detected_faces and face_score <= self.detected_faces[id]:
             logger.debug(

--- a/frigate/util/model.py
+++ b/frigate/util/model.py
@@ -166,7 +166,7 @@ class FaceClassificationModel:
         self.landmark_detector.loadModel("/config/model_cache/facedet/landmarkdet.yaml")
         self.recognizer: cv2.face.LBPHFaceRecognizer = (
             cv2.face.LBPHFaceRecognizer_create(
-                radius=2, threshold=(1 - config.threshold) * 1000
+                radius=2, threshold=(1 - config.min_score) * 1000
             )
         )
         self.label_map: dict[int, str] = {}

--- a/web/src/pages/FaceLibrary.tsx
+++ b/web/src/pages/FaceLibrary.tsx
@@ -162,22 +162,31 @@ function AttemptsGrid({ attemptImages }: AttemptsGridProps) {
   return (
     <div className="scrollbar-container flex flex-wrap gap-2 overflow-y-scroll">
       {attemptImages.map((image: string) => (
-        <FaceImage key={image} name={"something"} image={image} />
+        <FaceAttempt key={image} image={image} />
       ))}
     </div>
   );
 }
 
 type FaceAttemptProps = {
-  name: string;
   image: string;
 };
-function FaceAttempt({ name, image }: FaceAttemptProps) {
+function FaceAttempt({ image }: FaceAttemptProps) {
   const [hovered, setHovered] = useState(false);
+
+  const data = useMemo(() => {
+    const parts = image.split("-");
+
+    return {
+      eventId: `${parts[0]}-${parts[1]}`,
+      name: parts[2],
+      score: parts[3],
+    };
+  }, [image]);
 
   const onDelete = useCallback(() => {
     axios
-      .post(`/faces/${name}/delete`, { ids: [image] })
+      .post(`/faces/debug/delete`, { ids: [image] })
       .then((resp) => {
         if (resp.status == 200) {
           toast.error(`Successfully deleted face.`, { position: "top-center" });
@@ -194,11 +203,11 @@ function FaceAttempt({ name, image }: FaceAttemptProps) {
           });
         }
       });
-  }, [name, image]);
+  }, [image]);
 
   return (
     <div
-      className="relative h-40"
+      className="relative h-min"
       onMouseEnter={isDesktop ? () => setHovered(true) : undefined}
       onMouseLeave={isDesktop ? () => setHovered(false) : undefined}
       onClick={isDesktop ? undefined : () => setHovered(!hovered)}
@@ -213,10 +222,13 @@ function FaceAttempt({ name, image }: FaceAttemptProps) {
           </Chip>
         </div>
       )}
-      <img
-        className="h-40 rounded-md"
-        src={`${baseUrl}clips/faces/${name}/${image}`}
-      />
+      <div className="rounded-md bg-secondary">
+        <img
+          className="h-40 rounded-md"
+          src={`${baseUrl}clips/faces/debug/${image}`}
+        />
+        <div className="p-2">{`${data.name}: ${data.score}`}</div>
+      </div>
     </div>
   );
 }

--- a/web/src/pages/FaceLibrary.tsx
+++ b/web/src/pages/FaceLibrary.tsx
@@ -149,6 +149,7 @@ export default function FaceLibrary() {
             faceImages={faceImages}
             pageToggle={pageToggle}
             setUpload={setUpload}
+            onRefresh={refreshFaces}
           />
         ))}
     </div>
@@ -173,7 +174,7 @@ type FaceAttemptProps = {
   image: string;
   onRefresh: () => void;
 };
-function FaceAttempt({ image }: FaceAttemptProps) {
+function FaceAttempt({ image, onRefresh }: FaceAttemptProps) {
   const [hovered, setHovered] = useState(false);
 
   const data = useMemo(() => {
@@ -194,6 +195,7 @@ function FaceAttempt({ image }: FaceAttemptProps) {
           toast.success(`Successfully deleted face.`, {
             position: "top-center",
           });
+          onRefresh();
         }
       })
       .catch((error) => {
@@ -207,7 +209,7 @@ function FaceAttempt({ image }: FaceAttemptProps) {
           });
         }
       });
-  }, [image]);
+  }, [image, onRefresh]);
 
   return (
     <div
@@ -241,12 +243,23 @@ type FaceGridProps = {
   faceImages: string[];
   pageToggle: string;
   setUpload: (upload: boolean) => void;
+  onRefresh: () => void;
 };
-function FaceGrid({ faceImages, pageToggle, setUpload }: FaceGridProps) {
+function FaceGrid({
+  faceImages,
+  pageToggle,
+  setUpload,
+  onRefresh,
+}: FaceGridProps) {
   return (
     <div className="scrollbar-container flex flex-wrap gap-2 overflow-y-scroll">
       {faceImages.map((image: string) => (
-        <FaceImage key={image} name={pageToggle} image={image} />
+        <FaceImage
+          key={image}
+          name={pageToggle}
+          image={image}
+          onRefresh={onRefresh}
+        />
       ))}
       <Button key="upload" className="size-40" onClick={() => setUpload(true)}>
         <LuImagePlus className="size-10" />
@@ -258,8 +271,9 @@ function FaceGrid({ faceImages, pageToggle, setUpload }: FaceGridProps) {
 type FaceImageProps = {
   name: string;
   image: string;
+  onRefresh: () => void;
 };
-function FaceImage({ name, image }: FaceImageProps) {
+function FaceImage({ name, image, onRefresh }: FaceImageProps) {
   const [hovered, setHovered] = useState(false);
 
   const onDelete = useCallback(() => {
@@ -267,7 +281,10 @@ function FaceImage({ name, image }: FaceImageProps) {
       .post(`/faces/${name}/delete`, { ids: [image] })
       .then((resp) => {
         if (resp.status == 200) {
-          toast.error(`Successfully deleted face.`, { position: "top-center" });
+          toast.success(`Successfully deleted face.`, {
+            position: "top-center",
+          });
+          onRefresh();
         }
       })
       .catch((error) => {

--- a/web/src/pages/FaceLibrary.tsx
+++ b/web/src/pages/FaceLibrary.tsx
@@ -14,7 +14,7 @@ import { toast } from "sonner";
 import useSWR from "swr";
 
 export default function FaceLibrary() {
-  const [page, setPage] = useState<string>("attempts");
+  const [page, setPage] = useState<string>();
   const [pageToggle, setPageToggle] = useOptimisticState(page, setPage, 100);
   const tabsRef = useRef<HTMLDivElement | null>(null);
 
@@ -38,12 +38,18 @@ export default function FaceLibrary() {
   );
 
   useEffect(() => {
-    if (!pageToggle && faces) {
+    if (!pageToggle) {
+      if (faceAttempts.length > 0) {
+        setPageToggle("attempts");
+      } else if (faces) {
+        setPageToggle(faces[0]);
+      }
+    } else if (pageToggle == "attempts" && faceAttempts.length == 0) {
       setPageToggle(faces[0]);
     }
     // we need to listen on the value of the faces list
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [faces]);
+  }, [faceAttempts, faces]);
 
   // upload
 

--- a/web/src/pages/FaceLibrary.tsx
+++ b/web/src/pages/FaceLibrary.tsx
@@ -64,7 +64,7 @@ export default function FaceLibrary() {
             setUpload(false);
             refreshFaces();
             toast.success(
-              "Successfully uploaded iamge. View the file in the /exports folder.",
+              "Successfully uploaded image. View the file in the /exports folder.",
               { position: "top-center" },
             );
           }
@@ -143,7 +143,7 @@ export default function FaceLibrary() {
       </div>
       {pageToggle &&
         (pageToggle == "attempts" ? (
-          <AttemptsGrid attemptImages={faceAttempts} />
+          <AttemptsGrid attemptImages={faceAttempts} onRefresh={refreshFaces} />
         ) : (
           <FaceGrid
             faceImages={faceImages}
@@ -157,12 +157,13 @@ export default function FaceLibrary() {
 
 type AttemptsGridProps = {
   attemptImages: string[];
+  onRefresh: () => void;
 };
-function AttemptsGrid({ attemptImages }: AttemptsGridProps) {
+function AttemptsGrid({ attemptImages, onRefresh }: AttemptsGridProps) {
   return (
     <div className="scrollbar-container flex flex-wrap gap-2 overflow-y-scroll">
       {attemptImages.map((image: string) => (
-        <FaceAttempt key={image} image={image} />
+        <FaceAttempt key={image} image={image} onRefresh={onRefresh} />
       ))}
     </div>
   );
@@ -170,6 +171,7 @@ function AttemptsGrid({ attemptImages }: AttemptsGridProps) {
 
 type FaceAttemptProps = {
   image: string;
+  onRefresh: () => void;
 };
 function FaceAttempt({ image }: FaceAttemptProps) {
   const [hovered, setHovered] = useState(false);
@@ -189,7 +191,9 @@ function FaceAttempt({ image }: FaceAttemptProps) {
       .post(`/faces/debug/delete`, { ids: [image] })
       .then((resp) => {
         if (resp.status == 200) {
-          toast.error(`Successfully deleted face.`, { position: "top-center" });
+          toast.success(`Successfully deleted face.`, {
+            position: "top-center",
+          });
         }
       })
       .catch((error) => {

--- a/web/src/pages/FaceLibrary.tsx
+++ b/web/src/pages/FaceLibrary.tsx
@@ -304,7 +304,7 @@ function FaceImage({ name, image, onRefresh }: FaceImageProps) {
           });
         }
       });
-  }, [name, image]);
+  }, [name, image, onRefresh]);
 
   return (
     <div


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

This PR implements the following:
1. Changes the save image option to be enabled by default
2. Adds a min score that will save an image for a person but not mark the sub label.
3. Add UI tab in face library page to view face recognitions along with their score, making it easier to debug what faces are recognized and potentially move some of the specific face frames to the correct person in order to improve face recognition.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
