### PR TITLE
Improve notifications

### DIFF
--- a/.cspell/frigate-dictionary.txt
+++ b/.cspell/frigate-dictionary.txt
@@ -44,6 +44,7 @@ codeproject
 colormap
 colorspace
 comms
+cooldown
 coro
 ctypeslib
 CUDA

--- a/docs/docs/configuration/notifications.md
+++ b/docs/docs/configuration/notifications.md
@@ -11,13 +11,36 @@ Frigate offers native notifications using the [WebPush Protocol](https://web.dev
 
 In order to use notifications the following requirements must be met:
 
-- Frigate must be accessed via a secure https connection
+- Frigate must be accessed via a secure `https` connection ([see the authorization docs](/configuration/authentication)).
 - A supported browser must be used. Currently Chrome, Firefox, and Safari are known to be supported.
-- In order for notifications to be usable externally, Frigate must be accessible externally
+- In order for notifications to be usable externally, Frigate must be accessible externally.
 
 ### Configuration
 
 To configure notifications, go to the Frigate WebUI -> Settings -> Notifications and enable, then fill out the fields and save.
+
+Optionally, you can change the default cooldown period for notifications through the `cooldown` parameter in your config file. This parameter can also be overridden at the camera level.
+
+Notifications will be prevented if either:
+
+- The global cooldown period hasn't elapsed since any camera's last notification
+- The camera-specific cooldown period hasn't elapsed for the specific camera
+
+```yaml
+notifications:
+  enabled: True
+  email: "johndoe@gmail.com"
+  cooldown: 10 # wait 10 seconds before sending another notification from any camera
+```
+
+```yaml
+cameras:
+  doorbell:
+    ...
+    notifications:
+      enabled: True
+      cooldown: 30 # wait 30 seconds before sending another notification from the doorbell camera
+```
 
 ### Registration
 

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -420,6 +420,8 @@ notifications:
   # Optional: Email for push service to reach out to
   # NOTE: This is required to use notifications
   email: "admin@example.com"
+  # Optional: Cooldown time for notifications in seconds (default: shown below)
+  cooldown: 0
 
 # Optional: Record configuration
 # NOTE: Can be overridden at the camera level

--- a/frigate/config/camera/notification.py
+++ b/frigate/config/camera/notification.py
@@ -10,6 +10,9 @@ __all__ = ["NotificationConfig"]
 class NotificationConfig(FrigateBaseModel):
     enabled: bool = Field(default=False, title="Enable notifications")
     email: Optional[str] = Field(default=None, title="Email required for push.")
+    cooldown: Optional[int] = Field(
+        default=0, ge=0, title="Cooldown period for notifications (time in seconds)."
+    )
     enabled_in_config: Optional[bool] = Field(
         default=None, title="Keep track of original state of notifications."
     )

--- a/web/components.json
+++ b/web/components.json
@@ -11,6 +11,9 @@
   },
   "aliases": {
     "components": "@/components",
-    "utils": "@/lib/utils"
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
   }
 }

--- a/web/src/components/ui/alert.tsx
+++ b/web/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -61,19 +61,6 @@ export default function Settings() {
 
   const [searchParams] = useSearchParams();
 
-  // available settings views
-
-  const settingsViews = useMemo(() => {
-    const views = [...allSettingsViews];
-
-    if (!("Notification" in window) || !window.isSecureContext) {
-      const index = views.indexOf("notifications");
-      views.splice(index, 1);
-    }
-
-    return views;
-  }, []);
-
   // TODO: confirm leave page
   const [unsavedChanges, setUnsavedChanges] = useState(false);
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
@@ -160,7 +147,7 @@ export default function Settings() {
                 }
               }}
             >
