### PR TITLE
Enable audio by default

### DIFF
--- a/docker/main/rootfs/usr/local/go2rtc/create_config.py
+++ b/docker/main/rootfs/usr/local/go2rtc/create_config.py
@@ -80,24 +80,15 @@ if go2rtc_config["webrtc"].get("candidates") is None:
 
     go2rtc_config["webrtc"]["candidates"] = default_candidates
 
-# sets default RTSP response to be equivalent to ?video=h264,h265&audio=aac
-# this means user does not need to specify audio codec when using restream
-# as source for frigate and the integration supports HLS playback
-if go2rtc_config.get("rtsp") is None:
-    go2rtc_config["rtsp"] = {"default_query": "mp4"}
-else:
-    if go2rtc_config["rtsp"].get("default_query") is None:
-        go2rtc_config["rtsp"]["default_query"] = "mp4"
+if go2rtc_config["rtsp"].get("username") is not None:
+    go2rtc_config["rtsp"]["username"] = go2rtc_config["rtsp"]["username"].format(
+        **FRIGATE_ENV_VARS
+    )
 
-    if go2rtc_config["rtsp"].get("username") is not None:
-        go2rtc_config["rtsp"]["username"] = go2rtc_config["rtsp"]["username"].format(
-            **FRIGATE_ENV_VARS
-        )
-
-    if go2rtc_config["rtsp"].get("password") is not None:
-        go2rtc_config["rtsp"]["password"] = go2rtc_config["rtsp"]["password"].format(
-            **FRIGATE_ENV_VARS
-        )
+if go2rtc_config["rtsp"].get("password") is not None:
+    go2rtc_config["rtsp"]["password"] = go2rtc_config["rtsp"]["password"].format(
+        **FRIGATE_ENV_VARS
+    )
 
 # ensure ffmpeg path is set correctly
 path = config.get("ffmpeg", {}).get("path", "default")

--- a/frigate/config/camera/ffmpeg.py
+++ b/frigate/config/camera/ffmpeg.py
@@ -21,7 +21,7 @@ __all__ = [
 FFMPEG_GLOBAL_ARGS_DEFAULT = ["-hide_banner", "-loglevel", "warning", "-threads", "2"]
 FFMPEG_INPUT_ARGS_DEFAULT = "preset-rtsp-generic"
 
-RECORD_FFMPEG_OUTPUT_ARGS_DEFAULT = "preset-record-generic"
+RECORD_FFMPEG_OUTPUT_ARGS_DEFAULT = "preset-record-generic-audio-aac"
 DETECT_FFMPEG_OUTPUT_ARGS_DEFAULT = [
     "-threads",
     "2",


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

This PR:
- enables audio in recordings by default
- removes the query for go2rtc, making it simple for most users to have audio working by default

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
