### PR TITLE
Sub label snapshot

### DIFF
--- a/frigate/track/object_processing.py
+++ b/frigate/track/object_processing.py
@@ -172,7 +172,7 @@ class TrackedObjectProcessor(threading.Thread):
                         retain=True,
                     )
 
-                    if obj.obj_data["sub_label"]:
+                    if obj.obj_data.get("sub_label"):
                         sub_label = obj.obj_data["sub_label"][0]
 
                         if sub_label in self.config.model.all_attribute_logos:

--- a/frigate/track/object_processing.py
+++ b/frigate/track/object_processing.py
@@ -172,6 +172,16 @@ class TrackedObjectProcessor(threading.Thread):
                         retain=True,
                     )
 
+                    if obj.obj_data["sub_label"]:
+                        sub_label = obj.obj_data["sub_label"][0]
+
+                        if sub_label in self.config.model.all_attribute_logos:
+                            self.dispatcher.publish(
+                                f"{camera}/{sub_label}/snapshot",
+                                jpg_bytes,
+                                retain=True,
+                            )
+
         def camera_activity(camera, activity):
             last_activity = self.camera_activity.get(camera)
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

After enabling object counts for the tracked sub label logos (ups, fedex, etc.), the integration is showing but unable to get snapshots for these objects. This PR adds support so if an object is detected with one of these logo sub labels then it will have a snapshot published.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
