### PR TITLE
Consider pre and post capture when cleaning up recordings based on re…

### DIFF
--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -121,22 +121,29 @@ class RecordingCleanup(threading.Thread):
         review_start = 0
         deleted_recordings = set()
         kept_recordings: list[tuple[float, float]] = []
+        recording: Recordings
         for recording in recordings:
             keep = False
             mode = None
             # Now look for a reason to keep this recording segment
             for idx in range(review_start, len(reviews)):
                 review: ReviewSegment = reviews[idx]
+                severity = review.severity
+                pre_capture = config.record.get_review_pre_capture(severity)
+                post_capture = config.record.get_review_post_capture(severity)
 
                 # if the review starts in the future, stop checking reviews
                 # and let this recording segment expire
-                if review.start_time > recording.end_time:
+                if review.start_time - pre_capture > recording.end_time:
                     keep = False
                     break
 
                 # if the review is in progress or ends after the recording starts, keep it
                 # and stop looking at reviews
-                if review.end_time is None or review.end_time >= recording.start_time:
+                if (
+                    review.end_time is None
+                    or review.end_time + post_capture >= recording.start_time
+                ):
                     keep = True
                     mode = (
                         config.record.alerts.retain.mode
@@ -149,7 +156,7 @@ class RecordingCleanup(threading.Thread):
                 # this review and check the next review for an overlap.
                 # since the review and recordings are sorted, we can skip review
                 # that end before the previous recording segment started on future segments
-                if review.end_time < recording.start_time:
+                if review.end_time + post_capture < recording.start_time:
                     review_start = idx
 
             # Delete recordings outside of the retention window or based on the retention mode


### PR DESCRIPTION
…view segments

## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

This led to segments being kept but then being deleted on the next recording cleanup if they were only kept for pre / post capture. 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
