### PR TITLE
Proxy i18n locales dir for ingress

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -317,6 +317,7 @@ http {
             sub_filter '"/BASE_PATH/dist/' '"$http_x_ingress_path/dist/';
             sub_filter '"/BASE_PATH/js/' '"$http_x_ingress_path/js/';
             sub_filter '"/BASE_PATH/assets/' '"$http_x_ingress_path/assets/';
+            sub_filter '"/BASE_PATH/locales/' '"$http_x_ingress_path/locales/';
             sub_filter '"/BASE_PATH/monacoeditorwork/' '"$http_x_ingress_path/assets/';
             sub_filter 'return"/BASE_PATH/"' 'return window.baseUrl';
             sub_filter '<body>' '<body><script>window.baseUrl="$http_x_ingress_path/";</script>';


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
The `locales` directory containing the i18n json files was not being proxied, so users running the proxy addon would be seeing 404s for the json translation files and would have no text in the UI.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
