### PR TITLE
Fix display of save button in tracked object details pane

### DIFF
--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -543,16 +543,16 @@ function ObjectDetailsTab({
               )}
             </div>
           )}
-          {(config?.cameras[search.camera].genai.enabled && search.end_time) ||
-            (!config?.cameras[search.camera].genai.enabled && (
-              <Button
-                variant="select"
-                aria-label="Save"
-                onClick={updateDescription}
-              >
-                Save
-              </Button>
-            ))}
+          {((config?.cameras[search.camera].genai.enabled && search.end_time) ||
+            !config?.cameras[search.camera].genai.enabled) && (
+            <Button
+              variant="select"
+              aria-label="Save"
+              onClick={updateDescription}
+            >
+              Save
+            </Button>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Parentheses were in the wrong place. So when a user had genai enabled and was looking at the tracked object details pane for a completed tracked object, the end_time would incorrectly be displayed instead of the save button.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
