### PR TITLE
UI: optionally disable animations on all charts

### DIFF
--- a/web/src/components/graph/LineGraph.tsx
+++ b/web/src/components/graph/LineGraph.tsx
@@ -70,6 +70,9 @@ export function CameraLineGraph({
         zoom: {
           enabled: false,
         },
+        animations: {
+          enabled: false,
+        },
       },
       colors: GRAPH_COLORS,
       grid: {
@@ -195,6 +198,9 @@ export function EventsPerSecondsLineGraph({
           show: false,
         },
         zoom: {
+          enabled: false,
+        },
+        animations: {
           enabled: false,
         },
       },

--- a/web/src/components/graph/StorageGraph.tsx
+++ b/web/src/components/graph/StorageGraph.tsx
@@ -25,6 +25,9 @@ export function StorageGraph({ graphId, used, total }: StorageGraphProps) {
         zoom: {
           enabled: false,
         },
+        animations: {
+          enabled: false,
+        },
       },
       grid: {
         show: false,

--- a/web/src/components/graph/SystemGraph.tsx
+++ b/web/src/components/graph/SystemGraph.tsx
@@ -79,6 +79,9 @@ export function ThresholdBarGraph({
         zoom: {
           enabled: false,
         },
+        animations: {
+          enabled: false,
+        },
       },
       colors: [
         ({ value }: { value: number }) => {


### PR DESCRIPTION
## Proposed change

Chart animations would ideally have an opt-out. They are often sluggish on my mobile (Samsung S23 Ultra); on my desktop just opening the metrics page seems to fairly frequently cause my CPU (i7-14700k) cooler to spin up. Aside from that, they slow down actually seeing the information I'm looking for.

Draft as I wasn't sure where you would see config sitting; either in main config under e.g. `ui->chart_animations` or as a per-user/per-device setting in browser storage.

Arguably this could be extended to other UI animations like opening modals or sliding in settings windows, but those are far less impacting.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [] The code change is tested and works locally.
- [] Local tests pass. **Your PR cannot be merged unless tests pass**
- [] There is no commented out code in this PR.
- [] UI changes including text have used i18n keys and have been added to the `en` locale.
- [] The code has been formatted using Ruff (`ruff format frigate`)
