### PR TITLE
Fix nginx webmanifest sub_filter

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -41,6 +41,11 @@ http {
         default 1;
     }
 
+    map $http_x_ingress_path $ingress_path_filter {
+        "~*^.+"      $http_x_ingress_path;
+        default "/";
+    }
+
     upstream frigate_api {
         server 127.0.0.1:5001;
         keepalive 1024;
@@ -313,8 +318,10 @@ http {
                 proxy_set_header Accept-Encoding "";
                 sub_filter_once off;
                 sub_filter_types application/json;
-                sub_filter '"start_url": "/"' '"start_url" : "$http_x_ingress_path"';
-                sub_filter '"src": "/' '"src": "$http_x_ingress_path/';
+                sub_filter '"start_url": "/"' '"start_url" : "$ingress_path_filter"';
+                sub_filter '"src": "/' '"src": "$ingress_path_filter';
+
+
             }
 
             sub_filter 'href="/BASE_PATH/' 'href="$http_x_ingress_path/';


### PR DESCRIPTION
## Proposed change

Fix for issues with empty start_url value in webmanifest caused by https://github.com/blakeblackshear/frigate/pull/17030 - see discussion on that PR for background.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
