### PR TITLE
Add ffmpeg to PATH by default

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -19,7 +19,7 @@ sudo chown -R "$(id -u):$(id -g)" /media/frigate
 # When started as a service, LIBAVFORMAT_VERSION_MAJOR is defined in the
 # s6 service file. For dev, where frigate is started from an interactive
 # shell, we define it in .bashrc instead.
-echo 'export LIBAVFORMAT_VERSION_MAJOR=$(/usr/lib/ffmpeg/7.0/bin/ffmpeg -version | grep -Po "libavformat\W+\K\d+")' >> $HOME/.bashrc
+echo 'export LIBAVFORMAT_VERSION_MAJOR=$(ffmpeg -version | grep -Po "libavformat\W+\K\d+")' >> $HOME/.bashrc
 
 make version
 

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -223,7 +223,7 @@ ENV TRANSFORMERS_NO_ADVISORY_WARNINGS=1
 # Set OpenCV ffmpeg loglevel to fatal: https://ffmpeg.org/doxygen/trunk/log_8h.html
 ENV OPENCV_FFMPEG_LOGLEVEL=8
 
-ENV PATH="/usr/local/go2rtc/bin:/usr/local/tempio/bin:/usr/local/nginx/sbin:${PATH}"
+ENV PATH="/config/custom-ffmpeg/bin:/usr/lib/ffmpeg/default/bin:/usr/local/go2rtc/bin:/usr/local/tempio/bin:/usr/local/nginx/sbin:${PATH}"
 
 # Install dependencies
 RUN --mount=type=bind,source=docker/main/install_deps.sh,target=/deps/install_deps.sh \

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -31,29 +31,27 @@ unset DEBIAN_FRONTEND
 yes | dpkg -i /tmp/libedgetpu1-max.deb && export DEBIAN_FRONTEND=noninteractive
 rm /tmp/libedgetpu1-max.deb
 
-# btbn-ffmpeg -> amd64
+# ffmpeg
 if [[ "${TARGETARCH}" == "amd64" ]]; then
-    mkdir -p /usr/lib/ffmpeg/5.0
-    mkdir -p /usr/lib/ffmpeg/7.0
-    wget -qO btbn-ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linux64-gpl-5.1.tar.xz"
-    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1
-    rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/5.0/doc /usr/lib/ffmpeg/5.0/bin/ffplay
-    wget -qO btbn-ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2024-09-19-12-51/ffmpeg-n7.0.2-18-g3e6cec1286-linux64-gpl-7.0.tar.xz"
-    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1
-    rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/7.0/doc /usr/lib/ffmpeg/7.0/bin/ffplay
+    ffmpeg_arch="x64"
+elif [[ "${TARGETARCH}" == "arm64" ]]; then
+    ffmpeg_arch="arm64"
+else
+    echo "Unsupported architecture: ${TARGETARCH}" >&2
+    exit 1
 fi
 
-# ffmpeg -> arm64
-if [[ "${TARGETARCH}" == "arm64" ]]; then
-    mkdir -p /usr/lib/ffmpeg/5.0
-    mkdir -p /usr/lib/ffmpeg/7.0
-    wget -qO btbn-ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linuxarm64-gpl-5.1.tar.xz"
-    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1
-    rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/5.0/doc /usr/lib/ffmpeg/5.0/bin/ffplay
-    wget -qO btbn-ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2024-09-19-12-51/ffmpeg-n7.0.2-18-g3e6cec1286-linuxarm64-gpl-7.0.tar.xz"
-    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1
-    rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/7.0/doc /usr/lib/ffmpeg/7.0/bin/ffplay
-fi
+mkdir -p /usr/lib/ffmpeg/5.0
+wget -qO ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linu${ffmpeg_arch}-gpl-5.1.tar.xz"
+tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1
+rm -rf ffmpeg.tar.xz /usr/lib/ffmpeg/5.0/doc /usr/lib/ffmpeg/5.0/bin/ffplay
+mkdir -p /usr/lib/ffmpeg/7.0
+wget -qO ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2024-09-19-12-51/ffmpeg-n7.0.2-18-g3e6cec1286-linux${ffmpeg_arch}-gpl-7.0.tar.xz"
+tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1
+rm -rf ffmpeg.tar.xz /usr/lib/ffmpeg/7.0/doc /usr/lib/ffmpeg/7.0/bin/ffplay
+
+# set the default ffmpeg version
+ln -svf /usr/lib/ffmpeg/7.0 /usr/lib/ffmpeg/default
 
 # arch specific packages
 if [[ "${TARGETARCH}" == "amd64" ]]; then

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -42,7 +42,7 @@ else
 fi
 
 mkdir -p /usr/lib/ffmpeg/5.0
