### PR TITLE
Update tls.md instructions for letsencrypt archive dir

### DIFF
--- a/docs/docs/configuration/tls.md
+++ b/docs/docs/configuration/tls.md
@@ -36,8 +36,8 @@ Note that certbot uses symlinks, and those can't be followed by the container un
 frigate:
   ...
   volumes:
-    - /etc/letsencrypt/live/frigate:/etc/letsencrypt/live/frigate:ro
-    - /etc/letsencrypt/archive/frigate:/etc/letsencrypt/archive/frigate:ro
+    - /etc/letsencrypt/live/your.fqdn.net:/etc/letsencrypt/live/frigate:ro
+    - /etc/letsencrypt/archive/your.fqdn.net:/etc/letsencrypt/archive/your.fqdn.net:ro
   ...
 
 ```


### PR DESCRIPTION
Current instructions are a little ambiguous about which links need to point to the underlying fqdn dir created by letsencrypt

## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
