### PR TITLE
nginx: don't gzip png, gif, jpeg or jpg

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -30,7 +30,7 @@ http {
 
     gzip on;
     gzip_comp_level 6;
-    gzip_types text/plain text/css application/json application/x-javascript application/javascript text/javascript image/svg+xml image/x-icon image/bmp image/png image/gif image/jpeg image/jpg;
+    gzip_types text/plain text/css application/json application/x-javascript application/javascript text/javascript image/svg+xml image/x-icon image/bmp;
     gzip_proxied no-cache no-store private expired auth;
     gzip_vary on;
 


### PR DESCRIPTION
## Proposed change

It is generally held that compressing already-compressed image files (PNG, JPG, GIF) is pointless or even counterproductive. Currently Frigate does this via nginx config.

`gzip_types text/plain text/css application/json application/x-javascript application/javascript text/javascript image/svg+xml image/x-icon image/bmp image/png image/gif image/jpeg image/jpg;`

In the original PR when this was introduced you can see for two of the three images served it actually _increased_ their size https://github.com/blakeblackshear/frigate/pull/660 which is a commonly reported occurrence.

I compressed my `/media/frigate/clips` test directory containing ~7,300 files and it went from 58.3M to 57.8M, or ~0.7% reduction, which isn't remotely worth the CPU latency of compressing on the server and decompressing on device.

```
# ls -l thumbs/front_porch/ | wc -l
7322
# cp -r front_porch/ front_porch_gzip
# gzip -6 front_porch_gzip/*
# du front_porch/ front_porch_gzip/
57880   front_porch/
58332   front_porch_gzip/
```

The UI seems to be moving more and more to .webp anyway (also already compressed) - but not included in the `gzip_types` directive.

For anyone using a proxy this is likely irrelevant as nginx shouldn't cache when behind a proxy server.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
