### PR TITLE
Improve object tracking

### DIFF
--- a/frigate/camera/state.py
+++ b/frigate/camera/state.py
@@ -263,6 +263,27 @@ class CameraState:
                 current_detections[id],
             )
 
+            # add initial frame to frame cache
+            self.frame_cache[frame_time] = np.copy(current_frame)
+
+            # save initial thumbnail data and best object
+            thumbnail_data = {
+                "frame_time": frame_time,
+                "box": new_obj.obj_data["box"],
+                "area": new_obj.obj_data["area"],
+                "region": new_obj.obj_data["region"],
+                "score": new_obj.obj_data["score"],
+                "attributes": new_obj.obj_data["attributes"],
+                "current_estimated_speed": 0,
+                "velocity_angle": 0,
+                "path_data": [],
+                "recognized_license_plate": None,
+                "recognized_license_plate_score": None,
+            }
+            new_obj.thumbnail_data = thumbnail_data
+            tracked_objects[id].thumbnail_data = thumbnail_data
+            self.best_objects[new_obj.obj_data["label"]] = new_obj
+
             # call event handlers
             for c in self.callbacks["start"]:
                 c(self.name, new_obj, frame_name)

--- a/frigate/track/tracked_object.py
+++ b/frigate/track/tracked_object.py
@@ -144,8 +144,14 @@ class TrackedObject:
                 obj_data,
                 self.camera_config.frame_shape,
             ):
+                # use the current frame time if the object's frame time isn't in the frame cache
+                selected_frame_time = (
+                    current_frame_time
+                    if obj_data["frame_time"] not in self.frame_cache.keys()
+                    else obj_data["frame_time"]
+                )
                 self.thumbnail_data = {
-                    "frame_time": current_frame_time,
+                    "frame_time": selected_frame_time,
                     "box": obj_data["box"],
                     "area": obj_data["area"],
                     "region": obj_data["region"],


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR makes some improvements to object tracking, with the primary focus being on fast moving objects (like license plates on dedicated LPR cameras).

As a result of these changes, users can run recommended values for their `detect` stream `fps`. In my testing, objects crossing the entire frame in less than 2 seconds were detected, tracked, and saved even at 5fps. This represents a considerable resource savings where object detection hardware will not have to process as many frames. Some users may still need to use slightly higher values (10 or below), but that recommendation is mainly for users running dedicated LPR cameras. 

These changes also fix a bug where snapshots were showing a bounding box around an area of the frame that didn't represent the actual object that was detected.

Technical description:

- Objects that move quickly through the frame and are only seen briefly may not have the update() method called to save thumbnail_data, and may not have the initial frame saved to the tracked object frame cache. This caused a "Frame missing from frame cache" message that was patched by https://github.com/blakeblackshear/frigate/pull/7313 but this sometimes caused the wrong frame to be chosen for the thumb/snapshot.
- When registering new objects, use the past detections from Norfair to populate self.positions and self.stationary_box_history. This prevents the first call of update_position() from triggering a +1 on the object's stationary count (because the iou would be 1.0).
- Only check for position outliers when there are at least 5 and less than 10 position entries
- Add a specific tracker for dedicated LPR cam license_plate objects using a lower R value and higher distance threshold to account for fast moving plates.
- Add helpful debug messages and keep them disabled with `if False:`


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
