### PR TITLE
update FFmpeg to ensure compatibility with newer kernels

### DIFF
--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -22,6 +22,6 @@ ADD https://github.com/MarcA711/rknn-toolkit2/releases/download/v2.0.0/librknnrt
 
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffmpeg
 RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffprobe
-ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-5/ffmpeg /usr/lib/ffmpeg/6.0/bin/
-ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-5/ffprobe /usr/lib/ffmpeg/6.0/bin/
+ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-7/ffmpeg /usr/lib/ffmpeg/6.0/bin/
+ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-7/ffprobe /usr/lib/ffmpeg/6.0/bin/
 ENV PATH="/usr/lib/ffmpeg/6.0/bin/:${PATH}"


### PR DESCRIPTION
## Proposed change
An update of the VPU driver in the current vendor kernel causes incompatibilities with the current FFmpeg version (see https://github.com/blakeblackshear/frigate/discussions/16006#discussioncomment-11862085). This PR updates FFmpeg to fix this. The timing is bad because the new version wasn't tested in depth. However, I think it would still be good to ship v0.15 with the new version.

Two users want to test the new  version. Once they confirm that everything works, I will request reviewing/ merging this PR.


## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: https://github.com/blakeblackshear/frigate/discussions/16006, https://github.com/blakeblackshear/frigate/discussions/11502#discussioncomment-11859709
- This PR is related to issue: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
