### PR TITLE
Fix search sort when using score or estimated speed

### DIFF
--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -724,13 +724,15 @@ def events_search(request: Request, params: EventsSearchQueryParams = Depends())
     if (sort is None or sort == "relevance") and search_results:
         processed_events.sort(key=lambda x: x.get("search_distance", float("inf")))
     elif min_score is not None and max_score is not None and sort == "score_asc":
-        processed_events.sort(key=lambda x: x["score"])
+        processed_events.sort(key=lambda x: x["data"]["score"])
     elif min_score is not None and max_score is not None and sort == "score_desc":
-        processed_events.sort(key=lambda x: x["score"], reverse=True)
+        processed_events.sort(key=lambda x: x["data"]["score"], reverse=True)
     elif min_speed is not None and max_speed is not None and sort == "speed_asc":
-        processed_events.sort(key=lambda x: x["average_estimated_speed"])
+        processed_events.sort(key=lambda x: x["data"]["average_estimated_speed"])
     elif min_speed is not None and max_speed is not None and sort == "speed_desc":
-        processed_events.sort(key=lambda x: x["average_estimated_speed"], reverse=True)
+        processed_events.sort(
+            key=lambda x: x["data"]["average_estimated_speed"], reverse=True
+        )
     elif sort == "date_asc":
         processed_events.sort(key=lambda x: x["start_time"])
     else:


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
The score and average estimated speed values were not being retrieved from the nested `data` dict.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/17624
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
