### PR TITLE
Change Semantic Search reindex to reindex_on_startup and reset to false on completion

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -535,7 +535,8 @@ semantic_search:
   # Optional: Enable semantic search (default: shown below)
   enabled: False
   # Optional: Re-index embeddings database from historical tracked objects (default: shown below)
-  reindex: False
+  # Resets on successful completion
+  reindex_next_startup: False
   # Optional: Set the model used for embeddings. (default: shown below)
   model: "jinav1"
   # Optional: Set the model size used for embeddings. (default: shown below)

--- a/docs/docs/configuration/semantic_search.md
+++ b/docs/docs/configuration/semantic_search.md
@@ -24,14 +24,14 @@ Semantic Search is disabled by default, and must be enabled in your config file 
 ```yaml
 semantic_search:
   enabled: True
-  reindex: False
+  reindex_next_startup: False
 ```
 
 :::tip
 
-The embeddings database can be re-indexed from the existing tracked objects in your database by adding `reindex: True` to your `semantic_search` configuration or by toggling the switch on the Search Settings page in the UI and restarting Frigate. Depending on the number of tracked objects you have, it can take a long while to complete and may max out your CPU while indexing. Make sure to turn the UI's switch off or set the config back to `False` before restarting Frigate again.
+The embeddings database can be re-indexed from the existing tracked objects in your database by adding `reindex_next_startup: True` to your `semantic_search` configuration or by toggling the switch on the Search Settings page in the UI and restarting Frigate. Depending on the number of tracked objects you have, it can take a long while to complete and may max out your CPU while indexing. Once completed, this will automatically be set back to `False`.
 
-If you are enabling Semantic Search for the first time, be advised that Frigate does not automatically index older tracked objects. You will need to enable the `reindex` feature in order to do that.
+If you are enabling Semantic Search for the first time, be advised that Frigate does not automatically index older tracked objects. You will need to enable the `reindex_next_startup` feature in order to do that.
 
 :::
 

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -37,8 +37,9 @@ class ClassificationConfig(FrigateBaseModel):
 
 class SemanticSearchConfig(FrigateBaseModel):
     enabled: bool = Field(default=False, title="Enable semantic search.")