-wget -qO ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linu${ffmpeg_arch}-gpl-5.1.tar.xz"
+wget -qO ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linux${ffmpeg_arch}-gpl-5.1.tar.xz"
 tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1
 rm -rf ffmpeg.tar.xz /usr/lib/ffmpeg/5.0/doc /usr/lib/ffmpeg/5.0/bin/ffplay
 mkdir -p /usr/lib/ffmpeg/7.0

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
@@ -43,8 +43,7 @@ function migrate_db_path() {
 }
 
 function set_libva_version() {
-    local ffmpeg_path=$(python3 /usr/local/ffmpeg/get_ffmpeg_path.py)
-    export LIBAVFORMAT_VERSION_MAJOR=$($ffmpeg_path -version | grep -Po "libavformat\W+\K\d+")
+    export LIBAVFORMAT_VERSION_MAJOR=$(ffmpeg -version | grep -Po "libavformat\W+\K\d+")
 }
 
 echo "[INFO] Preparing Frigate..."

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
@@ -43,10 +43,16 @@ function get_ip_and_port_from_supervisor() {
     export FRIGATE_GO2RTC_WEBRTC_CANDIDATE_INTERNAL="${ip_address}:${webrtc_port}"
 }
 
-function set_libva_version() {
-    local ffmpeg_path=$(python3 /usr/local/ffmpeg/get_ffmpeg_path.py)
-    export LIBAVFORMAT_VERSION_MAJOR=$($ffmpeg_path -version | grep -Po "libavformat\W+\K\d+")
-}
+echo "[INFO] Preparing ffmpeg..."
+ffmpeg_path=$(python3 /usr/local/ffmpeg/get_ffmpeg_path.py)
+if [[ -n "${ffmpeg_path}" ]]; then
+    ln -svf "${ffmpeg_path}" /usr/lib/ffmpeg/default
+fi
+ffmpeg_version=$(ffmpeg -version)
+echo "[INFO] ffmpeg -version"
+echo "${ffmpeg_version}"
+export LIBAVFORMAT_VERSION_MAJOR=$(echo "${ffmpeg_version}" | grep -Po "libavformat\W+\K\d+")
+unset ffmpeg_path ffmpeg_version
 
 if [[ -f "/dev/shm/go2rtc.yaml" ]]; then
     echo "[INFO] Removing stale config from last run..."
@@ -65,8 +71,6 @@ if [[ ! -f "/dev/shm/go2rtc.yaml" ]]; then
 else
     echo "[WARNING] Unable to remove existing go2rtc config. Changes made to your frigate config file may not be recognized. Please remove the /dev/shm/go2rtc.yaml from your docker host manually."
 fi
-
-set_libva_version
 
 readonly config_path="/config"
 

--- a/docker/main/rootfs/usr/local/ffmpeg/get_ffmpeg_path.py
+++ b/docker/main/rootfs/usr/local/ffmpeg/get_ffmpeg_path.py
@@ -1,6 +1,5 @@
 import json
 import os
-import shutil
 import sys
 
 from ruamel.yaml import YAML
@@ -34,12 +33,7 @@ except FileNotFoundError:
     config: dict[str, any] = {}
 
 path = config.get("ffmpeg", {}).get("path", "default")