-              {Object.values(settingsViews).map((item) => (
+              {Object.values(allSettingsViews).map((item) => (
                 <ToggleGroupItem
                   key={item}
                   className={`flex scroll-mx-10 items-center justify-between gap-2 ${page == "UI settings" ? "last:mr-20" : ""} ${pageToggle == item ? "" : "*:text-muted-foreground"}`}

--- a/web/src/views/live/DraggableGridLayout.tsx
+++ b/web/src/views/live/DraggableGridLayout.tsx
@@ -584,6 +584,7 @@ export default function DraggableGridLayout({
                   resetPreferredLiveMode={() =>
                     resetPreferredLiveMode(camera.name)
                   }
+                  config={config}
                 >
                   <LivePlayer
                     key={camera.name}
@@ -790,6 +791,7 @@ type GridLiveContextMenuProps = {
   muteAll: () => void;
   unmuteAll: () => void;
   resetPreferredLiveMode: () => void;
+  config?: FrigateConfig;
 };
 
 const GridLiveContextMenu = React.forwardRef<
@@ -819,6 +821,7 @@ const GridLiveContextMenu = React.forwardRef<
       muteAll,
       unmuteAll,
       resetPreferredLiveMode,
+      config,
       ...props
     },
     ref,
@@ -849,6 +852,7 @@ const GridLiveContextMenu = React.forwardRef<
           muteAll={muteAll}
           unmuteAll={unmuteAll}
           resetPreferredLiveMode={resetPreferredLiveMode}
+          config={config}
         >
           {children}
         </LiveContextMenu>

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -507,6 +507,7 @@ export default function LiveDashboardView({
                   resetPreferredLiveMode={() =>
                     resetPreferredLiveMode(camera.name)
                   }
+                  config={config}
                 >
                   <LivePlayer
                     cameraRef={cameraRef}

--- a/web/src/views/settings/NotificationsSettingsView.tsx
+++ b/web/src/views/settings/NotificationsSettingsView.tsx
@@ -20,7 +20,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import axios from "axios";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
-import { LuCheck, LuExternalLink, LuX } from "react-icons/lu";
+import { LuAlertCircle, LuCheck, LuExternalLink, LuX } from "react-icons/lu";
 import { Link } from "react-router-dom";
 import { toast } from "sonner";
 import useSWR from "swr";
@@ -39,6 +39,7 @@ import {
 } from "@/components/ui/select";
 import { formatUnixTimestampToDateTime } from "@/utils/dateUtil";
 import FilterSwitch from "@/components/filter/FilterSwitch";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 const NOTIFICATION_SERVICE_WORKER = "notifications-worker.js";
 
@@ -161,6 +162,9 @@ export default function NotificationView({
     useState<ServiceWorkerRegistration | null>();
 
   useEffect(() => {
+    if (!("Notification" in window) || !window.isSecureContext) {
+      return;
+    }
     navigator.serviceWorker
       .getRegistration(NOTIFICATION_SERVICE_WORKER)
       .then((worker) => {
@@ -277,6 +281,60 @@ export default function NotificationView({
   function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
     saveToConfig(values as NotificationSettingsValueType);
+  }
+
+  if (!("Notification" in window) || !window.isSecureContext) {
+    return (
+      <div className="scrollbar-container order-last mb-10 mt-2 flex h-full w-full flex-col overflow-y-auto rounded-lg border-[1px] border-secondary-foreground bg-background_alt p-2 md:order-none md:mb-0 md:mr-2 md:mt-0">
+        <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="col-span-1">
+            <Heading as="h3" className="my-2">
+              Notification Settings
+            </Heading>
+            <div className="max-w-6xl">
+              <div className="mb-5 mt-2 flex max-w-5xl flex-col gap-2 text-sm text-primary-variant">
+                <p>
+                  Frigate can natively send push notifications to your device
+                  when it is running in the browser or installed as a PWA.
+                </p>
+                <div className="flex items-center text-primary">
+                  <Link
+                    to="https://docs.frigate.video/configuration/notifications"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline"
+                  >
+                    Read the Documentation{" "}
+                    <LuExternalLink className="ml-2 inline-flex size-3" />
+                  </Link>
+                </div>
+              </div>
+            </div>
+            <Alert variant="destructive">
+              <LuAlertCircle className="size-5" />
+              <AlertTitle>Notifications Unavailable</AlertTitle>
+
+              <AlertDescription>
+                Web push notifications require a secure context (
+                <code>https://...</code>). This is a browser limitation. Access
+                Frigate securely to use notifications.
+                <div className="mt-3 flex items-center">
+                  <Link
+                    to="https://docs.frigate.video/configuration/authentication"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline"
+                  >
+                    Read the Documentation{" "}
+                    <LuExternalLink className="ml-2 inline-flex size-3" />
+                  </Link>
+                </div>
+              </AlertDescription>
+            </Alert>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR is a followup to https://github.com/blakeblackshear/frigate/pull/16453 and makes the following changes:
- Adds the ability to configure a notification cooldown period (globally and per-camera).
- Shows a message and link to the docs on the notifications pane in Settings when accessed via an insecure context.
- Adds the ability to suspend notifications via the context menu on the Live dashboard.

The shadcn `Alert` component was installed and a small change to components.json had to be made because of https://github.com/shadcn-ui/ui/issues/6527


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
