### PR TITLE
Fix selection of tracked objects in Explore on desktop Safari

### DIFF
--- a/web/src/components/card/SearchThumbnail.tsx
+++ b/web/src/components/card/SearchThumbnail.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useApiHost } from "@/api";
 import { getIconForLabel } from "@/utils/iconUtil";
 import useSWR from "swr";
@@ -33,6 +33,16 @@ export default function SearchThumbnail({
     onClick(searchResult, true, false);
   });
 
+  const handleOnClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.metaKey) {
+        e.stopPropagation();
+        onClick(searchResult, true, false);
+      }
+    },
+    [searchResult, onClick],
+  );
+
   const objectLabel = useMemo(() => {
     if (
       !config ||
@@ -57,6 +67,7 @@ export default function SearchThumbnail({
       <div className={`size-full ${imgLoaded ? "visible" : "invisible"}`}>
         <img
           ref={imgRef}
+          onClick={handleOnClick}
           className={cn(
             "size-full select-none object-cover object-center opacity-100 transition-opacity",
           )}

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -554,13 +554,10 @@ export default function SearchView({
                           ctrl: boolean,
                           detail: boolean,
                         ) => {
-                          if (detail && selectedObjects.length == 0) {
+                          if (detail) {
                             setSearchDetail(value);
                           } else {
-                            onSelectSearch(
-                              value,
-                              ctrl || selectedObjects.length > 0,
-                            );
+                            onSelectSearch(value, ctrl);
                           }
                         }}
                       />

--- a/web/src/views/search/SearchView.tsx
+++ b/web/src/views/search/SearchView.tsx
@@ -554,10 +554,13 @@ export default function SearchView({
                           ctrl: boolean,
                           detail: boolean,
                         ) => {
-                          if (detail) {
+                          if (detail && selectedObjects.length == 0) {
                             setSearchDetail(value);
                           } else {
-                            onSelectSearch(value, ctrl);
+                            onSelectSearch(
+                              value,
+                              ctrl || selectedObjects.length > 0,
+                            );
                           }
                         }}
                       />


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
- Ensure meta click works on Safari desktop to select tracked objects in Explore


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/16046
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
