### PR TITLE
Bugfix: use np.copy for current frame in object processing

### DIFF
--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -406,7 +406,7 @@ class CameraState:
 
             if current_frame is not None:
                 self.current_frame_time = frame_time
-                self._current_frame = current_frame
+                self._current_frame = np.copy(current_frame)
 
                 if self.previous_frame_id is not None:
                     self.frame_manager.close(self.previous_frame_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Some users were seeing a segfault crash in `CameraState`'s `get_current_frame` method. This was because the `current_frame` in object processing's `update` method was using the same memory reference instead of copying it.

This fix was tested by a user in https://github.com/blakeblackshear/frigate/discussions/16514 and confirmed to be working.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: 
fixes https://github.com/blakeblackshear/frigate/discussions/15769
fixes https://github.com/blakeblackshear/frigate/discussions/16448
fixes https://github.com/blakeblackshear/frigate/discussions/15146
fixes https://github.com/blakeblackshear/frigate/discussions/16325
fixes https://github.com/blakeblackshear/frigate/discussions/16032
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
