### PR TITLE
Use persistence for HLS player muting

### DIFF
--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -144,7 +144,7 @@ export default function HlsVideoPlayer({
 
   const [tallCamera, setTallCamera] = useState(false);
   const [isPlaying, setIsPlaying] = useState(true);
-  const [muted, setMuted] = useOverlayState("playerMuted", true);
+  const [muted, setMuted] = usePersistence("hlsPlayerMuted", true);
   const [volume, setVolume] = useOverlayState("playerVolume", 1.0);
   const [defaultPlaybackRate] = usePersistence("playbackRate", 1);
   const [playbackRate, setPlaybackRate] = useOverlayState(
@@ -211,7 +211,7 @@ export default function HlsVideoPlayer({
             fullscreen: supportsFullscreen,
           }}
           setControlsOpen={setControlsOpen}
-          setMuted={(muted) => setMuted(muted, true)}
+          setMuted={(muted) => setMuted(muted)}
           playbackRate={playbackRate ?? 1}
           hotKeys={hotKeys}
           onPlayPause={onPlayPause}
@@ -280,9 +280,12 @@ export default function HlsVideoPlayer({
                 }
               : undefined
           }
-          onVolumeChange={() =>
-            setVolume(videoRef.current?.volume ?? 1.0, true)
-          }
+          onVolumeChange={() => {
+            setVolume(videoRef.current?.volume ?? 1.0, true);
+            if (!frigateControls) {
+              setMuted(videoRef.current?.muted);
+            }
+          }}
           onPlay={() => {
             setIsPlaying(true);
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR ensures the mute/unmute state is persisted for the HLS player.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue:
closes https://github.com/blakeblackshear/frigate/issues/15829
closes https://github.com/blakeblackshear/frigate/issues/12538
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
