### PR TITLE
Correctly calculate ffmpeg version based on ffmpeg path

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -215,7 +215,6 @@ ENV TRANSFORMERS_NO_ADVISORY_WARNINGS=1
 ENV OPENCV_FFMPEG_LOGLEVEL=8
 
 ENV PATH="/usr/local/go2rtc/bin:/usr/local/tempio/bin:/usr/local/nginx/sbin:${PATH}"
-ENV LIBAVFORMAT_VERSION_MAJOR=60
 
 # Install dependencies
 RUN --mount=type=bind,source=docker/main/install_deps.sh,target=/deps/install_deps.sh \

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
@@ -42,8 +42,14 @@ function migrate_db_path() {
     fi
 }
 
+function set_libva_version() {
+    local ffmpeg_path=$(python3 /usr/local/ffmpeg/get_ffmpeg_path.py)
+    export LIBAVFORMAT_VERSION_MAJOR=$($ffmpeg_path -version | grep -Po "libavformat\W+\K\d+")
+}
+
 echo "[INFO] Preparing Frigate..."
 migrate_db_path
+set_libva_version
 echo "[INFO] Starting Frigate..."
 
 cd /opt/frigate || echo "[ERROR] Failed to change working directory to /opt/frigate"

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
@@ -43,7 +43,7 @@ function migrate_db_path() {
 }
 
 function set_libva_version() {
-    local ffmpeg_path=$(python3 /usr/local/ffmpeg/get_ffmpeg_path.py)
+    local ffmpeg_path=$(python3 docker/main/rootfs/usr/local/ffmpeg/get_ffmpeg_path.py)
     export LIBAVFORMAT_VERSION_MAJOR=$($ffmpeg_path -version | grep -Po "libavformat\W+\K\d+")
 }
 

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
@@ -43,6 +43,11 @@ function get_ip_and_port_from_supervisor() {
     export FRIGATE_GO2RTC_WEBRTC_CANDIDATE_INTERNAL="${ip_address}:${webrtc_port}"
 }
 
+function set_libva_version() {
+    local ffmpeg_path=$(python3 /usr/local/ffmpeg/get_ffmpeg_path.py)
+    export LIBAVFORMAT_VERSION_MAJOR=$($ffmpeg_path -version | grep -Po "libavformat\W+\K\d+")
+}
+
 if [[ -f "/dev/shm/go2rtc.yaml" ]]; then
     echo "[INFO] Removing stale config from last run..."
     rm /dev/shm/go2rtc.yaml
@@ -60,6 +65,8 @@ if [[ ! -f "/dev/shm/go2rtc.yaml" ]]; then
 else
     echo "[WARNING] Unable to remove existing go2rtc config. Changes made to your frigate config file may not be recognized. Please remove the /dev/shm/go2rtc.yaml from your docker host manually."
 fi
+
+set_libva_version
 
 readonly config_path="/config"
 

--- a/docker/main/rootfs/usr/local/ffmpeg/get_ffmpeg_path.py
+++ b/docker/main/rootfs/usr/local/ffmpeg/get_ffmpeg_path.py
@@ -1,0 +1,46 @@
+import json
+import os
+import shutil
+import sys
+
+from ruamel.yaml import YAML
+
+sys.path.insert(0, "/opt/frigate")
+from frigate.const import (
+    DEFAULT_FFMPEG_VERSION,
+    INCLUDED_FFMPEG_VERSIONS,
+)
+
+sys.path.remove("/opt/frigate")
+
+yaml = YAML()
+
+config_file = os.environ.get("CONFIG_FILE", "/config/config.yml")
+
+# Check if we can use .yaml instead of .yml
+config_file_yaml = config_file.replace(".yml", ".yaml")
+if os.path.isfile(config_file_yaml):
+    config_file = config_file_yaml
+
+try:
+    with open(config_file) as f:
+        raw_config = f.read()
+
+    if config_file.endswith((".yaml", ".yml")):
+        config: dict[str, any] = yaml.load(raw_config)
+    elif config_file.endswith(".json"):
+        config: dict[str, any] = json.loads(raw_config)
+except FileNotFoundError:
+    config: dict[str, any] = {}
+
+path = config.get("ffmpeg", {}).get("path", "default")
+if path == "default":
+    if shutil.which("ffmpeg") is None:
+        print(f"/usr/lib/ffmpeg/{DEFAULT_FFMPEG_VERSION}/bin/ffmpeg")
+    else:
+        print("ffmpeg")
+elif path in INCLUDED_FFMPEG_VERSIONS:
+    print(f"/usr/lib/ffmpeg/{path}/bin/ffmpeg")
+else:
+    print(f"{path}/bin/ffmpeg")
+

--- a/docker/main/rootfs/usr/local/ffmpeg/get_ffmpeg_path.py
+++ b/docker/main/rootfs/usr/local/ffmpeg/get_ffmpeg_path.py
@@ -43,4 +43,3 @@ elif path in INCLUDED_FFMPEG_VERSIONS:
     print(f"/usr/lib/ffmpeg/{path}/bin/ffmpeg")
 else:
     print(f"{path}/bin/ffmpeg")
-

--- a/docker/rpi/Dockerfile
+++ b/docker/rpi/Dockerfile
@@ -12,7 +12,5 @@ RUN rm -rf /usr/lib/btbn-ffmpeg/
 RUN --mount=type=bind,source=docker/rpi/install_deps.sh,target=/deps/install_deps.sh \
     /deps/install_deps.sh
 
-ENV LIBAVFORMAT_VERSION_MAJOR=58
-
 WORKDIR /opt/frigate/
 COPY --from=rootfs / /


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

We can't assume the version based on the docker build, it needs to be calculated on startup

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
