### PR TITLE
Devcontainers - don't require /dev/bus/usb to be present

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,8 @@ services:
     #                     capabilities: [gpu]
     environment:
       YOLO_MODELS: ""
-    devices:
-      - /dev/bus/usb:/dev/bus/usb
+    # devices:
+      # - /dev/bus/usb:/dev/bus/usb # Uncomment for Google Coral USB
       # - /dev/dri:/dev/dri # for intel hwaccel, needs to be updated for your hardware
     volumes:
       - .:/workspace/frigate:cached
@@ -32,7 +32,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ./config:/config
       - ./debug:/media/frigate
-      - /dev/bus/usb:/dev/bus/usb
+     # - /dev/bus/usb:/dev/bus/usb # Uncomment for Google Coral USB
   mqtt:
     container_name: mqtt
     image: eclipse-mosquitto:1.6


### PR DESCRIPTION
## Proposed change

Github Codespaces fails trying to build the Frigate devcontainers as `/dev/bus/usb` is not accessible to the Codespaces VM. This probably never shows up on a desktop dev environment as you'd always expect a USB bus, but for cloud machines that's less likely.

It seems reasonable to expect contributors to uncomment this if required in their dev environment, given other device-specific settings in here.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
