### PR TITLE
Fix interpolation for autotracking cameras

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -405,19 +405,19 @@ class OnvifController:
         # The onvif spec says this can report as +INF and -INF, so this may need to be modified
         pan = numpy.interp(
             pan,
+            [-1, 1],
             [
                 self.cams[camera_name]["relative_fov_range"]["XRange"]["Min"],
                 self.cams[camera_name]["relative_fov_range"]["XRange"]["Max"],
             ],
-            [-1, 1],
         )
         tilt = numpy.interp(
             tilt,
+            [-1, 1],
             [
                 self.cams[camera_name]["relative_fov_range"]["YRange"]["Min"],
                 self.cams[camera_name]["relative_fov_range"]["YRange"]["Max"],
             ],
-            [-1, 1],
         )
 
         move_request.Speed = {
@@ -529,11 +529,11 @@ class OnvifController:
         # function takes in 0 to 1 for zoom, interpolate to the values of the camera.
         zoom = numpy.interp(
             zoom,
+            [0, 1],
             [
                 self.cams[camera_name]["absolute_zoom_range"]["XRange"]["Min"],
                 self.cams[camera_name]["absolute_zoom_range"]["XRange"]["Max"],
             ],
-            [0, 1],
         )
 
         move_request.Speed = {"Zoom": speed}


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Corrects a bug introduced in https://github.com/blakeblackshear/frigate/pull/14139 where interpolation logic was reversed.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
