### PR TITLE
Ensure sub label is null when submitting an empty string

### DIFF
--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -991,6 +991,10 @@ def set_sub_label(
     new_sub_label = body.subLabel
     new_score = body.subLabelScore
 
+    if new_sub_label == "":
+        new_sub_label = None
+        new_score = None
+
     if tracked_obj:
         tracked_obj.obj_data["sub_label"] = (new_sub_label, new_score)
 
@@ -1001,21 +1005,19 @@ def set_sub_label(
 
     if event:
         event.sub_label = new_sub_label
-
-        if new_score:
-            data = event.data
+        data = event.data
+        if new_sub_label is None:
+            data["sub_label_score"] = None
+        elif new_score is not None:
             data["sub_label_score"] = new_score
-            event.data = data
-
+        event.data = data
         event.save()
 
     return JSONResponse(
-        content=(
-            {
-                "success": True,
-                "message": "Event " + event_id + " sub label set to " + new_sub_label,
-            }
-        ),
+        content={
+            "success": True,
+            "message": f"Event {event_id} sub label set to {new_sub_label if new_sub_label is not None else 'None'}",
+        },
         status_code=200,
     )
 

--- a/frigate/test/test_http.py
+++ b/frigate/test/test_http.py
@@ -275,7 +275,7 @@ class TestHttp(unittest.TestCase):
             event = client.get(f"/events/{id}").json()
             assert event
             assert event["id"] == id
-            assert event["sub_label"] == ""
+            assert event["sub_label"] == None
 
     def test_sub_label_list(self):
         app = create_fastapi_app(

--- a/web/src/components/overlay/dialog/TextEntryDialog.tsx
+++ b/web/src/components/overlay/dialog/TextEntryDialog.tsx
@@ -86,7 +86,9 @@ export default function TextEntryDialog({
               )}
             />
             <DialogFooter className="pt-4">
-              <Button onClick={() => setOpen(false)}>Cancel</Button>
+              <Button type="button" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
               <Button variant="select" type="submit">
                 Save
               </Button>


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR:
- Ensures sub_label and score is set to null when submitting an empty string through the API
- Fixes a bug introduced in https://github.com/blakeblackshear/frigate/pull/16422 in the TextEntryDialog where the cancel button would still submit the form


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
