### PR TITLE
Implement enchrichments events per second graph

### DIFF
--- a/frigate/data_processing/common/license_plate/mixin.py
+++ b/frigate/data_processing/common/license_plate/mixin.py
@@ -955,7 +955,7 @@ class LicensePlateProcessingMixin:
         """
         Update inference metrics.
         """
-        self.metrics.alpr_pps.value = (self.metrics.alpr_pps.value * 9 + duration) / 10
+        self.metrics.alpr_speed.value = (self.metrics.alpr_speed.value * 9 + duration) / 10
 
     def _generate_plate_event(self, camera: str, plate: str, plate_score: float) -> str:
         """Generate a unique ID for a plate event based on camera and text."""

--- a/frigate/data_processing/common/license_plate/mixin.py
+++ b/frigate/data_processing/common/license_plate/mixin.py
@@ -949,8 +949,8 @@ class LicensePlateProcessingMixin:
         """
         Update inference metrics.
         """
-        self.metrics.yolov9_lpr_fps.value = (
-            self.metrics.yolov9_lpr_fps.value * 9 + duration
+        self.metrics.yolov9_lpr_speed.value = (
+            self.metrics.yolov9_lpr_speed.value * 9 + duration
         ) / 10
 
     def __update_lpr_metrics(self, duration: float) -> None:

--- a/frigate/data_processing/common/license_plate/mixin.py
+++ b/frigate/data_processing/common/license_plate/mixin.py
@@ -987,7 +987,7 @@ class LicensePlateProcessingMixin:
     ):
         """Look for license plates in image."""
         self.metrics.alpr_pps.value = self.plates_rec_second.eps()
-        self.metrics.yolov9_pps.value = self.plates_det_second.eps()
+        self.metrics.yolov9_lpr_pps.value = self.plates_det_second.eps()
         camera = obj_data if dedicated_lpr else obj_data["camera"]
         current_time = int(datetime.datetime.now().timestamp())
 

--- a/frigate/data_processing/common/license_plate/mixin.py
+++ b/frigate/data_processing/common/license_plate/mixin.py
@@ -24,6 +24,7 @@ from frigate.comms.event_metadata_updater import (
 from frigate.config.camera.camera import CameraTypeEnum
 from frigate.const import CLIPS_DIR
 from frigate.embeddings.onnx.lpr_embedding import LPR_EMBEDDING_SIZE
+from frigate.util.builtin import EventsPerSecond
 from frigate.util.image import area
 
 logger = logging.getLogger(__name__)
@@ -34,11 +35,12 @@ WRITE_DEBUG_IMAGES = False
 class LicensePlateProcessingMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
+        self.plates_rec_second = EventsPerSecond()
+        self.plates_rec_second.start()
+        self.plates_det_second = EventsPerSecond()
+        self.plates_det_second.start()
         self.event_metadata_publisher = EventMetadataPublisher()
-
         self.ctc_decoder = CTCDecoder()
-
         self.batch_size = 6
 
         # Detection specific parameters
@@ -955,7 +957,9 @@ class LicensePlateProcessingMixin:
         """
         Update inference metrics.
         """
-        self.metrics.alpr_speed.value = (self.metrics.alpr_speed.value * 9 + duration) / 10
+        self.metrics.alpr_speed.value = (
+            self.metrics.alpr_speed.value * 9 + duration
+        ) / 10
 
     def _generate_plate_event(self, camera: str, plate: str, plate_score: float) -> str:
         """Generate a unique ID for a plate event based on camera and text."""
@@ -982,6 +986,8 @@ class LicensePlateProcessingMixin:
         self, obj_data: dict[str, any], frame: np.ndarray, dedicated_lpr: bool = False
     ):
         """Look for license plates in image."""
+        self.metrics.alpr_pps.value = self.plates_rec_second.eps()
+        self.metrics.yolov9_pps.value = self.plates_det_second.eps()
         camera = obj_data if dedicated_lpr else obj_data["camera"]
         current_time = int(datetime.datetime.now().timestamp())
 
@@ -1011,6 +1017,7 @@ class LicensePlateProcessingMixin:
             logger.debug(
                 f"{camera}: YOLOv9 LPD inference time: {(datetime.datetime.now().timestamp() - yolov9_start) * 1000:.2f} ms"
             )
+            self.plates_det_second.update()
             self.__update_yolov9_metrics(
                 datetime.datetime.now().timestamp() - yolov9_start
             )
