### PR TITLE
GenAI: allow configuring additional send trigger after_significant_updates as well as event_end

### DIFF
--- a/docs/docs/configuration/genai.md
+++ b/docs/docs/configuration/genai.md
@@ -5,7 +5,7 @@ title: Generative AI
 
 Generative AI can be used to automatically generate descriptive text based on the thumbnails of your tracked objects. This helps with [Semantic Search](/configuration/semantic_search) in Frigate to provide more context about your tracked objects. Descriptions are accessed via the _Explore_ view in the Frigate UI by clicking on a tracked object's thumbnail.
 
-Requests for a description are sent off automatically to your AI provider at the end of the tracked object's lifecycle. Descriptions can also be regenerated manually via the Frigate UI.
+Requests for a description are sent off automatically to your AI provider at the end of the tracked object's lifecycle, or can optionally be sent earlier after a number of significantly changed frames, for example in use in more real-time notifications. Descriptions can also be regenerated manually via the Frigate UI.
 
 ## Configuration
 
@@ -147,6 +147,15 @@ While generating simple descriptions of detected objects is useful, understandin
 ### Using GenAI for notifications
 
 Frigate provides an [MQTT topic](/integrations/mqtt), `frigate/tracked_object_update`, that is updated with a JSON payload containing `event_id` and `description` when your AI provider returns a description for a tracked object. This description could be used directly in notifications, such as sending alerts to your phone or making audio announcements. If additional details from the tracked object are needed, you can query the [HTTP API](/integrations/api/event-events-event-id-get) using the `event_id`, eg: `http://frigate_ip:5000/api/events/<event_id>`.
+
+If looking to get notifications earlier than the end of the event, an additional send trigger can be configured of `after_significant_updates`.
+
+```yaml
+genai:
+  send_triggers:
+    event_end: true # default
+    after_significant_updates: 3 # how many updates to a live event before we should send an image
+```
 
 ## Custom Prompts
 

--- a/docs/docs/configuration/genai.md
+++ b/docs/docs/configuration/genai.md
@@ -148,13 +148,13 @@ While generating simple descriptions of detected objects is useful, understandin
 
 Frigate provides an [MQTT topic](/integrations/mqtt), `frigate/tracked_object_update`, that is updated with a JSON payload containing `event_id` and `description` when your AI provider returns a description for a tracked object. This description could be used directly in notifications, such as sending alerts to your phone or making audio announcements. If additional details from the tracked object are needed, you can query the [HTTP API](/integrations/api/event-events-event-id-get) using the `event_id`, eg: `http://frigate_ip:5000/api/events/<event_id>`.
 
-If looking to get notifications earlier than the end of the event, an additional send trigger can be configured of `after_significant_updates`.
+If looking to get notifications earlier than when an object ceases to be tracked, an additional send trigger can be configured of `after_significant_updates`.
 
 ```yaml
 genai:
   send_triggers:
-    event_end: true # default
-    after_significant_updates: 3 # how many updates to a live event before we should send an image
+    tracked_object_end: true # default
+    after_significant_updates: 3 # how many updates to a tracked object before we should send an image
 ```
 
 ## Custom Prompts

--- a/docs/docs/configuration/genai.md
+++ b/docs/docs/configuration/genai.md
@@ -5,7 +5,7 @@ title: Generative AI
 
 Generative AI can be used to automatically generate descriptive text based on the thumbnails of your tracked objects. This helps with [Semantic Search](/configuration/semantic_search) in Frigate to provide more context about your tracked objects. Descriptions are accessed via the _Explore_ view in the Frigate UI by clicking on a tracked object's thumbnail.
 
-Requests for a description are sent off automatically to your AI provider at the end of the tracked object's lifecycle, or can optionally be sent earlier after a number of significantly changed frames, for example in use in more real-time notifications. Descriptions can also be regenerated manually via the Frigate UI.
+Requests for a description are sent off automatically to your AI provider at the end of the tracked object's lifecycle, or can optionally be sent earlier after a number of significantly changed frames, for example in use in more real-time notifications. Descriptions can also be regenerated manually via the Frigate UI. Note that if you are manually entering a description for events prior to the event completing, this will be overwritten by the generated response.
 
 ## Configuration
 

