### PR TITLE
add AVX commentary in hardware requirements

### DIFF
--- a/docs/docs/frigate/hardware.md
+++ b/docs/docs/frigate/hardware.md
@@ -23,8 +23,7 @@ I may earn a small commission for my endorsement, recommendation, testimonial, o
 
 My current favorite is the Beelink EQ13 because of the efficient N100 CPU and dual NICs that allow you to setup a dedicated private network for your cameras where they can be blocked from accessing the internet. There are many used workstation options on eBay that work very well. Anything with an Intel CPU and capable of running Debian should work fine. As a bonus, you may want to look for devices with a M.2 or PCIe express slot that is compatible with the Hailo8 or Google Coral. I may earn a small commission for my endorsement, recommendation, testimonial, or link to any products or services from this website.
 
-WARNING: Frigate requires your CPU to support AVX instructions. Please verify your CPU supports AVX before trying to run Frigate. 
-
+WARNING: Frigate requires your CPU to support AVX instructions. CPUs made before 2011 likely do not support AVX. 
 | Name                                                                                                          | Notes                                                                                     |
 | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | Beelink EQ13 (<a href="https://amzn.to/4iQaBKu" target="_blank" rel="nofollow noopener sponsored">Amazon</a>) | Dual gigabit NICs for easy isolated camera network. Easily handles several 1080p cameras. |

--- a/docs/docs/frigate/hardware.md
+++ b/docs/docs/frigate/hardware.md
@@ -23,6 +23,8 @@ I may earn a small commission for my endorsement, recommendation, testimonial, o
 
 My current favorite is the Beelink EQ13 because of the efficient N100 CPU and dual NICs that allow you to setup a dedicated private network for your cameras where they can be blocked from accessing the internet. There are many used workstation options on eBay that work very well. Anything with an Intel CPU and capable of running Debian should work fine. As a bonus, you may want to look for devices with a M.2 or PCIe express slot that is compatible with the Hailo8 or Google Coral. I may earn a small commission for my endorsement, recommendation, testimonial, or link to any products or services from this website.
 
+WARNING: Frigate requires your CPU to support AVX instructions. Please verify your CPU supports AVX before trying to run Frigate. 
+
 | Name                                                                                                          | Notes                                                                                     |
 | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | Beelink EQ13 (<a href="https://amzn.to/4iQaBKu" target="_blank" rel="nofollow noopener sponsored">Amazon</a>) | Dual gigabit NICs for easy isolated camera network. Easily handles several 1080p cameras. |


### PR DESCRIPTION
## Proposed change
This is a simple documentation update in the hardware section. I lost a bunch of time trying to make frigate work on older hardware(discouraged, I know, but in my defense the coral was heavily touted in documentation as a solution), only to discover that lack of AVX support by my CPU was likely the cause of my issue, as well as others issues. 

The issue raised by the lack of AVX support for me was a generic message `2025-04-07 06:24:02.654913437  [INFO] Service Frigate exited with code 256 (by signal 4)` which has a large number of hits with very little resolution. I believe I could have avoided this time sink if this message were present in the hardware expectations area, as I typically try very hard to pay attention to these details. 

Perhaps there are more eloquent ways to say this, so feel free to edit my commentary in this PR to better represent the intention. 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: https://github.com/blakeblackshear/frigate/issues/14712
- This PR is related to issue: https://github.com/blakeblackshear/frigate/issues/14712

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
