### PR TITLE
Plus Settings: add base model and name

### DIFF
--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -566,7 +566,7 @@
       "trainDate": "Train Date",
       "baseModel": "Base Model",
       "plusModelType": {
-        "baseModel": "Default",
+        "baseModel": "Base Model",
         "userModel": "Fine-Tuned"
       },
       "supportedDetectors": "Supported Detectors",

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -570,7 +570,6 @@
         "userModel": "Fine-Tuned Model"
       },
       "supportedDetectors": "Supported Detectors",
-      "dimensions": "Dimensions",
       "cameras": "Cameras",
       "loading": "Loading model information...",
       "error": "Failed to load model information",

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -567,7 +567,7 @@
       "baseModel": "Base Model",
       "plusModelType": {
         "baseModel": "Base Model",
-        "userModel": "Fine-Tuned Model"
+        "userModel": "Fine-Tuned"
       },
       "supportedDetectors": "Supported Detectors",
       "cameras": "Cameras",

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -567,7 +567,7 @@
       "baseModel": "Base Model",
       "plusModelType": {
         "baseModel": "Base Model",
-        "userModel": "User Model"
+        "userModel": "Fine-Tuned Model"
       },
       "supportedDetectors": "Supported Detectors",
       "dimensions": "Dimensions",

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -566,7 +566,7 @@
       "trainDate": "Train Date",
       "baseModel": "Base Model",
       "plusModelType": {
-        "baseModel": "Base Model",
+        "baseModel": "Default",
         "userModel": "Fine-Tuned"
       },
       "supportedDetectors": "Supported Detectors",

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -565,6 +565,10 @@
       "modelType": "Model Type",
       "trainDate": "Train Date",
       "baseModel": "Base Model",
