### PR TITLE
Nginx: disable open_file_cache if media is on NFS

### DIFF
--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -89,6 +89,15 @@ python3 /usr/local/nginx/get_tls_settings.py | \
     tempio  -template /usr/local/nginx/templates/listen.gotmpl \
             -out /usr/local/nginx/conf/listen.conf
 
+# disable open_file_cache on NFS filesystems
+# https://trac.nginx.org/nginx/ticket/478
+NFS_CLIPS_FS=`findmnt -n -o FSTYPE --target /media/frigate/clips`
+
+shopt -s nocasematch; if [[ "$NFS_CLIPS_FS" =~ ^nfs* ]]; then
+    echo "[INFO] NFS mount detected for /media/frigate/clips, disabling NGINX open_file_cache"
+    echo "open_file_cache off;" > /usr/local/nginx/conf/open_file_cache.conf
+fi
+
 # Replace the bash process with the NGINX process, redirecting stderr to stdout
 exec 2>&1
 exec \

--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -75,10 +75,7 @@ http {
         vod_hls_mpegts_interleave_frames on;
 
         # file handle caching / aio
-        open_file_cache max=1000 inactive=5m;
-        open_file_cache_valid 2m;
-        open_file_cache_min_uses 1;
-        open_file_cache_errors on;
+        include open_file_cache.conf;
         aio on;
 
         # file upload size

--- a/docker/main/rootfs/usr/local/nginx/conf/open_file_cache.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/open_file_cache.conf
@@ -1,0 +1,4 @@
+open_file_cache max=1000 inactive=5m;
+open_file_cache_valid 2m;
+open_file_cache_min_uses 1;
+open_file_cache_errors on;


### PR DESCRIPTION
## Proposed change

This change disables nginx's open_file_cache if the /media/frigate/clips directory is detected to be an NFS mount.

https://github.com/blakeblackshear/frigate/discussions/17118#discussioncomment-12535500

Above comment covers the investigation into this in more details; TLDR = the creator of nginx says don't use open_file_cache with NFS mounts due to the filesystem not properly observing unix file semantics: https://trac.nginx.org/nginx/ticket/478

The nginx ticket is from 2014, but seeing as I see an issue without the fix, and it goes away with the fix, fair to assume it's still valid.

I have tested this locally in my devcontainer (non-NFS) and my test instance (NFSv4) and it seems to work fine. I don't observe any performance degradation browsing around the UI. Once betas start and a broader user-base is testing this, happy to look into any performance concerns.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
