### PR TITLE
Add MQTT topic to expose current camera review status

### DIFF
--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -305,6 +305,10 @@ Topic to adjust motion contour area for a camera. Expected value is an integer.
 
 Topic with current motion contour area for a camera. Published value is an integer.
 
+### `frigate/<camera_name>/review_status`
+
+Topic with current activity status of the camera. Possible values are `NONE`, `DETECTION`, or `ALERT`.
+
 ### `frigate/<camera_name>/ptz`
 
 Topic to send PTZ commands to camera.

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -181,7 +181,9 @@ class ReviewSegmentMaintainer(threading.Thread):
                 }
             ),
         )
-        self.requestor.send_data(f"{segment.camera}/review_status", segment.severity.value.upper())
+        self.requestor.send_data(
+            f"{segment.camera}/review_status", segment.severity.value.upper()
+        )
 
     def _publish_segment_update(
         self,
@@ -207,7 +209,9 @@ class ReviewSegmentMaintainer(threading.Thread):
                 }
             ),
         )
-        self.requestor.send_data(f"{segment.camera}/review_status", segment.severity.value.upper())
+        self.requestor.send_data(
+            f"{segment.camera}/review_status", segment.severity.value.upper()
+        )
 
     def _publish_segment_end(
         self,

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -181,6 +181,7 @@ class ReviewSegmentMaintainer(threading.Thread):
                 }
             ),
         )
+        self.requestor.send_data(f"{segment.camera}/review_status", segment.severity.value.upper())
 
     def _publish_segment_update(
         self,
@@ -206,6 +207,7 @@ class ReviewSegmentMaintainer(threading.Thread):
                 }
             ),
         )
+        self.requestor.send_data(f"{segment.camera}/review_status", segment.severity.value.upper())
 
     def _publish_segment_end(
         self,
@@ -225,6 +227,7 @@ class ReviewSegmentMaintainer(threading.Thread):
                 }
             ),
         )
+        self.requestor.send_data(f"{segment.camera}/review_status", "NONE")
         self.active_review_segments[segment.camera] = None
 
     def end_segment(self, camera: str) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This PR adds a new review_status topic that reflects the current status of each camera. This will be a better sensor to use in home assistant for alarms as it will directly match what frigate shows in the review UI

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/issues/3990
- fixes https://github.com/blakeblackshear/frigate/issues/3990
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
