### PR TITLE
Remove internal docker container IP from WebRTC candidates

### DIFF
--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -66,29 +66,32 @@ elif go2rtc_config["log"].get("format") is None:
     go2rtc_config["log"]["format"] = "text"
 
 # ensure there is a default webrtc config
-if not go2rtc_config.get("webrtc"):
+if go2rtc_config.get("webrtc") is None:
     go2rtc_config["webrtc"] = {}
 
 # go2rtc should listen on 8555 tcp & udp by default
-if not go2rtc_config["webrtc"].get("listen"):
+if go2rtc_config["webrtc"].get("listen") is None:
     go2rtc_config["webrtc"]["listen"] = ":8555"
 
-if not go2rtc_config["webrtc"].get("candidates", []):
+if go2rtc_config["webrtc"].get("candidates") is None:
     default_candidates = []
     # use internal candidate if it was discovered when running through the add-on
-    internal_candidate = os.environ.get(
-        "FRIGATE_GO2RTC_WEBRTC_CANDIDATE_INTERNAL", None
-    )
+    internal_candidate = os.environ.get("FRIGATE_GO2RTC_WEBRTC_CANDIDATE_INTERNAL")
     if internal_candidate is not None:
         default_candidates.append(internal_candidate)
     # should set default stun server so webrtc can work
     default_candidates.append("stun:8555")
 
-    go2rtc_config["webrtc"] = {"candidates": default_candidates}
-else:
-    print(
-        "[INFO] Not injecting WebRTC candidates into go2rtc config as it has been set manually",
-    )
+    go2rtc_config["webrtc"]["candidates"] = default_candidates
+
+# This prevents WebRTC from attempting to establish a connection to the internal
+# docker IPs which are not accessible from outside the container itself and just
+# wastes time during negotiation. Note that this is only necessary because
+# Frigate container doesn't run in host network mode.
+if go2rtc_config["webrtc"].get("filter") is None:
+    go2rtc_config["webrtc"]["filter"] = {"candidates": []}
+elif go2rtc_config["webrtc"]["filter"].get("candidates") is None:
+    go2rtc_config["webrtc"]["filter"]["candidates"] = []
 
 # sets default RTSP response to be equivalent to ?video=h264,h265&audio=aac
 # this means user does not need to specify audio codec when using restream


### PR DESCRIPTION
## Proposed change

<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Set go2rtc `webrtc.filter.candidates: []` by default, preventing WebRTC from trying to establish a connection to Frigate's docker internal IP.

This is only needed because Frigate container doesn't run in host network mode.

> Note: This change is probably unwanted for users running Frigate in host network mode, but this isn't recommended anywhere.

In real life, this means WebRTC will not spend useless time evaluating the connection with this candidate.

This PR also fixes the issue where any setting under `go2rtc.webrtc` would not be taken into account, unless `webrtc.candidates` was also set.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #16583
- This PR is related to issue: https://github.com/blakeblackshear/frigate-hass-integration/issues/796
- This PR is related to issue: https://github.com/AlexxIT/go2rtc/issues/283#issuecomment-2659559377

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
