### PR TITLE
Orient live camera feed for best screen fit when in fullscreen mode

### DIFF
--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -355,22 +355,26 @@ export default function LiveCameraView({
     }
   }, [fullscreen, isPortrait, cameraAspectRatio, containerAspectRatio]);
 
-  // On mobile devices that support it, orient screen to
-  // best fit the camera feed when in fullscreen
+  // On mobile devices that support it, try to orient screen
+  // to best fit the camera feed in fullscreen mode
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const screenOrientation = screen.orientation as any;
-    if (screenOrientation.lock && screenOrientation.unlock) {
-      if (fullscreen) {
-        const orientationForBestFit =
-          cameraAspectRatio > 1 ? "landscape" : "portrait";
-        screenOrientation.lock(orientationForBestFit).catch(() => {});
-      } else {
-        screenOrientation.unlock();
-      }
+    if (!screenOrientation.lock || !screenOrientation.unlock) {
+      // Browser does not support ScreenOrientation APIs that we need
+      return;
     }
 
-    return () => screen.orientation.unlock?.();
+    if (fullscreen) {
+      const orientationForBestFit =
+        cameraAspectRatio > 1 ? "landscape" : "portrait";
+
+      // If the current device doesn't support locking orientation,
+      // this promise will reject with an error that we can ignore
+      screenOrientation.lock(orientationForBestFit).catch(() => {});
+    }
+
+    return () => screenOrientation.unlock();
   }, [fullscreen, cameraAspectRatio]);
 
   const handleError = useCallback(

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -355,6 +355,24 @@ export default function LiveCameraView({
     }
   }, [fullscreen, isPortrait, cameraAspectRatio, containerAspectRatio]);
 
+  // On mobile devices that support it, orient screen to
+  // best fit the camera feed when in fullscreen
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const screenOrientation = screen.orientation as any;
+    if (screenOrientation.lock && screenOrientation.unlock) {
+      if (fullscreen) {
+        const orientationForBestFit =
+          cameraAspectRatio > 1 ? "landscape" : "portrait";
+        screenOrientation.lock(orientationForBestFit).catch(() => {});
+      } else {
+        screenOrientation.unlock();
+      }
+    }
+
+    return () => screen.orientation.unlock?.();
+  }, [fullscreen, cameraAspectRatio]);
+
   const handleError = useCallback(
     (e: LivePlayerError) => {
       if (e) {


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR uses the [ScreenOrientation.lock()](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/lock) and [ScreenOrientation.unlock()](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/unlock) APIs to attempt to automatically orient live feeds for individual cameras so that they fill as much screen as possible. This change only applies to fullscreen mode for a single camera, not to the home page or to dashboards which may have more than one camera. If the user changes to a different stream for the same camera while in fullscreen mode and the new stream uses a different aspect ratio, the orientation will update immediately.

Prior discusson on this behavior is in #16925, I'll continue my reasoning here. In my opinion, there are two main reasons to want to enter fullscreen mode when on a mobile device: to de-clutter the interface, and to make the content as large as possible to improve visibility. The existing fullscreen behavior when viewing the feed from a single camera already declutters the UI (hides most buttons, hides system nav bars) but if the video is oriented opposite to your mobile device's screen size, then the content becomes no more visible than it was initially.

There is lots of precedent for locking orientation in video players across mobile devices, including web-based players. Entering fullscreen on most video players will flip the screen orientation to landscape since most videos use a landscape aspect ratio. If the video being played has an aspect ratio that better fits portrait, the player may even flip out of landscape into portrait mode (see YouTube apps on mobile for example).

While the lock()/unlock() APIs are in my opinion the least-invasive way to implement this behavior, they have limited support and will currently only work in Chromium on Android. On other browsers, this change is inert, and the fullscreen view will use the system default orientation that the user was in prior to entering fullscreen mode. To get better cross-browser support and not need to manage the orientation manually, we would probably need to consider calling `requestFullscreen()` on the actual `<video>` element rather than an ancestor `<div>`. But since there are so many types of video playback in the application and the Live page reuses the same fullscreen element between different views, it seemed prudent to not attempt such a change.

Note that I have tested this change on my Android devices, and see it locking orientation on Chromium browsers but not on Firefox for Android (this is expected given API support). I have tested both landscape and portrait video feeds. I do not have an iOS device to test unfortunately, but I expect Safari to also not change behavior with this PR.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #16925
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`) (not applicable for JS)