--- a/docs/docs/configuration/genai.md
+++ b/docs/docs/configuration/genai.md
@@ -5,7 +5,7 @@ title: Generative AI
 
 Generative AI can be used to automatically generate descriptive text based on the thumbnails of your tracked objects. This helps with [Semantic Search](/configuration/semantic_search) in Frigate to provide more context about your tracked objects. Descriptions are accessed via the _Explore_ view in the Frigate UI by clicking on a tracked object's thumbnail.
 
-Requests for a description are sent off automatically to your AI provider at the end of the tracked object's lifecycle, or can optionally be sent earlier after a number of significantly changed frames, for example in use in more real-time notifications. Descriptions can also be regenerated manually via the Frigate UI. Note that if you are manually entering a description for events prior to the event completing, this will be overwritten by the generated response.
+Requests for a description are sent off automatically to your AI provider at the end of the tracked object's lifecycle, or can optionally be sent earlier after a number of significantly changed frames, for example in use in more real-time notifications. Descriptions can also be regenerated manually via the Frigate UI. Note that if you are manually entering a description for tracked objects prior to its end, this will be overwritten by the generated response.
 
 ## Configuration
 

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -813,6 +813,12 @@ cameras:
         - cat
       # Optional: Restrict generation to objects that entered any of the listed zones (default: none, all zones qualify)
       required_zones: []
+      # Optional: What triggers to use to send frames to generative AI during an event (default: shown below)
+      send_triggers:
+        # At the end of the event
+        event_end: True
+        # Optional: After X many significant updates are received (default: none, only at event end)
+        after_significant_updates: 0
       # Optional: Save thumbnails sent to generative AI for review/debugging purposes (default: shown below)
       debug_save_thumbnails: False
 

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -815,8 +815,8 @@ cameras:
       required_zones: []
       # Optional: What triggers to use to send frames to generative AI during an event (default: shown below)
       send_triggers:
-        # At the end of the event
-        event_end: True
+        # Once the object is no longer tracked
+        tracked_object_end: True
         # Optional: After X many significant updates are received (default: none, only at event end)
         after_significant_updates: None
       # Optional: Save thumbnails sent to generative AI for review/debugging purposes (default: shown below)

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -813,11 +813,11 @@ cameras:
         - cat
       # Optional: Restrict generation to objects that entered any of the listed zones (default: none, all zones qualify)
       required_zones: []
-      # Optional: What triggers to use to send frames to generative AI during an event (default: shown below)
+      # Optional: What triggers to use to send frames for a tracked object to generative AI (default: shown below)
       send_triggers:
         # Once the object is no longer tracked
         tracked_object_end: True
-        # Optional: After X many significant updates are received (default: none, only at event end)
+        # Optional: After X many significant updates are received (default: none)
         after_significant_updates: None
       # Optional: Save thumbnails sent to generative AI for review/debugging purposes (default: shown below)
       debug_save_thumbnails: False

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -817,7 +817,7 @@ cameras:
       send_triggers:
         # Once the object is no longer tracked
         tracked_object_end: True
-        # Optional: After X many significant updates are received (default: none)
+        # Optional: After X many significant updates are received (default: shown below)
         after_significant_updates: None
       # Optional: Save thumbnails sent to generative AI for review/debugging purposes (default: shown below)
       debug_save_thumbnails: False

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -818,7 +818,7 @@ cameras:
         # At the end of the event
         event_end: True
         # Optional: After X many significant updates are received (default: none, only at event end)
-        after_significant_updates: 0
+        after_significant_updates: None
       # Optional: Save thumbnails sent to generative AI for review/debugging purposes (default: shown below)
       debug_save_thumbnails: False
 

--- a/frigate/config/camera/genai.py
+++ b/frigate/config/camera/genai.py
@@ -15,6 +15,13 @@ class GenAIProviderEnum(str, Enum):
     gemini = "gemini"
     ollama = "ollama"
 
+class GenAISendTriggersConfig(BaseModel):
+    event_end: bool = Field(default=True, title="Send once the event has ended.")
+    after_significant_updates: Optional[int] = Field(
+        default=None,
+        title="Send an early request to generative AI when X frames accumulated.",
+        ge=1,
+    )
 
 # uses BaseModel because some global attributes are not available at the camera level
 class GenAICameraConfig(BaseModel):
@@ -42,10 +49,8 @@ class GenAICameraConfig(BaseModel):
         default=False,
         title="Save thumbnails sent to generative AI for debugging purposes.",
     )