@@ -1093,6 +1100,7 @@ class LicensePlateProcessingMixin:
                 logger.debug(
                     f"{camera}: YOLOv9 LPD inference time: {(datetime.datetime.now().timestamp() - yolov9_start) * 1000:.2f} ms"
                 )
+                self.plates_det_second.update()
                 self.__update_yolov9_metrics(
                     datetime.datetime.now().timestamp() - yolov9_start
                 )
@@ -1197,6 +1205,7 @@ class LicensePlateProcessingMixin:
         license_plates, confidences, areas = self._process_license_plate(
             camera, id, license_plate_frame
         )
+        self.plates_rec_second.update()
         self.__update_lpr_metrics(datetime.datetime.now().timestamp() - start)
 
         if license_plates:

--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -146,8 +146,8 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
         return face
 
     def __update_metrics(self, duration: float) -> None:
-        self.metrics.face_rec_fps.value = (
-            self.metrics.face_rec_fps.value * 9 + duration
+        self.metrics.face_rec_speed.value = (
+            self.metrics.face_rec_speed.value * 9 + duration
         ) / 10
 
     def process_frame(self, obj_data: dict[str, any], frame: np.ndarray):

--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -149,6 +149,7 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
         return face
 
     def __update_metrics(self, duration: float) -> None:
+        self.faces_per_second.update()
         self.metrics.face_rec_speed.value = (
             self.metrics.face_rec_speed.value * 9 + duration
         ) / 10
@@ -256,7 +257,6 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
                 max(0, face_box[0]) : min(frame.shape[1], face_box[2]),
             ]
 
-        self.faces_per_second.update()
         res = self.recognizer.classify(face_frame)
 
         if not res:

--- a/frigate/data_processing/types.py
+++ b/frigate/data_processing/types.py
@@ -6,18 +6,18 @@ from multiprocessing.sharedctypes import Synchronized
 
 
 class DataProcessorMetrics:
-    image_embeddings_fps: Synchronized
-    text_embeddings_sps: Synchronized
-    face_rec_fps: Synchronized
-    alpr_pps: Synchronized
-    yolov9_lpr_fps: Synchronized
+    image_embeddings_speed: Synchronized
+    text_embeddings_speed: Synchronized
+    face_rec_speed: Synchronized
+    alpr_speed: Synchronized
+    yolov9_lpr_speed: Synchronized
 
     def __init__(self):
-        self.image_embeddings_fps = mp.Value("d", 0.01)
-        self.text_embeddings_sps = mp.Value("d", 0.01)
-        self.face_rec_fps = mp.Value("d", 0.01)
-        self.alpr_pps = mp.Value("d", 0.01)
-        self.yolov9_lpr_fps = mp.Value("d", 0.01)
+        self.image_embeddings_speed = mp.Value("d", 0.01)
+        self.text_embeddings_speed = mp.Value("d", 0.01)
+        self.face_rec_speed = mp.Value("d", 0.01)
+        self.alpr_speed = mp.Value("d", 0.01)
+        self.yolov9_lpr_speed = mp.Value("d", 0.01)
 
 
 class DataProcessorModelRunner:

--- a/frigate/data_processing/types.py
+++ b/frigate/data_processing/types.py
@@ -25,7 +25,7 @@ class DataProcessorMetrics:
         self.alpr_speed = mp.Value("d", 0.01)
         self.alpr_pps = mp.Value("d", 0.0)
         self.yolov9_lpr_speed = mp.Value("d", 0.01)
-        self.yolov9_pps = mp.Value("d", 0.0)
+        self.yolov9_lpr_pps = mp.Value("d", 0.0)
 
 
 class DataProcessorModelRunner:

--- a/frigate/data_processing/types.py
+++ b/frigate/data_processing/types.py
@@ -11,7 +11,9 @@ class DataProcessorMetrics:
     face_rec_speed: Synchronized
     face_rec_fps: Synchronized
     alpr_speed: Synchronized
+    alpr_pps: Synchronized
     yolov9_lpr_speed: Synchronized
+    yolov9_lpr_pps: Synchronized
 
     def __init__(self):
         self.image_embeddings_speed = mp.Value("d", 0.01)
@@ -19,7 +21,9 @@ class DataProcessorMetrics:
         self.face_rec_speed = mp.Value("d", 0.01)
         self.face_rec_fps = mp.Value("d", 0.0)
         self.alpr_speed = mp.Value("d", 0.01)
