### PR TITLE
Dynamically enable/disable cameras

### DIFF
--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -222,11 +222,11 @@ Publishes the rms value for audio detected on this camera.
 
 **NOTE:** Requires audio detection to be enabled
 
-### `frigate/<camera_name>/enable/set`
+### `frigate/<camera_name>/enabled/set`
 
 Topic to turn Frigate's processing of a camera on and off. Expected values are `ON` and `OFF`.
 
-### `frigate/<camera_name>/enable/state`
+### `frigate/<camera_name>/enabled/state`
 
 Topic with current state of processing for a camera. Published values are `ON` and `OFF`.
 

--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -222,6 +222,14 @@ Publishes the rms value for audio detected on this camera.
 
 **NOTE:** Requires audio detection to be enabled
 
+### `frigate/<camera_name>/enable/set`
+
+Topic to turn Frigate's processing of a camera on and off. Expected values are `ON` and `OFF`.
+
+### `frigate/<camera_name>/enable/state`
+
+Topic with current state of processing for a camera. Published values are `ON` and `OFF`.
+
 ### `frigate/<camera_name>/detect/set`
 
 Topic to turn object detection for a camera on and off. Expected values are `ON` and `OFF`.

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -126,9 +126,7 @@ class FrigateApp:
     def init_camera_metrics(self) -> None:
         # create camera_metrics
         for camera_name in self.config.cameras.keys():
-            self.camera_metrics[camera_name] = CameraMetrics(
-                enabled=self.config.cameras[camera_name].enabled
-            )
+            self.camera_metrics[camera_name] = CameraMetrics()
             self.ptz_metrics[camera_name] = PTZMetrics(
                 autotracker_enabled=self.config.cameras[
                     camera_name
@@ -335,7 +333,6 @@ class FrigateApp:
             self.config,
             self.inter_config_updater,
             self.onvif_controller,
-            self.camera_metrics,
             self.ptz_metrics,
             comms,
         )

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -395,6 +395,7 @@ class FrigateApp:
             self.dispatcher,
             self.detected_frames_queue,
             self.ptz_autotracker_thread,
+            self.camera_metrics,
             self.stop_event,
         )
         self.detected_frames_processor.start()

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -403,7 +403,7 @@ class FrigateApp:
         output_processor = util.Process(
             target=output_frames,
             name="output_processor",
-            args=(self.config,),
+            args=(self.config, self.camera_metrics),
         )
         output_processor.daemon = True
         self.output_processor = output_processor

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -126,7 +126,9 @@ class FrigateApp:
     def init_camera_metrics(self) -> None:
         # create camera_metrics
         for camera_name in self.config.cameras.keys():
-            self.camera_metrics[camera_name] = CameraMetrics()
+            self.camera_metrics[camera_name] = CameraMetrics(
+                enabled=self.config.cameras[camera_name].enabled
+            )
             self.ptz_metrics[camera_name] = PTZMetrics(
                 autotracker_enabled=self.config.cameras[
                     camera_name
@@ -333,6 +335,7 @@ class FrigateApp:
             self.config,
             self.inter_config_updater,
             self.onvif_controller,
+            self.camera_metrics,
             self.ptz_metrics,
             comms,
         )

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -392,7 +392,6 @@ class FrigateApp:
             self.dispatcher,
             self.detected_frames_queue,
             self.ptz_autotracker_thread,
-            self.camera_metrics,
             self.stop_event,
         )
         self.detected_frames_processor.start()
@@ -401,7 +400,7 @@ class FrigateApp:
         output_processor = util.Process(
             target=output_frames,
             name="output_processor",
-            args=(self.config, self.camera_metrics),
+            args=(self.config,),
         )
         output_processor.daemon = True
         self.output_processor = output_processor

--- a/frigate/camera/__init__.py
+++ b/frigate/camera/__init__.py
@@ -14,13 +14,14 @@ class CameraMetrics:
     audio_rms: Synchronized
     audio_dBFS: Synchronized
 
+    enabled: Synchronized
     frame_queue: mp.Queue
 
     process: Optional[mp.Process]
     capture_process: Optional[mp.Process]
     ffmpeg_pid: Synchronized
 
-    def __init__(self):
+    def __init__(self, enabled: bool):
         self.camera_fps = mp.Value("d", 0)
         self.detection_fps = mp.Value("d", 0)
         self.detection_frame = mp.Value("d", 0)
@@ -30,6 +31,7 @@ class CameraMetrics:
         self.audio_rms = mp.Value("d", 0)
         self.audio_dBFS = mp.Value("d", 0)
 
+        self.enabled = mp.Value("i", enabled)
         self.frame_queue = mp.Queue(maxsize=2)
 
         self.process = None

--- a/frigate/camera/__init__.py
+++ b/frigate/camera/__init__.py
@@ -14,14 +14,13 @@ class CameraMetrics:
     audio_rms: Synchronized
     audio_dBFS: Synchronized
 
-    enabled: Synchronized
     frame_queue: mp.Queue
 
     process: Optional[mp.Process]
     capture_process: Optional[mp.Process]
     ffmpeg_pid: Synchronized
 
-    def __init__(self, enabled: bool):
+    def __init__(self):
         self.camera_fps = mp.Value("d", 0)
         self.detection_fps = mp.Value("d", 0)
         self.detection_frame = mp.Value("d", 0)
@@ -31,7 +30,6 @@ class CameraMetrics:
         self.audio_rms = mp.Value("d", 0)
         self.audio_dBFS = mp.Value("d", 0)
 
-        self.enabled = mp.Value("i", enabled)
         self.frame_queue = mp.Queue(maxsize=2)
 
         self.process = None

--- a/frigate/camera/activity_manager.py
+++ b/frigate/camera/activity_manager.py
@@ -20,7 +20,7 @@ class CameraActivityManager:
         self.all_zone_labels: dict[str, set[str]] = {}
 
         for camera_config in config.cameras.values():
-            if not camera_config.enabled:
+            if not camera_config.enabled_in_config:
                 continue
 
             self.last_camera_activity[camera_config.name] = {}

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -5,7 +5,7 @@ import json
 import logging
 from typing import Any, Callable, Optional
 
-from frigate.camera import CameraMetrics, PTZMetrics
+from frigate.camera import PTZMetrics
 from frigate.camera.activity_manager import CameraActivityManager
 from frigate.comms.base_communicator import Communicator
 from frigate.comms.config_updater import ConfigPublisher
@@ -40,14 +40,12 @@ class Dispatcher:
         config: FrigateConfig,
         config_updater: ConfigPublisher,
         onvif: OnvifController,
-        camera_metrics: dict[str, CameraMetrics],
         ptz_metrics: dict[str, PTZMetrics],
         communicators: list[Communicator],
     ) -> None:
         self.config = config
         self.config_updater = config_updater
         self.onvif = onvif
-        self.camera_metrics = camera_metrics
         self.ptz_metrics = ptz_metrics
         self.comms = communicators
         self.camera_activity = CameraActivityManager(config, self.publish)
@@ -292,14 +290,12 @@ class Dispatcher:
                     "Camera must be enabled in the config to be turned on via MQTT."
                 )
                 return
-            if not self.camera_metrics[camera_name].enabled.value:
+            if not camera_settings.enabled:
                 logger.info(f"Turning on camera {camera_name}")
-                self.camera_metrics[camera_name].enabled.value = True
                 camera_settings.enabled = True
         elif payload == "OFF":
-            if self.camera_metrics[camera_name].enabled.value:
+            if camera_settings.enabled:
                 logger.info(f"Turning off camera {camera_name}")
-                self.camera_metrics[camera_name].enabled.value = False
                 camera_settings.enabled = False
 
         self.config_updater.publish(f"config/enabled/{camera_name}", camera_settings)

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -284,7 +284,6 @@ class Dispatcher:
 
     def _on_enabled_command(self, camera_name: str, payload: str) -> None:
         """Callback for camera topic."""
-        # TODO: figure out what to do here so cameras don't disappear in the UI
         camera_settings = self.config.cameras[camera_name]
 
         if payload == "ON":
@@ -304,7 +303,7 @@ class Dispatcher:
                 camera_settings.enabled = False
 
         self.config_updater.publish(f"config/enabled/{camera_name}", camera_settings)
-        self.publish(f"{camera_name}/camera/state", payload, retain=True)
+        self.publish(f"{camera_name}/enabled/state", payload, retain=True)
 
     def _on_motion_command(self, camera_name: str, payload: str) -> None:
         """Callback for motion topic."""

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -296,13 +296,14 @@ class Dispatcher:
             if not self.camera_metrics[camera_name].enabled.value:
                 logger.info(f"Turning on camera {camera_name}")
                 self.camera_metrics[camera_name].enabled.value = True
-                # camera_settings.enabled = True
+                camera_settings.enabled = True
         elif payload == "OFF":
             if self.camera_metrics[camera_name].enabled.value:
                 logger.info(f"Turning off camera {camera_name}")
                 self.camera_metrics[camera_name].enabled.value = False
-                # camera_settings.enabled = False
+                camera_settings.enabled = False
 
+        self.config_updater.publish(f"config/enabled/{camera_name}", camera_settings)
         self.publish(f"{camera_name}/camera/state", payload, retain=True)
 
     def _on_motion_command(self, camera_name: str, payload: str) -> None:

--- a/frigate/config/camera/camera.py
+++ b/frigate/config/camera/camera.py
@@ -102,6 +102,9 @@ class CameraConfig(FrigateBaseModel):
     zones: dict[str, ZoneConfig] = Field(
         default_factory=dict, title="Zone configuration."
     )
+    enabled_in_config: Optional[bool] = Field(
+        default=None, title="Keep track of original state of camera."
+    )
 
     _ffmpeg_cmds: list[dict[str, list[str]]] = PrivateAttr()
 

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -526,6 +526,7 @@ class FrigateConfig(FrigateBaseModel):
                 camera_config.detect.stationary.interval = stationary_threshold
 
             # set config pre-value
+            camera_config.enabled_in_config = camera_config.enabled
             camera_config.audio.enabled_in_config = camera_config.audio.enabled
             camera_config.record.enabled_in_config = camera_config.record.enabled
             camera_config.notifications.enabled_in_config = (

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -705,7 +705,7 @@ class TrackedObjectProcessor(threading.Thread):
                         {"enabled": False, "motion": 0, "objects": []},
                     )
 
-    def _get_enabled_state(self, camera: str):
+    def _get_enabled_state(self, camera: str) -> bool:
         _, config_data = self.enabled_subscribers[camera].check_for_update()
         if config_data:
             enabled = config_data.enabled

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -428,7 +428,6 @@ class TrackedObjectProcessor(threading.Thread):
         dispatcher: Dispatcher,
         tracked_objects_queue,
         ptz_autotracker_thread,
-        camera_metrics,
         stop_event,
     ):
         super().__init__(name="detected_frames_processor")
@@ -440,7 +439,6 @@ class TrackedObjectProcessor(threading.Thread):
         self.frame_manager = SharedMemoryFrameManager()
         self.last_motion_detected: dict[str, float] = {}
         self.ptz_autotracker_thread = ptz_autotracker_thread
-        self.camera_metrics = camera_metrics
 
         self.enabled_subscribers = {
             camera: ConfigSubscriber(f"config/enabled/{camera}", True)

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -693,12 +693,12 @@ class TrackedObjectProcessor(threading.Thread):
                 camera_state = self.camera_states[camera]
 
                 if camera_state.prev_enabled and not current_enabled:
-                    logger.info(f"Not processing objects for disabled camera {camera}")
+                    logger.debug(f"Not processing objects for disabled camera {camera}")
                     last_frame_name = camera_state.previous_frame_id
                     for obj_id, obj in list(camera_state.tracked_objects.items()):
                         if "end_time" not in obj.obj_data:
-                            logger.info(
-                                f"Camera {camera} disabled, ending active events"
+                            logger.debug(
+                                f"Camera {camera} disabled, ending active event {obj_id}"
                             )
                             obj.obj_data["end_time"] = (
                                 datetime.datetime.now().timestamp()

--- a/frigate/object_processing.py
+++ b/frigate/object_processing.py
@@ -311,6 +311,7 @@ class CameraState:
         # TODO: can i switch to looking this up and only changing when an event ends?
         # maintain best objects
         camera_activity: dict[str, list[any]] = {
+            "enabled": True,
             "motion": len(motion_boxes) > 0,
             "objects": [],
         }
@@ -708,7 +709,10 @@ class TrackedObjectProcessor(threading.Thread):
 
                             # camera activity callbacks
                             for callback in camera_state.callbacks["camera_activity"]:
-                                callback(camera, {"motion": 0, "objects": []})
+                                callback(
+                                    camera,
+                                    {"enabled": False, "motion": 0, "objects": []},
+                                )
 
                 camera_state.prev_enabled = current_enabled
 

--- a/frigate/output/birdseye.py
+++ b/frigate/output/birdseye.py
@@ -16,7 +16,6 @@ from typing import Optional
 import cv2
 import numpy as np
 
-from frigate.camera import CameraMetrics
 from frigate.comms.config_updater import ConfigSubscriber
 from frigate.config import BirdseyeModeEnum, FfmpegConfig, FrigateConfig
 from frigate.const import BASE_DIR, BIRDSEYE_PIPE
@@ -272,7 +271,6 @@ class BirdsEyeFrameManager:
         self,
         config: FrigateConfig,
         stop_event: mp.Event,
-        camera_metrics: dict[str, CameraMetrics],
     ):
         self.config = config
         self.mode = config.birdseye.mode
@@ -283,7 +281,6 @@ class BirdsEyeFrameManager:
         self.canvas = Canvas(width, height, config.birdseye.layout.scaling_factor)
         self.stop_event = stop_event
         self.inactivity_threshold = config.birdseye.inactivity_threshold
-        self.camera_metrics = camera_metrics
 
         self.enabled_subscribers = {
             cam: ConfigSubscriber(f"config/enabled/{cam}", True)
@@ -754,7 +751,6 @@ class Birdseye:
         config: FrigateConfig,
         stop_event: mp.Event,
         websocket_server,
-        camera_metrics: dict[str, CameraMetrics],
     ) -> None:
         self.config = config
         self.input = queue.Queue(maxsize=10)
@@ -772,7 +768,7 @@ class Birdseye:
         self.broadcaster = BroadcastThread(
             "birdseye", self.converter, websocket_server, stop_event
         )
-        self.birdseye_manager = BirdsEyeFrameManager(config, stop_event, camera_metrics)
+        self.birdseye_manager = BirdsEyeFrameManager(config, stop_event)
         self.config_subscriber = ConfigSubscriber("config/birdseye/")
         self.frame_manager = SharedMemoryFrameManager()
         self.stop_event = stop_event

--- a/frigate/output/birdseye.py
+++ b/frigate/output/birdseye.py
@@ -9,11 +9,14 @@ import os
 import queue
 import subprocess as sp
 import threading
+import time
 import traceback
+from typing import Optional
 
 import cv2
 import numpy as np
 
+from frigate.camera import CameraMetrics
 from frigate.comms.config_updater import ConfigSubscriber
 from frigate.config import BirdseyeModeEnum, FfmpegConfig, FrigateConfig
 from frigate.const import BASE_DIR, BIRDSEYE_PIPE
@@ -269,6 +272,7 @@ class BirdsEyeFrameManager:
         self,
         config: FrigateConfig,
         stop_event: mp.Event,
+        camera_metrics: dict[str, CameraMetrics],
     ):
         self.config = config
         self.mode = config.birdseye.mode
@@ -279,6 +283,7 @@ class BirdsEyeFrameManager:
         self.canvas = Canvas(width, height, config.birdseye.layout.scaling_factor)
         self.stop_event = stop_event
         self.inactivity_threshold = config.birdseye.inactivity_threshold
+        self.camera_metrics = camera_metrics
 
         if config.birdseye.layout.max_cameras:
             self.last_refresh_time = 0
@@ -378,8 +383,11 @@ class BirdsEyeFrameManager:
         if mode == BirdseyeModeEnum.objects and object_box_count > 0:
             return True
 
-    def update_frame(self, frame: np.ndarray):
-        """Update to a new frame for birdseye."""
+    def update_frame(self, frame: Optional[np.ndarray] = None) -> bool:
+        """
+        Update birdseye, optionally with a new frame.
+        When no frame is passed, check the layout and update for any disabled cameras.
+        """
 
         # determine how many cameras are tracking objects within the last inactivity_threshold seconds
         active_cameras: set[str] = set(
@@ -387,11 +395,13 @@ class BirdsEyeFrameManager:
                 cam
                 for cam, cam_data in self.cameras.items()
                 if self.config.cameras[cam].birdseye.enabled
+                and self.camera_metrics[cam].enabled.value
                 and cam_data["last_active_frame"] > 0
                 and cam_data["current_frame_time"] - cam_data["last_active_frame"]
                 < self.inactivity_threshold
             ]
         )
+        logger.debug(f"Active cameras: {active_cameras}")
 
         max_cameras = self.config.birdseye.layout.max_cameras
         max_camera_refresh = False
@@ -409,118 +419,125 @@ class BirdsEyeFrameManager:
                         - self.cameras[active_camera]["last_active_frame"]
                     ),
                 )
-                active_cameras = limited_active_cameras[
-                    : self.config.birdseye.layout.max_cameras
-                ]
+                active_cameras = limited_active_cameras[:max_cameras]
                 max_camera_refresh = True
                 self.last_refresh_time = now
 
-        # if there are no active cameras
+        # Track if the frame changes
+        frame_changed = False
+
+        # If no active cameras and layout is already empty, no update needed
         if len(active_cameras) == 0:
             # if the layout is already cleared
             if len(self.camera_layout) == 0:
                 return False
             # if the layout needs to be cleared
-            else:
-                self.camera_layout = []
-                self.active_cameras = set()
-                self.clear_frame()
-                return True
-
-        # check if we need to reset the layout because there is a different number of cameras
-        if len(self.active_cameras) - len(active_cameras) == 0:
-            if len(self.active_cameras) == 1 and self.active_cameras != active_cameras:
-                reset_layout = True
-            elif max_camera_refresh:
-                reset_layout = True
-            else:
-                reset_layout = False
-        else:
-            reset_layout = True
-
-        # reset the layout if it needs to be different
-        if reset_layout:
-            logger.debug("Added new cameras, resetting layout...")
+            self.camera_layout = []
+            self.active_cameras = set()
             self.clear_frame()
