### PR TITLE
Change back to TranslationGenericSpace for RelativeMove

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -163,7 +163,7 @@ class OnvifController:
                     for i, space in enumerate(
                         ptz_config.Spaces.RelativePanTiltTranslationSpace
                     )
-                    if "TranslationSpaceFov" in space["URI"]
+                    if "TranslationGenericSpace" in space["URI"]
                 ),
                 None,
             )


### PR DESCRIPTION
Back in PR #10350 the space for Translation.PanTilt was changed to TranslationSpaceFov. This broke the absolute move status reporting for Hikvision cameras.

It is unclear why it was changed back then, maybe the TranslationGenericSpace doesn't work with how Frigate is doing relative moves.

Now Hikvision camera passes the calibration step.

## Proposed change
Fixes the PTZ auto tracking for Hikvision cameras.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #7958

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
