### PR TITLE
Use native arm runner for arm docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
             *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-jp5
             *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-jp5,mode=max
   jetson_jp6_build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Jetson Jetpack 6
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           tags: ${{ steps.setup.outputs.image-name }}-amd64
           cache-from: type=registry,ref=${{ steps.setup.outputs.cache-name }}-amd64
   arm64_build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
     name: ARM Build
     steps:
       - name: Check out code
@@ -178,7 +178,7 @@ jobs:
             rocm.tags=${{ steps.setup.outputs.image-name }}-rocm
             *.cache-from=type=gha
   arm64_extra_builds:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
     name: ARM Extra Build
     needs:
       - arm64_build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - dev
       - master
+      - fix-jetson
     paths-ignore:
       - "docs/**"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
             *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-jp5
             *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-jp5,mode=max
   jetson_jp6_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arm
     name: Jetson Jetpack 6
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - dev
       - master
-      - fix-jetson
     paths-ignore:
       - "docs/**"
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

This PR uses the native arm docker runner to:
- fix the jetson jetpack 6 build failing
- speed up all arm builds
