### PR TITLE
Add model ID to Frigate+ settings page

### DIFF
--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -540,6 +540,7 @@
     },
     "modelInfo": {
       "title": "Model Information",
+      "modelId": "Model ID",
       "modelType": "Model Type",
       "trainDate": "Train Date",
       "baseModel": "Base Model",

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -393,6 +393,7 @@ export interface FrigateConfig {
     all_attributes: [string];
     plus?: {
       name: string;
+      id: string;
       trainDate: string;
       baseModel: string;
       supportedDetectors: string[];

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -115,6 +115,12 @@ export default function FrigatePlusSettingsView() {
                         </div>
                         <div>
                           <Label className="text-muted-foreground">
+                            {t("frigatePlus.modelInfo.modelId")}
+                          </Label>
+                          <p>{config.model.plus.id}</p>
+                        </div>
+                        <div>
+                          <Label className="text-muted-foreground">
                             {t("frigatePlus.modelInfo.baseModel")}
                           </Label>
                           <p>{config.model.plus.baseModel}</p>


### PR DESCRIPTION
## Proposed change

Add Model ID to the Plus page for reference, ahead of a planned to PR to pull the list of model ID's from the Frigate+ API and allow for a one-click config update to the latest trained model (unless any objections...)

![image](https://github.com/user-attachments/assets/6b057b99-53e8-44cc-badf-c7ba7a2c4767)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
