### PR TITLE
Catch birdseye websocket error

### DIFF
--- a/frigate/output/birdseye.py
+++ b/frigate/output/birdseye.py
@@ -259,7 +259,7 @@ class BroadcastThread(threading.Thread):
                             ws.send(buf, binary=True)
                         except ValueError:
                             pass
-                        except (BrokenPipeError, ConnectionResetError) as e:
+                        except (BrokenPipeError, ConnectionResetError, OSError) as e:
                             logger.debug(f"Websocket unexpectedly closed {e}")
             elif self.converter.process.poll() is not None:
                 break


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Catch `OSError` in birdseye when the websocket is unexpectedly closed. For some reason this happens often with my wall tablet running birdseye. I've been running this fix for a while without issues, the birdseye websocket reconnects just fine.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
