### PR TITLE
LPR device selection

### DIFF
--- a/docs/docs/configuration/license_plate_recognition.md
+++ b/docs/docs/configuration/license_plate_recognition.md
@@ -68,7 +68,7 @@ Fine-tune the LPR feature using these optional parameters:
   - Depending on the resolution of your camera's `detect` stream, you can increase this value to ignore small or distant plates.
 - **`device`**: Device to use to run license plate recognition models.
   - Default: `CPU`
-  - This can be `CPU` or `GPU`. For users without a model that detects license plates natively, using a GPU may increase performance of the YOLOv9 license plate detector model.
+  - This can be `CPU` or `GPU`. For users without a model that detects license plates natively, using a GPU may increase performance of the models, especially the YOLOv9 license plate detector model.
 
 ### Recognition
 
@@ -170,6 +170,7 @@ An example configuration for a dedicated LPR camera using a Frigate+ model:
 # LPR global configuration
 lpr:
   enabled: True
+  device: CPU # can also be GPU if available
 
 # Dedicated LPR camera configuration
 cameras:
@@ -221,6 +222,7 @@ An example configuration for a dedicated LPR camera using the secondary pipeline
 # LPR global configuration
 lpr:
   enabled: True
+  device: CPU # can also be GPU if available
   detection_threshold: 0.7 # change if necessary
 
 # Dedicated LPR camera configuration

