### PR TITLE
Add ability to update Frigate+ model to latest from UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
     #                     capabilities: [gpu]
     environment:
       YOLO_MODELS: ""
-    # devices:
-      # - /dev/bus/usb:/dev/bus/usb # Uncomment for Google Coral USB
+    devices:
+      - /dev/bus/usb:/dev/bus/usb
       # - /dev/dri:/dev/dri # for intel hwaccel, needs to be updated for your hardware
     volumes:
       - .:/workspace/frigate:cached
@@ -33,7 +33,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ./config:/config
       - ./debug:/media/frigate
-     # - /dev/bus/usb:/dev/bus/usb # Uncomment for Google Coral USB
+      - /dev/bus/usb:/dev/bus/usb
   mqtt:
     container_name: mqtt
     image: eclipse-mosquitto:1.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
     #                     capabilities: [gpu]
     environment:
       YOLO_MODELS: ""
-    devices:
-      - /dev/bus/usb:/dev/bus/usb
+    # devices:
+      # - /dev/bus/usb:/dev/bus/usb # Uncomment for Google Coral USB
       # - /dev/dri:/dev/dri # for intel hwaccel, needs to be updated for your hardware
     volumes:
       - .:/workspace/frigate:cached
@@ -33,7 +33,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ./config:/config
       - ./debug:/media/frigate
-      - /dev/bus/usb:/dev/bus/usb
+     # - /dev/bus/usb:/dev/bus/usb # Uncomment for Google Coral USB
   mqtt:
     container_name: mqtt
     image: eclipse-mosquitto:1.6

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -640,6 +640,48 @@ def get_sub_labels(split_joined: Optional[int] = None):
     return JSONResponse(content=sub_labels)
 
 
+@router.get("/plus/models")
+def plusModels(request: Request, filterByCurrentModelDetector: bool = False):
+    if not request.app.frigate_config.plus_api.is_active:
+        return JSONResponse(
+            content=({"success": False, "message": "Frigate+ is not enabled"}),
+            status_code=400,
+        )
+
+    models: dict[any, any] = request.app.frigate_config.plus_api.get_models()
+
+    if not models["list"]:
+        return JSONResponse(
+            content=({"success": False, "message": "No models found"}),
+            status_code=400,
+        )
+
+    modelList = models["list"]
+
+    # current model type
+    modelType = request.app.frigate_config.model.model_type
+
+    # current detectorType for comparing to supportedDetectors
+    detectorType = list(request.app.frigate_config.detectors.values())[0].type
+
+    validModels = []
+
+    for model in sorted(
+        filter(
+            lambda m: (
+                not filterByCurrentModelDetector
+                or (detectorType in m["supportedDetectors"] and modelType in m["type"])
+            ),
+            modelList,
+        ),
+        key=(lambda m: m["trainDate"]),
+        reverse=True,
+    ):
+        validModels.append(model)
+
+    return JSONResponse(content=validModels)
+
+
 @router.get("/recognized_license_plates")
 def get_recognized_license_plates(split_joined: Optional[int] = None):
     try:

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -642,7 +642,7 @@ def get_sub_labels(split_joined: Optional[int] = None):
 
 @router.get("/plus/models")
 def plusModels(request: Request, filterByCurrentModelDetector: bool = False):
