### PR TITLE
Ensure restart dialog isn't shown if config isn't valid

### DIFF
--- a/web/src/pages/ConfigEditor.tsx
+++ b/web/src/pages/ConfigEditor.tsx
@@ -6,7 +6,7 @@ import { useApiHost } from "@/api";
 import Heading from "@/components/ui/heading";
 import ActivityIndicator from "@/components/indicators/activity-indicator";
 import { Button } from "@/components/ui/button";
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import copy from "copy-to-clipboard";
 import { useTheme } from "@/context/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
@@ -14,8 +14,14 @@ import { toast } from "sonner";
 import { LuCopy, LuSave } from "react-icons/lu";
 import { MdOutlineRestartAlt } from "react-icons/md";
 import RestartDialog from "@/components/overlay/dialog/RestartDialog";
+import { useRestart } from "@/api/ws";
 
 type SaveOptions = "saveonly" | "restart";
+
+type ApiErrorResponse = {
+  message?: string;
+  detail?: string;
+};
 
 function ConfigEditor() {
   const apiHost = useApiHost();
@@ -35,37 +41,40 @@ function ConfigEditor() {
   const schemaConfiguredRef = useRef(false);
 
   const [restartDialogOpen, setRestartDialogOpen] = useState(false);
+  const { send: sendRestart } = useRestart();
 
   const onHandleSaveConfig = useCallback(
-    async (save_option: SaveOptions) => {
+    async (save_option: SaveOptions): Promise<void> => {
       if (!editorRef.current) {
         return;
       }
 
-      axios
-        .post(
+      try {
+        const response = await axios.post(
           `config/save?save_option=${save_option}`,
           editorRef.current.getValue(),
           {
             headers: { "Content-Type": "text/plain" },
           },
-        )
-        .then((response) => {
-          if (response.status === 200) {
-            setError("");
-            toast.success(response.data.message, { position: "top-center" });
-          }
-        })
-        .catch((error) => {
-          toast.error("Error saving config", { position: "top-center" });
+        );
 
-          const errorMessage =
-            error.response?.data?.message ||
-            error.response?.data?.detail ||
-            "Unknown error";
+        if (response.status === 200) {
+          setError("");
+          setHasChanges(false);
+          toast.success(response.data.message, { position: "top-center" });
+        }
+      } catch (error) {
+        toast.error("Error saving config", { position: "top-center" });
 
-          setError(errorMessage);
-        });
+        const axiosError = error as AxiosError<ApiErrorResponse>;
+        const errorMessage =
+          axiosError.response?.data?.message ||
+          axiosError.response?.data?.detail ||
+          "Unknown error";
+
+        setError(errorMessage);
+        throw new Error(errorMessage);
+      }
     },
     [editorRef],
   );
@@ -78,6 +87,15 @@ function ConfigEditor() {
     copy(editorRef.current.getValue());
     toast.success("Config copied to clipboard.", { position: "top-center" });
   }, [editorRef]);
+
+  const handleSaveAndRestart = useCallback(async () => {
+    try {
+      await onHandleSaveConfig("saveonly");
+      setRestartDialogOpen(true);
+    } catch (error) {
+      // If save fails, error is already set in onHandleSaveConfig, no dialog opens
+    }
+  }, [onHandleSaveConfig]);
 
   useEffect(() => {
     if (!config) {
@@ -206,7 +224,7 @@ function ConfigEditor() {
               size="sm"
               className="flex items-center gap-2"
               aria-label="Save and restart"
-              onClick={() => setRestartDialogOpen(true)}
+              onClick={handleSaveAndRestart}
             >
               <div className="relative size-5">
                 <LuSave className="absolute left-0 top-0 size-3 text-secondary-foreground" />
@@ -238,7 +256,7 @@ function ConfigEditor() {
       <RestartDialog
         isOpen={restartDialogOpen}
         onClose={() => setRestartDialogOpen(false)}
-        onRestart={() => onHandleSaveConfig("restart")}
+        onRestart={() => sendRestart("restart")}
       />
     </div>
   );


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
The restart confirmation was shown if a user pressed "Save and Restart" and the config had errors. Restarting in this case would not occur, but the correct behavior is to show the errors and not present the opportunity to restart at all.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/17131
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