-    reindex: Optional[bool] = Field(
-        default=False, title="Reindex all tracked objects on startup."
+    reindex_next_startup: Optional[bool] = Field(
+        default=False,
+        title="Reindex all tracked objects on next startup. Resets to false on completion.",
     )
     model: Optional[SemanticSearchModelEnum] = Field(
         default=SemanticSearchModelEnum.jinav1,

--- a/frigate/embeddings/embeddings.py
+++ b/frigate/embeddings/embeddings.py
@@ -20,7 +20,8 @@ from frigate.data_processing.types import DataProcessorMetrics
 from frigate.db.sqlitevecq import SqliteVecQueueDatabase
 from frigate.models import Event
 from frigate.types import ModelStatusTypesEnum
-from frigate.util.builtin import serialize
+from frigate.util.builtin import serialize, update_yaml_file
+from frigate.util.config import find_config_file
 from frigate.util.path import get_event_thumbnail_bytes
 
 from .onnx.jina_v1_embedding import JinaV1ImageEmbedding, JinaV1TextEmbedding
@@ -366,5 +367,13 @@ class Embeddings:
             round(time.time() - st, 1),
         )
         totals["status"] = "completed"
+
+        self.config.semantic_search.reindex_next_startup = False
+
+        update_yaml_file(
+            find_config_file(),
+            ["semantic_search", "reindex_next_startup"],
+            False,
+        )
 
         self.requestor.send_data(UPDATE_EMBEDDINGS_REINDEX_PROGRESS, totals)

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -85,7 +85,7 @@ class EmbeddingMaintainer(threading.Thread):
             self.embeddings = Embeddings(config, db, metrics)
 
             # Check if we need to re-index events
-            if config.semantic_search.reindex:
+            if config.semantic_search.reindex_next_startup:
                 self.embeddings.reindex()
 
         # create communication for updating event descriptions

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -89,7 +89,7 @@
       "readTheDocumentation": "Read the Documentation",
       "reindexOnStartup": {
         "label": "Re-Index On Startup",
-        "desc": "Re-indexing will reprocess all thumbnails and descriptions (if enabled) and apply the embeddings on each startup. <em>Don't forget to disable the option after restarting!</em>"
+        "desc": "Re-indexing will reprocess all thumbnails and descriptions (if enabled) and apply the embeddings at next startup. This field will be reset after successfully completing."
       },
       "modelSize": {
         "label": "Model Size",

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -486,7 +486,7 @@ export interface FrigateConfig {
 
   semantic_search: {
     enabled: boolean;
-    reindex: boolean;
+    reindex_next_startup: boolean;
     model: SearchModel;
     model_size: SearchModelSize;
   };

--- a/web/src/views/settings/ClassificationSettingsView.tsx
+++ b/web/src/views/settings/ClassificationSettingsView.tsx
@@ -267,8 +267,13 @@ export default function ClassificationSettingsView({
               <Switch
                 id="reindex"
                 className="mr-3"
-                disabled={classificationSettings.search.reindex_next_startup === undefined}
-                checked={classificationSettings.search.reindex_next_startup === true}
+                disabled={
+                  classificationSettings.search.reindex_next_startup ===
+                  undefined
+                }
+                checked={
+                  classificationSettings.search.reindex_next_startup === true
+                }
                 onCheckedChange={(isChecked) => {
                   handleClassificationConfigChange({
                     search: { reindex_next_startup: isChecked },

--- a/web/src/views/settings/ClassificationSettingsView.tsx
+++ b/web/src/views/settings/ClassificationSettingsView.tsx
@@ -25,7 +25,7 @@ import { Trans, useTranslation } from "react-i18next";
 type ClassificationSettings = {
   search: {
     enabled?: boolean;
-    reindex?: boolean;
+    reindex_next_startup?: boolean;
     model_size?: SearchModelSize;
   };
   face: {
@@ -55,7 +55,7 @@ export default function ClassificationSettingsView({
     useState<ClassificationSettings>({
       search: {
         enabled: undefined,
-        reindex: undefined,
+        reindex_next_startup: undefined,
         model_size: undefined,
       },
       face: {
@@ -71,7 +71,7 @@ export default function ClassificationSettingsView({
     useState<ClassificationSettings>({
       search: {
         enabled: undefined,
-        reindex: undefined,
+        reindex_next_startup: undefined,
         model_size: undefined,
       },
       face: {
@@ -89,7 +89,7 @@ export default function ClassificationSettingsView({
         setClassificationSettings({
           search: {
             enabled: config.semantic_search.enabled,
-            reindex: config.semantic_search.reindex,
+            reindex_next_startup: config.semantic_search.reindex_next_startup,
             model_size: config.semantic_search.model_size,
           },
           face: {
@@ -105,7 +105,7 @@ export default function ClassificationSettingsView({
       setOrigSearchSettings({
         search: {
           enabled: config.semantic_search.enabled,
-          reindex: config.semantic_search.reindex,
+          reindex_next_startup: config.semantic_search.reindex_next_startup,
           model_size: config.semantic_search.model_size,
         },
         face: {
@@ -141,7 +141,7 @@ export default function ClassificationSettingsView({
 
     axios
       .put(
-        `config/set?semantic_search.enabled=${classificationSettings.search.enabled ? "True" : "False"}&semantic_search.reindex=${classificationSettings.search.reindex ? "True" : "False"}&semantic_search.model_size=${classificationSettings.search.model_size}&face_recognition.enabled=${classificationSettings.face.enabled ? "True" : "False"}&face_recognition.model_size=${classificationSettings.face.model_size}&lpr.enabled=${classificationSettings.lpr.enabled ? "True" : "False"}`,
+        `config/set?semantic_search.enabled=${classificationSettings.search.enabled ? "True" : "False"}&semantic_search.reindex_next_startup=${classificationSettings.search.reindex_next_startup ? "True" : "False"}&semantic_search.model_size=${classificationSettings.search.model_size}&face_recognition.enabled=${classificationSettings.face.enabled ? "True" : "False"}&face_recognition.model_size=${classificationSettings.face.model_size}&lpr.enabled=${classificationSettings.lpr.enabled ? "True" : "False"}`,
         {
           requires_restart: 0,
         },
@@ -267,11 +267,11 @@ export default function ClassificationSettingsView({
               <Switch
                 id="reindex"
                 className="mr-3"
-                disabled={classificationSettings.search.reindex === undefined}
-                checked={classificationSettings.search.reindex === true}
+                disabled={classificationSettings.search.reindex_next_startup === undefined}
+                checked={classificationSettings.search.reindex_next_startup === true}
                 onCheckedChange={(isChecked) => {
                   handleClassificationConfigChange({
-                    search: { reindex: isChecked },
+                    search: { reindex_next_startup: isChecked },
                   });
                 }}
               />


### PR DESCRIPTION
## Proposed change

As per title, some slightly more intuitive behaviour for users, having been bit by this again recently.

Draft because I have one thing I can't see how to do - trigger the front-end to reset that particular config key from the server. I could add to `reindexState` for `if (reindexState.status === "completed")` in `Statusbar.tsx`, but not sure if I'm missing a better way?

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
