### PR TITLE
LPR: reduce expansion of license_plate box for frigate+ models

### DIFF
--- a/frigate/data_processing/common/license_plate/mixin.py
+++ b/frigate/data_processing/common/license_plate/mixin.py
@@ -1135,9 +1135,9 @@ class LicensePlateProcessingMixin:
 
                 license_plate_frame = cv2.cvtColor(frame, cv2.COLOR_YUV2BGR_I420)
 
-                # Expand the license_plate_box by 30%
+                # Expand the license_plate_box by 10%
                 box_array = np.array(license_plate_box)
-                expansion = (box_array[2:] - box_array[:2]) * 0.30
+                expansion = (box_array[2:] - box_array[:2]) * 0.10
                 expanded_box = np.array(
                     [
                         license_plate_box[0] - expansion[0],


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Some characters (especially on commercial vehicles) were being picked up and assumed to be the recognized plate because of the amount of expansion of the license_plate box. This PR reduces that expansion to 10% (from 30%) of its size.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