+        self.alpr_pps = mp.Value("d", 0.0)
         self.yolov9_lpr_speed = mp.Value("d", 0.01)
+        self.yolov9_pps = mp.Value("d", 0.0)
 
 
 class DataProcessorModelRunner:

--- a/frigate/data_processing/types.py
+++ b/frigate/data_processing/types.py
@@ -9,6 +9,7 @@ class DataProcessorMetrics:
     image_embeddings_speed: Synchronized
     text_embeddings_speed: Synchronized
     face_rec_speed: Synchronized
+    face_rec_fps: Synchronized
     alpr_speed: Synchronized
     yolov9_lpr_speed: Synchronized
 
@@ -16,6 +17,7 @@ class DataProcessorMetrics:
         self.image_embeddings_speed = mp.Value("d", 0.01)
         self.text_embeddings_speed = mp.Value("d", 0.01)
         self.face_rec_speed = mp.Value("d", 0.01)
+        self.face_rec_fps = mp.Value("d", 0.0)
         self.alpr_speed = mp.Value("d", 0.01)
         self.yolov9_lpr_speed = mp.Value("d", 0.01)
 

--- a/frigate/data_processing/types.py
+++ b/frigate/data_processing/types.py
@@ -17,7 +17,9 @@ class DataProcessorMetrics:
 
     def __init__(self):
         self.image_embeddings_speed = mp.Value("d", 0.01)
+        self.image_embeddings_eps = mp.Value("d", 0.0)
         self.text_embeddings_speed = mp.Value("d", 0.01)
+        self.text_embeddings_eps = mp.Value("d", 0.0)
         self.face_rec_speed = mp.Value("d", 0.01)
         self.face_rec_fps = mp.Value("d", 0.0)
         self.alpr_speed = mp.Value("d", 0.01)

--- a/frigate/embeddings/embeddings.py
+++ b/frigate/embeddings/embeddings.py
@@ -175,8 +175,8 @@ class Embeddings:
             )
 
         duration = datetime.datetime.now().timestamp() - start
-        self.metrics.image_embeddings_fps.value = (
-            self.metrics.image_embeddings_fps.value * 9 + duration
+        self.metrics.image_embeddings_speed.value = (
+            self.metrics.image_embeddings_speed.value * 9 + duration
         ) / 10
 
         return embedding
@@ -209,8 +209,8 @@ class Embeddings:
             )
 
         duration = datetime.datetime.now().timestamp() - start
-        self.metrics.text_embeddings_sps.value = (
-            self.metrics.text_embeddings_sps.value * 9 + (duration / len(ids))
+        self.metrics.text_embeddings_speed.value = (
+            self.metrics.text_embeddings_speed.value * 9 + (duration / len(ids))
         ) / 10
 
         return embeddings
@@ -231,8 +231,8 @@ class Embeddings:
             )
 
         duration = datetime.datetime.now().timestamp() - start
-        self.metrics.text_embeddings_sps.value = (
-            self.metrics.text_embeddings_sps.value * 9 + duration
+        self.metrics.text_embeddings_speed.value = (
+            self.metrics.text_embeddings_speed.value * 9 + duration
         ) / 10
 
         return embedding
@@ -264,8 +264,8 @@ class Embeddings:
             )
 
         duration = datetime.datetime.now().timestamp() - start
