### PR TITLE
Fix bug where safari and firefox cache image for too long

### DIFF
--- a/web/src/components/camera/AutoUpdatingCameraImage.tsx
+++ b/web/src/components/camera/AutoUpdatingCameraImage.tsx
@@ -78,7 +78,10 @@ export default function AutoUpdatingCameraImage({
     let baseParam = "";
 
     if (periodicCache && !isCached) {
-      baseParam = "store=1";
+      const date = new Date(key);
+      date.setMinutes(date.getMinutes() - (date.getMinutes() % 10), 0, 0);
+
+      baseParam = `store=1&cache=${date.getTime() / 1000}`;
     } else {
       baseParam = `cache=${key}`;
     }


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality, 
  we encourage you to start a discussion first. This helps ensure your idea aligns with 
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are 
  made in this pull request.
-->

safari and firefox cached the image longer than expected, this will use a cache key to ensure the image is not cached longer than 10 minutes

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
