### PR TITLE
Retry onvif session

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -65,7 +65,6 @@ class OnvifController:
                     self.failed_cams.remove(cam_name)
             sleep(60)
 
-
     def _setup_onvif(self, camera_name: str) -> bool:
         try:
             onvif: ONVIFCamera = ONVIFCamera(
@@ -73,9 +72,7 @@ class OnvifController:
                 self.config.cameras[camera_name].onvif.port,
                 self.config.cameras[camera_name].onvif.user,
                 self.config.cameras[camera_name].onvif.password,
-                wsdl_dir=str(
-                    Path(find_spec("onvif").origin).parent / "wsdl"
-                ),
+                wsdl_dir=str(Path(find_spec("onvif").origin).parent / "wsdl"),
                 adjust_time=self.config.cameras[camera_name].onvif.ignore_time_mismatch,
                 encrypt=not self.config.cameras[camera_name].onvif.tls_insecure,
             )


### PR DESCRIPTION
## Proposed change
If camera is offline for any reason when frigate starts up first time, onvif session will not get established and PTZ will not work


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
