### PR TITLE
Moved camera specific options from custom prompts to configuration s…

### DIFF
--- a/docs/docs/configuration/genai.md
+++ b/docs/docs/configuration/genai.md
@@ -27,11 +27,22 @@ genai:
   model: gemini-1.5-flash
 
 cameras:
-  front_camera: ...
+  front_camera: 
+    genai:
+      enabled: True # <- enable GenAI for your front camera
+      use_snapshot: True
+      objects:
+        - person
+      required_zones:
+        - steps
   indoor_camera:
-    genai: # <- disable GenAI for your indoor camera
-      enabled: False
+    genai: 
+      enabled: False # <- disable GenAI for your indoor camera
 ```
+
+By default, descriptions will be generated for all tracked objects and all zones. But you can also optionally specify `objects` and `required_zones` to only generate descriptions for certain tracked objects or zones.
+
+Optionally, you can generate the description using a snapshot (if enabled) by setting `use_snapshot` to `True`. By default, this is set to `False`, which sends the uncompressed images from the `detect` stream collected over the object's lifetime to the model. Once the object lifecycle ends, only a single compressed and cropped thumbnail is saved with the tracked object. Using a snapshot might be useful when you want to _regenerate_ a tracked object's description as it will provide the AI with a higher-quality image (typically downscaled by the AI itself) than the cropped/compressed thumbnail. Using a snapshot otherwise has a trade-off in that only a single image is sent to your provider, which will limit the model's ability to determine object movement or direction.
 
 ## Ollama
 
@@ -182,9 +193,7 @@ genai:
     car: "Observe the primary vehicle in these images. Focus on its movement, direction, or purpose (e.g., parking, approaching, circling). If it's a delivery vehicle, mention the company."
 ```
 
-Prompts can also be overriden at the camera level to provide a more detailed prompt to the model about your specific camera, if you desire. By default, descriptions will be generated for all tracked objects and all zones. But you can also optionally specify `objects` and `required_zones` to only generate descriptions for certain tracked objects or zones.
-
-Optionally, you can generate the description using a snapshot (if enabled) by setting `use_snapshot` to `True`. By default, this is set to `False`, which sends the uncompressed images from the `detect` stream collected over the object's lifetime to the model. Once the object lifecycle ends, only a single compressed and cropped thumbnail is saved with the tracked object. Using a snapshot might be useful when you want to _regenerate_ a tracked object's description as it will provide the AI with a higher-quality image (typically downscaled by the AI itself) than the cropped/compressed thumbnail. Using a snapshot otherwise has a trade-off in that only a single image is sent to your provider, which will limit the model's ability to determine object movement or direction.
+Prompts can also be overriden at the camera level to provide a more detailed prompt to the model about your specific camera, if you desire. 
 
 ```yaml
 cameras:


### PR DESCRIPTION
…ection

## Proposed change

  This moves camera specific options `required_zones`, `objects` and `use_snapshot` from the Custom Prompts section of the genai docs to the Configuration section. I think this is a more appropriate section as they are more general configuration options rather than related to Custom Prompts



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
