### PR TITLE
Return 404 for non-existent vod module media

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -109,6 +109,14 @@ http {
             expires off;
 
             keepalive_disable safari;
+
+            # vod module returns 502 for non-existent media
+            # https://github.com/kaltura/nginx-vod-module/issues/468
+            error_page 502 =404 /vod-not-found;
+        }
+
+        location = /vod-not-found {
+            return 404;
         }
 
         location /stream/ {

--- a/web/src/components/player/GenericVideoPlayer.tsx
+++ b/web/src/components/player/GenericVideoPlayer.tsx
@@ -27,7 +27,7 @@ export function GenericVideoPlayer({
         const response = await fetch(url, { method: "HEAD" });
         // nginx vod module returns 502 for non existent media
         // https://github.com/kaltura/nginx-vod-module/issues/468
-        setSourceExists(response.status !== 502);
+        setSourceExists(response.status !== 502 && response.status !== 404);
       } catch (error) {
         setSourceExists(false);
       }

--- a/web/src/components/player/GenericVideoPlayer.tsx
+++ b/web/src/components/player/GenericVideoPlayer.tsx
@@ -25,6 +25,8 @@ export function GenericVideoPlayer({
     const checkSourceExists = async (url: string) => {
       try {
         const response = await fetch(url, { method: "HEAD" });
+        // nginx vod module returns 502 for non existent media
+        // https://github.com/kaltura/nginx-vod-module/issues/468
         setSourceExists(response.status !== 502);
       } catch (error) {
         setSourceExists(false);

--- a/web/src/components/player/GenericVideoPlayer.tsx
+++ b/web/src/components/player/GenericVideoPlayer.tsx
@@ -41,7 +41,7 @@ export function GenericVideoPlayer({
       <div className="relative flex flex-grow items-center justify-center">
         {!sourceExists ? (
           <div className="flex aspect-video w-full items-center justify-center bg-background_alt text-lg text-primary">
-            Video not found
+            Video not available
           </div>
         ) : (
           <>

--- a/web/src/components/player/GenericVideoPlayer.tsx
+++ b/web/src/components/player/GenericVideoPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { useVideoDimensions } from "@/hooks/use-video-dimensions";
 import HlsVideoPlayer from "./HlsVideoPlayer";
 import ActivityIndicator from "../indicators/activity-indicator";
@@ -15,37 +15,59 @@ export function GenericVideoPlayer({
   children,
 }: GenericVideoPlayerProps) {
   const [isLoading, setIsLoading] = useState(true);
+  const [sourceExists, setSourceExists] = useState(true);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const { videoDimensions, setVideoResolution } =
     useVideoDimensions(containerRef);
 
+  useEffect(() => {
+    const checkSourceExists = async (url: string) => {
+      try {
+        const response = await fetch(url, { method: "HEAD" });
+        setSourceExists(response.status !== 502);
+      } catch (error) {
+        setSourceExists(false);
+      }
+    };
+
+    checkSourceExists(source);
+  }, [source]);
+
   return (
     <div ref={containerRef} className="relative flex h-full w-full flex-col">
       <div className="relative flex flex-grow items-center justify-center">
-        {isLoading && (
-          <ActivityIndicator className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2" />
+        {!sourceExists ? (
+          <div className="flex aspect-video w-full items-center justify-center bg-background_alt text-lg text-primary">
+            Video not found
+          </div>
+        ) : (
+          <>
+            {isLoading && (
+              <ActivityIndicator className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2" />
+            )}
+            <div
+              className="relative flex items-center justify-center"
+              style={videoDimensions}
+            >
+              <HlsVideoPlayer
+                videoRef={videoRef}
+                currentSource={source}
+                hotKeys
+                visible
+                frigateControls={false}
+                fullscreen={false}
+                supportsFullscreen={false}
+                onPlaying={() => {
+                  setIsLoading(false);
+                  onPlaying?.();
+                }}
+                setFullResolution={setVideoResolution}
+              />
+              {!isLoading && children}
+            </div>
+          </>
         )}
-        <div
-          className="relative flex items-center justify-center"
-          style={videoDimensions}
-        >
-          <HlsVideoPlayer
-            videoRef={videoRef}
-            currentSource={source}
-            hotKeys
-            visible
-            frigateControls={false}
-            fullscreen={false}
-            supportsFullscreen={false}
-            onPlaying={() => {
-              setIsLoading(false);
-              onPlaying?.();
-            }}
-            setFullResolution={setVideoResolution}
-          />
-          {!isLoading && children}
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
The nginx vod module apparently returns 502 for non-existent media (https://github.com/kaltura/nginx-vod-module/issues/468). 

This PR:
- Configures nginx to return a proper 404 when vod module media is not found.
- Displays an appropriate message on the frontend in the `GenericVideoPlayer` when media is not found. This component is used in Explore and Export.



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue:
fixes https://github.com/blakeblackshear/frigate/discussions/16534
fixes https://github.com/blakeblackshear/frigate/discussions/16570
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
