### PR TITLE
Implement ONVIF retry mechanism

### DIFF
--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -106,10 +106,10 @@ def imagestream(
 
 
 @router.get("/{camera_name}/ptz/info")
-def camera_ptz_info(request: Request, camera_name: str):
+async def camera_ptz_info(request: Request, camera_name: str):
     if camera_name in request.app.frigate_config.cameras:
         return JSONResponse(
-            content=request.app.onvif.get_camera_info(camera_name),
+            content=await request.app.onvif.get_camera_info(camera_name),
         )
     else:
         return JSONResponse(


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->
When users configure ONVIF for a camera, Frigate attempts a connection (with initial retries and timeout), but never attempts to reconnect should the camera go offline afterwards. This PR implements  an ONVIF retry mechanism where up to 5 connection attempts are made with a 15 minute cooldown time before retrying again.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