-        self.metrics.text_embeddings_sps.value = (
-            self.metrics.text_embeddings_sps.value * 9 + (duration / len(ids))
+        self.metrics.text_embeddings_speed.value = (
+            self.metrics.text_embeddings_speed.value * 9 + (duration / len(ids))
         ) / 10
 
         return embeddings

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -236,6 +236,7 @@ class EmbeddingMaintainer(threading.Thread):
             return
 
         camera_config = self.config.cameras[camera]
+        self.embeddings.update_stats()
 
         # no need to process updated objects if face recognition, lpr, genai are disabled
         if not camera_config.genai.enabled and len(self.realtime_processors) == 0:

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -295,8 +295,14 @@ def stats_snapshot(
                     "image_embedding_speed": round(
                         embeddings_metrics.image_embeddings_speed.value * 1000, 2
                     ),
+                    "image_embedding": round(
+                        embeddings_metrics.image_embeddings_eps.value, 2
+                    ),
                     "text_embedding_speed": round(
                         embeddings_metrics.text_embeddings_speed.value * 1000, 2
+                    ),
+                    "text_embedding": round(
+                        embeddings_metrics.text_embeddings_eps.value, 2
                     ),
                 }
             )

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -293,27 +293,30 @@ def stats_snapshot(
             stats["embeddings"].update(
                 {
                     "image_embedding_speed": round(
-                        embeddings_metrics.image_embeddings_fps.value * 1000, 2
+                        embeddings_metrics.image_embeddings_speed.value * 1000, 2
                     ),
                     "text_embedding_speed": round(
-                        embeddings_metrics.text_embeddings_sps.value * 1000, 2
+                        embeddings_metrics.text_embeddings_speed.value * 1000, 2
                     ),
                 }
             )
 
         if config.face_recognition.enabled:
             stats["embeddings"]["face_recognition_speed"] = round(
-                embeddings_metrics.face_rec_fps.value * 1000, 2
+                embeddings_metrics.face_rec_speed.value * 1000, 2
+            )
+            stats["embeddings"]["face_recognition_rps"] = round(
+                embeddings_metrics.face_rec_rps, 2
             )
 
         if config.lpr.enabled:
             stats["embeddings"]["plate_recognition_speed"] = round(
-                embeddings_metrics.alpr_pps.value * 1000, 2
+                embeddings_metrics.alpr_speed.value * 1000, 2
             )
 
             if "license_plate" not in config.objects.all_objects:
                 stats["embeddings"]["yolov9_plate_detection_speed"] = round(
-                    embeddings_metrics.yolov9_lpr_fps.value * 1000, 2
+                    embeddings_metrics.yolov9_lpr_speed.value * 1000, 2
                 )
 
     get_processing_stats(config, stats, hwaccel_errors)

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -323,8 +323,7 @@ def stats_snapshot(
                 embeddings_metrics.alpr_pps.value, 2
             )
 
-            # covers dedicated and normal lpr modes
-            if embeddings_metrics.yolov9_lpr_pps.value:
+            if embeddings_metrics.yolov9_lpr_pps.value > 0.0:
                 stats["embeddings"]["yolov9_plate_detection_speed"] = round(
                     embeddings_metrics.yolov9_lpr_speed.value * 1000, 2
                 )

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -323,7 +323,7 @@ def stats_snapshot(
                 embeddings_metrics.alpr_pps.value, 2
             )
 
-            if "license_plate" not in config.objects.all_objects:
+            if embeddings_metrics.yolov9_lpr_pps.value:
                 stats["embeddings"]["yolov9_plate_detection_speed"] = round(
                     embeddings_metrics.yolov9_lpr_speed.value * 1000, 2
                 )

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -323,6 +323,7 @@ def stats_snapshot(
                 embeddings_metrics.alpr_pps.value, 2
             )
 
+            # covers dedicated and normal lpr modes
             if embeddings_metrics.yolov9_lpr_pps.value:
                 stats["embeddings"]["yolov9_plate_detection_speed"] = round(
                     embeddings_metrics.yolov9_lpr_speed.value * 1000, 2

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -305,18 +305,24 @@ def stats_snapshot(
             stats["embeddings"]["face_recognition_speed"] = round(
                 embeddings_metrics.face_rec_speed.value * 1000, 2
             )
-            stats["embeddings"]["face_recognition_fps"] = round(
-                embeddings_metrics.face_rec_speed.value, 2
+            stats["embeddings"]["face_recognition"] = round(
+                embeddings_metrics.face_rec_fps.value, 2
             )
 
         if config.lpr.enabled:
             stats["embeddings"]["plate_recognition_speed"] = round(
                 embeddings_metrics.alpr_speed.value * 1000, 2
             )
+            stats["embeddings"]["plate_recognition"] = round(
+                embeddings_metrics.alpr_pps.value, 2
+            )
 
             if "license_plate" not in config.objects.all_objects:
                 stats["embeddings"]["yolov9_plate_detection_speed"] = round(
                     embeddings_metrics.yolov9_lpr_speed.value * 1000, 2
+                )
+                stats["embeddings"]["yolov9_plate_detection"] = round(
+                    embeddings_metrics.yolov9_lpr_pps.value, 2
                 )
 
     get_processing_stats(config, stats, hwaccel_errors)

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -305,8 +305,8 @@ def stats_snapshot(
             stats["embeddings"]["face_recognition_speed"] = round(
                 embeddings_metrics.face_rec_speed.value * 1000, 2
             )
-            stats["embeddings"]["face_recognition_rps"] = round(
-                embeddings_metrics.face_rec_rps, 2
+            stats["embeddings"]["face_recognition_fps"] = round(
+                embeddings_metrics.face_rec_speed.value, 2
             )
 
         if config.lpr.enabled:

--- a/web/public/locales/en/views/system.json
+++ b/web/public/locales/en/views/system.json
@@ -3,7 +3,7 @@
     "cameras": "Cameras Stats - Frigate",
     "storage": "Storage Stats - Frigate",
     "general": "General Stats - Frigate",
-    "features": "Features Stats - Frigate",
+    "enrichments": "Enrichments Stats - Frigate",
     "logs": {
       "frigate": "Frigate Logs - Frigate",
       "go2rtc": "Go2RTC Logs - Frigate",
@@ -144,8 +144,9 @@
     "healthy": "System is healthy",
     "reindexingEmbeddings": "Reindexing embeddings ({{processed}}% complete)"
   },
-  "features": {
-    "title": "Features",
+  "enrichments": {
+    "title": "Enrichments",
+    "recsPerSecond": "Recognitions Per Second",
     "embeddings": {
       "image_embedding_speed": "Image Embedding Speed",
       "face_embedding_speed": "Face Embedding Speed",

--- a/web/public/locales/en/views/system.json
+++ b/web/public/locales/en/views/system.json
@@ -146,7 +146,7 @@
   },
   "enrichments": {
     "title": "Enrichments",
-    "recsPerSecond": "Recognitions Per Second",
+    "infPerSecond": "Inferences Per Second",
     "embeddings": {
       "image_embedding_speed": "Image Embedding Speed",
       "face_embedding_speed": "Face Embedding Speed",

--- a/web/src/pages/System.tsx
+++ b/web/src/pages/System.tsx
@@ -14,10 +14,10 @@ import CameraMetrics from "@/views/system/CameraMetrics";
 import { useHashState } from "@/hooks/use-overlay-state";
 import { Toaster } from "@/components/ui/sonner";
 import { FrigateConfig } from "@/types/frigateConfig";
-import FeatureMetrics from "@/views/system/FeatureMetrics";
+import EnrichmentMetrics from "@/views/system/EnrichmentMetrics";
 import { useTranslation } from "react-i18next";
 
-const allMetrics = ["general", "features", "storage", "cameras"] as const;
+const allMetrics = ["general", "enrichments", "storage", "cameras"] as const;
 type SystemMetric = (typeof allMetrics)[number];
 
 function System() {
@@ -34,7 +34,7 @@ function System() {
       !config?.lpr.enabled &&
       !config?.face_recognition.enabled
     ) {
-      const index = metrics.indexOf("features");
+      const index = metrics.indexOf("enrichments");
       metrics.splice(index, 1);
     }
 
@@ -89,7 +89,7 @@ function System() {
               aria-label={`Select ${item}`}
             >
               {item == "general" && <LuActivity className="size-4" />}
-              {item == "features" && <LuSearchCode className="size-4" />}
+              {item == "enrichments" && <LuSearchCode className="size-4" />}
               {item == "storage" && <LuHardDrive className="size-4" />}
               {item == "cameras" && <FaVideo className="size-4" />}
               {isDesktop && (
@@ -122,8 +122,8 @@ function System() {
           setLastUpdated={setLastUpdated}
         />
       )}
-      {page == "features" && (
-        <FeatureMetrics
+      {page == "enrichments" && (
+        <EnrichmentMetrics
           lastUpdated={lastUpdated}
           setLastUpdated={setLastUpdated}
         />

--- a/web/src/views/system/CameraMetrics.tsx
+++ b/web/src/views/system/CameraMetrics.tsx
@@ -1,5 +1,5 @@
 import { useFrigateStats } from "@/api/ws";
-import { CameraLineGraph } from "@/components/graph/CameraGraph";
+import { CameraLineGraph } from "@/components/graph/LineGraph";
 import CameraInfoDialog from "@/components/overlay/CameraInfoDialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { FrigateConfig } from "@/types/frigateConfig";

--- a/web/src/views/system/EnrichmentMetrics.tsx
+++ b/web/src/views/system/EnrichmentMetrics.tsx
@@ -7,19 +7,16 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ThresholdBarGraph } from "@/components/graph/SystemGraph";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
-import {
-  CameraLineGraph,
-  EventsPerSecondsLineGraph,
-} from "@/components/graph/LineGraph";
+import { EventsPerSecondsLineGraph } from "@/components/graph/LineGraph";
 
-type FeatureMetricsProps = {
+type EnrichmentMetricsProps = {
   lastUpdated: number;
   setLastUpdated: (last: number) => void;
 };
-export default function FeatureMetrics({
+export default function EnrichmentMetrics({
   lastUpdated,
   setLastUpdated,
-}: FeatureMetricsProps) {
+}: EnrichmentMetricsProps) {
   // stats
   const { t } = useTranslation(["views/system"]);
 
@@ -121,7 +118,7 @@ export default function FeatureMetrics({
                       key={series.name}
                       graphId={`${series.name}-fps`}
                       unit=""
-                      name="Recognitions Per Second"
+                      name={t("enrichments.recsPerSecond")}
                       updateTimes={updateTimes}
                       data={[series]}
                     />

--- a/web/src/views/system/EnrichmentMetrics.tsx
+++ b/web/src/views/system/EnrichmentMetrics.tsx
@@ -118,7 +118,7 @@ export default function EnrichmentMetrics({
                       key={series.name}
                       graphId={`${series.name}-fps`}
                       unit=""
-                      name={t("enrichments.recsPerSecond")}
+                      name={t("enrichments.infPerSecond")}
                       updateTimes={updateTimes}
                       data={[series]}
                     />

--- a/web/src/views/system/FeatureMetrics.tsx
+++ b/web/src/views/system/FeatureMetrics.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ThresholdBarGraph } from "@/components/graph/SystemGraph";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
+import { CameraLineGraph } from "@/components/graph/CameraGraph";
 
 type FeatureMetricsProps = {
   lastUpdated: number;
@@ -102,15 +103,26 @@ export default function FeatureMetrics({
               {embeddingInferenceTimeSeries.map((series) => (
                 <div className="rounded-lg bg-background_alt p-2.5 md:rounded-2xl">
                   <div className="mb-5 capitalize">{series.name}</div>
-                  <ThresholdBarGraph
-                    key={series.name}
-                    graphId={`${series.name}-inference`}
-                    name={series.name}
-                    unit="ms"
-                    threshold={EmbeddingThreshold}
-                    updateTimes={updateTimes}
-                    data={[series]}
-                  />
+                  {series.name.endsWith("Speed") ? (
+                    <ThresholdBarGraph
+                      key={series.name}
+                      graphId={`${series.name}-inference`}
+                      name={series.name}
+                      unit="ms"
+                      threshold={EmbeddingThreshold}
+                      updateTimes={updateTimes}
+                      data={[series]}
+                    />
+                  ) : (
+                    <CameraLineGraph
+                      key={series.name}
+                      graphId={`${series.name}-fps`}
+                      dataLabels={["Recognitions Per Second"]}
+                      unit=""
+                      updateTimes={updateTimes}
+                      data={[series]}
+                    />
+                  )}
                 </div>
               ))}
             </>

--- a/web/src/views/system/FeatureMetrics.tsx
+++ b/web/src/views/system/FeatureMetrics.tsx
@@ -7,7 +7,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ThresholdBarGraph } from "@/components/graph/SystemGraph";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
-import { CameraLineGraph } from "@/components/graph/CameraGraph";
+import {
+  CameraLineGraph,
+  EventsPerSecondsLineGraph,
+} from "@/components/graph/LineGraph";
 
 type FeatureMetricsProps = {
   lastUpdated: number;
@@ -114,11 +117,11 @@ export default function FeatureMetrics({
                       data={[series]}
                     />
                   ) : (
-                    <CameraLineGraph
+                    <EventsPerSecondsLineGraph
                       key={series.name}
                       graphId={`${series.name}-fps`}
-                      dataLabels={["Recognitions Per Second"]}
                       unit=""
+                      name="Recognitions Per Second"
                       updateTimes={updateTimes}
                       data={[series]}
                     />


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This PR implements a line graph for each enrichment that is enabled, making it easy to see not just the speed of inference but also the amount of inferences over time

![Screen Shot 2025-03-28 at 16 46 40 PM](https://github.com/user-attachments/assets/e4bfbd81-4f89-4912-8e03-c851d70cd7fb)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
