### PR TITLE
Review items per user

### DIFF
--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -9,10 +9,10 @@ import pandas as pd
 from fastapi import APIRouter
 from fastapi.params import Depends
 from fastapi.responses import JSONResponse
-from peewee import Case, DoesNotExist, fn, operator
+from peewee import Case, DoesNotExist, IntegrityError, fn, operator
 from playhouse.shortcuts import model_to_dict
 
-from frigate.api.auth import require_role
+from frigate.api.auth import get_current_user, require_role
 from frigate.api.defs.query.review_query_parameters import (
     ReviewActivityMotionQueryParams,
     ReviewQueryParams,
@@ -26,7 +26,7 @@ from frigate.api.defs.response.review_response import (
     ReviewSummaryResponse,
 )
 from frigate.api.defs.tags import Tags
-from frigate.models import Recordings, ReviewSegment
+from frigate.models import Recordings, ReviewSegment, UserReviewStatus
 from frigate.review.types import SeverityEnum
 from frigate.util.builtin import get_tz_modifiers
 
@@ -36,7 +36,15 @@ router = APIRouter(tags=[Tags.review])
 
 
 @router.get("/review", response_model=list[ReviewSegmentResponse])
-def review(params: ReviewQueryParams = Depends()):
+async def review(
+    params: ReviewQueryParams = Depends(),
+    current_user: dict = Depends(get_current_user),
+):
+    if isinstance(current_user, JSONResponse):
+        return current_user
+
+    user_id = current_user["username"]
+
     cameras = params.cameras
     labels = params.labels
     zones = params.zones
@@ -74,9 +82,7 @@ def review(params: ReviewQueryParams = Depends()):
                 (ReviewSegment.data["objects"].cast("text") % f'*"{label}"*')
                 | (ReviewSegment.data["audio"].cast("text") % f'*"{label}"*')
             )
-
-        label_clause = reduce(operator.or_, label_clauses)
-        clauses.append((label_clause))
+        clauses.append(reduce(operator.or_, label_clauses))
 
     if zones != "all":
         # use matching so segments with multiple zones
@@ -88,27 +94,52 @@ def review(params: ReviewQueryParams = Depends()):
             zone_clauses.append(
                 (ReviewSegment.data["zones"].cast("text") % f'*"{zone}"*')
             )
-
-        zone_clause = reduce(operator.or_, zone_clauses)
-        clauses.append((zone_clause))
-
-    if reviewed == 0:
-        clauses.append((ReviewSegment.has_been_reviewed == False))
+        clauses.append(reduce(operator.or_, zone_clauses))
 
     if severity:
         clauses.append((ReviewSegment.severity == severity))
 
-    review = (
-        ReviewSegment.select()
+    # Join with UserReviewStatus to get per-user review status
+    review_query = (
+        ReviewSegment.select(
+            ReviewSegment.id,
+            ReviewSegment.camera,
+            ReviewSegment.start_time,
+            ReviewSegment.end_time,
+            ReviewSegment.severity,
+            ReviewSegment.thumb_path,
+            ReviewSegment.data,
+            fn.COALESCE(UserReviewStatus.has_been_reviewed, False).alias(
+                "has_been_reviewed"
+            ),
+        )
+        .left_outer_join(
+            UserReviewStatus,
+            on=(
+                (ReviewSegment.id == UserReviewStatus.review_segment)
+                & (UserReviewStatus.user_id == user_id)
+            ),
+        )
         .where(reduce(operator.and_, clauses))
-        .order_by(ReviewSegment.severity.asc())
+    )
+
+    # Filter unreviewed items without subquery
+    if reviewed == 0:
+        review_query = review_query.where(
+            (UserReviewStatus.has_been_reviewed == False)
+            | (UserReviewStatus.has_been_reviewed.is_null())
+        )
+
+    # Apply ordering and limit
+    review_query = (
+        review_query.order_by(ReviewSegment.severity.asc())
         .order_by(ReviewSegment.start_time.desc())
         .limit(limit)
         .dicts()
         .iterator()
     )
 
-    return JSONResponse(content=[r for r in review])
+    return JSONResponse(content=[r for r in review_query])
 
 
 @router.get("/review_ids", response_model=list[ReviewSegmentResponse])
@@ -134,7 +165,15 @@ def review_ids(ids: str):
 
 
 @router.get("/review/summary", response_model=ReviewSummaryResponse)
-def review_summary(params: ReviewSummaryQueryParams = Depends()):
+async def review_summary(
+    params: ReviewSummaryQueryParams = Depends(),
+    current_user: dict = Depends(get_current_user),
+):
+    if isinstance(current_user, JSONResponse):
+        return current_user
+
+    user_id = current_user["username"]
+
     hour_modifier, minute_modifier, seconds_offset = get_tz_modifiers(params.timezone)
     day_ago = (datetime.datetime.now() - datetime.timedelta(hours=24)).timestamp()
     month_ago = (datetime.datetime.now() - datetime.timedelta(days=30)).timestamp()
@@ -160,10 +199,7 @@ def review_summary(params: ReviewSummaryQueryParams = Depends()):
                 (ReviewSegment.data["objects"].cast("text") % f'*"{label}"*')
                 | (ReviewSegment.data["audio"].cast("text") % f'*"{label}"*')
             )
