### PR TITLE
Update nginx webmanifest to use /BASE_PATH/

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -313,8 +313,8 @@ http {
                 proxy_set_header Accept-Encoding "";
                 sub_filter_once off;
                 sub_filter_types application/json;
-                sub_filter '"start_url": "/"' '"start_url" : "$http_x_ingress_path"';
-                sub_filter '"src": "/' '"src": "$http_x_ingress_path/';
+                sub_filter '"start_url": "/BASE_PATH/"' '"start_url" : "$http_x_ingress_path/"';
+                sub_filter '"src": "/BASE_PATH/' '"src": "$http_x_ingress_path/';
             }
 
             sub_filter 'href="/BASE_PATH/' 'href="$http_x_ingress_path/';

--- a/web/site.webmanifest
+++ b/web/site.webmanifest
@@ -1,28 +1,28 @@
 {
   "name": "Frigate",
   "short_name": "Frigate",
-  "start_url": "/",
+  "start_url": "/BASE_PATH/",
   "icons": [
     {
-      "src": "/images/android-chrome-512x512.png",
+      "src": "/BASE_PATH/images/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/images/android-chrome-192x192.png",
+      "src": "/BASE_PATH/images/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/images/maskable-icon.png",
+      "src": "/BASE_PATH/images/maskable-icon.png",
       "sizes": "180x180",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/images/maskable-badge.png",
+      "src": "/BASE_PATH/images/maskable-badge.png",
       "sizes": "96x96",
       "type": "image/png",
       "purpose": "maskable"


### PR DESCRIPTION
## Proposed change
Better fix for webmanifest path issue as suggested by Blake https://github.com/blakeblackshear/frigate/pull/17030#issuecomment-2745242028

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
