### PR TITLE
add tip about disabling TLS to use auth with HA integration

### DIFF
--- a/docs/docs/integrations/home-assistant.md
+++ b/docs/docs/integrations/home-assistant.md
@@ -113,6 +113,12 @@ If you run Frigate on a separate device within your local network, Home Assistan
 
 Use `http://<frigate_device_ip>:8971` as the URL for the integration so that authentication is required.
 
+:::tip
+The above URL assumes you have [disabled TLS](../configuration/tls).
+By default, TLS is enabled and Frigate will be using a self-signed certificate. HomeAssistant will fail to connect HTTPS to port 8971 since it fails to verify the self-signed certificate.
+Either disable TLS and use HTTP from HomeAssistant, or configure Frigate to be acessible with a valid certificate.
+:::
+
 ```yaml
 services:
   frigate:

--- a/docs/docs/integrations/home-assistant.md
+++ b/docs/docs/integrations/home-assistant.md
@@ -114,9 +114,11 @@ If you run Frigate on a separate device within your local network, Home Assistan
 Use `http://<frigate_device_ip>:8971` as the URL for the integration so that authentication is required.
 
 :::tip
+
 The above URL assumes you have [disabled TLS](../configuration/tls).
 By default, TLS is enabled and Frigate will be using a self-signed certificate. HomeAssistant will fail to connect HTTPS to port 8971 since it fails to verify the self-signed certificate.
 Either disable TLS and use HTTP from HomeAssistant, or configure Frigate to be acessible with a valid certificate.
+
 :::
 
 ```yaml


### PR DESCRIPTION
## Proposed change
The documentation provides an HTTP URL to users that implicitly assumes the user has disabled TLS.
This pull request adds an explicit note about disabling TLS for using authentication with HA.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
