### PR TITLE
LPR tweaks

### DIFF
--- a/docs/docs/configuration/license_plate_recognition.md
+++ b/docs/docs/configuration/license_plate_recognition.md
@@ -184,7 +184,7 @@ cameras:
     ffmpeg: ... # add your streams
     detect:
       enabled: True
-      fps: 5 # increase to 10 if vehicles move quickly across your frame. Higher than 10 is unnecessary and is not recommended.
+      fps: 5 # increase to 10 if vehicles move quickly across your frame. Higher than 15 is unnecessary and is not recommended.
       min_initialized: 2
       width: 1920
       height: 1080
@@ -267,7 +267,7 @@ With this setup:
 - Review items will always be classified as a `detection`.
 - Snapshots will always be saved.
 - Zones and object masks are **not** used.
-- The `frigate/events` MQTT topic will **not** publish tracked object updates, though `frigate/reviews` will if recordings are enabled.
+- The `frigate/events` MQTT topic will **not** publish tracked object updates with the license plate bounding box and score, though `frigate/reviews` will publish if recordings are enabled. If a plate is recognized as a known plate, publishing will occur with an updated `sub_label` field. If characters are recognized, publishing will occur with an updated `recognized_license_plate` field.
 - License plate snapshots are saved at the highest-scoring moment and appear in Explore.
 - Debug view will not show `license_plate` bounding boxes.
 
@@ -280,7 +280,7 @@ With this setup:
 | Object Detection        | Standard Frigate+ detection applies                    | Bypasses standard object detection                              |
 | Zones & Object Masks    | Supported                                              | Not supported                                                   |
 | Debug View              | May show `license_plate` bounding boxes                | May **not** show `license_plate` bounding boxes                 |
-| MQTT `frigate/events`   | Publishes tracked object updates                       | Does **not** publish tracked object updates                     |
+| MQTT `frigate/events`   | Publishes tracked object updates                       | Publishes limited updates                                       |
 | Explore                 | Recognized plates available in More Filters            | Recognized plates available in More Filters                     |
 
 By selecting the appropriate configuration, users can optimize their dedicated LPR cameras based on whether they are using a Frigate+ model or the secondary LPR pipeline.

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -513,9 +513,13 @@ class FrigateConfig(FrigateBaseModel):
                     )
 
             # Warn if detect fps > 10
-            if camera_config.detect.fps > 10:
+            if camera_config.detect.fps > 10 and camera_config.type != "lpr":
                 logger.warning(
                     f"{camera_config.name} detect fps is set to {camera_config.detect.fps}. This does NOT need to match your camera's frame rate. High values could lead to reduced performance. Recommended value is 5."
+                )
+            if camera_config.detect.fps > 15 and camera_config.type == "lpr":
+                logger.warning(
+                    f"{camera_config.name} detect fps is set to {camera_config.detect.fps}. This does NOT need to match your camera's frame rate. High values could lead to reduced performance. Recommended value for LPR cameras are between 5-15."
                 )
 
             # Default min_initialized configuration

--- a/frigate/data_processing/post/license_plate.py
+++ b/frigate/data_processing/post/license_plate.py
@@ -54,6 +54,9 @@ class LicensePlatePostProcessor(LicensePlateProcessingMixin, PostProcessorApi):
         Returns:
             None.
         """
+        # don't run LPR post processing for now
+        return
+
         event_id = data["event_id"]
         camera_name = data["camera"]
 

--- a/frigate/track/tracked_object.py
+++ b/frigate/track/tracked_object.py
@@ -138,11 +138,13 @@ class TrackedObject:
 
         if not self.false_positive and has_valid_frame:
             # determine if this frame is a better thumbnail
-            if self.thumbnail_data is None or is_better_thumbnail(
-                self.obj_data["label"],
-                self.thumbnail_data,
-                obj_data,
-                self.camera_config.frame_shape,
+            if self.thumbnail_data is None or (
+                better_thumb := is_better_thumbnail(
+                    self.obj_data["label"],
+                    self.thumbnail_data,
+                    obj_data,
+                    self.camera_config.frame_shape,
+                )
             ):
                 # use the current frame time if the object's frame time isn't in the frame cache
                 selected_frame_time = (
@@ -150,6 +152,13 @@ class TrackedObject:
                     if obj_data["frame_time"] not in self.frame_cache.keys()
                     else obj_data["frame_time"]
                 )
+                if (
+                    obj_data["frame_time"] not in self.frame_cache.keys()
+                    and not better_thumb
+                ):
+                    logger.warning(
+                        f"Frame time {obj_data['frame_time']} not not in frame cache, using current frame time {selected_frame_time}"
+                    )
                 self.thumbnail_data = {
                     "frame_time": selected_frame_time,
                     "box": obj_data["box"],

--- a/frigate/track/tracked_object.py
+++ b/frigate/track/tracked_object.py
@@ -157,7 +157,7 @@ class TrackedObject:
                     and not better_thumb
                 ):
                     logger.warning(
-                        f"Frame time {obj_data['frame_time']} not not in frame cache, using current frame time {selected_frame_time}"
+                        f"Frame time {obj_data['frame_time']} not in frame cache, using current frame time {selected_frame_time}"
                     )
                 self.thumbnail_data = {
                     "frame_time": selected_frame_time,


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR:
- Adds clarity to some of the LPR debug messages to help users better understand what the code is doing.
- Adds a log warning when frames are not in the frame cache. One user is still reporting misaligned bounding boxes on a dedicated LPR camera.
- Tweaks the LPR docs for clarity.
- Disables all LPR post-processing. It was technically not running before, but just adding a `return` at the top of the postprocessor method will ensure it doesn't even drop into the function.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
