### PR TITLE
fix(auth): Added trimming to jwt secret token read from .jwt_secret

### DIFF
--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -134,7 +134,7 @@ def get_jwt_secret() -> str:
             logger.debug("Using jwt secret from .jwt_secret file in config directory.")
             with open(jwt_secret_file) as f:
                 try:
-                    jwt_secret = f.readline()
+                    jwt_secret = f.readline().strip()
                 except Exception:
                     logger.warning(
                         "Unable to read jwt token from .jwt_secret file in config directory. A new jwt token will be created at each startup."


### PR DESCRIPTION
## Proposed change
Not cleaning leading and trailing spaces when reading a secret token from a file results in JWT tokens being generated with an incorrect secret.

When building a mini-app that works with the Frigate API, it was noticed that JWT tokens were being generated with a secret other than the one specified in the `.jwt_secret` file. After several hours of painstaking reverse engineering, it was discovered that the secret token reading functionality also reads spaces and special characters that appear when manually editing the file (for example, via `nano`).

This PR adds cleaning of spaces and special characters when reading the secret.

There are no breaking and critical changes. But the change will cause all users to logout from the system, since the algorithm for obtaining a secret token will be changed.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information
I injected logging in the `auth()` method and got the following results.

Before changes:
![Before changes](https://github.com/user-attachments/assets/0182d1d3-daab-4cf2-8d18-80bbe8e857d9)

After changes:
![After changes](https://github.com/user-attachments/assets/7d27d812-01bd-4dc5-8221-5bae9da86d55)

`.jwt_secret` file were created manually via `nano`.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
