### PR TITLE
Make all object path points clickable

### DIFF
--- a/web/src/components/overlay/detail/ObjectLifecycle.tsx
+++ b/web/src/components/overlay/detail/ObjectLifecycle.tsx
@@ -285,9 +285,16 @@ export default function ObjectLifecycle({
 
   useEffect(() => {
     if (eventSequence && eventSequence.length > 0) {
-      setTimeIndex(eventSequence?.[current].timestamp);
-      handleSetBox(eventSequence?.[current].data.box ?? []);
-      setLifecycleZones(eventSequence?.[current].data.zones);
+      if (current == -1) {
+        // normal path point
+        setBoxStyle(null);
+        setLifecycleZones([]);
+      } else {
+        // lifecycle point
+        setTimeIndex(eventSequence?.[current].timestamp);
+        handleSetBox(eventSequence?.[current].data.box ?? []);
+        setLifecycleZones(eventSequence?.[current].data.zones);
+      }
       setSelectedZone("");
     }
   }, [current, imgLoaded, handleSetBox, eventSequence]);
@@ -322,6 +329,10 @@ export default function ObjectLifecycle({
         mainApi.scrollTo(sequenceIndex);
         thumbnailApi.scrollTo(sequenceIndex);
         setCurrent(sequenceIndex);
+      } else {
+        // click on a normal path point, not a lifecycle point
+        setCurrent(-1);
+        setTimeIndex(pathPoints[index].timestamp);
       }
     },
     [mainApi, thumbnailApi, eventSequence, pathPoints],

--- a/web/src/components/overlay/detail/ObjectPath.tsx
+++ b/web/src/components/overlay/detail/ObjectPath.tsx
@@ -95,10 +95,8 @@ export function ObjectPath({
               fill={getPointColor(color, pos.lifecycle_item?.class_type)}
               stroke="white"
               strokeWidth={width / 2}
-              onClick={() =>
-                pos.lifecycle_item && onPointClick && onPointClick(index)
-              }
-              style={{ cursor: pos.lifecycle_item ? "pointer" : "default" }}
+              onClick={() => onPointClick && onPointClick(index)}
+              style={{ cursor: "pointer" }}
             />
           </TooltipTrigger>
           <TooltipPortal>


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Update the recording stream snapshot when an object path point is clicked and hide the box/zones if it's not a lifecycle point.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
