### PR TITLE
No longer fallback to look for a `ffmpeg` binary in `PATH`

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -19,7 +19,7 @@ sudo chown -R "$(id -u):$(id -g)" /media/frigate
 # When started as a service, LIBAVFORMAT_VERSION_MAJOR is defined in the
 # s6 service file. For dev, where frigate is started from an interactive
 # shell, we define it in .bashrc instead.
-echo 'export LIBAVFORMAT_VERSION_MAJOR=$(/usr/lib/ffmpeg/7.0/bin/ffmpeg -version | grep -Po "libavformat\W+\K\d+")' >> $HOME/.bashrc
+echo 'export LIBAVFORMAT_VERSION_MAJOR=$("$(python3 /usr/local/ffmpeg/get_ffmpeg_path.py)" -version | grep -Po "libavformat\W+\K\d+")' >> "$HOME/.bashrc"
 
 make version
 

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -231,6 +231,9 @@ ENV PATH="/usr/local/go2rtc/bin:/usr/local/tempio/bin:/usr/local/nginx/sbin:${PA
 RUN --mount=type=bind,source=docker/main/install_deps.sh,target=/deps/install_deps.sh \
     /deps/install_deps.sh
 
+ENV DEFAULT_FFMPEG_VERSION="7.0"
+ENV INCLUDED_FFMPEG_VERSIONS="${DEFAULT_FFMPEG_VERSION}:5.0"
+
 RUN wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py \
     && python3 get-pip.py "pip"
 

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -35,11 +35,11 @@ rm /tmp/libedgetpu1-max.deb
 if [[ "${TARGETARCH}" == "amd64" ]]; then
     mkdir -p /usr/lib/ffmpeg/5.0
     wget -qO ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linux64-gpl-5.1.tar.xz"
-    tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1 bin/ffmpeg bin/ffprobe
+    tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1 amd64/bin/ffmpeg amd64/bin/ffprobe
     rm -rf ffmpeg.tar.xz
     mkdir -p /usr/lib/ffmpeg/7.0
     wget -qO ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2024-09-19-12-51/ffmpeg-n7.0.2-18-g3e6cec1286-linux64-gpl-7.0.tar.xz"
-    tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1 bin/ffmpeg bin/ffprobe
+    tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1 amd64/bin/ffmpeg amd64/bin/ffprobe
     rm -rf ffmpeg.tar.xz
 fi
 
@@ -47,11 +47,11 @@ fi
 if [[ "${TARGETARCH}" == "arm64" ]]; then
     mkdir -p /usr/lib/ffmpeg/5.0
     wget -qO ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linuxarm64-gpl-5.1.tar.xz"
-    tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1 bin/ffmpeg bin/ffprobe
+    tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1 arm64/bin/ffmpeg arm64/bin/ffprobe
     rm -f ffmpeg.tar.xz
     mkdir -p /usr/lib/ffmpeg/7.0
     wget -qO ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2024-09-19-12-51/ffmpeg-n7.0.2-18-g3e6cec1286-linuxarm64-gpl-7.0.tar.xz"
-    tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1 bin/ffmpeg bin/ffprobe
+    tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1 arm64/bin/ffmpeg arm64/bin/ffprobe
     rm -f ffmpeg.tar.xz
 fi
 

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -31,28 +31,28 @@ unset DEBIAN_FRONTEND
 yes | dpkg -i /tmp/libedgetpu1-max.deb && export DEBIAN_FRONTEND=noninteractive
 rm /tmp/libedgetpu1-max.deb
 
-# btbn-ffmpeg -> amd64
+# ffmpeg -> amd64
 if [[ "${TARGETARCH}" == "amd64" ]]; then
     mkdir -p /usr/lib/ffmpeg/5.0
+    wget -qO ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linux64-gpl-5.1.tar.xz"
+    tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1 bin/ffmpeg bin/ffprobe
+    rm -rf ffmpeg.tar.xz
     mkdir -p /usr/lib/ffmpeg/7.0