-if path == "default":
-    if shutil.which("ffmpeg") is None:
-        print(f"/usr/lib/ffmpeg/{DEFAULT_FFMPEG_VERSION}/bin/ffmpeg")
-    else:
-        print("ffmpeg")
-elif path in INCLUDED_FFMPEG_VERSIONS:
-    print(f"/usr/lib/ffmpeg/{path}/bin/ffmpeg")
+if path is not DEFAULT_FFMPEG_VERSION and path in INCLUDED_FFMPEG_VERSIONS:
+    print(f"/usr/lib/ffmpeg/{path}")
 else:
-    print(f"{path}/bin/ffmpeg")
+    print(path)

--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -24,8 +24,6 @@ COPY docker/rockchip/conv2rknn.py /opt/conv2rknn.py
 
 ADD https://github.com/MarcA711/rknn-toolkit2/releases/download/v2.3.0/librknnrt.so /usr/lib/
 
-RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffmpeg
-RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffprobe
 ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-7/ffmpeg /usr/lib/ffmpeg/6.0/bin/
 ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-7/ffprobe /usr/lib/ffmpeg/6.0/bin/
-ENV PATH="/usr/lib/ffmpeg/6.0/bin/:${PATH}"
+RUN ln -svf /usr/lib/ffmpeg/6.0 /usr/lib/ffmpeg/default

--- a/docker/rpi/Dockerfile
+++ b/docker/rpi/Dockerfile
@@ -6,8 +6,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 FROM deps AS rpi-deps
 ARG TARGETARCH
 
-RUN rm -rf /usr/lib/btbn-ffmpeg/
-
 # Install dependencies
 RUN --mount=type=bind,source=docker/rpi/install_deps.sh,target=/deps/install_deps.sh \
     /deps/install_deps.sh

--- a/docker/tensorrt/Dockerfile.arm64
+++ b/docker/tensorrt/Dockerfile.arm64
@@ -76,8 +76,8 @@ RUN apt-get update \
     && apt-get install -y python-is-python3 libprotobuf23  \
     && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /usr/lib/btbn-ffmpeg/
 COPY --from=jetson-ffmpeg /rootfs /
+RUN ln -svf /usr/lib/ffmpeg/jetson /usr/lib/ffmpeg/default
 
 # ffmpeg runtime dependencies
 RUN apt-get -qq update \

--- a/docker/tensorrt/build_jetson_ffmpeg.sh
+++ b/docker/tensorrt/build_jetson_ffmpeg.sh
@@ -5,7 +5,7 @@
 
 set -euxo pipefail
 
