### PR TITLE
LPR bugfix

### DIFF
--- a/frigate/data_processing/post/license_plate.py
+++ b/frigate/data_processing/post/license_plate.py
@@ -139,7 +139,7 @@ class LicensePlatePostProcessor(LicensePlateProcessingMixin, PostProcessorApi):
         scale_y = image.shape[0] / detect_height
 
         # Determine which box to enlarge based on detection mode
-        if self.requires_license_plate_detection:
+        if "license_plate" not in self.config.cameras[camera_name].objects.track:
             # Scale and enlarge the car box
             box = obj_data.get("box")
             if not box:
@@ -189,7 +189,7 @@ class LicensePlatePostProcessor(LicensePlateProcessingMixin, PostProcessorApi):
         )
 
         keyframe_obj_data = obj_data.copy()
-        if self.requires_license_plate_detection:
+        if "license_plate" not in self.config.cameras[camera_name].objects.track:
             # car box
             keyframe_obj_data["box"] = [new_left, new_top, new_right, new_bottom]
         else:

--- a/frigate/embeddings/onnx/lpr_embedding.py
+++ b/frigate/embeddings/onnx/lpr_embedding.py
@@ -261,8 +261,10 @@ class LicensePlateDetector(BaseEmbedding):
     def _preprocess_inputs(self, raw_inputs):
         if isinstance(raw_inputs, list):
             raise ValueError("License plate embedding does not support batch inputs.")
-        # Get image as numpy array
-        img = self._process_image(raw_inputs)
+
+        pil = self._process_image(raw_inputs)
+        # image as numpy array
+        img = np.array(pil)
         height, width, channels = img.shape
 
         # Resize maintaining aspect ratio

--- a/frigate/embeddings/onnx/lpr_embedding.py
+++ b/frigate/embeddings/onnx/lpr_embedding.py
@@ -262,9 +262,7 @@ class LicensePlateDetector(BaseEmbedding):
         if isinstance(raw_inputs, list):
             raise ValueError("License plate embedding does not support batch inputs.")
 
-        pil = self._process_image(raw_inputs)
-        # image as numpy array
-        img = np.array(pil)
+        img = raw_inputs
         height, width, channels = img.shape
 
         # Resize maintaining aspect ratio


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
The face recognition refactor changed the embedding `_preprocess_image` function to return a PIL image, LPR required it to be a numpy array. This PR:
- removes the call to the preprocess function and just uses the raw input as the image.
- cleans up LPR debugging.
- changes the requirement for running the yolov9 lp detector to checking the camera specific config for no `license_plate` rather than the global `all_objects`


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
