### PR TITLE
Simplify auth check

### DIFF
--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -191,6 +191,12 @@ def set_jwt_cookie(response: Response, cookie_name, encoded_jwt, expiration, sec
 async def get_current_user(request: Request):
     username = request.headers.get("remote-user")
     role = request.headers.get("remote-role")
+
+    if not username or not role:
+        return JSONResponse(
+            content={"message": "No authorization headers."}, status_code=401
+        )
+
     return {"username": username, "role": role}
 
 

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -189,21 +189,9 @@ def set_jwt_cookie(response: Response, cookie_name, encoded_jwt, expiration, sec
 
 
 async def get_current_user(request: Request):
-    JWT_COOKIE_NAME = request.app.frigate_config.auth.cookie_name
-    encoded_token = request.cookies.get(JWT_COOKIE_NAME)
-    if not encoded_token:
-        return JSONResponse(content={"message": "No JWT token found"}, status_code=401)
-
-    try:
-        token = jwt.decode(encoded_token, request.app.jwt_token)
-        if "sub" not in token.claims or "role" not in token.claims:
-            return JSONResponse(
-                content={"message": "Invalid JWT token"}, status_code=401
-            )
-        return {"username": token.claims["sub"], "role": token.claims["role"]}
-    except Exception as e:
-        logger.error(f"Error parsing JWT: {e}")
-        return JSONResponse(content={"message": "Invalid JWT token"}, status_code=401)
+    username = request.headers.get("remote-user")
+    role = request.headers.get("remote-role")
+    return {"username": username, "role": role}
 
 
 def require_role(required_roles: List[str]):


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
`get_current_user` in auth can simply check headers because they are set on every request by nginx. No need to duplicate the jwt logic from /auth.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
