### PR TITLE
Add autotracking calibration message

### DIFF
--- a/docs/docs/configuration/autotracking.md
+++ b/docs/docs/configuration/autotracking.md
@@ -167,3 +167,7 @@ To maintain object tracking during PTZ moves, Frigate tracks the motion of your 
 ### Calibration seems to have completed, but the camera is not actually moving to track my object. Why?
 
 Some cameras have firmware that reports that FOV RelativeMove, the ONVIF command that Frigate uses for autotracking, is supported. However, if the camera does not pan or tilt when an object comes into the required zone, your camera's firmware does not actually support FOV RelativeMove. One such camera is the Uniview IPC672LR-AX4DUPK. It actually moves its zoom motor instead of panning and tilting and does not follow the ONVIF standard whatsoever.
+
+### Frigate reports an error saying that calibration has failed. Why?
+
+Calibration measures the amount of time it takes for Frigate to make a series of movements with your PTZ. This error message is recorded in the log if these values are too high for Frigate to support calibrated autotracking. This is often the case when your camera's motor or network connection is too slow or your camera's firmware doesn't report the motor status in a timely manner. You can try running without calibration (just remove the `movement_weights` line from your config and restart), but if calibration fails, this often means that autotracking will behave unpredictably.

--- a/frigate/config/camera/onvif.py
+++ b/frigate/config/camera/onvif.py
@@ -64,7 +64,9 @@ class PtzAutotrackConfig(FrigateBaseModel):
             raise ValueError("Invalid type for movement_weights")
 
         if len(weights) != 5:
-            raise ValueError("movement_weights must have exactly 5 floats")
+            raise ValueError(
+                "movement_weights must have exactly 5 floats, remove this line from your config and run autotracking calibration"
+            )
 
         return weights
 

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -500,9 +500,26 @@ class PtzAutoTracker:
 
             # simple linear regression with intercept
             X_with_intercept = np.column_stack((np.ones(X.shape[0]), X))
-            self.move_coefficients[camera] = np.linalg.lstsq(
-                X_with_intercept, y, rcond=None
-            )[0]
+            coefficients = np.linalg.lstsq(X_with_intercept, y, rcond=None)[0]
+
+            intercept, slope = coefficients
+
+            # Define reasonable bounds for PTZ movement times
+            MIN_MOVEMENT_TIME = 0.1  # Minimum time for any movement (100ms)
+            MAX_MOVEMENT_TIME = 10.0  # Maximum time for any movement
+            MAX_SLOPE = 2.0  # Maximum seconds per unit of movement
+
+            coefficients_valid = (
+                MIN_MOVEMENT_TIME <= intercept <= MAX_MOVEMENT_TIME
+                and 0 < slope <= MAX_SLOPE
+            )
+
+            if not coefficients_valid:
+                logger.warning(f"{camera}: Autotracking calibration failed")
+                return False
+
+            # If coefficients are valid, proceed with updates
+            self.move_coefficients[camera] = coefficients
 
             # only assign a new intercept if we're calibrating
             if calibration:

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -135,7 +135,7 @@ class PtzMotionEstimator:
 
             try:
                 logger.debug(
-                    f"{camera}: Motion estimator transformation: {self.coord_transformations.rel_to_abs([[0,0]])}"
+                    f"{camera}: Motion estimator transformation: {self.coord_transformations.rel_to_abs([[0, 0]])}"
                 )
             except Exception:
                 pass
@@ -471,7 +471,7 @@ class PtzAutoTracker:
                 self.onvif.get_camera_status(camera)
 
             logger.info(
-                f"Calibration for {camera} in progress: {round((step/num_steps)*100)}% complete"
+                f"Calibration for {camera} in progress: {round((step / num_steps) * 100)}% complete"
             )
 
         self.calibrating[camera] = False
@@ -515,7 +515,9 @@ class PtzAutoTracker:
             )
 
             if not coefficients_valid:
-                logger.warning(f"{camera}: Autotracking calibration failed")
+                logger.warning(
+                    f"{camera}: Autotracking calibration failed. See the Frigate documentation."
+                )
                 return False
 
             # If coefficients are valid, proceed with updates
