### PR TITLE
Revert go2rtc call checks for enabled camera state

### DIFF
--- a/web/src/components/settings/CameraStreamingDialog.tsx
+++ b/web/src/components/settings/CameraStreamingDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
-import { useCameraActivity } from "@/hooks/use-camera-activity";
+import { useEnabledState } from "@/api/ws";
 import { IoIosWarning } from "react-icons/io";
 import { Button } from "@/components/ui/button";
 import {
@@ -24,7 +24,6 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import {
   FrigateConfig,
-  CameraConfig,
   GroupStreamingSettings,
   StreamType,
 } from "@/types/frigateConfig";
@@ -66,9 +65,8 @@ export function CameraStreamingDialog({
   // metadata
 
   // camera enabled state
-  const { enabled: isCameraEnabled } = useCameraActivity(
-    config?.cameras[camera] ?? ({} as CameraConfig),
-  );
+  const { payload: enabledState } = useEnabledState(camera);
+  const cameraEnabled = enabledState === "ON";
 
   const isRestreamed = useMemo(
     () =>
@@ -78,7 +76,7 @@ export function CameraStreamingDialog({
   );
 
   const { data: cameraMetadata } = useSWR<LiveStreamMetadata>(
-    isCameraEnabled && isRestreamed ? `go2rtc/streams/${streamName}` : null,
+    cameraEnabled && isRestreamed ? `go2rtc/streams/${streamName}` : null,
     {
       revalidateOnFocus: false,
     },

--- a/web/src/components/settings/CameraStreamingDialog.tsx
+++ b/web/src/components/settings/CameraStreamingDialog.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
-import { useEnabledState } from "@/api/ws";
 import { IoIosWarning } from "react-icons/io";
 import { Button } from "@/components/ui/button";
 import {
@@ -64,10 +63,6 @@ export function CameraStreamingDialog({
 
   // metadata
 
-  // camera enabled state
-  const { payload: enabledState } = useEnabledState(camera);
-  const cameraEnabled = enabledState === "ON";
-
   const isRestreamed = useMemo(
     () =>
       config &&
@@ -76,7 +71,7 @@ export function CameraStreamingDialog({
   );
 
   const { data: cameraMetadata } = useSWR<LiveStreamMetadata>(
-    cameraEnabled && isRestreamed ? `go2rtc/streams/${streamName}` : null,
+    isRestreamed ? `go2rtc/streams/${streamName}` : null,
     {
       revalidateOnFocus: false,
     },

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -142,11 +142,8 @@ export default function LiveCameraView({
   const [{ width: windowWidth, height: windowHeight }] =
     useResizeObserver(window);
 
-  // camera enabled state
-  const { payload: enabledState } = useEnabledState(camera.name);
-  const cameraEnabled = enabledState === "ON";
-
   // supported features
+
   const [streamName, setStreamName] = usePersistence<string>(
     `${camera.name}-stream`,
     Object.values(camera.live.streams)[0],
@@ -160,7 +157,7 @@ export default function LiveCameraView({
   );
 
   const { data: cameraMetadata } = useSWR<LiveStreamMetadata>(
-    cameraEnabled && isRestreamed ? `go2rtc/streams/${streamName}` : null,
+    isRestreamed ? `go2rtc/streams/${streamName}` : null,
     {
       revalidateOnFocus: false,
     },
@@ -194,6 +191,10 @@ export default function LiveCameraView({
       ) != undefined
     );
   }, [cameraMetadata]);
+
+  // camera enabled state
+  const { payload: enabledState } = useEnabledState(camera.name);
+  const cameraEnabled = enabledState === "ON";
 
   // click overlay for ptzs
 

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -112,7 +112,6 @@ import {
   SelectTrigger,
 } from "@/components/ui/select";
 import { usePersistence } from "@/hooks/use-persistence";
-import { useCameraActivity } from "@/hooks/use-camera-activity";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import axios from "axios";
@@ -144,9 +143,8 @@ export default function LiveCameraView({
     useResizeObserver(window);
 
   // camera enabled state
-  const { enabled: isCameraEnabled } = useCameraActivity(
-    config?.cameras[camera.name] ?? ({} as CameraConfig),
-  );
+  const { payload: enabledState } = useEnabledState(camera.name);
+  const cameraEnabled = enabledState === "ON";
 
   // supported features
   const [streamName, setStreamName] = usePersistence<string>(
@@ -162,7 +160,7 @@ export default function LiveCameraView({
   );
 
   const { data: cameraMetadata } = useSWR<LiveStreamMetadata>(
-    isCameraEnabled && isRestreamed ? `go2rtc/streams/${streamName}` : null,
+    cameraEnabled && isRestreamed ? `go2rtc/streams/${streamName}` : null,
     {
       revalidateOnFocus: false,
     },
@@ -522,7 +520,7 @@ export default function LiveCameraView({
                       setPip(false);
                     }
                   }}
-                  disabled={!isCameraEnabled}
+                  disabled={!cameraEnabled}
                 />
               )}
               {supports2WayTalk && (
@@ -544,7 +542,7 @@ export default function LiveCameraView({
                       setAudio(true);
                     }
                   }}
-                  disabled={!isCameraEnabled}
+                  disabled={!cameraEnabled}
                 />
               )}
               {supportsAudioOutput && preferredLiveMode != "jsmpeg" && (
@@ -561,7 +559,7 @@ export default function LiveCameraView({
                     t("button.cameraAudio", { ns: "common" })
                   }
                   onClick={() => setAudio(!audio)}
-                  disabled={!isCameraEnabled}
+                  disabled={!cameraEnabled}
                 />
               )}
               <FrigateCameraFeatures
@@ -583,7 +581,7 @@ export default function LiveCameraView({
                 setLowBandwidth={setLowBandwidth}
                 supportsAudioOutput={supportsAudioOutput}
                 supports2WayTalk={supports2WayTalk}
-                cameraEnabled={isCameraEnabled ?? false}
+                cameraEnabled={cameraEnabled}
               />
             </div>
           </TooltipProvider>


### PR DESCRIPTION
## Proposed change

Revert the two commits where I introduced a check on camera enabled state before attempting connection to `api/go2rtc/streams/<camera>` because of possible side effects reported in dev builds.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
