### PR TITLE
Adapt openai.py to work with xAI

### DIFF
--- a/frigate/genai/openai.py
+++ b/frigate/genai/openai.py
@@ -28,17 +28,21 @@ class OpenAIClient(GenAIClient):
         encoded_images = [base64.b64encode(image).decode("utf-8") for image in images]
         messages_content = []
         for image in encoded_images:
-            messages_content.append({
-                "type": "image_url",
-                "image_url": {
-                    "url": f"data:image/jpeg;base64,{image}",
-                    "detail": "low",
-                },
-            })
-        messages_content.append({
-            "type": "text",
-            "text": prompt,
-        })
+            messages_content.append(
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{image}",
+                        "detail": "low",
+                    },
+                }
+            )
+        messages_content.append(
+            {
+                "type": "text",
+                "text": prompt,
+            }
+        )
         try:
             result = self.provider.chat.completions.create(
                 model=self.genai_config.model,

--- a/frigate/genai/openai.py
+++ b/frigate/genai/openai.py
@@ -26,23 +26,25 @@ class OpenAIClient(GenAIClient):
     def _send(self, prompt: str, images: list[bytes]) -> Optional[str]:
         """Submit a request to OpenAI."""
         encoded_images = [base64.b64encode(image).decode("utf-8") for image in images]
+        messages_content = []
+        for image in encoded_images:
+            messages_content.append({
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/jpeg;base64,{image}",
+                },
+            })
+        messages_content.append({
+            "type": "text",
+            "text": prompt,
+        })
         try:
             result = self.provider.chat.completions.create(
                 model=self.genai_config.model,
                 messages=[
                     {
                         "role": "user",
-                        "content": [
-                            {
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": f"data:image/jpeg;base64,{image}",
-                                    "detail": "low",
-                                },
-                            }
-                            for image in encoded_images
-                        ]
-                        + [prompt],
+                        "content": messages_content,
                     },
                 ],
                 timeout=self.timeout,

--- a/frigate/genai/openai.py
+++ b/frigate/genai/openai.py
@@ -32,6 +32,7 @@ class OpenAIClient(GenAIClient):
                 "type": "image_url",
                 "image_url": {
                     "url": f"data:image/jpeg;base64,{image}",
+                    "detail": "low",
                 },
             })
         messages_content.append({


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
It appears xAI is a bit more strict in regards to how the prompt is sent. This changes the prompt to be a dictionary with `"type": "text"` which works with OpenAI and xAI.

Without this edit, adding `OPENAI_BASE_URL: https://api.x.ai/v1` and changing the model to `grok-2-vision` in config.yaml results in the following error:

```
2025-03-01 14:46:33.217929334  [2025-03-01 14:46:33] httpx                          INFO    : HTTP Request: POST https://api.x.ai/v1/chat/completions "HTTP/1.1 422 Unprocessable Entity"
2025-03-01 14:46:33.225489731  Exception in thread embeddings_maintainer:
2025-03-01 14:46:33.225491364  Traceback (most recent call last):
2025-03-01 14:46:33.225492526    File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
2025-03-01 14:46:33.225495963      self.run()
2025-03-01 14:46:33.225497395    File "/opt/frigate/frigate/embeddings/maintainer.py", line 75, in run
2025-03-01 14:46:33.225498197      self._process_event_metadata()
2025-03-01 14:46:33.225515038    File "/opt/frigate/frigate/embeddings/maintainer.py", line 287, in _process_event_metadata
2025-03-01 14:46:33.225516281      self.handle_regenerate_description(event_id, source)
2025-03-01 14:46:33.225517633    File "/opt/frigate/frigate/embeddings/maintainer.py", line 398, in handle_regenerate_description
2025-03-01 14:46:33.225518395      self._embed_description(event, embed_image)
2025-03-01 14:46:33.225519226    File "/opt/frigate/frigate/embeddings/maintainer.py", line 313, in _embed_description
2025-03-01 14:46:33.225541258      description = self.genai_client.generate_description(
2025-03-01 14:46:33.225542200    File "/opt/frigate/frigate/genai/__init__.py", line 48, in generate_description
2025-03-01 14:46:33.225556917      return self._send(prompt, thumbnails)
2025-03-01 14:46:33.225557769    File "/opt/frigate/frigate/genai/openai.py", line 30, in _send
2025-03-01 14:46:33.225558551      result = self.provider.chat.completions.create(
2025-03-01 14:46:33.225559382    File "/usr/local/lib/python3.9/dist-packages/openai/_utils/_utils.py", line 274, in wrapper
2025-03-01 14:46:33.225560073      return func(*args, **kwargs)
2025-03-01 14:46:33.225560875    File "/usr/local/lib/python3.9/dist-packages/openai/resources/chat/completions.py", line 742, in create
2025-03-01 14:46:33.225561466      return self._post(
2025-03-01 14:46:33.225578117    File "/usr/local/lib/python3.9/dist-packages/openai/_base_client.py", line 1277, in post
2025-03-01 14:46:33.225579069      return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
2025-03-01 14:46:33.225579981    File "/usr/local/lib/python3.9/dist-packages/openai/_base_client.py", line 954, in request
2025-03-01 14:46:33.225580582      return self._request(
2025-03-01 14:46:33.225581444    File "/usr/local/lib/python3.9/dist-packages/openai/_base_client.py", line 1058, in _request
2025-03-01 14:46:33.225582616      raise self._make_status_error_from_response(err.response) from None
2025-03-01 14:46:33.225583668  openai.UnprocessableEntityError: Failed to deserialize the JSON body into the target type: messages[0]: data did not match any variant of untagged enum Content at line 1 column 6192
```

Tested the PR with `grok-2-vision` and `gpt-4o`. Both functioned without error. 


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: N/A (but I would open one if I didn't fix it myself)
- This PR is related to issue: N/A 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
