### PR TITLE
Fix ONVIF Camera Connectivity Behind NAT and Routers

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -142,6 +142,7 @@ RUN apt-get -qq update \
     apt-transport-https \
     gnupg \
     wget \
+    unzip \
     # the key fingerprint can be obtained from https://ftp-master.debian.org/keys.html
     && wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xA4285295FC7B1A81600062A9605C66F00D6C9793" | \
     gpg --dearmor > /usr/share/keyrings/debian-archive-bullseye-stable.gpg \
@@ -180,6 +181,14 @@ RUN /build_pysqlite3.sh
 COPY docker/main/requirements-wheels.txt /requirements-wheels.txt
 RUN pip3 wheel --wheel-dir=/wheels -r /requirements-wheels.txt
 
+# Download the python-onvif-zeep package, build the wheel, move it to the /wheels directory, and clean up temporary files
+RUN wget https://github.com/FalkTannhaeuser/python-onvif-zeep/archive/zeep.zip \
+    && unzip zeep.zip -d . \
+    && cd python-onvif-zeep-zeep \
+    && python3 setup.py bdist_wheel \
+    && mv dist/onvif_zeep-0.2.12-py3-none-any.whl /wheels/ \
+    && cd .. \
+    && rm -rf python-onvif-zeep-zeep zeep.zip
 
 # Collect deps in a single layer
 FROM scratch AS deps-rootfs

--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -12,7 +12,7 @@ pathvalidate == 3.2.*
 markupsafe == 2.1.*
 mypy == 1.6.1
 numpy == 1.26.*
-onvif_zeep == 0.2.12
+zeep == 4.2.1
 opencv-python-headless == 4.9.0.*
 paho-mqtt == 2.1.*
 pandas == 2.2.*


### PR DESCRIPTION
## Proposed change
This pull request addresses an issue with ONVIF cameras located behind NAT (Network Address Translation) routers in Frigate. When queried, these cameras return their private IP addresses and internal ports, making it impossible to access them externally. This issue is particularly relevant for users with cameras installed behind routers.

The solution involves rewriting the `xaddrs` in the ONVIF response to utilize the external IP address and port provided during the connection setup, a method already implemented in the `python-onvif-zeep` package.

I have tested this solution successfully in Frigate version 14.1, ensuring that it works as expected for cameras behind routers. This update will greatly improve connectivity in NAT environments and ensure that users can access their cameras from outside the local network.

## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #15885
- This PR is related to issue: [#75 of python-onvif-zeep](https://github.com/FalkTannhaeuser/python-onvif-zeep/pull/75)

## Checklist

- [x] The code change is tested and works locally. Also tested in realworld scenario with camera behind NAT.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)

Sorry had no time sofar to formt with ruff and run the local test pass.
