### PR TITLE
Simplify model config

### DIFF
--- a/docs/docs/configuration/index.md
+++ b/docs/docs/configuration/index.md
@@ -203,14 +203,13 @@ detectors:
   ov:
     type: openvino
     device: AUTO
-    model:
-      path: /openvino-model/ssdlite_mobilenet_v2.xml
 
 model:
   width: 300
   height: 300
   input_tensor: nhwc
   input_pixel_format: bgr
+  path: /openvino-model/ssdlite_mobilenet_v2.xml
   labelmap_path: /openvino-model/coco_91cl_bkgr.txt
 
 record:

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -144,7 +144,7 @@ detectors:
 
 #### SSDLite MobileNet v2
 
-An OpenVINO model is provided in the container at `/openvino-model/ssdlite_mobilenet_v2.xml` and is used by this detector type by default. The model comes from Intel's Open Model Zoo [SSDLite MobileNet V2](https://github.com/openvinotoolkit/open_model_zoo/tree/master/models/public/ssdlite_mobilenet_v2) and is converted to an FP16 precision IR model. 
+An OpenVINO model is provided in the container at `/openvino-model/ssdlite_mobilenet_v2.xml` and is used by this detector type by default. The model comes from Intel's Open Model Zoo [SSDLite MobileNet V2](https://github.com/openvinotoolkit/open_model_zoo/tree/master/models/public/ssdlite_mobilenet_v2) and is converted to an FP16 precision IR model.
 
 Use the model configuration shown below when using the OpenVINO detector with the default OpenVINO model:
 
@@ -506,11 +506,12 @@ detectors:
   cpu1:
     type: cpu
     num_threads: 3
-    model:
-      path: "/custom_model.tflite"
   cpu2:
     type: cpu
     num_threads: 3
+
+model:
+  path: "/custom_model.tflite"
 ```
 
 When using CPU detectors, you can add one CPU detector per camera. Adding more detectors than the number of cameras should not improve performance.
@@ -637,8 +638,6 @@ detectors:
   hailo8l:
     type: hailo8l
     device: PCIe
-    model:
-      path: /config/model_cache/h8l_cache/ssd_mobilenet_v1.hef
 
 model:
   width: 300
@@ -646,4 +645,5 @@ model:
   input_tensor: nhwc
   input_pixel_format: bgr
   model_type: ssd
+  path: /config/model_cache/h8l_cache/ssd_mobilenet_v1.hef
 ```

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -52,7 +52,7 @@ detectors:
   # Required: name of the detector
   detector_name:
     # Required: type of the detector
-    # Frigate provided types include 'cpu', 'edgetpu', 'openvino' and 'tensorrt' (default: shown below)
+    # Frigate provides many types, see https://docs.frigate.video/configuration/object_detectors for more details (default: shown below)
     # Additional detector types can also be plugged in.
     # Detectors may require additional configuration.
     # Refer to the Detectors configuration page for more information.

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -612,9 +612,7 @@ class FrigateConfig(FrigateBaseModel):
                     model_config["path"] = "/edgetpu_model.tflite"
 
             model = ModelConfig.model_validate(model_config)
-            model.check_and_load_plus_model(
-                self.plus_api, detector_config.type
-            )
+            model.check_and_load_plus_model(self.plus_api, detector_config.type)
             model.compute_model_hash()
             detector_config.model = model
             self.detectors[key] = detector_config

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -594,35 +594,29 @@ class FrigateConfig(FrigateBaseModel):
                 if isinstance(detector, dict)
                 else detector.model_dump(warnings="none")
             )
-            detector_config: DetectorConfig = adapter.validate_python(model_dict)
-            if detector_config.model is None:
-                detector_config.model = self.model.model_copy()
-            else:
-                path = detector_config.model.path
-                detector_config.model = self.model.model_copy()
-                detector_config.model.path = path
+            detector_config: BaseDetectorConfig = adapter.validate_python(model_dict)
 
-                if "path" not in model_dict or len(model_dict.keys()) > 1:
-                    logger.warning(
-                        "Customizing more than a detector model path is unsupported."
-                    )
+            # users should not set model themselves
+            if detector_config.model:
+                detector_config.model = None
 
-            merged_model = deep_merge(
-                detector_config.model.model_dump(exclude_unset=True, warnings="none"),
-                self.model.model_dump(exclude_unset=True, warnings="none"),
-            )
+            model_config = self.model.model_dump(exclude_unset=True, warnings="none")
 
