### PR TITLE
Add metadata to exports

### DIFF
--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -80,8 +80,8 @@ class RecordingExporter(threading.Thread):
         Path(os.path.join(CLIPS_DIR, "export")).mkdir(exist_ok=True)
 
     def get_datetime_from_timestamp(self, timestamp: int) -> str:
-        """Convenience fun to get a simple date time from timestamp."""
-        return datetime.datetime.fromtimestamp(timestamp).strftime("%Y/%m/%d %H:%M")
+        # return in iso format
+        return datetime.datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
 
     def save_thumbnail(self, id: str) -> str:
         thumb_path = os.path.join(CLIPS_DIR, f"export/{id}.webp")
@@ -236,6 +236,10 @@ class RecordingExporter(threading.Thread):
         if self.config.ffmpeg.apple_compatibility:
             ffmpeg_cmd += FFMPEG_HVC1_ARGS
 
+        # add metadata
+        title = f"Frigate Recording for {self.camera}, {self.get_datetime_from_timestamp(self.start_time)} - {self.get_datetime_from_timestamp(self.end_time)}"
+        ffmpeg_cmd.extend(["-metadata", f"title={title}"])
+
         ffmpeg_cmd.append(video_path)
 
         return ffmpeg_cmd, playlist_lines
@@ -322,6 +326,10 @@ class RecordingExporter(threading.Thread):
                     EncodeTypeEnum.timelapse,
                 )
             ).split(" ")
+
+        # add metadata
+        title = f"Frigate Preview for {self.camera}, {self.get_datetime_from_timestamp(self.start_time)} - {self.get_datetime_from_timestamp(self.end_time)}"
+        ffmpeg_cmd.extend(["-metadata", f"title={title}"])
 
         return ffmpeg_cmd, playlist_lines
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR adds a `title` metadata field to exports so that media players or software like Jellyfin displays a more appropriate title instead of just the filename.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
