### PR TITLE
video['global'] can be empty resulting in a divide by zero

### DIFF
--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -362,7 +362,7 @@ def get_intel_gpu_stats(sriov: bool) -> dict[str, str]:
                     if video_frame is not None:
                         video[key].append(float(video_frame))
 
-        if render["global"] and video['global']:
+        if render["global"] and video["global"]:
             results["gpu"] = (
                 f"{round(((sum(render['global']) / len(render['global'])) + (sum(video['global']) / len(video['global']))) / 2, 2)}%"
             )

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -362,7 +362,7 @@ def get_intel_gpu_stats(sriov: bool) -> dict[str, str]:
                     if video_frame is not None:
                         video[key].append(float(video_frame))
 
-        if render["global"]:
+        if render["global"] and video['global']:
             results["gpu"] = (
                 f"{round(((sum(render['global']) / len(render['global'])) + (sum(video['global']) / len(video['global']))) / 2, 2)}%"
             )


### PR DESCRIPTION
## Proposed change
`video['global']`  in `util/services.py#get_intel_gpu_stats()` can be empty resulting in a divide by zero error.
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information
```
2025-03-06 14:49:33.146592551  future: <Task finished name='Task-122' coro=<set_gpu_stats() done, defined at /opt/frigate/frigate/stats/util.py:138> exception=ZeroDivisionError('division by zero')>
2025-03-06 14:49:33.146593772  Traceback (most recent call last):
2025-03-06 14:49:33.146594944    File "/opt/frigate/frigate/stats/util.py", line 223, in set_gpu_stats
2025-03-06 14:49:33.146595832      intel_usage = get_intel_gpu_stats()
2025-03-06 14:49:33.146596853    File "/opt/frigate/frigate/util/services.py", line 363, in get_intel_gpu_stats
2025-03-06 14:49:33.146598030      f"{round(((sum(render['global']) / len(render['global'])) + (sum(video['global']) / len(video['global']))) / 2, 2)}%"
2025-03-06 14:49:33.146598835  ZeroDivisionError: division by zero
```
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