-    wget -qO btbn-ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linux64-gpl-5.1.tar.xz"
-    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1
-    rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/5.0/doc /usr/lib/ffmpeg/5.0/bin/ffplay
-    wget -qO btbn-ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2024-09-19-12-51/ffmpeg-n7.0.2-18-g3e6cec1286-linux64-gpl-7.0.tar.xz"
-    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1
-    rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/7.0/doc /usr/lib/ffmpeg/7.0/bin/ffplay
+    wget -qO ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2024-09-19-12-51/ffmpeg-n7.0.2-18-g3e6cec1286-linux64-gpl-7.0.tar.xz"
+    tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1 bin/ffmpeg bin/ffprobe
+    rm -rf ffmpeg.tar.xz
 fi
 
 # ffmpeg -> arm64
 if [[ "${TARGETARCH}" == "arm64" ]]; then
     mkdir -p /usr/lib/ffmpeg/5.0
+    wget -qO ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linuxarm64-gpl-5.1.tar.xz"
+    tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1 bin/ffmpeg bin/ffprobe
+    rm -f ffmpeg.tar.xz
     mkdir -p /usr/lib/ffmpeg/7.0
-    wget -qO btbn-ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2022-07-31-12-37/ffmpeg-n5.1-2-g915ef932a3-linuxarm64-gpl-5.1.tar.xz"
-    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/5.0 --strip-components 1
-    rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/5.0/doc /usr/lib/ffmpeg/5.0/bin/ffplay
-    wget -qO btbn-ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2024-09-19-12-51/ffmpeg-n7.0.2-18-g3e6cec1286-linuxarm64-gpl-7.0.tar.xz"
-    tar -xf btbn-ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1
-    rm -rf btbn-ffmpeg.tar.xz /usr/lib/ffmpeg/7.0/doc /usr/lib/ffmpeg/7.0/bin/ffplay
+    wget -qO ffmpeg.tar.xz "https://github.com/NickM-27/FFmpeg-Builds/releases/download/autobuild-2024-09-19-12-51/ffmpeg-n7.0.2-18-g3e6cec1286-linuxarm64-gpl-7.0.tar.xz"
+    tar -xf ffmpeg.tar.xz -C /usr/lib/ffmpeg/7.0 --strip-components 1 bin/ffmpeg bin/ffprobe
+    rm -f ffmpeg.tar.xz
 fi
 
 # arch specific packages

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
@@ -43,8 +43,10 @@ function migrate_db_path() {
 }
 
 function set_libva_version() {
-    local ffmpeg_path=$(python3 /usr/local/ffmpeg/get_ffmpeg_path.py)
-    export LIBAVFORMAT_VERSION_MAJOR=$($ffmpeg_path -version | grep -Po "libavformat\W+\K\d+")
+    local ffmpeg_path
+    ffmpeg_path=$(python3 /usr/local/ffmpeg/get_ffmpeg_path.py)
+    LIBAVFORMAT_VERSION_MAJOR=$("$ffmpeg_path" -version | grep -Po "libavformat\W+\K\d+")
+    export LIBAVFORMAT_VERSION_MAJOR
 }
 
 echo "[INFO] Preparing Frigate..."

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
@@ -44,9 +44,13 @@ function get_ip_and_port_from_supervisor() {
 }
 
 function set_libva_version() {
-    local ffmpeg_path=$(python3 /usr/local/ffmpeg/get_ffmpeg_path.py)
-    export LIBAVFORMAT_VERSION_MAJOR=$($ffmpeg_path -version | grep -Po "libavformat\W+\K\d+")
+    local ffmpeg_path
+    ffmpeg_path=$(python3 /usr/local/ffmpeg/get_ffmpeg_path.py)
+    LIBAVFORMAT_VERSION_MAJOR=$("$ffmpeg_path" -version | grep -Po "libavformat\W+\K\d+")
+    export LIBAVFORMAT_VERSION_MAJOR
 }
+
+set_libva_version
 
 if [[ -f "/dev/shm/go2rtc.yaml" ]]; then
     echo "[INFO] Removing stale config from last run..."
@@ -65,8 +69,6 @@ if [[ ! -f "/dev/shm/go2rtc.yaml" ]]; then
 else
     echo "[WARNING] Unable to remove existing go2rtc config. Changes made to your frigate config file may not be recognized. Please remove the /dev/shm/go2rtc.yaml from your docker host manually."
 fi
