### PR TITLE
update YOLO_NAS notebook for python 3.11

### DIFF
--- a/notebooks/YOLO_NAS_Pretrained_Export.ipynb
+++ b/notebooks/YOLO_NAS_Pretrained_Export.ipynb
@@ -8,14 +8,14 @@
       },
       "outputs": [],
       "source": [
-        "! pip install -q super_gradients==3.7.1"
+        "! pip install -q git+https://github.com/Deci-AI/super-gradients.git"
       ]
     },
     {
       "cell_type": "code",
       "source": [
-        "! sed -i 's/sghub.deci.ai/sg-hub-nv.s3.amazonaws.com/' /usr/local/lib/python3.10/dist-packages/super_gradients/training/pretrained_models.py\n",
-        "! sed -i 's/sghub.deci.ai/sg-hub-nv.s3.amazonaws.com/' /usr/local/lib/python3.10/dist-packages/super_gradients/training/utils/checkpoint_utils.py"
+        "! sed -i 's/sghub.deci.ai/sg-hub-nv.s3.amazonaws.com/' /usr/local/lib/python3.11/dist-packages/super_gradients/training/pretrained_models.py\n",
+        "! sed -i 's/sghub.deci.ai/sg-hub-nv.s3.amazonaws.com/' /usr/local/lib/python3.11/dist-packages/super_gradients/training/utils/checkpoint_utils.py"
       ],
       "metadata": {
         "id": "NiRCt917KKcL"


### PR DESCRIPTION
The YOLO_NAS notebook currently fails on Google Colab
Google Colab updated to python 3.11 per https://medium.com/google-colab/colab-updated-to-python-3-11-00197d6172b1
super-gradients v3.7.1 is not compatible with py3.11 and install fails
super-gradients committed a [fix to master branch](https://github.com/Deci-AI/super-gradients/pull/1946) but did not cut a release since (acquired by Nvidia in the meantime)

## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR installs super-gradients from master branch, so it installs successfully on Google Colab, which is now running python 3.11
This PR also modifies the sed arguments to reference the correct paths in python 3.11

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
