### PR TITLE
Ensure all streaming settings are saved correctly on mobile

### DIFF
--- a/web/src/components/menu/LiveContextMenu.tsx
+++ b/web/src/components/menu/LiveContextMenu.tsx
@@ -82,7 +82,7 @@ export default function LiveContextMenu({
     );
 
   useEffect(() => {
-    if (cameraGroup) {
+    if (cameraGroup && cameraGroup != "default") {
       setGroupStreamingSettings(allGroupsStreamingSettings[cameraGroup]);
     }
     // set individual group when all groups changes
@@ -91,7 +91,12 @@ export default function LiveContextMenu({
 
   const onSave = useCallback(
     (settings: GroupStreamingSettings) => {
-      if (!cameraGroup || !allGroupsStreamingSettings) {
+      if (
+        !cameraGroup ||
+        !allGroupsStreamingSettings ||
+        cameraGroup == "default" ||
+        !settings
+      ) {
         return;
       }
 

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -14,7 +14,11 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { usePersistence } from "@/hooks/use-persistence";
-import { CameraConfig, FrigateConfig } from "@/types/frigateConfig";
+import {
+  AllGroupsStreamingSettings,
+  CameraConfig,
+  FrigateConfig,
+} from "@/types/frigateConfig";
 import { ReviewSegment } from "@/types/review";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -38,6 +42,7 @@ import { FaCompress, FaExpand } from "react-icons/fa";
 import useCameraLiveMode from "@/hooks/use-camera-live-mode";
 import { useResizeObserver } from "@/hooks/resize-observer";
 import LiveContextMenu from "@/components/menu/LiveContextMenu";
+import { useStreamingSettings } from "@/context/streaming-settings-provider";
 
 type LiveDashboardViewProps = {
   cameras: CameraConfig[];
@@ -135,8 +140,6 @@ export default function LiveDashboardView({
 
   // camera live views
 
-  const [autoLiveView] = usePersistence("autoLiveView", true);
-
   const [{ height: containerHeight }] = useResizeObserver(containerRef);
 
   const hasScrollbar = useMemo(() => {
@@ -198,6 +201,17 @@ export default function LiveDashboardView({
     supportsAudioOutputStates,
   } = useCameraLiveMode(cameras, windowVisible);
 
+  const [globalAutoLive] = usePersistence("autoLiveView", true);
+
+  const { allGroupsStreamingSettings, setAllGroupsStreamingSettings } =
+    useStreamingSettings();
+
+  const currentGroupStreamingSettings = useMemo(() => {
+    if (cameraGroup && cameraGroup != "default" && allGroupsStreamingSettings) {
+      return allGroupsStreamingSettings[cameraGroup];
+    }
+  }, [allGroupsStreamingSettings, cameraGroup]);
+
   const cameraRef = useCallback(
     (node: HTMLElement | null) => {
       if (!visibleCameraObserver.current) {
@@ -245,6 +259,25 @@ export default function LiveDashboardView({
     }));
   };
 
+  useEffect(() => {
+    if (!allGroupsStreamingSettings) {
+      return;
+    }
+
+    const initialAudioStates: AudioState = {};
+    const initialVolumeStates: VolumeState = {};
+
+    Object.entries(allGroupsStreamingSettings).forEach(([_, groupSettings]) => {
+      Object.entries(groupSettings).forEach(([camera, cameraSettings]) => {
+        initialAudioStates[camera] = cameraSettings.playAudio ?? false;
+        initialVolumeStates[camera] = cameraSettings.volume ?? 1;
+      });
+    });
+
+    setAudioStates(initialAudioStates);
+    setVolumeStates(initialVolumeStates);
+  }, [allGroupsStreamingSettings]);
+
   const toggleAudio = (cameraName: string): void => {
     setAudioStates((prev) => ({
       ...prev,
@@ -252,12 +285,55 @@ export default function LiveDashboardView({
     }));
   };
 
+  const onSaveMuting = useCallback(
+    (playAudio: boolean) => {
+      if (
+        !cameraGroup ||
+        !allGroupsStreamingSettings ||
+        cameraGroup == "default"
+      ) {
+        return;
+      }
+
+      const existingGroupSettings =
+        allGroupsStreamingSettings[cameraGroup] || {};
+
+      const updatedSettings: AllGroupsStreamingSettings = {
+        ...Object.fromEntries(
+          Object.entries(allGroupsStreamingSettings || {}).filter(
+            ([key]) => key !== cameraGroup,
+          ),
+        ),
+        [cameraGroup]: {
+          ...existingGroupSettings,
+          ...Object.fromEntries(
+            Object.entries(existingGroupSettings).map(
+              ([cameraName, settings]) => [
+                cameraName,
+                {
+                  ...settings,
+                  playAudio: playAudio,
+                },
+              ],
+            ),
+          ),
+        },
+      };
+
+      if (cameraGroup != "default") {
+        setAllGroupsStreamingSettings?.(updatedSettings);
+      }
+    },
+    [cameraGroup, allGroupsStreamingSettings, setAllGroupsStreamingSettings],
+  );
+
   const muteAll = (): void => {
     const updatedStates: Record<string, boolean> = {};
     visibleCameras.forEach((cameraName) => {
       updatedStates[cameraName] = false;
     });
     setAudioStates(updatedStates);
+    onSaveMuting(false);
   };
 
   const unmuteAll = (): void => {
@@ -266,6 +342,7 @@ export default function LiveDashboardView({
       updatedStates[cameraName] = true;
     });
     setAudioStates(updatedStates);
+    onSaveMuting(true);
   };
 
   return (
@@ -392,19 +469,30 @@ export default function LiveDashboardView({
               } else {
                 grow = "aspect-video";
               }
+              const streamName =
+                currentGroupStreamingSettings?.[camera.name]?.streamName ||
+                Object.values(camera.live.streams)?.[0];
+              const autoLive =
+                currentGroupStreamingSettings?.[camera.name]?.streamType !==
+                "no-streaming";
+              const showStillWithoutActivity =
+                currentGroupStreamingSettings?.[camera.name]?.streamType !==
+                "continuous";
+              const useWebGL =
+                currentGroupStreamingSettings?.[camera.name]
+                  ?.compatibilityMode || false;
               return (
                 <LiveContextMenu
                   className={grow}
                   key={camera.name}
                   camera={camera.name}
                   cameraGroup={cameraGroup}
-                  streamName={Object.values(camera.live.streams)?.[0]}
+                  streamName={streamName}
                   preferredLiveMode={preferredLiveModes[camera.name] ?? "mse"}
                   isRestreamed={isRestreamedStates[camera.name]}
                   supportsAudio={
-                    supportsAudioOutputStates[
-                      Object.values(camera.live.streams)?.[0]
-                    ]?.supportsAudio ?? false
+                    supportsAudioOutputStates[streamName]?.supportsAudio ??
+                    false
                   }
                   audioState={audioStates[camera.name]}
                   toggleAudio={() => toggleAudio(camera.name)}
@@ -431,11 +519,12 @@ export default function LiveDashboardView({
                     }
                     cameraConfig={camera}
                     preferredLiveMode={preferredLiveModes[camera.name] ?? "mse"}
-                    autoLive={autoLiveView}
-                    useWebGL={false}
+                    autoLive={autoLive ?? globalAutoLive}
+                    showStillWithoutActivity={showStillWithoutActivity ?? true}
+                    useWebGL={useWebGL}
                     playInBackground={false}
                     showStats={statsStates[camera.name]}
-                    streamName={Object.values(camera.live.streams)[0]}
+                    streamName={streamName}
                     onClick={() => onSelectCamera(camera.name)}
                     onError={(e) => handleError(camera.name, e)}
                     onResetLiveMode={() => resetPreferredLiveMode(camera.name)}

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -320,9 +320,7 @@ export default function LiveDashboardView({
         },
       };
 
-      if (cameraGroup != "default") {
-        setAllGroupsStreamingSettings?.(updatedSettings);
-      }
+      setAllGroupsStreamingSettings?.(updatedSettings);
     },
     [cameraGroup, allGroupsStreamingSettings, setAllGroupsStreamingSettings],
   );


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Mobile devices don't use the draggable grid layout component for camera groups, so streaming settings were not being saved correctly.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