-
-set_libva_version
 
 readonly config_path="/config"
 

--- a/docker/main/rootfs/usr/local/ffmpeg/get_ffmpeg_path.py
+++ b/docker/main/rootfs/usr/local/ffmpeg/get_ffmpeg_path.py
@@ -1,6 +1,5 @@
 import json
 import os
-import shutil
 import sys
 
 from ruamel.yaml import YAML
@@ -35,10 +34,7 @@ except FileNotFoundError:
 
 path = config.get("ffmpeg", {}).get("path", "default")
 if path == "default":
-    if shutil.which("ffmpeg") is None:
-        print(f"/usr/lib/ffmpeg/{DEFAULT_FFMPEG_VERSION}/bin/ffmpeg")
-    else:
-        print("ffmpeg")
+    print(f"/usr/lib/ffmpeg/{DEFAULT_FFMPEG_VERSION}/bin/ffmpeg")
 elif path in INCLUDED_FFMPEG_VERSIONS:
     print(f"/usr/lib/ffmpeg/{path}/bin/ffmpeg")
 else:

--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import shutil
 import sys
 from pathlib import Path
 
@@ -115,10 +114,7 @@ else:
 # ensure ffmpeg path is set correctly
 path = config.get("ffmpeg", {}).get("path", "default")
 if path == "default":
-    if shutil.which("ffmpeg") is None:
-        ffmpeg_path = f"/usr/lib/ffmpeg/{DEFAULT_FFMPEG_VERSION}/bin/ffmpeg"
-    else:
-        ffmpeg_path = "ffmpeg"
+    ffmpeg_path = f"/usr/lib/ffmpeg/{DEFAULT_FFMPEG_VERSION}/bin/ffmpeg"
 elif path in INCLUDED_FFMPEG_VERSIONS:
     ffmpeg_path = f"/usr/lib/ffmpeg/{path}/bin/ffmpeg"
 else:
@@ -131,13 +127,11 @@ elif go2rtc_config["ffmpeg"].get("bin") is None:
 
 # need to replace ffmpeg command when using ffmpeg4
 if int(os.environ.get("LIBAVFORMAT_VERSION_MAJOR", "59") or "59") < 59:
-    if go2rtc_config["ffmpeg"].get("rtsp") is None:
-        go2rtc_config["ffmpeg"]["rtsp"] = (
-            "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"
-        )
-else:
+    rtsp_args = "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"
     if go2rtc_config.get("ffmpeg") is None:
-        go2rtc_config["ffmpeg"] = {"path": ""}
+        go2rtc_config["ffmpeg"] = {"rtsp": rtsp_args}
+    elif go2rtc_config["ffmpeg"].get("rtsp") is None:
+        go2rtc_config["ffmpeg"]["rtsp"] = rtsp_args
 
 for name in go2rtc_config.get("streams", {}):
     stream = go2rtc_config["streams"][name]

--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -126,7 +126,7 @@ elif go2rtc_config["ffmpeg"].get("bin") is None:
     go2rtc_config["ffmpeg"]["bin"] = ffmpeg_path
 
 # need to replace ffmpeg command when using ffmpeg4
-if int(os.environ.get("LIBAVFORMAT_VERSION_MAJOR", "59") or "59") < 59:
+if int(os.environ.get("LIBAVFORMAT_VERSION_MAJOR")) < 59:
     rtsp_args = "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"
     if go2rtc_config.get("ffmpeg") is None:
         go2rtc_config["ffmpeg"] = {"rtsp": rtsp_args}

--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -12,6 +12,7 @@ from frigate.const import (
     BIRDSEYE_PIPE,
     DEFAULT_FFMPEG_VERSION,
     INCLUDED_FFMPEG_VERSIONS,
+    LIBAVFORMAT_VERSION_MAJOR,
 )
 from frigate.ffmpeg_presets import parse_preset_hardware_acceleration_encode
 
