### PR TITLE
Disable detection by default

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -255,6 +255,8 @@ ffmpeg:
 # Optional: Detect configuration
 # NOTE: Can be overridden at the camera level
 detect:
+  # Optional: enables detection for the camera (default: shown below)
+  enabled: False
   # Optional: width of the frame for the input with the detect role (default: use native stream resolution)
   width: 1280
   # Optional: height of the frame for the input with the detect role (default: use native stream resolution)
@@ -262,8 +264,6 @@ detect:
   # Optional: desired fps for your camera for the input with the detect role (default: shown below)
   # NOTE: Recommended value of 5. Ideally, try and reduce your FPS on the camera.
   fps: 5
-  # Optional: enables detection for the camera (default: True)
-  enabled: True
   # Optional: Number of consecutive detection hits required for an object to be initialized in the tracker. (default: 1/2 the frame rate)
   min_initialized: 2
   # Optional: Number of frames without a detection before Frigate considers an object to be gone. (default: 5x the frame rate)

--- a/docs/docs/guides/getting_started.md
+++ b/docs/docs/guides/getting_started.md
@@ -151,8 +151,6 @@ cameras:
         - path: rtsp://10.0.10.10:554/rtsp # <----- The stream you want to use for detection
           roles:
             - detect
-    detect:
-      enabled: False # <---- disable detection until you have a working camera feed
 ```
 
 ### Step 2: Start Frigate
@@ -307,7 +305,7 @@ By default, Frigate will retain video of all tracked objects for 10 days. The fu
 
 ### Step 7: Complete config
 
-At this point you have a complete config with basic functionality. 
+At this point you have a complete config with basic functionality.
 - View [common configuration examples](../configuration/index.md#common-configuration-examples) for a list of common configuration examples.
 - View [full config reference](../configuration/reference.md) for a complete list of configuration options.
 

--- a/frigate/config/camera/detect.py
+++ b/frigate/config/camera/detect.py
@@ -32,6 +32,7 @@ class StationaryConfig(FrigateBaseModel):
 
 
 class DetectConfig(FrigateBaseModel):
+    enabled: bool = Field(default=False, title="Detection Enabled.")
     height: Optional[int] = Field(
         default=None, title="Height of the stream for the detect role."
     )
@@ -41,7 +42,6 @@ class DetectConfig(FrigateBaseModel):
     fps: int = Field(
         default=5, title="Number of frames per second to process through detection."
     )
-    enabled: bool = Field(default=True, title="Detection Enabled.")
     min_initialized: Optional[int] = Field(
         default=None,
         title="Minimum number of consecutive hits for an object to be initialized by the tracker.",

--- a/frigate/util/config.py
+++ b/frigate/util/config.py
@@ -300,6 +300,12 @@ def migrate_016_0(config: dict[str, dict[str, any]]) -> dict[str, dict[str, any]
     """Handle migrating frigate config to 0.16-0"""
     new_config = config.copy()
 
+    # migrate config that does not have detect -> enabled explicitly set to have it enabled
+    if new_config.get("detect", {}).get("enabled") is None:
+        detect_config = new_config.get("detect", {})
+        detect_config["enabled"] = True
+        new_config["detect"] = detect_config
+
     for name, camera in config.get("cameras", {}).items():
         camera_config: dict[str, dict[str, any]] = camera.copy()
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

Frigate was once detection only so it made sense to have it enabled. But now users typically start Frigate by just getting camera live streams going and then enable features as they build out their system, disabling detect by default makes it easier to get started and reduces the chance that a user mistakes the detection CPU load for base CPU load.

A config migration will ensure all users main experience remains the same

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/issues/16878
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
