### PR TITLE
UI: use correct icon/i18n for Face Library on mobile

### DIFF
--- a/web/src/components/menu/GeneralSettings.tsx
+++ b/web/src/components/menu/GeneralSettings.tsx
@@ -7,6 +7,7 @@ import {
   LuLogOut,
   LuMoon,
   LuSquarePen,
+  LuScanFace,
   LuRotateCw,
   LuSettings,
   LuSun,
@@ -284,10 +285,10 @@ export default function GeneralSettings({ className }: GeneralSettingsProps) {
                   <Link to="/faces">
                     <MenuItem
                       className="flex w-full items-center p-2 text-sm"
-                      aria-label="Face Library"
+                      aria-label={t("menu.faceLibrary")}
                     >
-                      <LuSquarePen className="mr-2 size-4" />
-                      <span>Face Library</span>
+                      <LuScanFace className="mr-2 size-4" />
+                      <span>{t("menu.faceLibrary")}</span>
                     </MenuItem>
                   </Link>
                 </>


### PR DESCRIPTION
## Proposed change

Wrong icon was bugging me, and spotted while there it needed i18n.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
