### PR TITLE
Fix missing restart notification in Classification settings

### DIFF
--- a/web/src/views/settings/ClassificationSettingsView.tsx
+++ b/web/src/views/settings/ClassificationSettingsView.tsx
@@ -176,8 +176,8 @@ export default function ClassificationSettingsView({
       })
       .finally(() => {
         addMessage(
-          "search_settings",
-          `Restart Required (Classification settings changed)`,
+          "search_settings_restart",
+          `Restart required (Classification settings changed)`,
           undefined,
           "search_settings",
         );

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -131,12 +131,6 @@ export default function FrigatePlusSettingsView({
             position: "top-center",
           });
           setChangedValue(false);
-          addMessage(
-            "plus_restart",
-            "Restart required (Frigate+ model changed)",
-            undefined,
-            "plus_restart",
-          );
           updateConfig();
         } else {
           toast.error(
@@ -160,6 +154,12 @@ export default function FrigatePlusSettingsView({
         );
       })
       .finally(() => {
+        addMessage(
+          "plus_restart",
+          "Restart required (Frigate+ model changed)",
+          undefined,
+          "plus_restart",
+        );
         setIsLoading(false);
       });
   }, [updateConfig, addMessage, frigatePlusSettings, t]);


### PR DESCRIPTION
## Proposed change
The restart message on the Classification settings paged was being added then almost instantly cleared because it used the same message `key` as the unsaved changes message, which was cleared out by `changedValue`'s state.

Fix that, and move the restart message I added recently to the Frigate+ settings to the finally() block as well for consistency.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
