### PR TITLE
Add ability to set MQTT QoS in config

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -46,6 +46,11 @@ mqtt:
   tls_insecure: false
   # Optional: interval in seconds for publishing stats (default: shown below)
   stats_interval: 60
+  # Optional: QoS level for subscriptions and publishing (default: shown below)
+  # 0 = at most once
+  # 1 = at least once
+  # 2 = exactly once
+  qos: 0
 
 # Optional: Detectors configuration. Defaults to a single CPU detector
 detectors:

--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -31,7 +31,10 @@ class MqttClient(Communicator):  # type: ignore[misc]
             return
 
         self.client.publish(
-            f"{self.mqtt_config.topic_prefix}/{topic}", payload, retain=retain
+            f"{self.mqtt_config.topic_prefix}/{topic}",
+            payload,
+            qos=self.config.mqtt.qos,
+            retain=retain,
         )
 
     def stop(self) -> None:
@@ -151,7 +154,7 @@ class MqttClient(Communicator):  # type: ignore[misc]
 
         self.connected = True
         logger.debug("MQTT connected")
-        client.subscribe(f"{self.mqtt_config.topic_prefix}/#")
+        client.subscribe(f"{self.mqtt_config.topic_prefix}/#", qos=self.config.mqtt.qos)
         self._set_initial_topics()
 
     def _on_disconnect(

--- a/frigate/config/mqtt.py
+++ b/frigate/config/mqtt.py
@@ -30,6 +30,7 @@ class MqttConfig(FrigateBaseModel):
     )
     tls_client_key: Optional[str] = Field(default=None, title="MQTT TLS Client Key")
     tls_insecure: Optional[bool] = Field(default=None, title="MQTT TLS Insecure")
+    qos: Optional[int] = Field(default=0, title="MQTT QoS")
 
     @model_validator(mode="after")
     def user_requires_pass(self, info: ValidationInfo) -> Self:


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR adds the ability to set the MQTT subscribe and publish QoS in the config file.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: closes https://github.com/blakeblackshear/frigate/issues/14963
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
