### PR TITLE
feat: Focus peaking through Edge Detection

### DIFF
--- a/frigate/api/defs/query/media_query_parameters.py
+++ b/frigate/api/defs/query/media_query_parameters.py
@@ -20,6 +20,8 @@ class MediaLatestFrameQueryParams(BaseModel):
     regions: Optional[int] = None
     quality: Optional[int] = 70
     height: Optional[int] = None
+    edges: Optional[int] = None
+    ethreshold: Optional[int] = None
 
 
 class MediaEventsSnapshotQueryParams(BaseModel):

--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -131,6 +131,8 @@ def latest_frame(
         "mask": params.mask,
         "motion_boxes": params.motion,
         "regions": params.regions,
+        "edges": params.edges,
+        "edges_threshold": params.ethreshold,
     }
     quality = params.quality
 

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -75,6 +75,15 @@ class CameraState:
 
         frame_copy = cv2.cvtColor(frame_copy, cv2.COLOR_YUV2BGR_I420)
         # draw on the frame
+
+        if draw_options.get("edges") and draw_options.get("edges_threshold"):
+            # Higher Threshold = 3 * Lower Threshold (following Canny's recommendation)
+            high_threshold = np.clip(draw_options.get("edges_threshold"), 0, 255)
+            low_threshold = np.floor_divide(high_threshold, 3)
+
+            edges = cv2.Canny(frame_copy, low_threshold, high_threshold)
+            frame_copy[edges==255] = (0,0,255)
+
         if draw_options.get("mask"):
             mask_overlay = np.where(self.camera_config.motion.mask == [0])
             frame_copy[mask_overlay] = [0, 0, 0]


### PR DESCRIPTION
## Proposed change
Adding camera debug options to enable [Focus peaking](https://en.wikipedia.org/wiki/Focus_peaking) through simple Edge Detection using the [Canny Filter](https://en.wikipedia.org/wiki/Canny_edge_detector). This can help to set the camera focus.

I am unsure about the UI aspects though, which is why I opened this PR for discussion. Right now I am using the Debug Tab:

![Screenshot From 2025-01-06 14-21-25](https://github.com/user-attachments/assets/13b38647-d62b-47b6-abfe-16073aef9a79)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
