### PR TITLE
Fix webUI generating HTTP500s when camera disabled

### DIFF
--- a/web/src/components/settings/CameraStreamingDialog.tsx
+++ b/web/src/components/settings/CameraStreamingDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
+import { useEnabledState } from "@/api/ws";
 import { IoIosWarning } from "react-icons/io";
 import { Button } from "@/components/ui/button";
 import {
@@ -63,6 +64,10 @@ export function CameraStreamingDialog({
 
   // metadata
 
+  // camera enabled state
+  const { payload: enabledState } = useEnabledState(camera);
+  const cameraEnabled = enabledState === "ON";
+
   const isRestreamed = useMemo(
     () =>
       config &&
@@ -71,7 +76,7 @@ export function CameraStreamingDialog({
   );
 
   const { data: cameraMetadata } = useSWR<LiveStreamMetadata>(
-    isRestreamed ? `go2rtc/streams/${streamName}` : null,
+    cameraEnabled && isRestreamed ? `go2rtc/streams/${streamName}` : null,
     {
       revalidateOnFocus: false,
     },

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -142,8 +142,11 @@ export default function LiveCameraView({
   const [{ width: windowWidth, height: windowHeight }] =
     useResizeObserver(window);
 
-  // supported features
+  // camera enabled state
+  const { payload: enabledState } = useEnabledState(camera.name);
+  const cameraEnabled = enabledState === "ON";
 
+  // supported features
   const [streamName, setStreamName] = usePersistence<string>(
     `${camera.name}-stream`,
     Object.values(camera.live.streams)[0],
@@ -157,7 +160,7 @@ export default function LiveCameraView({
   );
 
   const { data: cameraMetadata } = useSWR<LiveStreamMetadata>(
-    isRestreamed ? `go2rtc/streams/${streamName}` : null,
+    (cameraEnabled && isRestreamed) ? `go2rtc/streams/${streamName}` : null,
     {
       revalidateOnFocus: false,
     },
@@ -192,9 +195,7 @@ export default function LiveCameraView({
     );
   }, [cameraMetadata]);
 
-  // camera enabled state
-  const { payload: enabledState } = useEnabledState(camera.name);
-  const cameraEnabled = enabledState === "ON";
+
 
   // click overlay for ptzs
 

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -160,7 +160,7 @@ export default function LiveCameraView({
   );
 
   const { data: cameraMetadata } = useSWR<LiveStreamMetadata>(
-    (cameraEnabled && isRestreamed) ? `go2rtc/streams/${streamName}` : null,
+    cameraEnabled && isRestreamed ? `go2rtc/streams/${streamName}` : null,
     {
       revalidateOnFocus: false,
     },
@@ -194,8 +194,6 @@ export default function LiveCameraView({
       ) != undefined
     );
   }, [cameraMetadata]);
-
-
 
   // click overlay for ptzs
 


### PR DESCRIPTION
## Proposed change

Fix webUI generating HTTP500s through calling the backend for go2rtc stream state when camera is disabled.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