-
-        label_clause = reduce(operator.or_, label_clauses)
-        clauses.append((label_clause))
-
+        clauses.append(reduce(operator.or_, label_clauses))
     if zones != "all":
         # use matching so segments with multiple zones
         # still match on a search where any zone matches
@@ -172,21 +208,20 @@ def review_summary(params: ReviewSummaryQueryParams = Depends()):
 
         for zone in filtered_zones:
             zone_clauses.append(
-                (ReviewSegment.data["zones"].cast("text") % f'*"{zone}"*')
+                ReviewSegment.data["zones"].cast("text") % f'*"{zone}"*'
             )
+        clauses.append(reduce(operator.or_, zone_clauses))
 
-        zone_clause = reduce(operator.or_, zone_clauses)
-        clauses.append((zone_clause))
-
-    last_24 = (
+    last_24_query = (
         ReviewSegment.select(
             fn.SUM(
                 Case(
                     None,
                     [
                         (
-                            (ReviewSegment.severity == SeverityEnum.alert),
-                            ReviewSegment.has_been_reviewed,
+                            (ReviewSegment.severity == SeverityEnum.alert)
+                            & (UserReviewStatus.has_been_reviewed == True),
+                            1,
                         )
                     ],
                     0,
@@ -197,8 +232,9 @@ def review_summary(params: ReviewSummaryQueryParams = Depends()):
                     None,
                     [
                         (
-                            (ReviewSegment.severity == SeverityEnum.detection),
-                            ReviewSegment.has_been_reviewed,
+                            (ReviewSegment.severity == SeverityEnum.detection)
+                            & (UserReviewStatus.has_been_reviewed == True),
+                            1,
                         )
                     ],
                     0,
@@ -228,6 +264,13 @@ def review_summary(params: ReviewSummaryQueryParams = Depends()):
                     0,
                 )
             ).alias("total_detection"),
+        )
+        .left_outer_join(
+            UserReviewStatus,
+            on=(
+                (ReviewSegment.id == UserReviewStatus.review_segment)
+                & (UserReviewStatus.user_id == user_id)
+            ),
         )
         .where(reduce(operator.and_, clauses))
         .dicts()
@@ -248,14 +291,12 @@ def review_summary(params: ReviewSummaryQueryParams = Depends()):
 
         for label in filtered_labels:
             label_clauses.append(
-                (ReviewSegment.data["objects"].cast("text") % f'*"{label}"*')
+                ReviewSegment.data["objects"].cast("text") % f'*"{label}"*'
             )
-
-        label_clause = reduce(operator.or_, label_clauses)
-        clauses.append((label_clause))
+        clauses.append(reduce(operator.or_, label_clauses))
 
     day_in_seconds = 60 * 60 * 24
-    last_month = (
+    last_month_query = (
         ReviewSegment.select(
             fn.strftime(
                 "%Y-%m-%d",
@@ -271,8 +312,9 @@ def review_summary(params: ReviewSummaryQueryParams = Depends()):
                     None,
                     [
                         (
-                            (ReviewSegment.severity == SeverityEnum.alert),
-                            ReviewSegment.has_been_reviewed,
+                            (ReviewSegment.severity == SeverityEnum.alert)
+                            & (UserReviewStatus.has_been_reviewed == True),
+                            1,
                         )
                     ],
                     0,
@@ -283,8 +325,9 @@ def review_summary(params: ReviewSummaryQueryParams = Depends()):
                     None,
                     [
                         (
-                            (ReviewSegment.severity == SeverityEnum.detection),
-                            ReviewSegment.has_been_reviewed,
+                            (ReviewSegment.severity == SeverityEnum.detection)
+                            & (UserReviewStatus.has_been_reviewed == True),
+                            1,
                         )
                     ],
                     0,
@@ -315,28 +358,59 @@ def review_summary(params: ReviewSummaryQueryParams = Depends()):
                 )
             ).alias("total_detection"),
         )
+        .left_outer_join(
+            UserReviewStatus,
+            on=(
+                (ReviewSegment.id == UserReviewStatus.review_segment)
+                & (UserReviewStatus.user_id == user_id)
+            ),
+        )
         .where(reduce(operator.and_, clauses))
         .group_by(
-            (ReviewSegment.start_time + seconds_offset).cast("int") / day_in_seconds,
+            (ReviewSegment.start_time + seconds_offset).cast("int") / day_in_seconds
         )
         .order_by(ReviewSegment.start_time.desc())
     )
 
     data = {
-        "last24Hours": last_24,
+        "last24Hours": last_24_query,
     }
 
-    for e in last_month.dicts().iterator():
+    for e in last_month_query.dicts().iterator():
         data[e["day"]] = e
 
     return JSONResponse(content=data)
 
 
 @router.post("/reviews/viewed", response_model=GenericResponse)
-def set_multiple_reviewed(body: ReviewModifyMultipleBody):
-    ReviewSegment.update(has_been_reviewed=True).where(
-        ReviewSegment.id << body.ids
-    ).execute()
+async def set_multiple_reviewed(
+    body: ReviewModifyMultipleBody,
+    current_user: dict = Depends(get_current_user),
+):
+    if isinstance(current_user, JSONResponse):
+        return current_user
+
+    user_id = current_user["username"]
+
+    for review_id in body.ids:
+        try:
+            review_status = UserReviewStatus.get(
+                UserReviewStatus.user_id == user_id,
+                UserReviewStatus.review_segment == review_id,
+            )
+            # If it exists and isn’t reviewed, update it
+            if not review_status.has_been_reviewed:
+                review_status.has_been_reviewed = True
+                review_status.save()
+        except DoesNotExist:
+            try:
+                UserReviewStatus.create(
+                    user_id=user_id,
+                    review_segment=ReviewSegment.get(id=review_id),
+                    has_been_reviewed=True,
+                )
+            except IntegrityError:
+                pass
 
     return JSONResponse(
         content=({"success": True, "message": "Reviewed multiple items"}),
@@ -389,6 +463,9 @@ def delete_reviews(body: ReviewModifyMultipleBody):
     # delete recordings and review segments
     Recordings.delete().where(Recordings.id << recording_ids).execute()
     ReviewSegment.delete().where(ReviewSegment.id << list_of_ids).execute()
+    UserReviewStatus.delete().where(
+        UserReviewStatus.review_segment << list_of_ids
+    ).execute()
 
     return JSONResponse(
         content=({"success": True, "message": "Deleted review items."}), status_code=200
@@ -502,7 +579,15 @@ def get_review(review_id: str):
 
 
 @router.delete("/review/{review_id}/viewed", response_model=GenericResponse)
-def set_not_reviewed(review_id: str):
+async def set_not_reviewed(
+    review_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    if isinstance(current_user, JSONResponse):
+        return current_user
+
+    user_id = current_user["username"]
+
     try:
         review: ReviewSegment = ReviewSegment.get(ReviewSegment.id == review_id)
     except DoesNotExist:
@@ -513,8 +598,15 @@ def set_not_reviewed(review_id: str):
             status_code=404,
         )
 
-    review.has_been_reviewed = False
-    review.save()
+    try:
+        user_review = UserReviewStatus.get(
+            UserReviewStatus.user_id == user_id,
+            UserReviewStatus.review_segment == review,
+        )
+        # we could update here instead of delete if we need
+        user_review.delete_instance()
+    except DoesNotExist:
+        pass  # Already effectively "not reviewed"
 
     return JSONResponse(
         content=({"success": True, "message": f"Set Review {review_id} as not viewed"}),

--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -409,7 +409,7 @@ async def set_multiple_reviewed(
                     review_segment=ReviewSegment.get(id=review_id),
                     has_been_reviewed=True,
                 )
-            except IntegrityError:
+            except (DoesNotExist, IntegrityError):
                 pass
 
     return JSONResponse(

--- a/frigate/models.py
+++ b/frigate/models.py
@@ -3,6 +3,7 @@ from peewee import (
     CharField,
     DateTimeField,
     FloatField,
+    ForeignKeyField,
     IntegerField,
     Model,
     TextField,
@@ -92,10 +93,18 @@ class ReviewSegment(Model):  # type: ignore[misc]
     camera = CharField(index=True, max_length=20)
     start_time = DateTimeField()
     end_time = DateTimeField()
-    has_been_reviewed = BooleanField(default=False)
     severity = CharField(max_length=30)  # alert, detection
     thumb_path = CharField(unique=True)
     data = JSONField()  # additional data about detection like list of labels, zone, areas of significant motion
+
+
+class UserReviewStatus(Model):  # type: ignore[misc]
+    user_id = CharField(max_length=30)
+    review_segment = ForeignKeyField(ReviewSegment, backref="user_reviews")
+    has_been_reviewed = BooleanField(default=False)
+
+    class Meta:
+        indexes = ((("user_id", "review_segment"), True),)
 
 
 class Previews(Model):  # type: ignore[misc]

--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -12,7 +12,7 @@ from playhouse.sqlite_ext import SqliteExtDatabase
 
 from frigate.config import CameraConfig, FrigateConfig, RetainModeEnum
 from frigate.const import CACHE_DIR, CLIPS_DIR, MAX_WAL_SIZE, RECORD_DIR
-from frigate.models import Previews, Recordings, ReviewSegment
+from frigate.models import Previews, Recordings, ReviewSegment, UserReviewStatus
 from frigate.record.util import remove_empty_directories, sync_recordings
 from frigate.util.builtin import clear_and_unlink, get_tomorrow_at_time
 
@@ -89,6 +89,10 @@ class RecordingCleanup(threading.Thread):
         for i in range(0, len(deleted_reviews_list), max_deletes):
             ReviewSegment.delete().where(
                 ReviewSegment.id << deleted_reviews_list[i : i + max_deletes]
+            ).execute()
+            UserReviewStatus.delete().where(
+                UserReviewStatus.review_segment
+                << deleted_reviews_list[i : i + max_deletes]
             ).execute()
 
     def expire_existing_camera_recordings(

--- a/frigate/test/http_api/base_http_test.py
+++ b/frigate/test/http_api/base_http_test.py
@@ -157,16 +157,14 @@ class BaseTestHttp(unittest.TestCase):
         start_time: float = datetime.datetime.now().timestamp(),
         end_time: float = datetime.datetime.now().timestamp() + 20,
         severity: SeverityEnum = SeverityEnum.alert,
-        has_been_reviewed: bool = False,
         data: Json = {},
-    ) -> Event:
+    ) -> ReviewSegment:
         """Inserts a review segment model with a given id."""
         return ReviewSegment.insert(
             id=id,
             camera="front_door",
             start_time=start_time,
             end_time=end_time,
-            has_been_reviewed=has_been_reviewed,
             severity=severity,
             thumb_path=False,
             data=data,

--- a/migrations/030_create_user_review_status.py
+++ b/migrations/030_create_user_review_status.py
@@ -1,0 +1,85 @@
+"""Peewee migrations -- 030_create_user_review_status.py.
+
+This migration creates the UserReviewStatus table to track per-user review states,
+migrates existing has_been_reviewed data from ReviewSegment to all users in the user table,
+and drops the has_been_reviewed column. Rollback drops UserReviewStatus and restores the column.
+
+Some examples (model - class or model_name)::
+
+    > Model = migrator.orm['model_name']            # Return model in current state by name
+    > migrator.sql(sql)                             # Run custom SQL
+    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.create_model(Model)                  # Create a model (could be used as decorator)
+    > migrator.remove_model(model, cascade=True)    # Remove a model
+    > migrator.add_fields(model, **fields)          # Add fields to a model
+    > migrator.change_fields(model, **fields)       # Change fields
+    > migrator.remove_fields(model, *field_names, cascade=True)
+    > migrator.rename_field(model, old_field_name, new_field_name)
+    > migrator.rename_table(model, new_table_name)
+    > migrator.add_index(model, *col_names, unique=False)
+    > migrator.drop_index(model, *col_names)
+    > migrator.add_not_null(model, *field_names)
+    > migrator.drop_not_null(model, *field_names)
+    > migrator.add_default(model, field_name, default)
+
+"""
+
+import peewee as pw
+
+from frigate.models import User, UserReviewStatus
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    User._meta.database = database
+    UserReviewStatus._meta.database = database
+
+    migrator.sql(
+        """
+        CREATE TABLE IF NOT EXISTS "userreviewstatus" (
+            "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            "user_id" VARCHAR(30) NOT NULL,
+            "review_segment_id" VARCHAR(30) NOT NULL,
+            "has_been_reviewed" INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY ("review_segment_id") REFERENCES "reviewsegment" ("id") ON DELETE CASCADE
+        )
+        """
+    )
+
+    # Add unique index on (user_id, review_segment_id)
+    migrator.sql(
+        'CREATE UNIQUE INDEX IF NOT EXISTS "userreviewstatus_user_segment" ON "userreviewstatus" ("user_id", "review_segment_id")'
+    )
+
+    # Migrate existing has_been_reviewed data to UserReviewStatus for all users
+    def migrate_data():
+        all_users = list(User.select())
+        if not all_users:
+            return
+
+        cursor = database.execute_sql(
+            'SELECT "id" FROM "reviewsegment" WHERE "has_been_reviewed" = 1'
+        )
+        reviewed_segment_ids = [row[0] for row in cursor.fetchall()]
+
+        for segment_id in reviewed_segment_ids:
+            for user in all_users:
+                UserReviewStatus.create(
+                    user_id=user.username,
+                    review_segment=segment_id,
+                    has_been_reviewed=True,
+                )
+
+    if not fake:  # Only run data migration if not faking
+        migrator.python(migrate_data)
+
+    migrator.sql('ALTER TABLE "reviewsegment" DROP COLUMN "has_been_reviewed"')
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.sql('DROP TABLE IF EXISTS "userreviewstatus"')
+    # Restore has_been_reviewed column to reviewsegment (no data restoration)
+    migrator.sql(
+        'ALTER TABLE "reviewsegment" ADD COLUMN "has_been_reviewed" INTEGER NOT NULL DEFAULT 0'
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
With the introduction of the viewer role in https://github.com/blakeblackshear/frigate/pull/16978, users may want the ability to mark review items as *reviewed* separately - for example, a Jim's `admin` account may not want to have review items hidden because Jill's `viewer` account marked them as *reviewed*.

This PR implements this feature through database and API changes only.

- A new migrator creates a new database table that is used for left joining for review item queries.
  - The migrator also marks all existing *reviewed* review items as *reviewed* for all users.
- Entires in the new table are cleaned up according to review item retention.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: closes https://github.com/blakeblackshear/frigate/issues/11621
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
