### PR TITLE
i18n Settings fixes

### DIFF
--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -11,9 +11,9 @@
     "frigatePlus": "Frigate+ Settings - Frigate"
   },
   "menu": {
-    "uiSettings": "UI Settings",
-    "classificationSettings": "Classification Settings",
-    "cameraSettings": "Camera Settings",
+    "ui": "UI",
+    "classification": "Classification",
+    "cameras": "Camera Settings",
     "masksAndZones": "Masks / Zones",
     "motionTuner": "Motion Tuner",
     "debug": "Debug",

--- a/web/public/locales/zh-CN/views/settings.json
+++ b/web/public/locales/zh-CN/views/settings.json
@@ -11,9 +11,9 @@
     "frigatePlus": "Frigate+ 设置 - Frigate"
   },
   "menu": {
-    "uiSettings": "界面设置",
-    "classificationSettings": "分类设置",
-    "cameraSettings": "摄像头设置",
+    "ui": "界面设置",
+    "classification": "分类设置",
+    "cameras": "摄像头设置",
     "masksAndZones": "遮罩/ 区域",
     "motionTuner": "运动调整器",
     "debug": "调试",
@@ -109,16 +109,16 @@
       "desc": "人脸识别功能允许为人物分配名称，当识别到他们的面孔时，Frigate 会将人物的名字作为子标签进行分配。这些信息会显示在界面、过滤器以及通知中。",
       "readTheDocumentation": "阅读文档（英文）",
       "modelSize": {
-          "label": "模型大小",
-          "desc": "用于人脸识别的模型尺寸。",
-          "small": {
-              "title": "小模型",
-              "desc": "使用<em>小模型</em>将采用OpenCV的局部二值模式直方图(LBPH)算法，可在大多数CPU上高效运行。"
-          },
-          "large": {
-              "title": "大模型",
-              "desc": "使用<em>大模型</em>将采用ArcFace人脸嵌入模型，若适用将自动在GPU上运行。"
-          }
+        "label": "模型大小",
+        "desc": "用于人脸识别的模型尺寸。",
+        "small": {
+          "title": "小模型",
+          "desc": "使用<em>小模型</em>将采用OpenCV的局部二值模式直方图(LBPH)算法，可在大多数CPU上高效运行。"
+        },
+        "large": {
+          "title": "大模型",
+          "desc": "使用<em>大模型</em>将采用ArcFace人脸嵌入模型，若适用将自动在GPU上运行。"
+        }
       }
     },
     "licensePlateRecognition": {
@@ -565,8 +565,8 @@
       "modelSelect": "您可以在Frigate+上选择可用的模型。请注意，只能选择与当前探测器配置兼容的模型。"
     },
     "toast": {
-        "success": "Frigate+ 设置已保存。请重启 Frigate 以应用更改。",
-        "error": "配置更改保存失败：{{errorMessage}}"
+      "success": "Frigate+ 设置已保存。请重启 Frigate 以应用更改。",
+      "error": "配置更改保存失败：{{errorMessage}}"
     }
   }
 }


### PR DESCRIPTION
## Proposed change

Several of the i18n keys were wrong for the Settings topbar. The only reason this wasn't noticeable is that the web was capitalising the first letter of the settings page name; I spotted it because of "Ui".

Fixed the keys and shortened the English strings to match what was previously displayed.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
