### PR TITLE
Face rec: only consider webp files in /faces and handle_request

### DIFF
--- a/frigate/api/classification.py
+++ b/frigate/api/classification.py
@@ -39,7 +39,7 @@ def get_faces():
         face_dict[name] = []
 
         for file in sorted(
-            os.listdir(face_dir),
+            filter(lambda f: (f.endswith(".webp")), os.listdir(face_dir)),
             key=lambda f: os.path.getctime(os.path.join(face_dir, f)),
             reverse=True,
         ):

--- a/frigate/api/classification.py
+++ b/frigate/api/classification.py
@@ -39,7 +39,10 @@ def get_faces():
         face_dict[name] = []
 
         for file in sorted(
-            filter(lambda f: (f.endswith(".webp")), os.listdir(face_dir)),
+            filter(
+                lambda f: (f.lower().endswith((".webp", ".png", ".jpg", ".jpeg"))),
+                os.listdir(face_dir),
+            ),
             key=lambda f: os.path.getctime(os.path.join(face_dir, f)),
             reverse=True,
         ):

--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -484,7 +484,7 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
                 shutil.move(current_file, new_file)
 
                 files = sorted(
-                    os.listdir(folder),
+                    filter(lambda f: (f.endswith(".webp")), os.listdir(folder)),
                     key=lambda f: os.path.getctime(os.path.join(folder, f)),
                     reverse=True,
                 )


### PR DESCRIPTION
## Proposed change

Re: https://github.com/blakeblackshear/frigate/discussions/17118#discussioncomment-12531118

The `os.listdir` call doesn't filter out non-webp files. There are various reasons these might exist, for example OS-created thumbnail files, or NFS lockfiles (per the above comment).

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update


## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
