### PR TITLE
Edit sub labels from the UI

### DIFF
--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -449,7 +449,7 @@ function ObjectDetailsTab({
         })
         .then((response) => {
           if (response.status === 200) {
-            toast.success("Successfully updated sub-label", {
+            toast.success("Successfully updated sub label.", {
               position: "top-center",
             });
 
@@ -493,7 +493,7 @@ function ObjectDetailsTab({
           }
         })
         .catch(() => {
-          toast.error("Failed to update sub-label", {
+          toast.error("Failed to update sub label.", {
             position: "top-center",
           });
         });

--- a/web/src/components/overlay/dialog/TextEntryDialog.tsx
+++ b/web/src/components/overlay/dialog/TextEntryDialog.tsx
@@ -43,6 +43,8 @@ export default function TextEntryDialog({
   });
   const fileRef = form.register("text");
 
+  // upload handler
+
   const onSubmit = useCallback(
     (data: z.infer<typeof formSchema>) => {
       if (!allowEmpty && !data["text"]) {

--- a/web/src/components/overlay/dialog/TextEntryDialog.tsx
+++ b/web/src/components/overlay/dialog/TextEntryDialog.tsx
@@ -10,7 +10,7 @@ import {
 import { Form, FormControl, FormField, FormItem } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -20,13 +20,18 @@ type TextEntryDialogProps = {
   description?: string;
   setOpen: (open: boolean) => void;
   onSave: (text: string) => void;
+  defaultValue?: string;
+  allowEmpty?: boolean;
 };
+
 export default function TextEntryDialog({
   open,
   title,
   description,
   setOpen,
   onSave,
+  defaultValue = "",
+  allowEmpty = false,
 }: TextEntryDialogProps) {
   const formSchema = z.object({
     text: z.string(),
@@ -34,21 +39,25 @@ export default function TextEntryDialog({
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
+    defaultValues: { text: defaultValue },
   });
   const fileRef = form.register("text");
 
-  // upload handler
-
   const onSubmit = useCallback(
     (data: z.infer<typeof formSchema>) => {
-      if (!data["text"]) {
+      if (!allowEmpty && !data["text"]) {
         return;
       }
-
       onSave(data["text"]);
     },
-    [onSave],
+    [onSave, allowEmpty],
   );
+
+  useEffect(() => {
+    if (open) {
+      form.reset({ text: defaultValue });
+    }
+  }, [open, defaultValue, form]);
 
   return (
     <Dialog open={open} defaultOpen={false} onOpenChange={setOpen}>


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR adds the ability to edit sub labels through the UI's Tracked Object Details dialog in Explore. A small pencil icon can be clicked/tapped to show an edit dialog.

This should aid users in editing faces and license plates that have been incorrectly recognized.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
