### PR TITLE
Trim group name before length validation

### DIFF
--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -657,10 +657,11 @@ export function CameraGroupEdit({
   const formSchema = z.object({
     name: z
       .string()
+      .trim()
       .min(2, {
         message: t("group.name.errorMessage.mustLeastCharacters"),
       })
-      .transform((val: string) => val.trim().replace(/\s+/g, "_"))
+      .transform((val: string) => val.replace(/\s+/g, "_"))
       .refine(
         (value: string) => {
           return (


### PR DESCRIPTION
## Proposed change

This change fixes a bug in the camera group-naming process that allowed groups to be created with names <2 characters long as the trim operation was performed after the length check. For example, entering two spaces would create a group with no name.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