-            self.active_cameras = active_cameras
-
-            # this also converts added_cameras from a set to a list since we need
-            # to pop elements in order
-            active_cameras_to_add = sorted(
-                active_cameras,
-                # sort cameras by order and by name if the order is the same
-                key=lambda active_camera: (
-                    self.config.cameras[active_camera].birdseye.order,
-                    active_camera,
-                ),
-            )
-
-            if len(active_cameras) == 1:
-                # show single camera as fullscreen
-                camera = active_cameras_to_add[0]
-                camera_dims = self.cameras[camera]["dimensions"].copy()
-                scaled_width = int(self.canvas.height * camera_dims[0] / camera_dims[1])
-
-                # center camera view in canvas and ensure that it fits
-                if scaled_width < self.canvas.width:
-                    coefficient = 1
-                    x_offset = int((self.canvas.width - scaled_width) / 2)
+            frame_changed = True
+        else:
+            # Determine if layout needs resetting
+            if len(self.active_cameras) - len(active_cameras) == 0:
+                if (
+                    len(self.active_cameras) == 1
+                    and self.active_cameras != active_cameras
+                ):
+                    reset_layout = True
+                elif max_camera_refresh:
+                    reset_layout = True
                 else:
-                    coefficient = self.canvas.width / scaled_width
-                    x_offset = int(
-                        (self.canvas.width - (scaled_width * coefficient)) / 2
-                    )
-
-                self.camera_layout = [
-                    [
-                        (
-                            camera,
-                            (
-                                x_offset,
-                                0,
-                                int(scaled_width * coefficient),
-                                int(self.canvas.height * coefficient),
-                            ),
-                        )
-                    ]
-                ]
+                    reset_layout = False
             else:
-                # calculate optimal layout
-                coefficient = self.canvas.get_coefficient(len(active_cameras))
-                calculating = True
+                reset_layout = True
 
-                # decrease scaling coefficient until height of all cameras can fit into the birdseye canvas
-                while calculating:
-                    if self.stop_event.is_set():
-                        return
+            if reset_layout:
+                logger.debug("Resetting Birdseye layout...")
+                self.clear_frame()
+                self.active_cameras = active_cameras
 
