### PR TITLE
i18n fix for English rendering of TimeAgo seconds

### DIFF
--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -32,7 +32,7 @@
     "hour": "{{time}} hours",
     "m": "{{time}}m",
     "minute": "{{time}} minutes",
-    "s": "s",
+    "s": "{{time}}s",
     "second": "{{time}} seconds",
     "formattedTimestamp": {
       "12hour": "%b %-d, %I:%M:%S %p",


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
The `{{time}}` parameter was missing from the i18n key.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