-    if not request.app.frigate_config.plus_api.is_active:
+    if not request.app.frigate_config.plus_api.is_active():
         return JSONResponse(
             content=({"success": False, "message": "Frigate+ is not enabled"}),
             status_code=400,

--- a/frigate/plus.py
+++ b/frigate/plus.py
@@ -234,3 +234,11 @@ class PlusApi:
             raise Exception(r.text)
 
         return r.json()
+
+    def get_models(self) -> Any:
+        r = self._get("model/list")
+
+        if not r.ok:
+            raise Exception(r.text)
+
+        return r.json()

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -540,7 +540,6 @@
     },
     "modelInfo": {
       "title": "Model Information",
-      "modelId": "Model ID",
       "modelType": "Model Type",
       "trainDate": "Train Date",
       "baseModel": "Base Model",
@@ -548,6 +547,7 @@
       "cameras": "Cameras",
       "loading": "Loading model information...",
       "error": "Failed to load model information",
+      "availableModels": "Available Models",
       "modelSelect": "Your available models on Frigate+ can be selected here. Note that only models compatible with your current detector configuration are shown."
     },
     "toast": {

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -547,7 +547,12 @@
       "supportedDetectors": "Supported Detectors",
       "cameras": "Cameras",
       "loading": "Loading model information...",
-      "error": "Failed to load model information"
+      "error": "Failed to load model information",
+      "modelSelect": "Your available models on Frigate+ can be selected here. Note that only models compatible with your current detector configuration are shown."
+    },
+    "toast": {
+      "success": "Frigate+ settings have been saved. Restart Frigate to apply changes.",
+      "error": "Failed to save config changes: {{errorMessage}}"
     }
   }
 }

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -544,10 +544,12 @@
       "trainDate": "Train Date",
       "baseModel": "Base Model",
       "supportedDetectors": "Supported Detectors",
+      "dimensions": "Dimensions",
       "cameras": "Cameras",
       "loading": "Loading model information...",
       "error": "Failed to load model information",
       "availableModels": "Available Models",
