### PR TITLE
Bugfix: Check websocket correctly when no cameras are enabled/defined

### DIFF
--- a/web/src/api/ws.tsx
+++ b/web/src/api/ws.tsx
@@ -46,7 +46,7 @@ function useValue(): useValueReturn {
 
     const cameraActivity: { [key: string]: object } = JSON.parse(activityValue);
 
-    if (!cameraActivity) {
+    if (Object.keys(cameraActivity).length === 0) {
       return;
     }
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
Users who try to start Frigate without any cameras defined or enabled in their config would be presented with an oddly behaving web UI. This was traced back to the websocket code where the `cameraActivity` was being checked. The fix was simply to check for an empty object rather than checking the truth value (an empty object will always be truthy unless it's null or undefined).


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/16761
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