-    send_after_frames: Optional[int] = Field(
-        default=None,
-        title="Send an early request to generative AI when X frames accumulated.",
-        ge=1,
+    send_triggers: GenAISendTriggersConfig = Field(
+        default_factory=GenAISendTriggersConfig, title="What triggers to use to send frames to generative AI during an event."
     )
 
     @field_validator("required_zones", mode="before")

--- a/frigate/config/camera/genai.py
+++ b/frigate/config/camera/genai.py
@@ -42,6 +42,10 @@ class GenAICameraConfig(BaseModel):
         default=False,
         title="Save thumbnails sent to generative AI for debugging purposes.",
     )
+    send_after_frames: Optional[int] = Field(
+        default=None, 
+        title="Send an early request to generative AI when X frames accumulated.",
+        ge=1,)
 
     @field_validator("required_zones", mode="before")
     @classmethod

--- a/frigate/config/camera/genai.py
+++ b/frigate/config/camera/genai.py
@@ -15,6 +15,7 @@ class GenAIProviderEnum(str, Enum):
     gemini = "gemini"
     ollama = "ollama"
 
+
 class GenAISendTriggersConfig(BaseModel):
     event_end: bool = Field(default=True, title="Send once the event has ended.")
     after_significant_updates: Optional[int] = Field(
@@ -22,6 +23,7 @@ class GenAISendTriggersConfig(BaseModel):
         title="Send an early request to generative AI when X frames accumulated.",
         ge=1,
     )
+
 
 # uses BaseModel because some global attributes are not available at the camera level
 class GenAICameraConfig(BaseModel):
@@ -50,7 +52,8 @@ class GenAICameraConfig(BaseModel):
         title="Save thumbnails sent to generative AI for debugging purposes.",
     )
     send_triggers: GenAISendTriggersConfig = Field(
-        default_factory=GenAISendTriggersConfig, title="What triggers to use to send frames to generative AI during an event."
+        default_factory=GenAISendTriggersConfig,
+        title="What triggers to use to send frames to generative AI during an event.",
     )
 
     @field_validator("required_zones", mode="before")

--- a/frigate/config/camera/genai.py
+++ b/frigate/config/camera/genai.py
@@ -43,9 +43,10 @@ class GenAICameraConfig(BaseModel):
         title="Save thumbnails sent to generative AI for debugging purposes.",
     )
     send_after_frames: Optional[int] = Field(
-        default=None, 
+        default=None,
         title="Send an early request to generative AI when X frames accumulated.",
-        ge=1,)
+        ge=1,
+    )
 
     @field_validator("required_zones", mode="before")
     @classmethod

--- a/frigate/config/camera/genai.py
+++ b/frigate/config/camera/genai.py
@@ -17,7 +17,9 @@ class GenAIProviderEnum(str, Enum):
 
 
 class GenAISendTriggersConfig(BaseModel):
-    event_end: bool = Field(default=True, title="Send once the event has ended.")
+    tracked_object_end: bool = Field(
+        default=True, title="Send once the object is no longer tracked."
+    )
     after_significant_updates: Optional[int] = Field(
         default=None,
         title="Send an early request to generative AI when X frames accumulated.",
@@ -53,7 +55,7 @@ class GenAICameraConfig(BaseModel):
     )
     send_triggers: GenAISendTriggersConfig = Field(
         default_factory=GenAISendTriggersConfig,
-        title="What triggers to use to send frames to generative AI during an event.",
+        title="What triggers to use to send frames to generative AI for a tracked object.",
     )
 
     @field_validator("required_zones", mode="before")

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -236,10 +236,13 @@ class EmbeddingMaintainer(threading.Thread):
 
             self.tracked_events[data["id"]].append(data)
 
-        # check if we're configured to send an early request after a minimum number of frames received
+        # check if we're configured to send an early request after a minimum number of updates received
         # we don't check required zones here - probably should, but does that run the risk in this simple logic
         # that the object doesn't get into the required zones until later in the event?
