### PR TITLE
Tracking fixes

### DIFF
--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -266,6 +266,7 @@ class NorfairTracker(ObjectTracker):
         obj_match = next(
             (o for o in tracker.tracked_objects if o.global_id == track_id), None
         )
+        # if we don't have a match, we have a new object
         obj["score_history"] = (
             [p.data["score"] for p in obj_match.past_detections] if obj_match else []
         )

--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -519,7 +519,11 @@ class NorfairTracker(ObjectTracker):
                 default_detections.extend(dets)
 
         # Update default tracker with untracked detections
-        mode = "ptz" if self.ptz_metrics.autotracker_enabled.value else "static"
+        mode = (
+            "ptz"
+            if self.camera_config.onvif.autotracking.enabled_in_config
+            else "static"
+        )
         tracked_objects = self.default_tracker[mode].update(
             detections=default_detections, coord_transformations=coord_transformations
         )

--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -263,12 +263,12 @@ class NorfairTracker(ObjectTracker):
 
         # Get the correct tracker for this object's label
         tracker = self.get_tracker(obj["label"])
-        obj["score_history"] = [
-            p.data["score"]
-            for p in next(
-                (o for o in tracker.tracked_objects if o.global_id == track_id)
-            ).past_detections
-        ]
+        obj_match = next(
+            (o for o in tracker.tracked_objects if o.global_id == track_id), None
+        )
+        obj["score_history"] = (
+            [p.data["score"] for p in obj_match.past_detections] if obj_match else []
+        )
         self.tracked_objects[id] = obj
         self.disappeared[id] = 0
         self.positions[id] = {


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR fixes two small bugs:
1. Always use the `ptz` instance of the Norfair tracker for `enabled_in_config` autotracking cameras.
2. Ensure we have an object match before accessing score history. Depending on what objects were detected and which trackers were initialized first, `tracker.tracked_objects` might be empty, so `next()` would crash with `StopIteration`. 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
