### PR TITLE
Bugfix: Activity manager fails to publish object counts in some circumstances

### DIFF
--- a/frigate/camera/activity_manager.py
+++ b/frigate/camera/activity_manager.py
@@ -33,7 +33,11 @@ class CameraActivityManager:
                     self.zone_active_object_counts[zone] = Counter()
                     self.all_zone_labels[zone] = set()
 
-                self.all_zone_labels[zone].update(zone_config.objects)
+                self.all_zone_labels[zone].update(
+                    zone_config.objects
+                    if zone_config.objects
+                    else camera_config.objects.track
+                )
 
     def update_activity(self, new_activity: dict[str, dict[str, any]]) -> None:
         all_objects: list[dict[str, any]] = []


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR fixes a bug in the [refactored activity manager](https://github.com/blakeblackshear/frigate/pull/15803) where zones without an explicit list of objects were not having object counts updated. The fix was simply to copy the list of objects from the camera config.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
