### PR TITLE
fix syntax error: missing space

### DIFF
--- a/docker/tensorrt/detector/rootfs/etc/s6-overlay/s6-rc.d/trt-model-prepare/run
+++ b/docker/tensorrt/detector/rootfs/etc/s6-overlay/s6-rc.d/trt-model-prepare/run
@@ -20,7 +20,7 @@ FIRST_MODEL=true
 MODEL_DOWNLOAD=""
 MODEL_CONVERT=""
 
-if [ -z "$YOLO_MODELS"]; then
+if [ -z "$YOLO_MODELS" ]; then
     echo "tensorrt model preparation disabled"
     exit 0
 fi


### PR DESCRIPTION
## Proposed change
Fix syntax error:
/etc/s6-overlay/s6-rc.d/trt-model-prepare/run: line 23: [: missing `]'


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
