### PR TITLE
Only match on exact config name in some cases

### DIFF
--- a/frigate/motion/improved_motion.py
+++ b/frigate/motion/improved_motion.py
@@ -49,7 +49,7 @@ class ImprovedMotionDetector(MotionDetector):
         self.contrast_values = np.zeros((contrast_frame_history, 2), np.uint8)
         self.contrast_values[:, 1:2] = 255
         self.contrast_values_index = 0
-        self.config_subscriber = ConfigSubscriber(f"config/motion/{name}")
+        self.config_subscriber = ConfigSubscriber(f"config/motion/{name}", True)
         self.ptz_metrics = ptz_metrics
         self.last_stop_time = None
 

--- a/frigate/output/preview.py
+++ b/frigate/output/preview.py
@@ -172,7 +172,9 @@ class PreviewRecorder:
 
         # create communication for finished previews
         self.requestor = InterProcessRequestor()
-        self.config_subscriber = ConfigSubscriber(f"config/record/{self.config.name}", True)
+        self.config_subscriber = ConfigSubscriber(
+            f"config/record/{self.config.name}", True
+        )
 
         y, u1, u2, v1, v2 = get_yuv_crop(
             self.config.frame_shape_yuv,

--- a/frigate/output/preview.py
+++ b/frigate/output/preview.py
@@ -172,7 +172,7 @@ class PreviewRecorder:
 
         # create communication for finished previews
         self.requestor = InterProcessRequestor()
-        self.config_subscriber = ConfigSubscriber(f"config/record/{self.config.name}")
+        self.config_subscriber = ConfigSubscriber(f"config/record/{self.config.name}", True)
 
         y, u1, u2, v1, v2 = get_yuv_crop(
             self.config.frame_shape_yuv,

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -539,7 +539,7 @@ def process_frames(
     exit_on_empty: bool = False,
 ):
     next_region_update = get_tomorrow_at_time(2)
-    config_subscriber = ConfigSubscriber(f"config/detect/{camera_name}")
+    config_subscriber = ConfigSubscriber(f"config/detect/{camera_name}", True)
 
     fps_tracker = EventsPerSecond()
     fps_tracker.start()


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

There was a bug where disabling detect for cam_1 would also disable it for cam_11 and cam_12. This adds an exact flag to only run on exact topic match in some cases.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