@@ -126,7 +127,7 @@ elif go2rtc_config["ffmpeg"].get("bin") is None:
     go2rtc_config["ffmpeg"]["bin"] = ffmpeg_path
 
 # need to replace ffmpeg command when using ffmpeg4
-if int(os.environ.get("LIBAVFORMAT_VERSION_MAJOR")) < 59:
+if LIBAVFORMAT_VERSION_MAJOR < 59:
     rtsp_args = "-fflags nobuffer -flags low_delay -stimeout 5000000 -user_agent go2rtc/ffmpeg -rtsp_transport tcp -i {input}"
     if go2rtc_config.get("ffmpeg") is None:
         go2rtc_config["ffmpeg"] = {"rtsp": rtsp_args}

--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -28,8 +28,7 @@ COPY docker/rockchip/conv2rknn.py /opt/conv2rknn.py
 
 ADD https://github.com/MarcA711/rknn-toolkit2/releases/download/v2.3.0/librknnrt.so /usr/lib/
 
-RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffmpeg
-RUN rm -rf /usr/lib/btbn-ffmpeg/bin/ffprobe
 ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-7/ffmpeg /usr/lib/ffmpeg/6.0/bin/
 ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-7/ffprobe /usr/lib/ffmpeg/6.0/bin/
-ENV PATH="/usr/lib/ffmpeg/6.0/bin/:${PATH}"
+ENV DEFAULT_FFMPEG_VERSION="6.0"
+ENV INCLUDED_FFMPEG_VERSIONS="${DEFAULT_FFMPEG_VERSION}:${INCLUDED_FFMPEG_VERSIONS}"

--- a/docker/rpi/Dockerfile
+++ b/docker/rpi/Dockerfile
@@ -6,11 +6,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 FROM deps AS rpi-deps
 ARG TARGETARCH
 
-RUN rm -rf /usr/lib/btbn-ffmpeg/
-
 # Install dependencies
 RUN --mount=type=bind,source=docker/rpi/install_deps.sh,target=/deps/install_deps.sh \
     /deps/install_deps.sh
+
+ENV DEFAULT_FFMPEG_VERSION="rpi"
+ENV INCLUDED_FFMPEG_VERSIONS="${DEFAULT_FFMPEG_VERSION}:${INCLUDED_FFMPEG_VERSIONS}"
 
 WORKDIR /opt/frigate/
 COPY --from=rootfs / /

--- a/docker/rpi/install_deps.sh
+++ b/docker/rpi/install_deps.sh
@@ -28,4 +28,7 @@ if [[ "${TARGETARCH}" == "arm64" ]]; then
     echo "deb [signed-by=/usr/share/keyrings/raspbian.gpg] https://archive.raspberrypi.org/debian/ bookworm main" | tee /etc/apt/sources.list.d/raspi.list
     apt-get -qq update
     apt-get -qq install --no-install-recommends --no-install-suggests -y ffmpeg
+    mkdir -p /usr/lib/ffmpeg/rpi/bin
+    ln -svf /usr/bin/ffmpeg /usr/lib/ffmpeg/rpi/bin/ffmpeg
+    ln -svf /usr/bin/ffprobe /usr/lib/ffmpeg/rpi/bin/ffprobe
 fi