-INSTALL_PREFIX=/rootfs/usr/local
+INSTALL_PREFIX=/rootfs/usr/lib/ffmpeg/jetson
 
 apt-get -qq update
 apt-get -qq install -y --no-install-recommends build-essential ccache clang cmake pkg-config

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -36,8 +36,7 @@ See [the go2rtc docs](https://github.com/AlexxIT/go2rtc?tab=readme-ov-file#modul
 
 ```yaml
 go2rtc:
-  streams:
-    ...
+  streams: ...
   log:
     exec: trace
 ```
@@ -176,15 +175,12 @@ listen [::]:5000 ipv6only=off;
 
 ### Custom ffmpeg build
 
-Included with Frigate is a build of ffmpeg that works for the vast majority of users. However, there exists some hardware setups which have incompatibilities with the included build. In this case, statically built ffmpeg binary can be downloaded to /config and used.
+Included with Frigate is a build of ffmpeg that works for the vast majority of users. However, there exists some hardware setups which have incompatibilities with the included build. In this case, statically built ffmpeg binary can be downloaded to `/config/custom-ffmpeg/bin` and used.
 
 To do this:
 
-1. Download your ffmpeg build and uncompress to the Frigate config folder.
-2. Update your docker-compose or docker CLI to include `'/home/appdata/frigate/custom-ffmpeg':'/usr/lib/btbn-ffmpeg':'ro'` in the volume mappings.
-3. Restart Frigate and the custom version will be used if the mapping was done correctly.
-
-NOTE: The folder that is set for the config needs to be the folder that contains `/bin`. So if the full structure is `/home/appdata/frigate/custom-ffmpeg/bin/ffmpeg` then the `ffmpeg -> path` field should be `/config/custom-ffmpeg/bin`.
+1. Download your ffmpeg build and uncompress it to the `/config/custom-ffmpeg/bin` folder. Verify that the ffmpeg binary is located at `/config/custom-ffmpeg/bin/ffmpeg`.
+2. Restart Frigate and the custom version will be used if the mapping was done correctly.
 
 ### Custom go2rtc version
 

--- a/frigate/config/camera/ffmpeg.py
+++ b/frigate/config/camera/ffmpeg.py
@@ -4,8 +4,6 @@ from typing import Union
 
 from pydantic import Field, field_validator
 
-from frigate.const import DEFAULT_FFMPEG_VERSION, INCLUDED_FFMPEG_VERSIONS
-
 from ..base import FrigateBaseModel
 from ..env import EnvString
 
@@ -70,27 +68,15 @@ class FfmpegConfig(FrigateBaseModel):
 
     @property
     def ffmpeg_path(self) -> str:
-        if self.path == "default":
-            if shutil.which("ffmpeg") is None:
-                return f"/usr/lib/ffmpeg/{DEFAULT_FFMPEG_VERSION}/bin/ffmpeg"
-            else:
-                return "ffmpeg"
-        elif self.path in INCLUDED_FFMPEG_VERSIONS:
-            return f"/usr/lib/ffmpeg/{self.path}/bin/ffmpeg"
-        else:
-            return f"{self.path}/bin/ffmpeg"
+        if shutil.which("ffmpeg") is None:
+            raise FileNotFoundError("ffmpeg not found in PATH.")
+        return "ffmpeg"
 
     @property
     def ffprobe_path(self) -> str:
-        if self.path == "default":
-            if shutil.which("ffprobe") is None:
-                return f"/usr/lib/ffmpeg/{DEFAULT_FFMPEG_VERSION}/bin/ffprobe"
-            else:
-                return "ffprobe"
-        elif self.path in INCLUDED_FFMPEG_VERSIONS:
-            return f"/usr/lib/ffmpeg/{self.path}/bin/ffprobe"
-        else:
-            return f"{self.path}/bin/ffprobe"
+        if shutil.which("ffprobe") is None:
+            raise FileNotFoundError("ffprobe not found in PATH.")
+        return "ffprobe"
 
 
 class CameraRoleEnum(str, Enum):

--- a/frigate/config/camera/ffmpeg.py
+++ b/frigate/config/camera/ffmpeg.py
@@ -1,8 +1,9 @@
-import shutil
 from enum import Enum
 from typing import Union
 
 from pydantic import Field, field_validator
+
+from frigate.const import INCLUDED_FFMPEG_VERSIONS
 
 from ..base import FrigateBaseModel
 from ..env import EnvString
@@ -68,15 +69,21 @@ class FfmpegConfig(FrigateBaseModel):
 
     @property
     def ffmpeg_path(self) -> str:
-        if shutil.which("ffmpeg") is None:
-            raise FileNotFoundError("ffmpeg not found in PATH.")
-        return "ffmpeg"
+        if self.path == "default":
+            return "ffmpeg"
+        elif self.path in INCLUDED_FFMPEG_VERSIONS:
+            return f"/usr/lib/ffmpeg/{self.path}/bin/ffmpeg"
+        else:
+            return f"{self.path}/bin/ffmpeg"
 
     @property
     def ffprobe_path(self) -> str:
-        if shutil.which("ffprobe") is None:
-            raise FileNotFoundError("ffprobe not found in PATH.")
-        return "ffprobe"
+        if self.path == "default":
+            return "ffprobe"
+        elif self.path in INCLUDED_FFMPEG_VERSIONS:
+            return f"/usr/lib/ffmpeg/{self.path}/bin/ffprobe"
+        else:
+            return f"{self.path}/bin/ffprobe"
 
 
 class CameraRoleEnum(str, Enum):


### PR DESCRIPTION
## Proposed change

<!--
  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Since Frigate 0.15, ffmpeg was removed from PATH, requiring users to set the full path to ffmpeg in certain cases, like when using the go2rtc `exec:` source.

This PR improves this by adding the chosen ffmpeg to the `PATH`, avoiding having to handle ffmpeg path in multiple cases.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
