### PR TITLE
Fix renaming exports bug

### DIFF
--- a/frigate/api/defs/request/export_rename_body.py
+++ b/frigate/api/defs/request/export_rename_body.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel, Field
+
+
+class ExportRenameBody(BaseModel):
+    name: str = Field(title="Friendly name", max_length=256)

--- a/frigate/api/export.py
+++ b/frigate/api/export.py
@@ -12,6 +12,7 @@ from peewee import DoesNotExist
 from playhouse.shortcuts import model_to_dict
 
 from frigate.api.defs.request.export_recordings_body import ExportRecordingsBody
+from frigate.api.defs.request.export_rename_body import ExportRenameBody
 from frigate.api.defs.tags import Tags
 from frigate.const import EXPORT_DIR
 from frigate.models import Export, Previews, Recordings
@@ -129,8 +130,8 @@ def export_recording(
     )
 
 
-@router.patch("/export/{event_id}/{new_name}")
-def export_rename(event_id: str, new_name: str):
+@router.patch("/export/{event_id}/rename")
+def export_rename(event_id: str, body: ExportRenameBody):
     try:
         export: Export = Export.get(Export.id == event_id)
     except DoesNotExist:
@@ -144,7 +145,7 @@ def export_rename(event_id: str, new_name: str):
             status_code=404,
         )
 
-    export.name = new_name
+    export.name = body.name
     export.save()
     return JSONResponse(
         content=(

--- a/web/src/pages/Exports.tsx
+++ b/web/src/pages/Exports.tsx
@@ -83,9 +83,11 @@ function Exports() {
   const onHandleRename = useCallback(
     (id: string, update: string) => {
       axios
-        .patch(`export/${id}/${encodeURIComponent(update)}`)
+        .patch(`export/${id}/rename`, {
+          name: update,
+        })
         .then((response) => {
-          if (response.status == 200) {
+          if (response.status === 200) {
             setDeleteClip(undefined);
             mutate();
           }


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
When the name of an export had a slash in it, the api returned 404. This PR fixes the bug by moving the patch request to the body rather than the url. 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: 
fixes https://github.com/blakeblackshear/frigate/issues/15765
fixes https://github.com/blakeblackshear/frigate/discussions/15764
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