-                    layout_candidate = self.calculate_layout(
-                        active_cameras_to_add,
-                        coefficient,
+                # this also converts added_cameras from a set to a list since we need
+                # to pop elements in order
+                active_cameras_to_add = sorted(
+                    active_cameras,
+                    # sort cameras by order and by name if the order is the same
+                    key=lambda active_camera: (
+                        self.config.cameras[active_camera].birdseye.order,
+                        active_camera,
+                    ),
+                )
+                if len(active_cameras) == 1:
+                    # show single camera as fullscreen
+                    camera = active_cameras_to_add[0]
+                    camera_dims = self.cameras[camera]["dimensions"].copy()
+                    scaled_width = int(
+                        self.canvas.height * camera_dims[0] / camera_dims[1]
                     )
 
-                    if not layout_candidate:
-                        if coefficient < 10:
-                            coefficient += 1
-                            continue
-                        else:
-                            logger.error("Error finding appropriate birdseye layout")
+                    # center camera view in canvas and ensure that it fits
+                    if scaled_width < self.canvas.width:
+                        coefficient = 1
+                        x_offset = int((self.canvas.width - scaled_width) / 2)
+                    else:
+                        coefficient = self.canvas.width / scaled_width
+                        x_offset = int(
+                            (self.canvas.width - (scaled_width * coefficient)) / 2
+                        )
+
+                    self.camera_layout = [
+                        [
+                            (
+                                camera,
+                                (
+                                    x_offset,
+                                    0,
+                                    int(scaled_width * coefficient),
+                                    int(self.canvas.height * coefficient),
+                                ),
+                            )
+                        ]
+                    ]
+                else:
+                    # calculate optimal layout
+                    coefficient = self.canvas.get_coefficient(len(active_cameras))
+                    calculating = True
+
+                    # decrease scaling coefficient until height of all cameras can fit into the birdseye canvas
+                    while calculating:
+                        if self.stop_event.is_set():
                             return
 
-                    calculating = False
-                    self.canvas.set_coefficient(len(active_cameras), coefficient)
+                        layout_candidate = self.calculate_layout(
+                            active_cameras_to_add, coefficient
+                        )
 
-                self.camera_layout = layout_candidate
+                        if not layout_candidate:
+                            if coefficient < 10:
+                                coefficient += 1
+                                continue
+                            else:
+                                logger.error(
+                                    "Error finding appropriate birdseye layout"
+                                )
+                                return
+                        calculating = False
+                        self.canvas.set_coefficient(len(active_cameras), coefficient)
 
-        for row in self.camera_layout:
-            for position in row:
-                self.copy_to_position(
-                    position[1],
-                    position[0],
-                    self.cameras[position[0]]["current_frame"],
-                )
+                    self.camera_layout = layout_candidate
+                frame_changed = True
 
-        return True
+            # Draw the layout
+            for row in self.camera_layout:
+                for position in row:
+                    src_frame = self.cameras[position[0]]["current_frame"]
+                    if src_frame is None or src_frame.size == 0:
+                        logger.debug(f"Skipping invalid frame for {position[0]}")
+                        continue
+                    self.copy_to_position(position[1], position[0], src_frame)
+            if frame is not None:  # Frame presence indicates a potential change
+                frame_changed = True
+
+        return frame_changed
 
     def calculate_layout(
         self,
@@ -676,11 +693,8 @@ class BirdsEyeFrameManager:
         # don't process if birdseye is disabled for this camera
         camera_config = self.config.cameras[camera].birdseye
 
-        if not camera_config.enabled:
-            return False
-
         # disabling birdseye is a little tricky
-        if not camera_config.enabled:
+        if not camera_config.enabled or not self.camera_metrics[camera].enabled.value:
             # if we've rendered a frame (we have a value for last_active_frame)
             # then we need to set it to zero
             if self.cameras[camera]["last_active_frame"] > 0:
@@ -721,6 +735,7 @@ class Birdseye:
         config: FrigateConfig,
         stop_event: mp.Event,
         websocket_server,
+        camera_metrics: dict[str, CameraMetrics],
     ) -> None:
         self.config = config
         self.input = queue.Queue(maxsize=10)
@@ -738,9 +753,10 @@ class Birdseye:
         self.broadcaster = BroadcastThread(
             "birdseye", self.converter, websocket_server, stop_event
         )
-        self.birdseye_manager = BirdsEyeFrameManager(config, stop_event)
+        self.birdseye_manager = BirdsEyeFrameManager(config, stop_event, camera_metrics)
         self.config_subscriber = ConfigSubscriber("config/birdseye/")
         self.frame_manager = SharedMemoryFrameManager()
+        self.stop_event = stop_event
 
         if config.birdseye.restream:
             self.birdseye_buffer = self.frame_manager.create(
@@ -750,6 +766,16 @@ class Birdseye:
 
         self.converter.start()
         self.broadcaster.start()
+        self.monitor_thread = threading.Thread(
+            target=self.monitor_enabled_states, daemon=True
+        )
+        self.monitor_thread.start()
+
+    def monitor_enabled_states(self):
+        while not self.stop_event.is_set():
+            # Update layout with no frame when camera is disabled
+            self.birdseye_manager.update_frame()
+            time.sleep(1)
 
     def write_data(
         self,
@@ -794,3 +820,4 @@ class Birdseye:
         self.config_subscriber.stop()
         self.converter.join()
         self.broadcaster.join()
+        self.monitor_thread.join()

--- a/frigate/output/birdseye.py
+++ b/frigate/output/birdseye.py
@@ -9,7 +9,6 @@ import os
 import queue
 import subprocess as sp
 import threading
-import time
 import traceback
 from typing import Optional
 
@@ -386,7 +385,7 @@ class BirdsEyeFrameManager:
         if mode == BirdseyeModeEnum.objects and object_box_count > 0:
             return True
 
-    def _get_enabled_state(self, camera: str):
+    def _get_enabled_state(self, camera: str) -> bool:
         """Fetch the latest enabled state for a camera from ZMQ."""
         _, config_data = self.enabled_subscribers[camera].check_for_update()
         if config_data:
@@ -781,16 +780,6 @@ class Birdseye:
 
         self.converter.start()
         self.broadcaster.start()
-        self.monitor_thread = threading.Thread(
-            target=self.monitor_enabled_states, daemon=True
-        )
-        self.monitor_thread.start()
-
-    def monitor_enabled_states(self):
-        while not self.stop_event.is_set():
-            # Update layout with no frame when camera is disabled
-            self.birdseye_manager.update_frame()
-            time.sleep(1)
 
     def write_data(
         self,
@@ -836,4 +825,3 @@ class Birdseye:
         self.birdseye_manager.stop()
         self.converter.join()
         self.broadcaster.join()
-        self.monitor_thread.join()

--- a/frigate/output/output.py
+++ b/frigate/output/output.py
@@ -17,7 +17,6 @@ from ws4py.server.wsgirefserver import (
 )
 from ws4py.server.wsgiutils import WebSocketWSGIApplication
 
-from frigate.camera import CameraMetrics
 from frigate.comms.config_updater import ConfigSubscriber
 from frigate.comms.detections_updater import DetectionSubscriber, DetectionTypeEnum
 from frigate.comms.ws import WebSocket
@@ -33,7 +32,6 @@ logger = logging.getLogger(__name__)
 
 def output_frames(
     config: FrigateConfig,
-    camera_metrics: dict[str, CameraMetrics],
 ):
     threading.current_thread().name = "output"
     setproctitle("frigate.output")
@@ -85,7 +83,7 @@ def output_frames(
         preview_write_times[camera] = 0
 
     if config.birdseye.enabled:
-        birdseye = Birdseye(config, stop_event, websocket_server, camera_metrics)
+        birdseye = Birdseye(config, stop_event, websocket_server)
 
     websocket_thread.start()
 

--- a/frigate/output/output.py
+++ b/frigate/output/output.py
@@ -18,6 +18,7 @@ from ws4py.server.wsgirefserver import (
 from ws4py.server.wsgiutils import WebSocketWSGIApplication
 
 from frigate.camera import CameraMetrics
+from frigate.comms.config_updater import ConfigSubscriber
 from frigate.comms.detections_updater import DetectionSubscriber, DetectionTypeEnum
 from frigate.comms.ws import WebSocket
 from frigate.config import FrigateConfig
@@ -61,6 +62,12 @@ def output_frames(
 
     detection_subscriber = DetectionSubscriber(DetectionTypeEnum.video)
 
+    enabled_subscribers = {
+        camera: ConfigSubscriber(f"config/enabled/{camera}", True)
+        for camera in config.cameras.keys()
+        if config.cameras[camera].enabled_in_config
+    }
+
     jsmpeg_cameras: dict[str, JsmpegCamera] = {}
     birdseye: Optional[Birdseye] = None
     preview_recorders: dict[str, PreviewRecorder] = {}
@@ -82,6 +89,13 @@ def output_frames(
 
     websocket_thread.start()
 
+    def get_enabled_state(camera: str):
+        _, config_data = enabled_subscribers[camera].check_for_update()
+        if config_data:
+            return config_data.enabled
+        # default
+        return config.cameras[camera].enabled
+
     while not stop_event.is_set():
         (topic, data) = detection_subscriber.check_for_update(timeout=1)
 
@@ -97,7 +111,7 @@ def output_frames(
             _,
         ) = data
 
-        if not camera_metrics[camera].enabled.value:
+        if not get_enabled_state(camera):
             continue
 
         frame = frame_manager.get(frame_name, config.cameras[camera].frame_shape_yuv)
@@ -188,6 +202,9 @@ def output_frames(
 
     if birdseye is not None:
         birdseye.stop()
+
+    for subscriber in enabled_subscribers.values():
+        subscriber.stop()
 
     websocket_server.manager.close_all()
     websocket_server.manager.stop()

--- a/frigate/output/output.py
+++ b/frigate/output/output.py
@@ -87,7 +87,7 @@ def output_frames(
 
     websocket_thread.start()
 
-    def get_enabled_state(camera: str):
+    def get_enabled_state(camera: str) -> bool:
         _, config_data = enabled_subscribers[camera].check_for_update()
         if config_data:
             return config_data.enabled

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -193,7 +193,7 @@ class CameraWatchdog(threading.Thread):
         self.config_subscriber = ConfigSubscriber(f"config/enabled/{camera_name}", True)
         self.was_enabled = self.config.enabled
 
-    def _update_enabled_state(self):
+    def _update_enabled_state(self) -> bool:
         """Fetch the latest config and update enabled state."""
         _, config_data = self.config_subscriber.check_for_update()
         if config_data:

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -189,6 +189,22 @@ class CameraWatchdog(threading.Thread):
     def run(self):
         if self.enabled.value:
             self.start_ffmpeg_detect()
+            for c in self.config.ffmpeg_cmds:
+                if "detect" in c["roles"]:
+                    continue
+                logpipe = LogPipe(
+                    f"ffmpeg.{self.camera_name}.{'_'.join(sorted(c['roles']))}"
+                )
+                self.ffmpeg_other_processes.append(
+                    {
+                        "cmd": c["cmd"],
+                        "roles": c["roles"],
+                        "logpipe": logpipe,
+                        "process": start_or_restart_ffmpeg(
+                            c["cmd"], self.logger, logpipe
+                        ),
+                    }
+                )
 
         time.sleep(self.sleeptime)
         while not self.stop_event.wait(self.sleeptime):

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -195,7 +195,7 @@ class CameraWatchdog(threading.Thread):
             enabled = self.enabled.value
             if enabled != self.was_enabled:
                 if enabled:
-                    self.logger.info(f"Enabling camera {self.camera_name}")
+                    self.logger.debug(f"Enabling camera {self.camera_name}")
                     self.start_ffmpeg_detect()
                     for c in self.config.ffmpeg_cmds:
                         if "detect" in c["roles"]:
@@ -214,7 +214,7 @@ class CameraWatchdog(threading.Thread):
                             }
                         )
                 else:
-                    self.logger.info(f"Disabling camera {self.camera_name}")
+                    self.logger.debug(f"Disabling camera {self.camera_name}")
                     self.stop_all_ffmpeg()
                 self.was_enabled = enabled
                 continue

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -112,7 +112,7 @@ def capture_frames(
 
     while True:
         if not enabled.value:
-            logger.info(f"Stopping capture thread for disabled {config.name}")
+            logger.debug(f"Stopping capture thread for disabled {config.name}")
             break
 
         fps.value = frame_rate.eps()

--- a/web/src/api/ws.tsx
+++ b/web/src/api/ws.tsx
@@ -56,6 +56,7 @@ function useValue(): useValueReturn {
       const {
         record,
         detect,
+        enabled,
         snapshots,
         audio,
         notifications,
@@ -67,6 +68,7 @@ function useValue(): useValueReturn {
         // @ts-expect-error we know this is correct
         state["config"];
       cameraStates[`${name}/recordings/state`] = record ? "ON" : "OFF";
+      cameraStates[`${name}/enabled/state`] = enabled ? "ON" : "OFF";
       cameraStates[`${name}/detect/state`] = detect ? "ON" : "OFF";
       cameraStates[`${name}/snapshots/state`] = snapshots ? "ON" : "OFF";
       cameraStates[`${name}/audio/state`] = audio ? "ON" : "OFF";
@@ -162,6 +164,17 @@ export function useWs(watchTopic: string, publishTopic: string) {
   );
 
   return { value, send };
+}
+
+export function useEnabledState(camera: string): {
+  payload: ToggleableSetting;
+  send: (payload: ToggleableSetting, retain?: boolean) => void;
+} {
+  const {
+    value: { payload },
+    send,
+  } = useWs(`${camera}/enabled/state`, `${camera}/enabled/set`);
+  return { payload: payload as ToggleableSetting, send };
 }
 
 export function useDetectState(camera: string): {

--- a/web/src/components/camera/CameraImage.tsx
+++ b/web/src/components/camera/CameraImage.tsx
@@ -5,6 +5,7 @@ import ActivityIndicator from "../indicators/activity-indicator";
 import { useResizeObserver } from "@/hooks/resize-observer";
 import { isDesktop } from "react-device-detect";
 import { cn } from "@/lib/utils";
+import { useEnabledState } from "@/api/ws";
 
 type CameraImageProps = {
   className?: string;
@@ -26,7 +27,8 @@ export default function CameraImage({
   const imgRef = useRef<HTMLImageElement | null>(null);
 
   const { name } = config ? config.cameras[camera] : "";
-  const enabled = config ? config.cameras[camera].enabled : "True";
+  const { payload: enabledState } = useEnabledState(camera);
+  const enabled = enabledState === "ON" || enabledState === undefined;
 
   const [{ width: containerWidth, height: containerHeight }] =
     useResizeObserver(containerRef);
@@ -96,7 +98,7 @@ export default function CameraImage({
           loading="lazy"
         />
       ) : (
-        <div className="pt-6 text-center">Camera is disabled.</div>
+        <div className="size-full rounded-lg border-2 border-muted bg-background_alt text-center md:rounded-2xl" />
       )}
       {!imageLoaded && enabled ? (
         <div className="absolute bottom-0 left-0 right-0 top-0 flex items-center justify-center">

--- a/web/src/components/camera/CameraImage.tsx
+++ b/web/src/components/camera/CameraImage.tsx
@@ -96,9 +96,7 @@ export default function CameraImage({
           loading="lazy"
         />
       ) : (
-        <div className="pt-6 text-center">
-          Camera is disabled in config, no stream or snapshot available!
-        </div>
+        <div className="pt-6 text-center">Camera is disabled.</div>
       )}
       {!imageLoaded && enabled ? (
         <div className="absolute bottom-0 left-0 right-0 top-0 flex items-center justify-center">

--- a/web/src/components/camera/ResizingCameraImage.tsx
+++ b/web/src/components/camera/ResizingCameraImage.tsx
@@ -108,9 +108,7 @@ export default function CameraImage({
           width={scaledWidth}
         />
       ) : (
-        <div className="pt-6 text-center">
-          Camera is disabled in config, no stream or snapshot available!
-        </div>
+        <div className="pt-6 text-center">Camera is disabled.</div>
       )}
       {!hasLoaded && enabled ? (
         <div

--- a/web/src/components/dynamic/CameraFeatureToggle.tsx
+++ b/web/src/components/dynamic/CameraFeatureToggle.tsx
@@ -11,11 +11,15 @@ const variants = {
   primary: {
     active: "font-bold text-white bg-selected rounded-lg",
     inactive: "text-secondary-foreground bg-secondary rounded-lg",
+    disabled:
+      "text-secondary-foreground bg-secondary rounded-lg cursor-not-allowed opacity-50",
   },
   overlay: {
     active: "font-bold text-white bg-selected rounded-full",
     inactive:
       "text-primary rounded-full bg-gradient-to-br from-gray-400 to-gray-500 bg-gray-500",
+    disabled:
+      "bg-gradient-to-br from-gray-400 to-gray-500 bg-gray-500 rounded-full cursor-not-allowed opacity-50",
   },
 };
 
@@ -26,6 +30,7 @@ type CameraFeatureToggleProps = {
   Icon: IconType;
   title: string;
   onClick?: () => void;
+  disabled?: boolean; // New prop for disabling
 };
 
 export default function CameraFeatureToggle({
@@ -35,18 +40,28 @@ export default function CameraFeatureToggle({
   Icon,
   title,
   onClick,
+  disabled = false, // Default to false
 }: CameraFeatureToggleProps) {
   const content = (
     <div
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
       className={cn(
         "flex flex-col items-center justify-center",
-        variants[variant][isActive ? "active" : "inactive"],
+        disabled
+          ? variants[variant].disabled
+          : variants[variant][isActive ? "active" : "inactive"],
         className,
       )}
     >
       <Icon
-        className={`size-5 md:m-[6px] ${isActive ? "text-white" : "text-secondary-foreground"}`}
+        className={cn(
+          "size-5 md:m-[6px]",
+          disabled
+            ? "text-gray-400"
+            : isActive
+              ? "text-white"
+              : "text-secondary-foreground",
+        )}
       />
     </div>
   );
@@ -54,7 +69,7 @@ export default function CameraFeatureToggle({
   if (isDesktop) {
     return (
       <Tooltip>
-        <TooltipTrigger>{content}</TooltipTrigger>
+        <TooltipTrigger disabled={disabled}>{content}</TooltipTrigger>
         <TooltipContent side="bottom">
           <p>{title}</p>
         </TooltipContent>

--- a/web/src/components/menu/LiveContextMenu.tsx
+++ b/web/src/components/menu/LiveContextMenu.tsx
@@ -39,7 +39,11 @@ import {
 import { cn } from "@/lib/utils";
 import { useNavigate } from "react-router-dom";
 import { formatUnixTimestampToDateTime } from "@/utils/dateUtil";
-import { useNotifications, useNotificationSuspend } from "@/api/ws";
+import {
+  useEnabledState,
+  useNotifications,
+  useNotificationSuspend,
+} from "@/api/ws";
 
 type LiveContextMenuProps = {
   className?: string;
@@ -82,6 +86,11 @@ export default function LiveContextMenu({
   children,
 }: LiveContextMenuProps) {
   const [showSettings, setShowSettings] = useState(false);
+
+  // camera enabled
+
+  const { payload: enabledState, send: sendEnabled } = useEnabledState(camera);
+  const isEnabled = enabledState === "ON";
 
   // streaming settings
 
@@ -263,7 +272,7 @@ export default function LiveContextMenu({
                       onClick={handleVolumeIconClick}
                     />
                     <VolumeSlider
-                      disabled={!audioState}
+                      disabled={!audioState || !isEnabled}
                       className="my-3 ml-0.5 rounded-lg bg-background/60"
                       value={[volumeState ?? 0]}
                       min={0}
@@ -280,34 +289,49 @@ export default function LiveContextMenu({
           <ContextMenuItem>
             <div
               className="flex w-full cursor-pointer items-center justify-start gap-2"
-              onClick={muteAll}
+              onClick={() => sendEnabled(isEnabled ? "OFF" : "ON")}
+            >
+              <div className="text-primary">
+                {isEnabled ? "Disable" : "Enable"} Camera
+              </div>
+            </div>
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem disabled={!isEnabled}>
+            <div
+              className="flex w-full cursor-pointer items-center justify-start gap-2"
+              onClick={isEnabled ? muteAll : undefined}
             >
               <div className="text-primary">Mute All Cameras</div>
             </div>
           </ContextMenuItem>
-          <ContextMenuItem>
+          <ContextMenuItem disabled={!isEnabled}>
             <div
               className="flex w-full cursor-pointer items-center justify-start gap-2"
-              onClick={unmuteAll}
+              onClick={isEnabled ? unmuteAll : undefined}
             >
               <div className="text-primary">Unmute All Cameras</div>
             </div>
           </ContextMenuItem>
           <ContextMenuSeparator />
-          <ContextMenuItem>
+          <ContextMenuItem disabled={!isEnabled}>
             <div
               className="flex w-full cursor-pointer items-center justify-start gap-2"
-              onClick={toggleStats}
+              onClick={isEnabled ? toggleStats : undefined}
             >
               <div className="text-primary">
                 {statsState ? "Hide" : "Show"} Stream Stats
               </div>
             </div>
           </ContextMenuItem>
-          <ContextMenuItem>
+          <ContextMenuItem disabled={!isEnabled}>
             <div
               className="flex w-full cursor-pointer items-center justify-start gap-2"
-              onClick={() => navigate(`/settings?page=debug&camera=${camera}`)}
+              onClick={
+                isEnabled
+                  ? () => navigate(`/settings?page=debug&camera=${camera}`)
+                  : undefined
+              }
             >
               <div className="text-primary">Debug View</div>
             </div>
@@ -315,10 +339,10 @@ export default function LiveContextMenu({
           {cameraGroup && cameraGroup !== "default" && (
             <>
               <ContextMenuSeparator />
-              <ContextMenuItem>
+              <ContextMenuItem disabled={!isEnabled}>
                 <div
                   className="flex w-full cursor-pointer items-center justify-start gap-2"
-                  onClick={() => setShowSettings(true)}
+                  onClick={isEnabled ? () => setShowSettings(true) : undefined}
                 >
                   <div className="text-primary">Streaming Settings</div>
                 </div>
@@ -328,10 +352,10 @@ export default function LiveContextMenu({
           {preferredLiveMode == "jsmpeg" && isRestreamed && (
             <>
               <ContextMenuSeparator />
-              <ContextMenuItem>
+              <ContextMenuItem disabled={!isEnabled}>
                 <div
                   className="flex w-full cursor-pointer items-center justify-start gap-2"
-                  onClick={resetPreferredLiveMode}
+                  onClick={isEnabled ? resetPreferredLiveMode : undefined}
                 >
                   <div className="text-primary">Reset</div>
                 </div>
@@ -342,7 +366,7 @@ export default function LiveContextMenu({
             <>
               <ContextMenuSeparator />
               <ContextMenuSub>
-                <ContextMenuSubTrigger>
+                <ContextMenuSubTrigger disabled={!isEnabled}>
                   <div className="flex items-center gap-2">
                     <span>Notifications</span>
                   </div>
@@ -382,10 +406,15 @@ export default function LiveContextMenu({
                     <>
                       <ContextMenuSeparator />
                       <ContextMenuItem
-                        onClick={() => {
-                          sendNotification("ON");
-                          sendNotificationSuspend(0);
-                        }}
+                        disabled={!isEnabled}
+                        onClick={
+                          isEnabled
+                            ? () => {
+                                sendNotification("ON");
+                                sendNotificationSuspend(0);
+                              }
+                            : undefined
+                        }
                       >
                         <div className="flex w-full flex-col gap-2">
                           {notificationState === "ON" ? (
@@ -405,36 +434,71 @@ export default function LiveContextMenu({
                             Suspend for:
                           </p>
                           <div className="space-y-1">
-                            <ContextMenuItem onClick={() => handleSuspend("5")}>
+                            <ContextMenuItem
+                              disabled={!isEnabled}
+                              onClick={
+                                isEnabled ? () => handleSuspend("5") : undefined
+                              }
+                            >
                               5 minutes
                             </ContextMenuItem>
                             <ContextMenuItem
-                              onClick={() => handleSuspend("10")}
+                              disabled={!isEnabled}
+                              onClick={
+                                isEnabled
+                                  ? () => handleSuspend("10")
+                                  : undefined
+                              }
                             >
                               10 minutes
                             </ContextMenuItem>
                             <ContextMenuItem
-                              onClick={() => handleSuspend("30")}
+                              disabled={!isEnabled}
+                              onClick={
+                                isEnabled
+                                  ? () => handleSuspend("30")
+                                  : undefined
+                              }
                             >
                               30 minutes
                             </ContextMenuItem>
                             <ContextMenuItem
-                              onClick={() => handleSuspend("60")}
+                              disabled={!isEnabled}
+                              onClick={
+                                isEnabled
+                                  ? () => handleSuspend("60")
+                                  : undefined
+                              }
                             >
                               1 hour
                             </ContextMenuItem>
                             <ContextMenuItem
-                              onClick={() => handleSuspend("840")}
+                              disabled={!isEnabled}
+                              onClick={
+                                isEnabled
+                                  ? () => handleSuspend("840")
+                                  : undefined
+                              }
                             >
                               12 hours
                             </ContextMenuItem>
                             <ContextMenuItem
-                              onClick={() => handleSuspend("1440")}
+                              disabled={!isEnabled}
+                              onClick={
+                                isEnabled
+                                  ? () => handleSuspend("1440")
+                                  : undefined
+                              }
                             >
                               24 hours
                             </ContextMenuItem>
                             <ContextMenuItem
-                              onClick={() => handleSuspend("off")}
+                              disabled={!isEnabled}
+                              onClick={
+                                isEnabled
+                                  ? () => handleSuspend("off")
+                                  : undefined
+                              }
                             >
                               Until restart
                             </ContextMenuItem>

--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -22,7 +22,6 @@ import { TbExclamationCircle } from "react-icons/tb";
 import { TooltipPortal } from "@radix-ui/react-tooltip";
 import { baseUrl } from "@/api/baseUrl";
 import { PlayerStats } from "./PlayerStats";
-import { useEnabledState } from "@/api/ws";
 import { LuVideoOff } from "react-icons/lu";
 
 type LivePlayerProps = {
@@ -86,31 +85,15 @@ export default function LivePlayer({
     droppedFrameRate: 0, // percentage
   });
 
-  // enabled state
-
-  const { payload: enabledState } = useEnabledState(cameraConfig.name);
-  const cameraEnabled = enabledState === "ON";
-
-  // Track previous cameraEnabled state
-  const prevCameraEnabledRef = useRef(cameraEnabled);
-
-  useEffect(() => {
-    if (!prevCameraEnabledRef.current && cameraEnabled) {
-      // Camera enabled
-      setLiveReady(false);
-      setKey((prevKey) => prevKey + 1);
-    } else if (prevCameraEnabledRef.current && !cameraEnabled) {
-      // Camera disabled
-      setLiveReady(false);
-      setKey((prevKey) => prevKey + 1);
-    }
-    prevCameraEnabledRef.current = cameraEnabled;
-  }, [cameraEnabled]);
-
   // camera activity
 
-  const { activeMotion, activeTracking, objects, offline } =
-    useCameraActivity(cameraConfig);
+  const {
+    enabled: cameraEnabled,
+    activeMotion,
+    activeTracking,
+    objects,
+    offline,
+  } = useCameraActivity(cameraConfig);
 
   const cameraActive = useMemo(
     () =>
@@ -214,6 +197,31 @@ export default function LivePlayer({
     setLiveReady(true);
   }, []);
 
+  // enabled states
+
+  const [isReEnabling, setIsReEnabling] = useState(false);
+  const prevCameraEnabledRef = useRef(cameraEnabled);
+
+  useEffect(() => {
+    if (!prevCameraEnabledRef.current && cameraEnabled) {
+      // Camera enabled
+      setLiveReady(false);
+      setIsReEnabling(true);
+      setKey((prevKey) => prevKey + 1);
+    } else if (prevCameraEnabledRef.current && !cameraEnabled) {
+      // Camera disabled
+      setLiveReady(false);
+      setKey((prevKey) => prevKey + 1);
+    }
+    prevCameraEnabledRef.current = cameraEnabled;
+  }, [cameraEnabled]);
+
+  useEffect(() => {
+    if (liveReady && isReEnabling) {
+      setIsReEnabling(false);
+    }
+  }, [liveReady, isReEnabling]);
+
   if (!cameraConfig) {
     return <ActivityIndicator />;
   }
@@ -290,6 +298,22 @@ export default function LivePlayer({
     player = <ActivityIndicator />;
   }
 
+  // if (cameraConfig.name == "lpr")
+  //   console.log(
+  //     cameraConfig.name,
+  //     "enabled",
+  //     cameraEnabled,
+  //     "prev enabled",
+  //     prevCameraEnabledRef.current,
+  //     "offline",
+  //     offline,
+  //     "show still",
+  //     showStillWithoutActivity,
+  //     "live ready",
+  //     liveReady,
+  //     player,
+  //   );
+
   return (
     <div
       ref={cameraRef ?? internalContainerRef}
@@ -318,9 +342,10 @@ export default function LivePlayer({
           </>
         )}
       {player}
-      {cameraEnabled && !offline && !showStillWithoutActivity && !liveReady && (
-        <ActivityIndicator />
-      )}
+      {cameraEnabled &&
+        !offline &&
+        (!showStillWithoutActivity || isReEnabling) &&
+        !liveReady && <ActivityIndicator />}
 
       {((showStillWithoutActivity && !liveReady) || liveReady) &&
         objects.length > 0 && (
@@ -368,7 +393,9 @@ export default function LivePlayer({
       <div
         className={cn(
           "absolute inset-0 w-full",
-          showStillWithoutActivity && !liveReady ? "visible" : "invisible",
+          showStillWithoutActivity && !liveReady && !isReEnabling
+            ? "visible"
+            : "invisible",
         )}
       >
         <AutoUpdatingCameraImage
@@ -399,9 +426,6 @@ export default function LivePlayer({
         <div className="relative flex h-full w-full items-center justify-center">
           <div className="flex h-32 flex-col items-center justify-center rounded-lg p-4 md:h-48 md:w-48">
             <LuVideoOff className="mb-2 size-8 md:size-10" />
-            <p className="mb-3 text-base md:text-lg">
-              {capitalizeFirstLetter(cameraConfig.name)}
-            </p>
             <p className="max-w-32 text-center text-sm md:max-w-40 md:text-base">
               Camera is disabled
             </p>
@@ -416,7 +440,7 @@ export default function LivePlayer({
           ((showStillWithoutActivity && !liveReady) || liveReady) && (
             <MdCircle className="mr-2 size-2 animate-pulse text-danger shadow-danger drop-shadow-md" />
           )}
-        {offline && showStillWithoutActivity && (
+        {((offline && showStillWithoutActivity) || !cameraEnabled) && (
           <Chip
             className={`z-0 flex items-start justify-between space-x-1 bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500 text-xs capitalize`}
           >

--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -218,7 +218,7 @@ export default function LivePlayer({
   }
 
   let player;
-  if (!autoLive || !streamName) {
+  if (!autoLive || !streamName || !cameraEnabled) {
     player = null;
   } else if (preferredLiveMode == "webrtc") {
     player = (

--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -23,6 +23,7 @@ import { TooltipPortal } from "@radix-ui/react-tooltip";
 import { baseUrl } from "@/api/baseUrl";
 import { PlayerStats } from "./PlayerStats";
 import { useEnabledState } from "@/api/ws";
+import { LuVideoOff } from "react-icons/lu";
 
 type LivePlayerProps = {
   cameraRef?: (ref: HTMLDivElement | null) => void;
@@ -395,13 +396,15 @@ export default function LivePlayer({
       )}
 
       {!cameraEnabled && (
-        <div className="absolute inset-0 left-1/2 top-1/2 flex h-96 w-96 -translate-x-1/2 -translate-y-1/2">
-          <div className="flex w-full flex-col items-center justify-center rounded-lg bg-background/50 p-5">
-            <p className="my-5 text-lg">
+        <div className="relative flex h-full w-full items-center justify-center">
+          <div className="flex h-32 flex-col items-center justify-center rounded-lg p-4 md:h-48 md:w-48">
+            <LuVideoOff className="mb-2 size-8 md:size-10" />
+            <p className="mb-3 text-base md:text-lg">
               {capitalizeFirstLetter(cameraConfig.name)}
             </p>
-            <TbExclamationCircle className="mb-3 size-10" />
-            <p className="max-w-96 text-center">Camera is disabled</p>
+            <p className="max-w-32 text-center text-sm md:max-w-40 md:text-base">
+              Camera is disabled
+            </p>
           </div>
         </div>
       )}

--- a/web/src/components/settings/ZoneEditPane.tsx
+++ b/web/src/components/settings/ZoneEditPane.tsx
@@ -68,7 +68,7 @@ export default function ZoneEditPane({
     }
 
     return Object.values(config.cameras)
-      .filter((conf) => conf.ui.dashboard && conf.enabled)
+      .filter((conf) => conf.ui.dashboard && conf.enabled_in_config)
       .sort((aConf, bConf) => aConf.ui.order - bConf.ui.order);
   }, [config]);
 

--- a/web/src/hooks/use-camera-activity.ts
+++ b/web/src/hooks/use-camera-activity.ts
@@ -1,4 +1,5 @@
 import {
+  useEnabledState,
   useFrigateEvents,
   useInitialCameraState,
   useMotionActivity,
@@ -15,6 +16,7 @@ import useSWR from "swr";
 import { getAttributeLabels } from "@/utils/iconUtil";
 
 type useCameraActivityReturn = {
+  enabled: boolean;
   activeTracking: boolean;
   activeMotion: boolean;
   objects: ObjectType[];
@@ -56,6 +58,7 @@ export function useCameraActivity(
     [objects],
   );
 
+  const { payload: cameraEnabled } = useEnabledState(camera.name);
   const { payload: detectingMotion } = useMotionActivity(camera.name);
   const { payload: event } = useFrigateEvents();
   const updatedEvent = useDeepMemo(event);
@@ -145,12 +148,17 @@ export function useCameraActivity(
     return cameras[camera.name].camera_fps == 0 && stats["service"].uptime > 60;
   }, [camera, stats]);
 
+  const isCameraEnabled = cameraEnabled === "ON";
+
   return {
-    activeTracking: hasActiveObjects,
-    activeMotion: detectingMotion
-      ? detectingMotion === "ON"
-      : updatedCameraState?.motion === true,
-    objects,
+    enabled: isCameraEnabled,
+    activeTracking: isCameraEnabled ? hasActiveObjects : false,
+    activeMotion: isCameraEnabled
+      ? detectingMotion
+        ? detectingMotion === "ON"
+        : updatedCameraState?.motion === true
+      : false,
+    objects: isCameraEnabled ? objects : [],
     offline,
   };
 }

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -101,12 +101,14 @@ function Live() {
     ) {
       const group = config.camera_groups[cameraGroup];
       return Object.values(config.cameras)
-        .filter((conf) => conf.enabled && group.cameras.includes(conf.name))
+        .filter(
+          (conf) => conf.enabled_in_config && group.cameras.includes(conf.name),
+        )
         .sort((aConf, bConf) => aConf.ui.order - bConf.ui.order);
     }
 
     return Object.values(config.cameras)
-      .filter((conf) => conf.ui.dashboard && conf.enabled)
+      .filter((conf) => conf.ui.dashboard && conf.enabled_in_config)
       .sort((aConf, bConf) => aConf.ui.order - bConf.ui.order);
   }, [config, cameraGroup]);
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -71,7 +71,7 @@ export default function Settings() {
     }
 
     return Object.values(config.cameras)
-      .filter((conf) => conf.ui.dashboard && conf.enabled)
+      .filter((conf) => conf.ui.dashboard && conf.enabled_in_config)
       .sort((aConf, bConf) => aConf.ui.order - bConf.ui.order);
   }, [config]);
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -39,6 +39,7 @@ import SearchSettingsView from "@/views/settings/SearchSettingsView";
 import UiSettingsView from "@/views/settings/UiSettingsView";
 import { useSearchEffect } from "@/hooks/use-overlay-state";
 import { useSearchParams } from "react-router-dom";
+import { useInitialCameraState } from "@/api/ws";
 
 const allSettingsViews = [
   "UI settings",
@@ -77,6 +78,27 @@ export default function Settings() {
 
   const [selectedCamera, setSelectedCamera] = useState<string>("");
 
+  const { payload: allCameraStates } = useInitialCameraState(
+    cameras.length > 0 ? cameras[0].name : "",
+    true,
+  );
+
+  const cameraEnabledStates = useMemo(() => {
+    const states: Record<string, boolean> = {};
+    if (allCameraStates) {
+      Object.entries(allCameraStates).forEach(([camName, state]) => {
+        states[camName] = state.config?.enabled ?? false;
+      });
+    }
+    // fallback to config if ws data isn’t available yet
+    cameras.forEach((cam) => {
+      if (!(cam.name in states)) {
+        states[cam.name] = cam.enabled;
+      }
+    });
+    return states;
+  }, [allCameraStates, cameras]);
+
   const [filterZoneMask, setFilterZoneMask] = useState<PolygonType[]>();
 
   const handleDialog = useCallback(
@@ -91,10 +113,25 @@ export default function Settings() {
   );
 
   useEffect(() => {
-    if (cameras.length > 0 && selectedCamera === "") {
-      setSelectedCamera(cameras[0].name);
+    if (cameras.length > 0) {
+      if (!selectedCamera) {
+        // Set to first enabled camera initially if no selection
+        const firstEnabledCamera =
+          cameras.find((cam) => cameraEnabledStates[cam.name]) || cameras[0];
+        setSelectedCamera(firstEnabledCamera.name);
+      } else if (
+        !cameraEnabledStates[selectedCamera] &&
+        page !== "camera settings"
+      ) {
+        // Switch to first enabled camera if current one is disabled, unless on "camera settings" page
+        const firstEnabledCamera =
+          cameras.find((cam) => cameraEnabledStates[cam.name]) || cameras[0];
+        if (firstEnabledCamera.name !== selectedCamera) {
+          setSelectedCamera(firstEnabledCamera.name);
+        }
+      }
     }
-  }, [cameras, selectedCamera]);
+  }, [cameras, selectedCamera, cameraEnabledStates, page]);
 
   useEffect(() => {
     if (tabsRef.current) {
@@ -177,6 +214,8 @@ export default function Settings() {
               allCameras={cameras}
               selectedCamera={selectedCamera}
               setSelectedCamera={setSelectedCamera}
+              cameraEnabledStates={cameraEnabledStates}
+              currentPage={page}
             />
           </div>
         )}
@@ -244,17 +283,21 @@ type CameraSelectButtonProps = {
   allCameras: CameraConfig[];
   selectedCamera: string;
   setSelectedCamera: React.Dispatch<React.SetStateAction<string>>;
+  cameraEnabledStates: Record<string, boolean>;
+  currentPage: SettingsType;
 };
 
 function CameraSelectButton({
   allCameras,
   selectedCamera,
   setSelectedCamera,
+  cameraEnabledStates,
+  currentPage,
 }: CameraSelectButtonProps) {
   const [open, setOpen] = useState(false);
 
   if (!allCameras.length) {
-    return;
+    return null;
   }
 
   const trigger = (
@@ -283,19 +326,24 @@ function CameraSelectButton({
       )}
       <div className="scrollbar-container mb-5 h-auto max-h-[80dvh] overflow-y-auto overflow-x-hidden p-4 md:mb-1">
         <div className="flex flex-col gap-2.5">
-          {allCameras.map((item) => (
-            <FilterSwitch
-              key={item.name}
-              isChecked={item.name === selectedCamera}
-              label={item.name.replaceAll("_", " ")}
-              onCheckedChange={(isChecked) => {
-                if (isChecked) {
-                  setSelectedCamera(item.name);
-                  setOpen(false);
-                }
-              }}
-            />
-          ))}
+          {allCameras.map((item) => {
+            const isEnabled = cameraEnabledStates[item.name];
+            const isCameraSettingsPage = currentPage === "camera settings";
+            return (
+              <FilterSwitch
+                key={item.name}
+                isChecked={item.name === selectedCamera}
+                label={item.name.replaceAll("_", " ")}
+                onCheckedChange={(isChecked) => {
+                  if (isChecked && (isEnabled || isCameraSettingsPage)) {
+                    setSelectedCamera(item.name);
+                    setOpen(false);
+                  }
+                }}
+                disabled={!isEnabled && !isCameraSettingsPage}
+              />
+            );
+          })}
         </div>
       </div>
     </>

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -56,6 +56,7 @@ export interface CameraConfig {
     width: number;
   };
   enabled: boolean;
+  enabled_in_config: boolean;
   ffmpeg: {
     global_args: string[];
     hwaccel_args: string;

--- a/web/src/types/ws.ts
+++ b/web/src/types/ws.ts
@@ -52,6 +52,7 @@ export type ObjectType = {
 };
 
 export interface FrigateCameraState {
+  enabled: boolean;
   motion: boolean;
   objects: ObjectType[];
 }

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -1055,15 +1055,7 @@ function FrigateCameraFeatures({
           Icon={enabledState == "ON" ? LuPower : LuPowerOff}
           isActive={enabledState == "ON"}
           title={`${enabledState == "ON" ? "Disable" : "Enable"} Camera`}
-          onClick={() => sendEnabled("ON")}
-        />
-        <CameraFeatureToggle
-          className="p-2 md:p-0"
-          variant={fullscreen ? "overlay" : "primary"}
-          Icon={LuPowerOff}
-          isActive={enabledState == "OFF"}
-          title={`${enabledState == "ON" ? "Disable" : "Enable"} Camera`}
-          onClick={() => sendEnabled("OFF")}
+          onClick={() => sendEnabled(enabledState == "ON" ? "OFF" : "ON")}
         />
         <CameraFeatureToggle
           className="p-2 md:p-0"

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -460,7 +460,6 @@ export default function LiveCameraView({
                   isActive={fullscreen}
                   title={fullscreen ? "Close" : "Fullscreen"}
                   onClick={toggleFullscreen}
-                  disabled={!cameraEnabled}
                 />
               )}
               {!isIOS && !isFirefox && preferredLiveMode != "jsmpeg" && (

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -2,6 +2,7 @@ import {
   useAudioState,
   useAutotrackingState,
   useDetectState,
+  useEnabledState,
   usePtzCommand,
   useRecordingsState,
   useSnapshotsState,
@@ -82,6 +83,8 @@ import {
   LuHistory,
   LuInfo,
   LuPictureInPicture,
+  LuPower,
+  LuPowerOff,
   LuVideo,
   LuVideoOff,
   LuX,
@@ -935,6 +938,9 @@ function FrigateCameraFeatures({
   const { payload: detectState, send: sendDetect } = useDetectState(
     camera.name,
   );
+  const { payload: enabledState, send: sendEnabled } = useEnabledState(
+    camera.name,
+  );
   const { payload: recordState, send: sendRecord } = useRecordingsState(
     camera.name,
   );
@@ -1043,6 +1049,22 @@ function FrigateCameraFeatures({
   if (isDesktop || isTablet) {
     return (
       <>
+        <CameraFeatureToggle
+          className="p-2 md:p-0"
+          variant={fullscreen ? "overlay" : "primary"}
+          Icon={enabledState == "ON" ? LuPower : LuPowerOff}
+          isActive={enabledState == "ON"}
+          title={`${enabledState == "ON" ? "Disable" : "Enable"} Camera`}
+          onClick={() => sendEnabled("ON")}
+        />
+        <CameraFeatureToggle
+          className="p-2 md:p-0"
+          variant={fullscreen ? "overlay" : "primary"}
+          Icon={LuPowerOff}
+          isActive={enabledState == "OFF"}
+          title={`${enabledState == "ON" ? "Disable" : "Enable"} Camera`}
+          onClick={() => sendEnabled("OFF")}
+        />
         <CameraFeatureToggle
           className="p-2 md:p-0"
           variant={fullscreen ? "overlay" : "primary"}

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -188,6 +188,10 @@ export default function LiveCameraView({
     );
   }, [cameraMetadata]);
 
+  // camera enabled state
+  const { payload: enabledState } = useEnabledState(camera.name);
+  const cameraEnabled = enabledState === "ON";
+
   // click overlay for ptzs
 
   const [clickOverlay, setClickOverlay] = useState(false);
@@ -456,6 +460,7 @@ export default function LiveCameraView({
                   isActive={fullscreen}
                   title={fullscreen ? "Close" : "Fullscreen"}
                   onClick={toggleFullscreen}
+                  disabled={!cameraEnabled}
                 />
               )}
               {!isIOS && !isFirefox && preferredLiveMode != "jsmpeg" && (
@@ -473,6 +478,7 @@ export default function LiveCameraView({
                       setPip(false);
                     }
                   }}
+                  disabled={!cameraEnabled}
                 />
               )}
               {supports2WayTalk && (
@@ -484,11 +490,11 @@ export default function LiveCameraView({
                   title={`${mic ? "Disable" : "Enable"} Two Way Talk`}
                   onClick={() => {
                     setMic(!mic);
-                    // Turn on audio when enabling the mic if audio is currently off
                     if (!mic && !audio) {
                       setAudio(true);
                     }
                   }}
+                  disabled={!cameraEnabled}
                 />
               )}
               {supportsAudioOutput && preferredLiveMode != "jsmpeg" && (
@@ -499,6 +505,7 @@ export default function LiveCameraView({
                   isActive={audio ?? false}
                   title={`${audio ? "Disable" : "Enable"} Camera Audio`}
                   onClick={() => setAudio(!audio)}
+                  disabled={!cameraEnabled}
                 />
               )}
               <FrigateCameraFeatures
@@ -520,6 +527,7 @@ export default function LiveCameraView({
                 setLowBandwidth={setLowBandwidth}
                 supportsAudioOutput={supportsAudioOutput}
                 supports2WayTalk={supports2WayTalk}
+                cameraEnabled={cameraEnabled}
               />
             </div>
           </TooltipProvider>
@@ -916,6 +924,7 @@ type FrigateCameraFeaturesProps = {
   setLowBandwidth: React.Dispatch<React.SetStateAction<boolean>>;
   supportsAudioOutput: boolean;
   supports2WayTalk: boolean;
+  cameraEnabled: boolean;
 };
 function FrigateCameraFeatures({
   camera,
@@ -934,6 +943,7 @@ function FrigateCameraFeatures({
   setLowBandwidth,
   supportsAudioOutput,
   supports2WayTalk,
+  cameraEnabled,
 }: FrigateCameraFeaturesProps) {
   const { payload: detectState, send: sendDetect } = useDetectState(
     camera.name,
@@ -1056,6 +1066,7 @@ function FrigateCameraFeatures({
           isActive={enabledState == "ON"}
           title={`${enabledState == "ON" ? "Disable" : "Enable"} Camera`}
           onClick={() => sendEnabled(enabledState == "ON" ? "OFF" : "ON")}
+          disabled={false}
         />
         <CameraFeatureToggle
           className="p-2 md:p-0"
@@ -1064,6 +1075,7 @@ function FrigateCameraFeatures({
           isActive={detectState == "ON"}
           title={`${detectState == "ON" ? "Disable" : "Enable"} Detect`}
           onClick={() => sendDetect(detectState == "ON" ? "OFF" : "ON")}
+          disabled={!cameraEnabled}
         />
         <CameraFeatureToggle
           className="p-2 md:p-0"
@@ -1072,6 +1084,7 @@ function FrigateCameraFeatures({
           isActive={recordState == "ON"}
           title={`${recordState == "ON" ? "Disable" : "Enable"} Recording`}
           onClick={() => sendRecord(recordState == "ON" ? "OFF" : "ON")}
+          disabled={!cameraEnabled}
         />
         <CameraFeatureToggle
           className="p-2 md:p-0"
@@ -1080,6 +1093,7 @@ function FrigateCameraFeatures({
           isActive={snapshotState == "ON"}
           title={`${snapshotState == "ON" ? "Disable" : "Enable"} Snapshots`}
           onClick={() => sendSnapshot(snapshotState == "ON" ? "OFF" : "ON")}
+          disabled={!cameraEnabled}
         />
         {audioDetectEnabled && (
           <CameraFeatureToggle
@@ -1089,6 +1103,7 @@ function FrigateCameraFeatures({
             isActive={audioState == "ON"}
             title={`${audioState == "ON" ? "Disable" : "Enable"} Audio Detect`}
             onClick={() => sendAudio(audioState == "ON" ? "OFF" : "ON")}
+            disabled={!cameraEnabled}
           />
         )}
         {autotrackingEnabled && (
@@ -1101,6 +1116,7 @@ function FrigateCameraFeatures({
             onClick={() =>
               sendAutotracking(autotrackingState == "ON" ? "OFF" : "ON")
             }
+            disabled={!cameraEnabled}
           />
         )}
         <CameraFeatureToggle
@@ -1113,6 +1129,7 @@ function FrigateCameraFeatures({
           isActive={isRecording}
           title={`${isRecording ? "Stop" : "Start"} on-demand recording`}
           onClick={handleEventButtonClick}
+          disabled={!cameraEnabled}
         />
 
         <DropdownMenu modal={false}>

--- a/web/src/views/settings/CameraSettingsView.tsx
+++ b/web/src/views/settings/CameraSettingsView.tsx
@@ -29,7 +29,7 @@ import { MdCircle } from "react-icons/md";
 import { cn } from "@/lib/utils";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { useAlertsState, useDetectionsState } from "@/api/ws";
+import { useAlertsState, useDetectionsState, useEnabledState } from "@/api/ws";
 
 type CameraSettingsViewProps = {
   selectedCamera: string;
@@ -108,6 +108,8 @@ export default function CameraSettingsView({
   const watchedAlertsZones = form.watch("alerts_zones");
   const watchedDetectionsZones = form.watch("detections_zones");
 
+  const { payload: enabledState, send: sendEnabled } =
+    useEnabledState(selectedCamera);
   const { payload: alertsState, send: sendAlerts } =
     useAlertsState(selectedCamera);
   const { payload: detectionsState, send: sendDetections } =
@@ -251,6 +253,31 @@ export default function CameraSettingsView({
           </Heading>
 
           <Separator className="my-2 flex bg-secondary" />
+
+          <Heading as="h4" className="my-2">
+            Streams
+          </Heading>
+
+          <div className="flex flex-row items-center">
+            <Switch
+              id="camera-enabled"
+              className="mr-3"
+              checked={enabledState === "ON"}
+              onCheckedChange={(isChecked) => {
+                sendEnabled(isChecked ? "ON" : "OFF");
+              }}
+            />
+            <div className="space-y-0.5">
+              <Label htmlFor="camera-enabled">Enable</Label>
+            </div>
+          </div>
+          <div className="mt-3 text-sm text-muted-foreground">
+            Disabling a camera completely stops Frigate's processing of this
+            camera's streams. Detection, recording, and debugging will be
+            unavailable.
+            <br /> <em>Note: This does not disable go2rtc restreams.</em>
+          </div>
+          <Separator className="mb-2 mt-4 flex bg-secondary" />
 
           <Heading as="h4" className="my-2">
             Review

--- a/web/src/views/settings/NotificationsSettingsView.tsx
+++ b/web/src/views/settings/NotificationsSettingsView.tsx
@@ -80,7 +80,7 @@ export default function NotificationView({
     return Object.values(config.cameras)
       .filter(
         (conf) =>
-          conf.enabled &&
+          conf.enabled_in_config &&
           conf.notifications &&
           conf.notifications.enabled_in_config,
       )


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR adds the ability to enable/disable cameras via MQTT and via the UI. When a camera is disabled, the main ffmpeg processes are stopped and resources are freed. 
- On disable, all active tracked objects on the camera are ended and camera activity callbacks are run with empty values.
- UI changes to prevent operations on disabled cameras.
- MQTT docs updates.

Notes:
- Previews will require a bit of a refactor.
- Cameras must be initially enabled in the config. The existing behavior for `enabled: false` prevents cameras from starting *and* hides them in the UI. This PR makes no changes to that behavior.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: closes https://github.com/blakeblackshear/frigate/issues/1911
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
