### PR TITLE
Ensure audio listener is defined before trying to stop ffmpeg

### DIFF
--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -351,7 +351,8 @@ class AudioEventMaintainer(threading.Thread):
 
             self.read_audio()
 
-        stop_ffmpeg(self.audio_listener, self.logger)
+        if self.audio_listener:
+            stop_ffmpeg(self.audio_listener, self.logger)
         self.logpipe.close()
         self.requestor.stop()
         self.config_subscriber.stop()


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
If a camera with audio detection is disabled and Frigate shuts down, ensure we check `audio_listener` before attempting to shut down ffmpeg.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
