### PR TITLE
Catch OpenVINO exception

### DIFF
--- a/frigate/embeddings/onnx/runner.py
+++ b/frigate/embeddings/onnx/runner.py
@@ -94,9 +94,13 @@ class ONNXModelRunner:
         if self.type == "ov":
             infer_request = self.interpreter.create_infer_request()
 
-            # This ensures the model starts with a clean state for each sequence
-            # Important for RNN models like PaddleOCR recognition
-            infer_request.reset_state()
+            try:
+                # This ensures the model starts with a clean state for each sequence
+                # Important for RNN models like PaddleOCR recognition
+                infer_request.reset_state()
+            except Exception:
+                # this will raise an exception for models with AUTO set as the device
+                pass
 
             outputs = infer_request.infer(input)
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
https://github.com/blakeblackshear/frigate/pull/17592 introduced a `reset_state()` call when running inference on onnx models with OV. For models that set `device` as `AUTO` (like the face embedder), this PR will catch a `Not Implemented` exception that fires. The reset call is really only important for RNN models (like LPR recognition), so any similar models implemented in the future will just need to set device to `GPU` rather than `AUTO` to run with OpenVINO.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
