### PR TITLE
Add camera name to tracked object update mqtt

### DIFF
--- a/docs/docs/configuration/genai.md
+++ b/docs/docs/configuration/genai.md
@@ -146,7 +146,7 @@ While generating simple descriptions of detected objects is useful, understandin
 
 ### Using GenAI for notifications
 
-Frigate provides an [MQTT topic](/integrations/mqtt), `frigate/tracked_object_update`, that is updated with a JSON payload containing `event_id` and `description` when your AI provider returns a description for a tracked object. This description could be used directly in notifications, such as sending alerts to your phone or making audio announcements. If additional details from the tracked object are needed, you can query the [HTTP API](/integrations/api/event-events-event-id-get) using the `event_id`, eg: `http://frigate_ip:5000/api/events/<event_id>`.
+Frigate provides an [MQTT topic](/integrations/mqtt), `frigate/tracked_object_update`, that is updated with a JSON payload containing `event_id`, `description` an d `camera` when your AI provider returns a description for a tracked object. This description could be used directly in notifications, such as sending alerts to your phone or making audio announcements. If additional details from the tracked object are needed, you can query the [HTTP API](/integrations/api/event-events-event-id-get) using the `event_id`, eg: `http://frigate_ip:5000/api/events/<event_id>`.
 
 ## Custom Prompts
 

--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -102,7 +102,8 @@ Message published for updates to tracked object metadata, for example when GenAI
 {
   "type": "description",
   "id": "1607123955.475377-mxklsc",
-  "description": "The car is a red sedan moving away from the camera."
+  "description": "The car is a red sedan moving away from the camera.",
+  "camera": "front_door"
 }
 ```
 

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -143,6 +143,7 @@ class Dispatcher:
                         "type": TrackedObjectUpdateTypesEnum.description,
                         "id": event.id,
                         "description": event.data["description"],
+                        "camera": event.camera,
                     }
                 ),
             )


### PR DESCRIPTION
## Proposed change
Adding the camera name in the tracked_object_update, so you don't need to look up the camera name in the api, when using the tracked_object_update. This will make it easier for notifications in Home Assistant 


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