+      "plusModelType": {
+        "baseModel": "Base Model",
+        "userModel": "User Model"
+      },
       "supportedDetectors": "Supported Detectors",
       "dimensions": "Dimensions",
       "cameras": "Cameras",

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -408,6 +408,7 @@ export interface FrigateConfig {
       id: string;
       trainDate: string;
       baseModel: string;
+      isBaseModel: boolean;
       supportedDetectors: string[];
       width: number;
       height: number;

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -279,7 +279,7 @@ export default function FrigatePlusSettingsView({
                           </Label>
                           <p>
                             {config.model.plus.baseModel} (
-                            {availableModels[config.model.plus.id].isBaseModel
+                            {availableModels[config.model.plus.id]?.isBaseModel
                               ? t(
                                   "frigatePlus.modelInfo.plusModelType.baseModel",
                                 )

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -275,13 +275,17 @@ export default function FrigatePlusSettingsView({
                       <div className="grid grid-cols-2 gap-4">
                         <div>
                           <Label className="text-muted-foreground">
-                            {t("frigatePlus.modelInfo.modelType")}
+                            {t("frigatePlus.modelInfo.baseModel")}
                           </Label>
                           <p>
-                            {config.model.plus.name} (
-                            {config.model.plus.width +
-                              "x" +
-                              config.model.plus.height}
+                            {config.model.plus.baseModel} (
+                            {availableModels[config.model.plus.id].isBaseModel
+                              ? t(
+                                  "frigatePlus.modelInfo.plusModelType.baseModel",
+                                )
+                              : t(
+                                  "frigatePlus.modelInfo.plusModelType.userModel",
+                                )}
                             )
                           </p>
                         </div>
@@ -297,9 +301,15 @@ export default function FrigatePlusSettingsView({
                         </div>
                         <div>
                           <Label className="text-muted-foreground">
-                            {t("frigatePlus.modelInfo.baseModel")}
+                            {t("frigatePlus.modelInfo.modelType")}
                           </Label>
-                          <p>{config.model.plus.baseModel}</p>
+                          <p>
+                            {config.model.plus.name} (
+                            {config.model.plus.width +
+                              "x" +
+                              config.model.plus.height}
+                            )
+                          </p>
                         </div>
                         <div>
                           <Label className="text-muted-foreground">

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -279,7 +279,7 @@ export default function FrigatePlusSettingsView({
                           </Label>
                           <p>
                             {config.model.plus.baseModel} (
-                            {availableModels[config.model.plus.id]?.isBaseModel
+                            {config.model.plus.isBaseModel
                               ? t(
                                   "frigatePlus.modelInfo.plusModelType.baseModel",
                                 )

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -26,6 +26,8 @@ import {
 type FrigatePlusModel = {
   id: string;
   type: string;
+  name: string;
+  isBaseModel: boolean;
   supportedDetectors: string[];
   trainDate: string;
   baseModel: string;
@@ -336,6 +338,10 @@ export default function FrigatePlusSettingsView({
                                       frigatePlusSettings.model.id
                                     ].trainDate,
                                   ).toLocaleString() +
+                                  " " +
+                                  availableModels[frigatePlusSettings.model.id]
+                                    .name +
+                                  " " +
                                   " (" +
                                   availableModels[frigatePlusSettings.model.id]
                                     .width +
@@ -366,7 +372,15 @@ export default function FrigatePlusSettingsView({
                                       {new Date(
                                         model.trainDate,
                                       ).toLocaleString()}{" "}
-                                      ({model.baseModel})
+                                      {model.name} ({model.baseModel}) (
+                                      {model.isBaseModel
+                                        ? t(
+                                            "frigatePlus.modelInfo.plusModelType.baseModel",
+                                          )
+                                        : t(
+                                            "frigatePlus.modelInfo.plusModelType.userModel",
+                                          )}
+                                      )
                                       <div>
                                         {t(
                                           "frigatePlus.modelInfo.supportedDetectors",

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -340,29 +340,45 @@ export default function FrigatePlusSettingsView({
                               })
                             }
                           >
-                            <SelectTrigger>
-                              {frigatePlusSettings.model.id &&
-                              availableModels?.[frigatePlusSettings.model.id]
-                                ? new Date(
-                                    availableModels[
-                                      frigatePlusSettings.model.id
-                                    ].trainDate,
-                                  ).toLocaleString() +
+                            {frigatePlusSettings.model.id &&
+                            availableModels?.[frigatePlusSettings.model.id] ? (
+                              <SelectTrigger>
+                                {new Date(
+                                  availableModels[
+                                    frigatePlusSettings.model.id
+                                  ].trainDate,
+                                ).toLocaleString() +
                                   " " +
                                   availableModels[frigatePlusSettings.model.id]
+                                    .baseModel +
+                                  " (" +
+                                  (availableModels[frigatePlusSettings.model.id]
+                                    .isBaseModel
+                                    ? t(
+                                        "frigatePlus.modelInfo.plusModelType.baseModel",
+                                      )
+                                    : t(
+                                        "frigatePlus.modelInfo.plusModelType.userModel",
+                                      )) +
+                                  ") " +
+                                  availableModels[frigatePlusSettings.model.id]
                                     .name +
-                                  " " +
                                   " (" +
                                   availableModels[frigatePlusSettings.model.id]
                                     .width +
                                   "x" +
                                   availableModels[frigatePlusSettings.model.id]
                                     .height +
-                                  ")"
-                                : t(
-                                    "frigatePlus.modelInfo.loadingAvailableModels",
-                                  )}
-                            </SelectTrigger>
+                                  ")"}
+                              </SelectTrigger>
+                            ) : (
+                              <SelectTrigger>
+                                {t(
+                                  "frigatePlus.modelInfo.loadingAvailableModels",
+                                )}
+                              </SelectTrigger>
+                            )}
+
                             <SelectContent>
                               <SelectGroup>
                                 {Object.entries(availableModels || {}).map(
@@ -382,15 +398,17 @@ export default function FrigatePlusSettingsView({
                                       {new Date(
                                         model.trainDate,
                                       ).toLocaleString()}{" "}
-                                      ({model.baseModel}) (
-                                      {model.isBaseModel
-                                        ? t(
-                                            "frigatePlus.modelInfo.plusModelType.baseModel",
-                                          )
-                                        : t(
-                                            "frigatePlus.modelInfo.plusModelType.userModel",
-                                          )}
-                                      )<div></div>
+                                      <div>
+                                        {model.baseModel} {" ("}
+                                        {model.isBaseModel
+                                          ? t(
+                                              "frigatePlus.modelInfo.plusModelType.baseModel",
+                                            )
+                                          : t(
+                                              "frigatePlus.modelInfo.plusModelType.userModel",
+                                            )}
+                                        {")"}
+                                      </div>
                                       <div>
                                         {model.name} (
                                         {model.width + "x" + model.height})

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -372,7 +372,7 @@ export default function FrigatePlusSettingsView({
                                       {new Date(
                                         model.trainDate,
                                       ).toLocaleString()}{" "}
-                                      (
+                                      ({model.baseModel}) (
                                       {model.isBaseModel
                                         ? t(
                                             "frigatePlus.modelInfo.plusModelType.baseModel",
@@ -380,13 +380,10 @@ export default function FrigatePlusSettingsView({
                                         : t(
                                             "frigatePlus.modelInfo.plusModelType.userModel",
                                           )}
-                                      )
+                                      )<div></div>
                                       <div>
-                                        {model.name} ({model.baseModel})
-                                      </div>
-                                      <div>
-                                        {t("frigatePlus.modelInfo.dimensions")}:{" "}
-                                        {model.width + "x" + model.height}
+                                        {model.name} (
+                                        {model.width + "x" + model.height})
                                       </div>
                                       <div>
                                         {t(

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -372,7 +372,7 @@ export default function FrigatePlusSettingsView({
                                       {new Date(
                                         model.trainDate,
                                       ).toLocaleString()}{" "}
-                                      {model.name} ({model.baseModel}) (
+                                      (
                                       {model.isBaseModel
                                         ? t(
                                             "frigatePlus.modelInfo.plusModelType.baseModel",
@@ -382,14 +382,17 @@ export default function FrigatePlusSettingsView({
                                           )}
                                       )
                                       <div>
-                                        {t(
-                                          "frigatePlus.modelInfo.supportedDetectors",
-                                        )}
-                                        : {model.supportedDetectors.join(", ")}
+                                        {model.name} ({model.baseModel})
                                       </div>
                                       <div>
                                         {t("frigatePlus.modelInfo.dimensions")}:{" "}
                                         {model.width + "x" + model.height}
+                                      </div>
+                                      <div>
+                                        {t(
+                                          "frigatePlus.modelInfo.supportedDetectors",
+                                        )}
+                                        : {model.supportedDetectors.join(", ")}
                                       </div>
                                       <div className="text-xs text-muted-foreground">
                                         {id}


### PR DESCRIPTION
## Proposed change
2025.1 base models are now available. Tweaked the Frigate+ settings page to distinguish between these models and user-tuned ones. Also add the name per Blake's suggestion in the discussion.

Ref https://github.com/blakeblackshear/frigate/discussions/17730#discussion-8209109 

Looks like this:

![image](https://github.com/user-attachments/assets/38f75414-67a0-49da-9797-8aedfbc7e77d)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