@@ -707,7 +709,7 @@ class PtzAutoTracker:
                             f"{camera}: Predicted movement time: {self._predict_movement_time(camera, pan, tilt)}"
                         )
                         logger.debug(
-                            f"{camera}: Actual movement time: {self.ptz_metrics[camera].stop_time.value-self.ptz_metrics[camera].start_time.value}"
+                            f"{camera}: Actual movement time: {self.ptz_metrics[camera].stop_time.value - self.ptz_metrics[camera].start_time.value}"
                         )
 
                     # save metrics for better estimate calculations
@@ -1000,10 +1002,10 @@ class PtzAutoTracker:
             logger.debug(f"{camera}: Zoom test: at max zoom: {at_max_zoom}")
             logger.debug(f"{camera}: Zoom test: at min zoom: {at_min_zoom}")
             logger.debug(
-                f'{camera}: Zoom test: zoom in hysteresis limit: {zoom_in_hysteresis} value: {AUTOTRACKING_ZOOM_IN_HYSTERESIS} original: {self.tracked_object_metrics[camera]["original_target_box"]} max: {self.tracked_object_metrics[camera]["max_target_box"]} target: {calculated_target_box if calculated_target_box else self.tracked_object_metrics[camera]["target_box"]}'
+                f"{camera}: Zoom test: zoom in hysteresis limit: {zoom_in_hysteresis} value: {AUTOTRACKING_ZOOM_IN_HYSTERESIS} original: {self.tracked_object_metrics[camera]['original_target_box']} max: {self.tracked_object_metrics[camera]['max_target_box']} target: {calculated_target_box if calculated_target_box else self.tracked_object_metrics[camera]['target_box']}"
             )
             logger.debug(
-                f'{camera}: Zoom test: zoom out hysteresis limit: {zoom_out_hysteresis} value: {AUTOTRACKING_ZOOM_OUT_HYSTERESIS} original: {self.tracked_object_metrics[camera]["original_target_box"]} max: {self.tracked_object_metrics[camera]["max_target_box"]} target: {calculated_target_box if calculated_target_box else self.tracked_object_metrics[camera]["target_box"]}'
+                f"{camera}: Zoom test: zoom out hysteresis limit: {zoom_out_hysteresis} value: {AUTOTRACKING_ZOOM_OUT_HYSTERESIS} original: {self.tracked_object_metrics[camera]['original_target_box']} max: {self.tracked_object_metrics[camera]['max_target_box']} target: {calculated_target_box if calculated_target_box else self.tracked_object_metrics[camera]['target_box']}"
             )
 
         # Zoom in conditions (and)
@@ -1086,7 +1088,7 @@ class PtzAutoTracker:
                 pan = ((centroid_x / camera_width) - 0.5) * 2
                 tilt = (0.5 - (centroid_y / camera_height)) * 2
 
-            logger.debug(f'{camera}: Original box: {obj.obj_data["box"]}')
+            logger.debug(f"{camera}: Original box: {obj.obj_data['box']}")
             logger.debug(f"{camera}: Predicted box: {tuple(predicted_box)}")
             logger.debug(
                 f"{camera}: Velocity: {tuple(np.round(average_velocity).flatten().astype(int))}"
@@ -1196,7 +1198,7 @@ class PtzAutoTracker:
                     )
                     zoom = (ratio - 1) / (ratio + 1)
                     logger.debug(
-                        f'{camera}: limit: {self.tracked_object_metrics[camera]["max_target_box"]}, ratio: {ratio} zoom calculation: {zoom}'
+                        f"{camera}: limit: {self.tracked_object_metrics[camera]['max_target_box']}, ratio: {ratio} zoom calculation: {zoom}"
                     )
                     if not result:
                         # zoom out with special condition if zooming out because of velocity, edges, etc.


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR adds code to check autotracking calibration values before writing them to the user's config. If they are out of a reasonable range, a log message is printed. 

If some users find that the range is unreasonable, we can tweak these values.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/blakeblackshear/frigate/discussions/16241

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
