### PR TITLE
Docs: Fix broken shm calculation

### DIFF
--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -84,8 +84,8 @@ You can calculate the **minimum** shm size for each camera with the following fo
 $ python -c 'print("{:.2f}MB".format((<width> * <height> * 1.5 * 20 + 270480) / 1048576))'
 
 # Example for 1280x720, including logs
-$ python -c 'print("{:.2f}MB".format((1280 * 720 * 1.5 * 20 + 270480) / 1048576)) + 40'
-46.63MB
+$ python -c 'print("{:.2f}MB".format((1280 * 720 * 1.5 * 20 + 270480) / 1048576 + 40))'
+66.63MB
 
 # Example for eight cameras detecting at 1280x720, including logs
 $ python -c 'print("{:.2f}MB".format(((1280 * 720 * 1.5 * 20 + 270480) / 1048576) * 8 + 40))'

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -80,7 +80,7 @@ The Frigate container also stores logs in shm, which can take up to **40MB**, so
 You can calculate the **minimum** shm size for each camera with the following formula using the resolution specified for detect:
 
 ```console
-# Replace <width> and <height>
+# Template for one camera without logs, replace <width> and <height>
 $ python -c 'print("{:.2f}MB".format((<width> * <height> * 1.5 * 20 + 270480) / 1048576))'
 
 # Example for 1280x720, including logs


### PR DESCRIPTION
## Proposed change
Fixes shm calculation in docs.

```
# Example for 1280x720, including logs
$ python -c 'print("{:.2f}MB".format((1280 * 720 * 1.5 * 20 + 270480) / 1048576)) + 40'
46.63MB
```
results in 
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```

It should be:

```
# Example for 1280x720, including logs
$ python -c 'print("{:.2f}MB".format((1280 * 720 * 1.5 * 20 + 270480) / 1048576 + 40))'
66.63MB
```

The other examples are mostly fine.
Just to be sure, is it intentional that [in the first example](https://github.com/blakeblackshear/frigate/blob/dev/docs/docs/frigate/installation.md?plain=1#L84) the log size (+ 40) is not included in the calculation?

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
