### PR TITLE
Increase the initial stall timeout of the MSE player

### DIFF
--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -461,6 +461,7 @@ function MSEPlayer({
         setBufferTimeout(undefined);
       }
 
+      const timeoutDuration = bufferTime == 0 ? 5000 : 3000;
       setBufferTimeout(
         setTimeout(() => {
           if (
@@ -471,7 +472,7 @@ function MSEPlayer({
             onDisconnect();
             onError("stalled");
           }
-        }, 3000),
+        }, timeoutDuration),
       );
     }
   }, [


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Increase the initial timeout to 5 seconds from 3. Since introducing this in 0.14, it seems like users have generally preferred waiting a little more time to see a high quality stream rather than a jsmpeg fallback more quickly.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
