### PR TITLE
 Fixed the support of custom rknn models by filling the model type.

### DIFF
--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -85,6 +85,9 @@ class Rknn(DetectionApi):
         if "/" in model_path:
             model_props["preset"] = False
             model_props["path"] = model_path
+            for model_type in ModelTypeEnum:
+                if model_type in model_path:
+                    model_props["model_type"] = model_type
         else:
             model_props["preset"] = True
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

Currently, RKNN custom models are not supported. If a model path instead of a model name is provided, `model_type` is not filled in `model_props`, resulting in errors during post processing.

This PR fixed this issue by filling the model name included in the path.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
