### PR TITLE
Ensure disabling a camera also disables audio detection

### DIFF
--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -309,9 +309,10 @@ class AudioEventMaintainer(threading.Thread):
         """Fetch the latest config and update enabled state."""
         _, config_data = self.enabled_subscriber.check_for_update()
         if config_data:
-            enabled = config_data.enabled
-            return enabled
-        return self.was_enabled if self.was_enabled is not None else self.config.enabled
+            self.config.enabled = config_data.enabled
+            return config_data.enabled
+
+        return self.config.enabled
 
     def run(self) -> None:
         if self._update_enabled_state():
@@ -362,9 +363,9 @@ class AudioTfl:
     def __init__(self, stop_event: threading.Event, num_threads=2):
         self.stop_event = stop_event
         self.num_threads = num_threads
-        self.labels = load_labels("/audio-labelmap.txt", prefill=521)
+        self.labels = load_labels("audio-labelmap.txt", prefill=521)
         self.interpreter = Interpreter(
-            model_path="/cpu_audio_model.tflite",
+            model_path="cpu_audio_model.tflite",
             num_threads=self.num_threads,
         )
 

--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -135,7 +135,12 @@ class AudioEventMaintainer(threading.Thread):
         # create communication for audio detections
         self.requestor = InterProcessRequestor()
         self.config_subscriber = ConfigSubscriber(f"config/audio/{camera.name}")
+        self.enabled_subscriber = ConfigSubscriber(
+            f"config/enabled/{camera.name}", True
+        )
         self.detection_publisher = DetectionPublisher(DetectionTypeEnum.audio)
+
+        self.was_enabled = camera.enabled
 
     def detect_audio(self, audio) -> None:
         if not self.config.audio.enabled or self.stop_event.is_set():
@@ -248,6 +253,23 @@ class AudioEventMaintainer(threading.Thread):
                         f"Failed to end audio event {detection['id']} with status code {resp.status_code}"
                     )
 
+    def expire_all_detections(self) -> None:
+        """Immediately end all current detections"""
+        now = datetime.datetime.now().timestamp()
+        for label, detection in list(self.detections.items()):
+            if detection:
+                self.requestor.send_data(f"{self.config.name}/audio/{label}", "OFF")
+                resp = requests.put(
+                    f"{FRIGATE_LOCALHOST}/api/events/{detection['id']}/end",
+                    json={"end_time": now},
+                )
+                if resp.status_code == 200:
+                    self.detections[label] = None
+                else:
+                    self.logger.warning(
+                        f"Failed to end audio event {detection['id']} with status code {resp.status_code}"
+                    )
+
     def start_or_restart_ffmpeg(self) -> None:
         self.audio_listener = start_or_restart_ffmpeg(
             self.ffmpeg_cmd,
@@ -283,10 +305,40 @@ class AudioEventMaintainer(threading.Thread):
             self.logger.error(f"Error reading audio data from ffmpeg process: {e}")
             log_and_restart()
 
+    def _update_enabled_state(self) -> bool:
+        """Fetch the latest config and update enabled state."""
+        _, config_data = self.enabled_subscriber.check_for_update()
+        if config_data:
+            enabled = config_data.enabled
+            return enabled
+        return self.was_enabled if self.was_enabled is not None else self.config.enabled
+
     def run(self) -> None:
-        self.start_or_restart_ffmpeg()
+        if self._update_enabled_state():
+            self.start_or_restart_ffmpeg()
 
         while not self.stop_event.is_set():
+            enabled = self._update_enabled_state()
+            if enabled != self.was_enabled:
+                if enabled:
+                    self.logger.debug(
+                        f"Enabling audio detections for {self.config.name}"
+                    )
+                    self.start_or_restart_ffmpeg()
+                else:
+                    self.logger.debug(
+                        f"Disabling audio detections for {self.config.name}, ending events"
+                    )
+                    self.expire_all_detections()
+                    stop_ffmpeg(self.audio_listener, self.logger)
+                    self.audio_listener = None
+                self.was_enabled = enabled
+                continue
+
+            if not enabled:
+                time.sleep(0.1)
+                continue
+
             # check if there is an updated config
             (
                 updated_topic,
@@ -302,6 +354,7 @@ class AudioEventMaintainer(threading.Thread):
         self.logpipe.close()
         self.requestor.stop()
         self.config_subscriber.stop()
+        self.enabled_subscriber.stop()
         self.detection_publisher.stop()
 
 

--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -363,9 +363,9 @@ class AudioTfl:
     def __init__(self, stop_event: threading.Event, num_threads=2):
         self.stop_event = stop_event
         self.num_threads = num_threads
-        self.labels = load_labels("audio-labelmap.txt", prefill=521)
+        self.labels = load_labels("/audio-labelmap.txt", prefill=521)
         self.interpreter = Interpreter(
-            model_path="cpu_audio_model.tflite",
+            model_path="/cpu_audio_model.tflite",
             num_threads=self.num_threads,
         )
 

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -197,9 +197,10 @@ class CameraWatchdog(threading.Thread):
         """Fetch the latest config and update enabled state."""
         _, config_data = self.config_subscriber.check_for_update()
         if config_data:
-            enabled = config_data.enabled
-            return enabled
-        return self.was_enabled if self.was_enabled is not None else self.config.enabled
+            self.config.enabled = config_data.enabled
+            return config_data.enabled
+
+        return self.config.enabled
 
     def run(self):
         if self._update_enabled_state():


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
This PR follows up on the changes made in https://github.com/blakeblackshear/frigate/pull/16894 and ensures that audio detection is also enabled/disabled when a camera is enabled/disabled.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/blakeblackshear/frigate/pull/16894

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
