### PR TITLE
Update docs for /api/config/save

### DIFF
--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -203,16 +203,16 @@ When frigate starts up, it checks whether your config file is valid, and if it i
 
 ### Via API
 
-Frigate can accept a new configuration file as JSON at the `/config/save` endpoint. When updating the config this way, Frigate will validate the config before saving it, and return a `400` if the config is not valid.
+Frigate can accept a new configuration file as JSON at the `/api/config/save` endpoint. When updating the config this way, Frigate will validate the config before saving it, and return a `400` if the config is not valid.
 
 ```bash
-curl -X POST http://frigate_host:5000/config/save -d @config.json
+curl -X POST http://frigate_host:5000/api/config/save -d @config.json
 ```
 
 if you'd like you can use your yaml config directly by using [`yq`](https://github.com/mikefarah/yq) to convert it to json:
 
 ```bash
-yq r -j config.yml | curl -X POST http://frigate_host:5000/config/save -d @-
+yq r -j config.yml | curl -X POST http://frigate_host:5000/api/config/save -d @-
 ```
 
 ### Via Command Line


### PR DESCRIPTION
## Proposed change

Pull Request corrects the [Advanced Options](https://docs.frigate.video/configuration/advanced/#via-api) documentation for the `/config/save` API by changing it to `/api/config/save`. I was spinning my wheels on why i was getting a 405 Not Allowed error when trying to use the API to save a config.json file.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update