--- a/docker/tensorrt/Dockerfile.arm64
+++ b/docker/tensorrt/Dockerfile.arm64
@@ -76,8 +76,9 @@ RUN apt-get update \
     && apt-get install -y python-is-python3 libprotobuf23  \
     && rm -rf /var/lib/apt/lists/*
 
-RUN rm -rf /usr/lib/btbn-ffmpeg/
 COPY --from=jetson-ffmpeg /rootfs /
+ENV DEFAULT_FFMPEG_VERSION="jetson"
+ENV INCLUDED_FFMPEG_VERSIONS="${DEFAULT_FFMPEG_VERSION}:${INCLUDED_FFMPEG_VERSIONS}"
 
 # ffmpeg runtime dependencies
 RUN apt-get -qq update \

--- a/docker/tensorrt/build_jetson_ffmpeg.sh
+++ b/docker/tensorrt/build_jetson_ffmpeg.sh
@@ -5,7 +5,7 @@
 
 set -euxo pipefail
 
-INSTALL_PREFIX=/rootfs/usr/local
+INSTALL_PREFIX=/rootfs/usr/lib/ffmpeg/jetson
 
 apt-get -qq update
 apt-get -qq install -y --no-install-recommends build-essential ccache clang cmake pkg-config

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -36,7 +36,8 @@ See [the go2rtc docs](https://github.com/AlexxIT/go2rtc?tab=readme-ov-file#modul
 
 ```yaml
 go2rtc:
-  streams: ...
+  streams:
+    # ...
   log:
     exec: trace
 ```

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -36,8 +36,7 @@ See [the go2rtc docs](https://github.com/AlexxIT/go2rtc?tab=readme-ov-file#modul
 
 ```yaml
 go2rtc:
-  streams:
-    ...
+  streams: ...
   log:
     exec: trace
 ```
@@ -176,15 +175,13 @@ listen [::]:5000 ipv6only=off;
 
 ### Custom ffmpeg build
 
-Included with Frigate is a build of ffmpeg that works for the vast majority of users. However, there exists some hardware setups which have incompatibilities with the included build. In this case, statically built ffmpeg binary can be downloaded to /config and used.
+Included with Frigate is a build of ffmpeg that works for the vast majority of users. However, there exists some hardware setups which have incompatibilities with the included build. In this case, statically built ffmpeg binary can be downloaded to `/config/custom-ffmpeg/bin` and used.
 
 To do this:
 
-1. Download your ffmpeg build and uncompress to the Frigate config folder.
-2. Update your docker-compose or docker CLI to include `'/home/appdata/frigate/custom-ffmpeg':'/usr/lib/btbn-ffmpeg':'ro'` in the volume mappings.
+1. Download your ffmpeg build and uncompress it to the `/config/custom-ffmpeg` folder. Verify that the ffmpeg binary is located at `/config/custom-ffmpeg/bin/ffmpeg`.
+2. Update the `ffmpeg.path` in your Frigate config to `/config/custom-ffmpeg`.
 3. Restart Frigate and the custom version will be used if the mapping was done correctly.
-
-NOTE: The folder that is set for the config needs to be the folder that contains `/bin`. So if the full structure is `/home/appdata/frigate/custom-ffmpeg/bin/ffmpeg` then the `ffmpeg -> path` field should be `/config/custom-ffmpeg/bin`.
 
 ### Custom go2rtc version
 
@@ -192,7 +189,7 @@ Frigate currently includes go2rtc v1.9.2, there may be certain cases where you w
 
 To do this:
 
-1. Download the go2rtc build to the /config folder.
+1. Download the go2rtc build to the `/config` folder.
 2. Rename the build to `go2rtc`.
 3. Give `go2rtc` execute permission.
 4. Restart Frigate and the custom version will be used, you can verify by checking go2rtc logs.

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -175,13 +175,13 @@ listen [::]:5000 ipv6only=off;
 
 ### Custom ffmpeg build
 
-Included with Frigate is a build of ffmpeg that works for the vast majority of users. However, there exists some hardware setups which have incompatibilities with the included build. In this case, statically built ffmpeg binary can be downloaded to `/config/custom-ffmpeg/bin` and used.
+Included with Frigate is a build of ffmpeg that works for the vast majority of users. However, there exists some hardware setups which have incompatibilities with the included build. In this case, statically built `ffmpeg` and `ffprobe` binaries can be placed in `/config/custom-ffmpeg/bin` for Frigate to use.
 
 To do this:
 
-1. Download your ffmpeg build and uncompress it to the `/config/custom-ffmpeg` folder. Verify that the ffmpeg binary is located at `/config/custom-ffmpeg/bin/ffmpeg`.
+1. Download your ffmpeg build and uncompress it to the `/config/custom-ffmpeg` folder. Verify that both the `ffmpeg` and `ffprobe` binaries are located in `/config/custom-ffmpeg/bin`.
 2. Update the `ffmpeg.path` in your Frigate config to `/config/custom-ffmpeg`.
-3. Restart Frigate and the custom version will be used if the mapping was done correctly.
+3. Restart Frigate and the custom version will be used if the steps above were done correctly.
 
 ### Custom go2rtc version
 

--- a/frigate/config/camera/ffmpeg.py
+++ b/frigate/config/camera/ffmpeg.py
@@ -1,4 +1,3 @@
-import shutil
 from enum import Enum
 from typing import Union
 
@@ -71,10 +70,7 @@ class FfmpegConfig(FrigateBaseModel):
     @property
     def ffmpeg_path(self) -> str:
         if self.path == "default":
-            if shutil.which("ffmpeg") is None:
-                return f"/usr/lib/ffmpeg/{DEFAULT_FFMPEG_VERSION}/bin/ffmpeg"
-            else:
-                return "ffmpeg"
+            return f"/usr/lib/ffmpeg/{DEFAULT_FFMPEG_VERSION}/bin/ffmpeg"
         elif self.path in INCLUDED_FFMPEG_VERSIONS:
             return f"/usr/lib/ffmpeg/{self.path}/bin/ffmpeg"
         else:
@@ -83,10 +79,7 @@ class FfmpegConfig(FrigateBaseModel):
     @property
     def ffprobe_path(self) -> str:
         if self.path == "default":
-            if shutil.which("ffprobe") is None:
-                return f"/usr/lib/ffmpeg/{DEFAULT_FFMPEG_VERSION}/bin/ffprobe"
-            else:
-                return "ffprobe"
+            return f"/usr/lib/ffmpeg/{DEFAULT_FFMPEG_VERSION}/bin/ffprobe"
         elif self.path in INCLUDED_FFMPEG_VERSIONS:
             return f"/usr/lib/ffmpeg/{self.path}/bin/ffprobe"
         else:

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 CONFIG_DIR = "/config"
@@ -61,8 +62,8 @@ MAX_WAL_SIZE = 10  # MB
 
 # Ffmpeg constants
 
-DEFAULT_FFMPEG_VERSION = "7.0"
-INCLUDED_FFMPEG_VERSIONS = ["7.0", "5.0"]
+DEFAULT_FFMPEG_VERSION = str(os.environ.get("DEFAULT_FFMPEG_VERSION"))
+INCLUDED_FFMPEG_VERSIONS = str(os.environ.get("INCLUDED_FFMPEG_VERSIONS")).split(":")
 FFMPEG_HWACCEL_NVIDIA = "preset-nvidia"
 FFMPEG_HWACCEL_VAAPI = "preset-vaapi"
 FFMPEG_HWACCEL_VULKAN = "preset-vulkan"

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -62,8 +62,9 @@ MAX_WAL_SIZE = 10  # MB
 
 # Ffmpeg constants
 
-DEFAULT_FFMPEG_VERSION = str(os.environ.get("DEFAULT_FFMPEG_VERSION"))
-INCLUDED_FFMPEG_VERSIONS = str(os.environ.get("INCLUDED_FFMPEG_VERSIONS")).split(":")
+DEFAULT_FFMPEG_VERSION = os.environ.get("DEFAULT_FFMPEG_VERSION", "")
+INCLUDED_FFMPEG_VERSIONS = os.environ.get("INCLUDED_FFMPEG_VERSIONS", "").split(":")
+LIBAVFORMAT_VERSION_MAJOR = int(os.environ.get("LIBAVFORMAT_VERSION_MAJOR", "59"))
 FFMPEG_HWACCEL_NVIDIA = "preset-nvidia"
 FFMPEG_HWACCEL_VAAPI = "preset-vaapi"
 FFMPEG_HWACCEL_VULKAN = "preset-vulkan"

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -65,8 +65,8 @@ PRESETS_HW_ACCEL_DECODE = {
     "preset-rpi-64-h264": "-c:v:1 h264_v4l2m2m",
     "preset-rpi-64-h265": "-c:v:1 hevc_v4l2m2m",
     FFMPEG_HWACCEL_VAAPI: f"-hwaccel_flags allow_profile_mismatch -hwaccel vaapi -hwaccel_device {_gpu_selector.get_selected_gpu()} -hwaccel_output_format vaapi",
-    "preset-intel-qsv-h264": f"-hwaccel qsv -qsv_device {_gpu_selector.get_selected_gpu()} -hwaccel_output_format qsv -c:v h264_qsv{' -bsf:v dump_extra' if LIBAV_VERSION >= 61 else ''}",  # https://trac.ffmpeg.org/ticket/9766#comment:17
-    "preset-intel-qsv-h265": f"-load_plugin hevc_hw -hwaccel qsv -qsv_device {_gpu_selector.get_selected_gpu()} -hwaccel_output_format qsv{' -bsf:v dump_extra' if LIBAV_VERSION >= 61 else ''}",  # https://trac.ffmpeg.org/ticket/9766#comment:17
+    "preset-intel-qsv-h264": f"-hwaccel qsv -qsv_device {_gpu_selector.get_selected_gpu()} -hwaccel_output_format qsv -c:v h264_qsv{' -bsf:v dump_extra' if LIBAVFORMAT_VERSION_MAJOR >= 61 else ''}",  # https://trac.ffmpeg.org/ticket/9766#comment:17
+    "preset-intel-qsv-h265": f"-load_plugin hevc_hw -hwaccel qsv -qsv_device {_gpu_selector.get_selected_gpu()} -hwaccel_output_format qsv{' -bsf:v dump_extra' if LIBAVFORMAT_VERSION_MAJOR >= 61 else ''}",  # https://trac.ffmpeg.org/ticket/9766#comment:17
     FFMPEG_HWACCEL_NVIDIA: "-hwaccel cuda -hwaccel_output_format cuda",
     "preset-jetson-h264": "-c:v h264_nvmpi -resize {1}x{2}",
     "preset-jetson-h265": "-c:v hevc_nvmpi -resize {1}x{2}",

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -10,6 +10,7 @@ from frigate.const import (
     FFMPEG_HWACCEL_NVIDIA,
     FFMPEG_HWACCEL_VAAPI,
     FFMPEG_HWACCEL_VULKAN,
+    LIBAVFORMAT_VERSION_MAJOR,
 )
 from frigate.util.services import vainfo_hwaccel
 from frigate.version import VERSION
@@ -51,9 +52,8 @@ class LibvaGpuSelector:
         return ""
 
 
-LIBAV_VERSION = int(os.getenv("LIBAVFORMAT_VERSION_MAJOR"))
-FPS_VFR_PARAM = "-fps_mode vfr" if LIBAV_VERSION >= 59 else "-vsync 2"
-TIMEOUT_PARAM = "-timeout" if LIBAV_VERSION >= 59 else "-stimeout"
+FPS_VFR_PARAM = "-fps_mode vfr" if LIBAVFORMAT_VERSION_MAJOR >= 59 else "-vsync 2"
+TIMEOUT_PARAM = "-timeout" if LIBAVFORMAT_VERSION_MAJOR >= 59 else "-stimeout"
 
 _gpu_selector = LibvaGpuSelector()
 _user_agent_args = [

--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -51,7 +51,7 @@ class LibvaGpuSelector:
         return ""
 
 
-LIBAV_VERSION = int(os.getenv("LIBAVFORMAT_VERSION_MAJOR", "59") or "59")
+LIBAV_VERSION = int(os.getenv("LIBAVFORMAT_VERSION_MAJOR"))
 FPS_VFR_PARAM = "-fps_mode vfr" if LIBAV_VERSION >= 59 else "-vsync 2"
 TIMEOUT_PARAM = "-timeout" if LIBAV_VERSION >= 59 else "-stimeout"
 


### PR DESCRIPTION
## Proposed change

<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This PR extracts the good bits of #16667 and improves handling of multiple ffmpeg versions.

Now, Frigate will no longer look for ffmpeg on `PATH`, and instead will rely on `DEFAULT_FFMPEG_VERSION` and `INCLUDED_FFMPEG_VERSIONS` to determine which ffmpeg version to use.

Each image that requires a custom ffmpeg version will now come with proper `DEFAULT_FFMPEG_VERSION` and `INCLUDED_FFMPEG_VERSIONS` environment variables.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