-            if "path" not in merged_model:
+            if detector_config.model_path:
+                model_config["path"] = detector_config.model_path
+
+            if "path" not in model_config:
                 if detector_config.type == "cpu":
-                    merged_model["path"] = "/cpu_model.tflite"
+                    model_config["path"] = "/cpu_model.tflite"
                 elif detector_config.type == "edgetpu":
-                    merged_model["path"] = "/edgetpu_model.tflite"
+                    model_config["path"] = "/edgetpu_model.tflite"
 
-            detector_config.model = ModelConfig.model_validate(merged_model)
-            detector_config.model.check_and_load_plus_model(
+            model = ModelConfig.model_validate(model_config)
+            model.check_and_load_plus_model(
                 self.plus_api, detector_config.type
             )
-            detector_config.model.compute_model_hash()
+            model.compute_model_hash()
+            detector_config.model = model
             self.detectors[key] = detector_config
 
         return self

--- a/frigate/detectors/detector_config.py
+++ b/frigate/detectors/detector_config.py
@@ -194,6 +194,9 @@ class BaseDetectorConfig(BaseModel):
     model: Optional[ModelConfig] = Field(
         default=None, title="Detector specific model configuration."
     )
+    model_path: Optional[str] = Field(
+        default=None, title="Detector specific model path."
+    )
     model_config = ConfigDict(
         extra="allow", arbitrary_types_allowed=True, protected_namespaces=()
     )

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -75,11 +75,11 @@ class TestConfig(unittest.TestCase):
             "detectors": {
                 "cpu": {
                     "type": "cpu",
-                    "model": {"path": "/cpu_model.tflite"},
+                    "model_path": "/cpu_model.tflite",
                 },
                 "edgetpu": {
                     "type": "edgetpu",
-                    "model": {"path": "/edgetpu_model.tflite"},
+                    "model_path": "/edgetpu_model.tflite",
                 },
                 "openvino": {
                     "type": "openvino",

--- a/frigate/util/config.py
+++ b/frigate/util/config.py
@@ -285,6 +285,7 @@ def migrate_015_1(config: dict[str, dict[str, any]]) -> dict[str, dict[str, any]
             new_config["detectors"][detector]["model_path"] = path
             del new_config["detectors"][detector]["model"]
 
+    new_config["version"] = "0.15-1"
     return new_config
 
 

--- a/frigate/util/config.py
+++ b/frigate/util/config.py
@@ -13,7 +13,7 @@ from frigate.util.services import get_video_properties
 
 logger = logging.getLogger(__name__)
 
-CURRENT_CONFIG_VERSION = "0.15-0"
+CURRENT_CONFIG_VERSION = "0.15-1"
 DEFAULT_CONFIG_FILE = "/config/config.yml"
 
 
@@ -76,6 +76,13 @@ def migrate_frigate_config(config_file: str):
         with open(config_file, "w") as f:
             yaml.dump(new_config, f)
         previous_version = "0.15-0"
+
+    if previous_version < "0.15-1":
+        logger.info(f"Migrating frigate config from {previous_version} to 0.15-1...")
+        new_config = migrate_015_1(config)
+        with open(config_file, "w") as f:
+            yaml.dump(new_config, f)
+        previous_version = "0.15-1"
 
     logger.info("Finished frigate config migration...")
 
@@ -264,6 +271,20 @@ def migrate_015_0(config: dict[str, dict[str, any]]) -> dict[str, dict[str, any]
         new_config["cameras"][name] = camera_config
 
     new_config["version"] = "0.15-0"
+    return new_config
+
+
+def migrate_015_1(config: dict[str, dict[str, any]]) -> dict[str, dict[str, any]]:
+    """Handle migrating frigate config to 0.15-1"""
+    new_config = config.copy()
+
+    for detector, detector_config in config.get("detectors", {}).items():
+        path = detector_config.get("model", {}).get("path")
+
+        if path:
+            new_config["detectors"][detector]["model_path"] = path
+            del new_config["detectors"][detector]["model"]
+
     return new_config
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

Many users mistake the `detector.{name}.model` config and end up creating a separate detector. This config is confusing as it no longer supports all fields of a model and is mainly used internally. 

This PR adds a new `model_path` field to detector and leaves `model` as an internal only field

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [x] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
