### PR TITLE
Fix non-awaited onvif calls

### DIFF
--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -1,5 +1,6 @@
 """Automatically pan, tilt, and zoom on detected objects via onvif."""
 
+import asyncio
 import copy
 import logging
 import queue
@@ -253,7 +254,7 @@ class PtzAutoTracker:
             return
 
         if not self.onvif.cams[camera]["init"]:
-            if not self.onvif._init_onvif(camera):
+            if not asyncio.run(self.onvif._init_onvif(camera)):
                 logger.warning(
                     f"Disabling autotracking for {camera}: Unable to initialize onvif"
                 )

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -145,7 +145,7 @@ class OnvifController:
         ):
             request = ptz.create_type("GetConfigurationOptions")
             request.ConfigurationToken = profile.PTZConfiguration.token
-            ptz_config = ptz.GetConfigurationOptions(request)
+            ptz_config = await ptz.GetConfigurationOptions(request)
             logger.debug(f"Onvif config for {camera_name}: {ptz_config}")
 
             service_capabilities_request = ptz.create_type("GetServiceCapabilities")
@@ -169,7 +169,7 @@ class OnvifController:
             status_request.ProfileToken = profile.token
             self.cams[camera_name]["status_request"] = status_request
             try:
-                status = ptz.GetStatus(status_request)
+                status = await ptz.GetStatus(status_request)
                 logger.debug(f"Onvif status config for {camera_name}: {status}")
             except Exception as e:
                 logger.warning(f"Unable to get status from camera: {camera_name}: {e}")


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Ensure all autotracking onvif calls use `await` now since we are using `onvif-zeep-async`.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