--- a/docs/docs/configuration/license_plate_recognition.md
+++ b/docs/docs/configuration/license_plate_recognition.md
@@ -19,7 +19,7 @@ When a plate is recognized, the recognized name is:
 
 Users running a Frigate+ model (or any custom model that natively detects license plates) should ensure that `license_plate` is added to the [list of objects to track](https://docs.frigate.video/plus/#available-label-types) either globally or for a specific camera. This will improve the accuracy and performance of the LPR model.
 
-Users without a model that detects license plates can still run LPR. Frigate uses a lightweight YOLOv9 license plate detection model that runs on your CPU or GPU. In this case, you should _not_ define `license_plate` in your list of objects to track.
+Users without a model that detects license plates can still run LPR. Frigate uses a lightweight YOLOv9 license plate detection model that can be configured to run on your CPU or GPU. In this case, you should _not_ define `license_plate` in your list of objects to track.
 
 :::note
 
@@ -29,7 +29,7 @@ In the default mode, Frigate's LPR needs to first detect a `car` before it can r
 
 ## Minimum System Requirements
 
-License plate recognition works by running AI models locally on your system. The models are relatively lightweight and will be auto-selected to run on your CPU. At least 4GB of RAM is required.
+License plate recognition works by running AI models locally on your system. The models are relatively lightweight and can run on your CPU or GPU, depending on your configuration. At least 4GB of RAM is required.
 
 ## Configuration
 
@@ -66,6 +66,9 @@ Fine-tune the LPR feature using these optional parameters:
 - **`min_area`**: Defines the minimum area (in pixels) a license plate must be before recognition runs.
   - Default: `1000` pixels. Note: this is intentionally set very low as it is an _area_ measurement (length x width). For reference, 1000 pixels represents a ~32x32 pixel square in your camera image.
   - Depending on the resolution of your camera's `detect` stream, you can increase this value to ignore small or distant plates.
+- **`device`**: Device to use to run license plate recognition models.
+  - Default: `CPU`
+  - This can be `CPU` or `GPU`. For users without a model that detects license plates natively, using a GPU may increase performance of the YOLOv9 license plate detector model.
 
 ### Recognition
 
@@ -280,7 +283,7 @@ By selecting the appropriate configuration, users can optimize their dedicated L
 - Disable the `improve_contrast` motion setting, especially if you are running LPR at night and the frame is mostly dark. This will prevent small pixel changes and smaller areas of motion from triggering license plate detection.
 - Ensure your camera's timestamp is covered with a motion mask so that it's not incorrectly detected as a license plate.
 - For non-Frigate+ users, you may need to change your camera settings for a clearer image or decrease your global `recognition_threshold` config if your plates are not being accurately recognized at night.
-- The secondary pipeline mode runs a local AI model on your CPU or GPU (auto-selected) to detect plates. Increasing detect `fps` will increase resource usage proportionally.
+- The secondary pipeline mode runs a local AI model on your CPU or GPU (depending on how `device` is configured) to detect plates. Increasing detect `fps` will increase resource usage proportionally.
 
 ## FAQ
 
@@ -341,7 +344,7 @@ Use `match_distance` to allow small character mismatches. Alternatively, define 
 
 LPR's performance impact depends on your hardware. Ensure you have at least 4GB RAM and a capable CPU or GPU for optimal results. If you are running the Dedicated LPR Camera mode, resource usage will be higher compared to users who run a model that natively detects license plates. Tune your motion detection settings for your dedicated LPR camera so that the license plate detection model runs only when necessary.
 
-### I am seeing a YOLOv9 plate detection metric in Enrichment Metrics, but I have a Frigate+ or custom model that detects `license_plate`. Why is the YOLOv9 model running?
+### I am seeing a YOLOv9 plate detection metric in Enrichment Metrics, but I have a Frigate+ model that detects `license_plate`. Why is the YOLOv9 model running?
 
 The YOLOv9 license plate detector model will run (and the metric will appear) if you've enabled LPR but haven't defined `license_plate` as an object to track, either at the global or camera level.
 

--- a/docs/docs/configuration/license_plate_recognition.md
+++ b/docs/docs/configuration/license_plate_recognition.md
@@ -344,7 +344,7 @@ Use `match_distance` to allow small character mismatches. Alternatively, define 
 
 LPR's performance impact depends on your hardware. Ensure you have at least 4GB RAM and a capable CPU or GPU for optimal results. If you are running the Dedicated LPR Camera mode, resource usage will be higher compared to users who run a model that natively detects license plates. Tune your motion detection settings for your dedicated LPR camera so that the license plate detection model runs only when necessary.
 
-### I am seeing a YOLOv9 plate detection metric in Enrichment Metrics, but I have a Frigate+ model that detects `license_plate`. Why is the YOLOv9 model running?
+### I am seeing a YOLOv9 plate detection metric in Enrichment Metrics, but I have a Frigate+ or custom model that detects `license_plate`. Why is the YOLOv9 model running?
 
 The YOLOv9 license plate detector model will run (and the metric will appear) if you've enabled LPR but haven't defined `license_plate` as an object to track, either at the global or camera level.
 

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -19,6 +19,12 @@ class SemanticSearchModelEnum(str, Enum):
     jinav2 = "jinav2"
 
 
+class LPRDeviceEnum(str, Enum):
+    AUTO = "AUTO"
+    GPU = "GPU"
+    CPU = "CPU"
+
+
 class BirdClassificationConfig(FrigateBaseModel):
     enabled: bool = Field(default=False, title="Enable bird classification.")
     threshold: float = Field(
@@ -94,6 +100,10 @@ class CameraFaceRecognitionConfig(FrigateBaseModel):
 
 class LicensePlateRecognitionConfig(FrigateBaseModel):
     enabled: bool = Field(default=False, title="Enable license plate recognition.")
+    device: Optional[LPRDeviceEnum] = Field(
+        default=LPRDeviceEnum.AUTO,
+        title="The device used for license plate recognition.",
+    )
     detection_threshold: float = Field(
         default=0.7,
         title="License plate object confidence score required to begin running recognition.",

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -20,7 +20,6 @@ class SemanticSearchModelEnum(str, Enum):
 
 
 class LPRDeviceEnum(str, Enum):
-    AUTO = "AUTO"
     GPU = "GPU"
     CPU = "CPU"
 
@@ -101,7 +100,7 @@ class CameraFaceRecognitionConfig(FrigateBaseModel):
 class LicensePlateRecognitionConfig(FrigateBaseModel):
     enabled: bool = Field(default=False, title="Enable license plate recognition.")
     device: Optional[LPRDeviceEnum] = Field(
-        default=LPRDeviceEnum.AUTO,
+        default=LPRDeviceEnum.CPU,
         title="The device used for license plate recognition.",
     )
     detection_threshold: float = Field(

--- a/frigate/data_processing/common/license_plate/model.py
+++ b/frigate/data_processing/common/license_plate/model.py
@@ -12,13 +12,13 @@ class LicensePlateModelRunner(DataProcessorModelRunner):
     def __init__(self, requestor, device: str = "CPU", model_size: str = "large"):
         super().__init__(requestor, device, model_size)
         self.detection_model = PaddleOCRDetection(
-            model_size=model_size, requestor=requestor, device="CPU"
+            model_size=model_size, requestor=requestor, device=device
         )
         self.classification_model = PaddleOCRClassification(
-            model_size=model_size, requestor=requestor, device="CPU"
+            model_size=model_size, requestor=requestor, device=device
         )
         self.recognition_model = PaddleOCRRecognition(
-            model_size=model_size, requestor=requestor, device="CPU"
+            model_size=model_size, requestor=requestor, device=device
         )
         self.yolov9_detection_model = LicensePlateDetector(
             model_size=model_size, requestor=requestor, device=device

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -108,7 +108,9 @@ class EmbeddingMaintainer(threading.Thread):
 
         # model runners to share between realtime and post processors
         if self.config.lpr.enabled:
-            lpr_model_runner = LicensePlateModelRunner(self.requestor, device="AUTO")
+            lpr_model_runner = LicensePlateModelRunner(
+                self.requestor, device=self.config.lpr.device
+            )
 
         # realtime processors
         self.realtime_processors: list[RealTimeProcessorApi] = []

--- a/frigate/embeddings/onnx/runner.py
+++ b/frigate/embeddings/onnx/runner.py
@@ -94,6 +94,10 @@ class ONNXModelRunner:
         if self.type == "ov":
             infer_request = self.interpreter.create_infer_request()
 
+            # This ensures the model starts with a clean state for each sequence
+            # Important for RNN models like PaddleOCR recognition
+            infer_request.reset_state()
+
             outputs = infer_request.infer(input)
 
             return outputs


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR adds the ability for users to select `CPU` or `GPU` to run the LPR models on (including the YOLOv9 detector model for users without a model that natively detects `license_plate`.

Testing on my iGPU decreased inference time from ~45ms to ~22ms (recognition) and dropped the YOLOv9 detection model down from ~18ms to ~10ms.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