-        if self.genai_client is not None and camera_config.genai.send_triggers.after_significant_updates:
+        if (
+            self.genai_client is not None
+            and camera_config.genai.send_triggers.after_significant_updates
+        ):
             if (
                 len(self.tracked_events[data["id"]])
                 == camera_config.genai.send_triggers.after_significant_updates

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -241,7 +241,7 @@ class EmbeddingMaintainer(threading.Thread):
         # that the object doesn't get into the required zones until later in the event?
         if self.genai_client is not None and camera_config.genai.send_after_frames:
             if (
-                len(self.tracked_events[data["id"]]) 
+                len(self.tracked_events[data["id"]])
                 == camera_config.genai.send_after_frames
             ):
                 event: Event = Event.get(Event.id == data["id"])

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -334,7 +334,7 @@ class EmbeddingMaintainer(threading.Thread):
                 # Run GenAI
                 if (
                     camera_config.genai.enabled
-                    and camera_config.genai.send_triggers.event_end
+                    and camera_config.genai.send_triggers.tracked_object_end
                     and self.genai_client is not None
                     and (
                         not camera_config.genai.objects

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -239,10 +239,10 @@ class EmbeddingMaintainer(threading.Thread):
         # check if we're configured to send an early request after a minimum number of frames received
         # we don't check required zones here - probably should, but does that run the risk in this simple logic
         # that the object doesn't get into the required zones until later in the event?
-        if self.genai_client is not None and camera_config.genai.send_after_frames:
+        if self.genai_client is not None and camera_config.genai.send_triggers.after_significant_updates:
             if (
                 len(self.tracked_events[data["id"]])
-                == camera_config.genai.send_after_frames
+                == camera_config.genai.send_triggers.after_significant_updates
             ):
                 event: Event = Event.get(Event.id == data["id"])
 
@@ -324,6 +324,7 @@ class EmbeddingMaintainer(threading.Thread):
                 # Run GenAI
                 if (
                     camera_config.genai.enabled
+                    and camera_config.genai.send_triggers.event_end
                     and self.genai_client is not None
                     and (
                         not camera_config.genai.objects

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -240,12 +240,16 @@ class EmbeddingMaintainer(threading.Thread):
         # we don't check required zones here - probably should, but does that run the risk in this simple logic
         # that the object doesn't get into the required zones until later in the event?
         if self.genai_client is not None and camera_config.genai.send_after_frames:
-            if len(self.tracked_events[data["id"]]) == camera_config.genai.send_after_frames:
-
+            if (
+                len(self.tracked_events[data["id"]]) 
+                == camera_config.genai.send_after_frames
+            ):
                 event: Event = Event.get(Event.id == data["id"])
 
-                if (not camera_config.genai.objects
-                        or event.label in camera_config.genai.objects):
+                if (
+                    not camera_config.genai.objects
+                    or event.label in camera_config.genai.objects
+                ):
                     logger.debug(f"{camera} sending early request to GenAI")
                     threading.Thread(
                         target=self._genai_embed_description,
@@ -253,7 +257,10 @@ class EmbeddingMaintainer(threading.Thread):
                         daemon=True,
                         args=(
                             event,
-                            [data["thumbnail"] for data in self.tracked_events[data["id"]]],
+                            [
+                                data["thumbnail"]
+                                for data in self.tracked_events[data["id"]]
+                            ],
                         ),
                     ).start()
 

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -238,8 +238,6 @@ class EmbeddingMaintainer(threading.Thread):
             self.tracked_events[data["id"]].append(data)
 
         # check if we're configured to send an early request after a minimum number of updates received
-        # we don't check required zones here - probably should, but does that run the risk in this simple logic
-        # that the object doesn't get into the required zones until later in the event?
         if (
             self.genai_client is not None
             and camera_config.genai.send_triggers.after_significant_updates
@@ -255,6 +253,10 @@ class EmbeddingMaintainer(threading.Thread):
                     if (
                         not camera_config.genai.objects
                         or event.label in camera_config.genai.objects
+                    ) and (
+                        not camera_config.genai.required_zones
+                        or set(data["entered_zones"])
+                        & set(camera_config.genai.required_zones)
                     ):
                         logger.debug(f"{camera} sending early request to GenAI")
 


### PR DESCRIPTION
## Proposed change

Based on discussion on https://github.com/blakeblackshear/frigate/issues/16528, a partial implementation to add configuration that allows users to add an extra trigger point on GenAI when a certain number of images have been accumulated. This is disabled by default.

Removed the check for a blank description in the existing end of event code, to ensure the finalized event description is still updated (I'm not sure why this check was necessary; what would have already added a description?).

Draft until my devcontainer starts working again; I will do docs updates too.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes [#](https://github.com/blakeblackshear/frigate/issues/16528)

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [] The code has been formatted using Ruff (`ruff format frigate`)