+      "loadingAvailableModels": "Loading available models...",
       "modelSelect": "Your available models on Frigate+ can be selected here. Note that only models compatible with your current detector configuration can be selected."
     },
     "toast": {

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -548,7 +548,7 @@
       "loading": "Loading model information...",
       "error": "Failed to load model information",
       "availableModels": "Available Models",
-      "modelSelect": "Your available models on Frigate+ can be selected here. Note that only models compatible with your current detector configuration are shown."
+      "modelSelect": "Your available models on Frigate+ can be selected here. Note that only models compatible with your current detector configuration can be selected."
     },
     "toast": {
       "success": "Frigate+ settings have been saved. Restart Frigate to apply changes.",

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -278,7 +278,9 @@ export default function Settings() {
         {page == "notifications" && (
           <NotificationView setUnsavedChanges={setUnsavedChanges} />
         )}
-        {page == "frigateplus" && <FrigatePlusSettingsView />}
+        {page == "frigateplus" && (
+          <FrigatePlusSettingsView setUnsavedChanges={setUnsavedChanges} />
+        )}
       </div>
       {confirmationDialogOpen && (
         <AlertDialog

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -397,6 +397,8 @@ export interface FrigateConfig {
       trainDate: string;
       baseModel: string;
       supportedDetectors: string[];
+      width: number;
+      height: number;
     };
   };
 

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -339,7 +339,7 @@ export default function FrigatePlusSettingsView({
                                       frigatePlusSettings.model.id
                                     ].width + "x" + availableModels[
                                       frigatePlusSettings.model.id
-                                    ].height) + ")
+                                    ].height) + ")"
                                : "Retrieving models..."}
                             </SelectTrigger>
                             <SelectContent>

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -122,7 +122,9 @@ export default function FrigatePlusSettingsView({
     setIsLoading(true);
 
     axios
-      .put(`config/set?model.path=plus://${frigatePlusSettings.model.id}`, {})
+      .put(`config/set?model.path=plus://${frigatePlusSettings.model.id}`, {
+        requires_restart: 0,
+      })
       .then((res) => {
         if (res.status === 200) {
           toast.success(t("frigatePlus.toast.success"), {
@@ -321,15 +323,14 @@ export default function FrigatePlusSettingsView({
                             }
                           >
                             <SelectTrigger>
-                              {(() => {
-                                const modelId = frigatePlusSettings?.model?.id;
-                                return modelId &&
-                                  availableModels?.[modelId]?.trainDate
-                                  ? new Date(
-                                      availableModels[modelId].trainDate,
-                                    ).toLocaleString()
-                                  : "Retrieving models...";
-                              })()}
+                              {frigatePlusSettings.model.id &&
+                              availableModels?.[frigatePlusSettings.model.id]
+                                ? new Date(
+                                    availableModels[
+                                      frigatePlusSettings.model.id
+                                    ].trainDate,
+                                  ).toLocaleString()
+                                : "Retrieving models..."}
                             </SelectTrigger>
                             <SelectContent>
                               <SelectGroup>

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -25,7 +25,10 @@ import {
 
 type FrigatePlusModel = {
   id: string;
+  type: string;
+  supportedDetectors: string[];
   trainDate: string;
+  baseModel: string;
 };
 
 type FrigatePlusSettings = {
@@ -305,7 +308,10 @@ export default function FrigatePlusSettingsView({
                             }
                           >
                             <SelectTrigger>
-                              {frigatePlusSettings.model.id}
+                              {new Date(
+                                config.model.plus.trainDate,
+                              ).toLocaleString()}{" "}
+                              ({config.model.plus.baseModel})
                             </SelectTrigger>
                             <SelectContent>
                               <SelectGroup>
@@ -314,9 +320,17 @@ export default function FrigatePlusSettingsView({
                                     key={model.id}
                                     className="cursor-pointer"
                                     value={model.id}
+                                    disabled={
+                                      model.type != config.model.model_type ||
+                                      !model.supportedDetectors.includes(
+                                        Object.values(config.detectors)[0].type,
+                                      )
+                                    }
                                   >
-                                    {new Date(model.trainDate).toLocaleString()}
-                                    <div className="text-muted-foreground">
+                                    {new Date(model.trainDate).toLocaleString()}{" "}
+                                    ({model.baseModel}) (
+                                    {model.supportedDetectors.join(", ")})
+                                    <div className="text-xs text-muted-foreground">
                                       {model.id}
                                     </div>
                                   </SelectItem>

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -131,6 +131,12 @@ export default function FrigatePlusSettingsView({
             position: "top-center",
           });
           setChangedValue(false);
+          addMessage(
+            "plus_restart",
+            "Restart required (Frigate+ model changed)",
+            undefined,
+            "plus_restart",
+          );
           updateConfig();
         } else {
           toast.error(
@@ -156,7 +162,7 @@ export default function FrigatePlusSettingsView({
       .finally(() => {
         setIsLoading(false);
       });
-  }, [updateConfig, frigatePlusSettings, t]);
+  }, [updateConfig, addMessage, frigatePlusSettings, t]);
 
   const onCancel = useCallback(() => {
     setFrigatePlusSettings(origPlusSettings);

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -331,16 +331,21 @@ export default function FrigatePlusSettingsView({
                             <SelectTrigger>
                               {frigatePlusSettings.model.id &&
                               availableModels?.[frigatePlusSettings.model.id]
-                                ? (new Date(
+                                ? new Date(
                                     availableModels[
                                       frigatePlusSettings.model.id
                                     ].trainDate,
-                                  ).toLocaleString() + " (" + availableModels[
-                                      frigatePlusSettings.model.id
-                                    ].width + "x" + availableModels[
-                                      frigatePlusSettings.model.id
-                                    ].height) + ")"
-                               : "Retrieving models..."}
+                                  ).toLocaleString() +
+                                  " (" +
+                                  availableModels[frigatePlusSettings.model.id]
+                                    .width +
+                                  "x" +
+                                  availableModels[frigatePlusSettings.model.id]
+                                    .height +
+                                  ")"
+                                : t(
+                                    "frigatePlus.modelInfo.loadingAvailableModels",
+                                  )}
                             </SelectTrigger>
                             <SelectContent>
                               <SelectGroup>
@@ -363,11 +368,16 @@ export default function FrigatePlusSettingsView({
                                       ).toLocaleString()}{" "}
                                       ({model.baseModel})
                                       <div>
-                                        Supported Detectors: ({model.supportedDetectors.join(", ")})
+                                        {t(
+                                          "frigatePlus.modelInfo.supportedDetectors",
+                                        )}
+                                        : ({model.supportedDetectors.join(", ")}
+                                        )
                                       </div>
                                       <div>
-                                        Dimensions ({model.width + "x" + model.height})
-                                      </div>                                      
+                                        {t("frigatePlus.modelInfo.dimensions")}{" "}
+                                        ({model.width + "x" + model.height})
+                                      </div>
                                       <div className="text-xs text-muted-foreground">
                                         {id}
                                       </div>

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -328,7 +328,7 @@ export default function FrigatePlusSettingsView({
                                   ? new Date(
                                       availableModels[modelId].trainDate,
                                     ).toLocaleString()
-                                  : "N/A";
+                                  : "Retrieving models...";
                               })()}
                             </SelectTrigger>
                             <SelectContent>

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -269,12 +269,6 @@ export default function FrigatePlusSettingsView({
                             ).toLocaleString()}
                           </p>
                         </div>
-                        <div className="col-span-2 md:col-span-1">
-                          <Label className="text-muted-foreground">
-                            {t("frigatePlus.modelInfo.modelId")}
-                          </Label>
-                          <p>{config.model.plus.id}</p>
-                        </div>
                         <div>
                           <Label className="text-muted-foreground">
                             {t("frigatePlus.modelInfo.baseModel")}
@@ -292,7 +286,7 @@ export default function FrigatePlusSettingsView({
                         <div className="col-span-2">
                           <div className="space-y-2">
                             <div className="text-md">
-                              {t("frigatePlus.modelInfo.modelId")}
+                              {t("frigatePlus.modelInfo.availableModels")}
                             </div>
                             <div className="space-y-3 text-sm text-muted-foreground">
                               <p>
@@ -321,9 +315,10 @@ export default function FrigatePlusSettingsView({
                                     className="cursor-pointer"
                                     value={model.id}
                                   >
-                                    {model.id} (
                                     {new Date(model.trainDate).toLocaleString()}
-                                    )
+                                    <div className="text-muted-foreground">
+                                      {model.id}
+                                    </div>
                                   </SelectItem>
                                 ))}
                               </SelectGroup>

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -357,9 +357,11 @@ export default function FrigatePlusSettingsView({
                                       {new Date(
                                         model.trainDate,
                                       ).toLocaleString()}{" "}
-                                      ({model.baseModel}) (
-                                      {model.supportedDetectors.join(", ")}) (
-                                      {model.width + "x" + model.height})
+                                      ({model.baseModel})
+                                      <div>
+                                        Supported Detectors: ({model.supportedDetectors.join(", ")}) Dimensions (
+                                        {model.width + "x" + model.height})
+                                      </div>
                                       <div className="text-xs text-muted-foreground">
                                         {id}
                                       </div>

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -1,19 +1,171 @@
 import Heading from "@/components/ui/heading";
 import { Label } from "@/components/ui/label";
-import { useEffect } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { Toaster } from "sonner";
 import { Separator } from "../../components/ui/separator";
+import ActivityIndicator from "@/components/indicators/activity-indicator";
+import { toast } from "sonner";
 import useSWR from "swr";
+import axios from "axios";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { CheckCircle2, XCircle } from "lucide-react";
 import { Trans, useTranslation } from "react-i18next";
 import { IoIosWarning } from "react-icons/io";
+import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
 import { LuExternalLink } from "react-icons/lu";
+import { StatusBarMessagesContext } from "@/context/statusbar-provider";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
 
-export default function FrigatePlusSettingsView() {
-  const { data: config } = useSWR<FrigateConfig>("config");
+type FrigatePlusModel = {
+  id: string;
+  trainDate: string;
+};
+
+type FrigatePlusSettings = {
+  model: {
+    id?: string;
+  };
+};
+
+type FrigateSettingsViewProps = {
+  setUnsavedChanges: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export default function FrigatePlusSettingsView({
+  setUnsavedChanges,
+}: FrigateSettingsViewProps) {
   const { t } = useTranslation("views/settings");
+  const { data: config, mutate: updateConfig } =
+    useSWR<FrigateConfig>("config");
+  const [changedValue, setChangedValue] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { addMessage, removeMessage } = useContext(StatusBarMessagesContext)!;
+
+  const [frigatePlusSettings, setFrigatePlusSettings] =
+    useState<FrigatePlusSettings>({
+      model: {
+        id: undefined,
+      },
+    });
+
+  const [origPlusSettings, setOrigPlusSettings] = useState<FrigatePlusSettings>(
+    {
+      model: {
+        id: undefined,
+      },
+    },
+  );
+
+  const { data: availableModels } = useSWR<FrigatePlusModel[]>("/plus/models", {
+    fallbackData: [],
+    fetcher: (url) =>
+      axios
+        .get(url, {
+          params: { filterByCurrentModelDetector: true },
+          withCredentials: true,
+        })
+        .then((res) => res.data),
+  });
+
+  useEffect(() => {
+    if (config) {
+      if (frigatePlusSettings?.model.id == undefined) {
+        setFrigatePlusSettings({
+          model: {
+            id: config.model.plus?.id,
+          },
+        });
+      }
+
+      setOrigPlusSettings({
+        model: {
+          id: config.model.plus?.id,
+        },
+      });
+    }
+    // we know that these deps are correct
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [config]);
+
+  const handleFrigatePlusConfigChange = (
+    newConfig: Partial<FrigatePlusSettings>,
+  ) => {
+    setFrigatePlusSettings((prevConfig) => ({
+      model: {
+        ...prevConfig.model,
+        ...newConfig.model,
+      },
+    }));
+    setUnsavedChanges(true);
+    setChangedValue(true);
+  };
+
+  const saveToConfig = useCallback(async () => {
+    setIsLoading(true);
+
+    axios
+      .put(`config/set?model.path=plus://${frigatePlusSettings.model.id}`, {})
+      .then((res) => {
+        if (res.status === 200) {
+          toast.success(t("frigatePlus.toast.success"), {
+            position: "top-center",
+          });
+          setChangedValue(false);
+          updateConfig();
+        } else {
+          toast.error(
+            t("frigatePlus.toast.error", { errorMessage: res.statusText }),
+            {
+              position: "top-center",
+            },
+          );
+        }
+      })
+      .catch((error) => {
+        const errorMessage =
+          error.response?.data?.message ||
+          error.response?.data?.detail ||
+          "Unknown error";
+        toast.error(
+          t("toast.save.error.title", { errorMessage, ns: "common" }),
+          {
+            position: "top-center",
+          },
+        );
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [updateConfig, frigatePlusSettings, t]);
+
+  const onCancel = useCallback(() => {
+    setFrigatePlusSettings(origPlusSettings);
+    setChangedValue(false);
+    removeMessage("plus_settings", "plus_settings");
+  }, [origPlusSettings, removeMessage]);
+
+  useEffect(() => {
+    if (changedValue) {
+      addMessage(
+        "plus_settings",
+        `Unsaved Frigate+ settings changes`,
+        undefined,
+        "plus_settings",
+      );
+    } else {
+      removeMessage("plus_settings", "plus_settings");
+    }
+    // we know that these deps are correct
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [changedValue]);
 
   useEffect(() => {
     document.title = t("documentTitle.frigatePlus");
@@ -27,6 +179,10 @@ export default function FrigatePlusSettingsView() {
       (camera) => camera.snapshots.enabled && !camera.snapshots.clean_copy,
     );
   };
+
+  if (!config) {
+    return <ActivityIndicator />;
+  }
 
   return (
     <>
@@ -133,6 +289,47 @@ export default function FrigatePlusSettingsView() {
                             {config.model.plus.supportedDetectors.join(", ")}
                           </p>
                         </div>
+                        <div className="col-span-2">
+                          <div className="space-y-2">
+                            <div className="text-md">
+                              {t("frigatePlus.modelInfo.modelId")}
+                            </div>
+                            <div className="space-y-3 text-sm text-muted-foreground">
+                              <p>
+                                <Trans ns="views/settings">
+                                  frigatePlus.modelInfo.modelSelect
+                                </Trans>
+                              </p>
+                            </div>
+                          </div>
+                          <Select
+                            value={frigatePlusSettings.model.id}
+                            onValueChange={(value) =>
+                              handleFrigatePlusConfigChange({
+                                model: { id: value as string },
+                              })
+                            }
+                          >
+                            <SelectTrigger>
+                              {frigatePlusSettings.model.id}
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectGroup>
+                                {availableModels?.map((model) => (
+                                  <SelectItem
+                                    key={model.id}
+                                    className="cursor-pointer"
+                                    value={model.id}
+                                  >
+                                    {model.id} (
+                                    {new Date(model.trainDate).toLocaleString()}
+                                    )
+                                  </SelectItem>
+                                ))}
+                              </SelectGroup>
+                            </SelectContent>
+                          </Select>
+                        </div>
                       </div>
                     )}
                   </div>
@@ -226,6 +423,34 @@ export default function FrigatePlusSettingsView() {
                   </div>
                 )}
               </div>
+            </div>
+
+            <Separator className="my-2 flex bg-secondary" />
+
+            <div className="flex w-full flex-row items-center gap-2 pt-2 md:w-[25%]">
+              <Button
+                className="flex flex-1"
+                aria-label={t("button.reset", { ns: "common" })}
+                onClick={onCancel}
+              >
+                {t("button.reset", { ns: "common" })}
+              </Button>
+              <Button
+                variant="select"
+                disabled={!changedValue || isLoading}
+                className="flex flex-1"
+                aria-label="Save"
+                onClick={saveToConfig}
+              >
+                {isLoading ? (
+                  <div className="flex flex-row items-center gap-2">
+                    <ActivityIndicator />
+                    <span>{t("button.saving", { ns: "common" })}</span>
+                  </div>
+                ) : (
+                  t("button.save", { ns: "common" })
+                )}
+              </Button>
             </div>
           </div>
         </div>

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -331,12 +331,16 @@ export default function FrigatePlusSettingsView({
                             <SelectTrigger>
                               {frigatePlusSettings.model.id &&
                               availableModels?.[frigatePlusSettings.model.id]
-                                ? new Date(
+                                ? (new Date(
                                     availableModels[
                                       frigatePlusSettings.model.id
                                     ].trainDate,
-                                  ).toLocaleString()
-                                : "Retrieving models..."}
+                                  ).toLocaleString() + " (" + availableModels[
+                                      frigatePlusSettings.model.id
+                                    ].width + "x" + availableModels[
+                                      frigatePlusSettings.model.id
+                                    ].height) + ")
+                               : "Retrieving models..."}
                             </SelectTrigger>
                             <SelectContent>
                               <SelectGroup>
@@ -359,9 +363,11 @@ export default function FrigatePlusSettingsView({
                                       ).toLocaleString()}{" "}
                                       ({model.baseModel})
                                       <div>
-                                        Supported Detectors: ({model.supportedDetectors.join(", ")}) Dimensions (
-                                        {model.width + "x" + model.height})
+                                        Supported Detectors: ({model.supportedDetectors.join(", ")})
                                       </div>
+                                      <div>
+                                        Dimensions ({model.width + "x" + model.height})
+                                      </div>                                      
                                       <div className="text-xs text-muted-foreground">
                                         {id}
                                       </div>

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -374,7 +374,7 @@ export default function FrigatePlusSettingsView({
                                         : {model.supportedDetectors.join(", ")}
                                       </div>
                                       <div>
-                                        {t("frigatePlus.modelInfo.dimensions")}{" "}
+                                        {t("frigatePlus.modelInfo.dimensions")}:{" "}
                                         {model.width + "x" + model.height}
                                       </div>
                                       <div className="text-xs text-muted-foreground">

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -371,12 +371,11 @@ export default function FrigatePlusSettingsView({
                                         {t(
                                           "frigatePlus.modelInfo.supportedDetectors",
                                         )}
-                                        : ({model.supportedDetectors.join(", ")}
-                                        )
+                                        : {model.supportedDetectors.join(", ")}
                                       </div>
                                       <div>
                                         {t("frigatePlus.modelInfo.dimensions")}{" "}
-                                        ({model.width + "x" + model.height})
+                                        {model.width + "x" + model.height}
                                       </div>
                                       <div className="text-xs text-muted-foreground">
                                         {id}


### PR DESCRIPTION
## Proposed change

* Adds an `/api/plus/models` endpoint which itself calls Frigate+'s `model/list` endpoint.
* Adds a dropdown to the Settings->Frigate+ page to show the available models for the current detector type and allow saving

![image](https://github.com/user-attachments/assets/6877c24b-1653-4ca4-8694-ebcedfd09ad2)

This borrows heavily from the Classification settings page. The React / UI design may need some review.

@blakeblackshear do you have any objection to the Frigate+ API being called when users navigate to the Frigate+ settings page? I'm assuming this is relatively infrequent and so won't generate excessive load on your infrastructure but if you would prefer it was a manual "Check for updates" link I could change to that.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
