### PR TITLE
Implement YOLOx for RKNN

### DIFF
--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -815,62 +815,7 @@ This implementation uses the [Rockchip's RKNN-Toolkit2](https://github.com/airoc
 
 ### Prerequisites
 
-Make sure to follow the [Rockchip specific installation instrucitions](/frigate/installation#rockchip-platform).
-
-### Configuration
-
-This `config.yml` shows all relevant options to configure the detector and explains them. All values shown are the default values (except for two). Lines that are required at least to use the detector are labeled as required, all other lines are optional.
-
-```yaml
-detectors: # required
-  rknn: # required
-    type: rknn # required
-    # number of NPU cores to use
-    # 0 means choose automatically
-    # increase for better performance if you have a multicore NPU e.g. set to 3 on rk3588
-    num_cores: 0
-
-model: # required
-  # name of model (will be automatically downloaded) or path to your own .rknn model file
-  # possible values are:
-  # - deci-fp16-yolonas_s
-  # - deci-fp16-yolonas_m
-  # - deci-fp16-yolonas_l
-  # - /config/model_cache/your_custom_model.rknn
-  path: deci-fp16-yolonas_s
-  # width and height of detection frames
-  width: 320
-  height: 320
-  # pixel format of detection frame
-  # default value is rgb but yolo models usually use bgr format
-  input_pixel_format: bgr # required
-  # shape of detection frame
-  input_tensor: nhwc
-  # needs to be adjusted to model, see below
-  labelmap_path: /labelmap.txt # required
-```
-
-The correct labelmap must be loaded for each model. If you use a custom model (see notes below), you must make sure to provide the correct labelmap. The table below lists the correct paths for the bundled models:
-
-| `path`                | `labelmap_path`       |
-| --------------------- | --------------------- |
-| deci-fp16-yolonas\_\* | /labelmap/coco-80.txt |
-
-### Choosing a model
-
-:::warning
-
-The pre-trained YOLO-NAS weights from DeciAI are subject to their license and can't be used commercially. For more information, see: https://docs.deci.ai/super-gradients/latest/LICENSE.YOLONAS.html
-
-:::
-
-The inference time was determined on a rk3588 with 3 NPU cores.
-
-| Model               | Size in mb | Inference time in ms |
-| ------------------- | ---------- | -------------------- |
-| deci-fp16-yolonas_s | 24         | 25                   |
-| deci-fp16-yolonas_m | 62         | 35                   |
-| deci-fp16-yolonas_l | 81         | 45                   |
+Make sure to follow the [Rockchip specific installation instructions](/frigate/installation#rockchip-platform).
 
 :::tip
 
@@ -883,8 +828,70 @@ $ cat /sys/kernel/debug/rknpu/load
 
 :::
 
+### Supported Models
+
+This `config.yml` shows all relevant options to configure the detector and explains them. All values shown are the default values (except for two). Lines that are required at least to use the detector are labeled as required, all other lines are optional.
+
+```yaml
+detectors: # required
+  rknn: # required
+    type: rknn # required
+    # number of NPU cores to use
+    # 0 means choose automatically
+    # increase for better performance if you have a multicore NPU e.g. set to 3 on rk3588
+    num_cores: 0
+```
+
+The inference time was determined on a rk3588 with 3 NPU cores.
+
+| Model               | Size in mb | Inference time in ms |
+| ------------------- | ---------- | -------------------- |
+| deci-fp16-yolonas_s | 24         | 25                   |
+| deci-fp16-yolonas_m | 62         | 35                   |
+| deci-fp16-yolonas_l | 81         | 45                   |
+| yolox_nano          | 3          | 16                   |
+| yolox_tiny          | 6          | 20                   |
+
 - All models are automatically downloaded and stored in the folder `config/model_cache/rknn_cache`. After upgrading Frigate, you should remove older models to free up space.
 - You can also provide your own `.rknn` model. You should not save your own models in the `rknn_cache` folder, store them directly in the `model_cache` folder or another subfolder. To convert a model to `.rknn` format see the `rknn-toolkit2` (requires a x86 machine). Note, that there is only post-processing for the supported models.
+
+#### YOLO-NAS
+
+```yaml
+model: # required
+  # name of model (will be automatically downloaded) or path to your own .rknn model file
+  # possible values are:
+  # - deci-fp16-yolonas_s
+  # - deci-fp16-yolonas_m
+  # - deci-fp16-yolonas_l
+  path: deci-fp16-yolonas_s
+  width: 320
+  height: 320
+  input_pixel_format: bgr
+  input_tensor: nhwc
+  labelmap_path: /labelmap/coco-80.txt
+```
+
+:::warning
+
+The pre-trained YOLO-NAS weights from DeciAI are subject to their license and can't be used commercially. For more information, see: https://docs.deci.ai/super-gradients/latest/LICENSE.YOLONAS.html
+
+:::
+
+#### YOLOx
+
+```yaml
+model: # required
+  # name of model (will be automatically downloaded) or path to your own .rknn model file
+  # possible values are:
+  # - yolox_nano
+  # - yolox_tiny
+  path: yolox_tiny
+  width: 416
+  height: 416
+  input_tensor: nhwc
+  labelmap_path: /labelmap/coco-80.txt
+```
 
 ### Converting your own onnx model to rknn format
 

--- a/frigate/detectors/detection_api.py
+++ b/frigate/detectors/detection_api.py
@@ -24,7 +24,7 @@ class DetectionApi(ABC):
     def detect_raw(self, tensor_input):
         pass
 
-    def calculate_grids_strides(self) -> None:
+    def calculate_grids_strides(self, expanded=True) -> None:
         grids = []
         expanded_strides = []
 
@@ -35,10 +35,24 @@ class DetectionApi(ABC):
 
         for hsize, wsize, stride in zip(hsizes, wsizes, strides):
             xv, yv = np.meshgrid(np.arange(wsize), np.arange(hsize))
-            grid = np.stack((xv, yv), 2).reshape(1, -1, 2)
-            grids.append(grid)
-            shape = grid.shape[:2]
-            expanded_strides.append(np.full((*shape, 1), stride))
 
-        self.grids = np.concatenate(grids, 1)
-        self.expanded_strides = np.concatenate(expanded_strides, 1)
+            if expanded:
+                grid = np.stack((xv, yv), 2).reshape(1, -1, 2)
+                grids.append(grid)
+                shape = grid.shape[:2]
+                expanded_strides.append(np.full((*shape, 1), stride))
+            else:
+                xv = xv.reshape(1, 1, hsize, wsize)
+                yv = yv.reshape(1, 1, hsize, wsize)
+                grids.extend(np.concatenate((xv, yv), axis=1).tolist())
+                expanded_strides.extend(np.array([stride, stride]).reshape(1, 2, 1, 1).tolist())
+
+        if expanded:
+            self.grids = np.concatenate(grids, 1)
+            self.expanded_strides = np.concatenate(expanded_strides, 1)
+        else:
+            self.grids = grids
+            self.expanded_strides = expanded_strides
+
+        print(f"grids {self.grids}")
+        print(f"expanded strides {self.expanded_strides}")

--- a/frigate/detectors/detection_api.py
+++ b/frigate/detectors/detection_api.py
@@ -45,7 +45,9 @@ class DetectionApi(ABC):
                 xv = xv.reshape(1, 1, hsize, wsize)
                 yv = yv.reshape(1, 1, hsize, wsize)
                 grids.extend(np.concatenate((xv, yv), axis=1).tolist())
-                expanded_strides.extend(np.array([stride, stride]).reshape(1, 2, 1, 1).tolist())
+                expanded_strides.extend(
+                    np.array([stride, stride]).reshape(1, 2, 1, 1).tolist()
+                )
 
         if expanded:
             self.grids = np.concatenate(grids, 1)
@@ -53,6 +55,3 @@ class DetectionApi(ABC):
         else:
             self.grids = grids
             self.expanded_strides = expanded_strides
-
-        print(f"grids {self.grids}")
-        print(f"expanded strides {self.expanded_strides}")

--- a/frigate/util/model.py
+++ b/frigate/util/model.py
@@ -180,7 +180,7 @@ def __post_process_multipart_yolo(
                 x2 / width,
             ]
 
-    return np.array(results, dtype=np.float32)
+    return results
 
 
 def __post_process_nms_yolo(predictions: np.ndarray, width, height) -> np.ndarray:


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This PR:
- implements YOLOx for RKNN
- improves the strides and grids calculation depending on desired format
- Adjusts rknn docs now that multiple model archs will be supported to match other detector documentation

@MarcA711 I wasn't sure if you would want to add the yolox models to your repo, I have the onnx models that I am happy to share. Below is the config I used to convert to RKNN:

```yaml
soc: ["rk3588"]
quantization: true

output_name: "{input_basename}"

config:
  mean_values: [[0, 0, 0]]
  std_values: [[1, 1, 1]]
```

I did have to build the onnx models from https://github.com/airockchip/YOLOX since only small and large are hosted on the RKNN model zoo and the small model gave me much higher inference times of 60ms, likely due to the larger 640x640 input.

I am happy to make any docs or implementation changes that you think would be good. And if you want to add those files to your repo then I can add the automatic download.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
