### PR TITLE
Add YOLOv9 support to RKNN

### DIFF
--- a/docker/rockchip/rk.mk
+++ b/docker/rockchip/rk.mk
@@ -9,7 +9,7 @@ build-rk: version
 	docker buildx bake --file=docker/rockchip/rk.hcl rk \
 		--set rk.tags=$(IMAGE_REPO):${GITHUB_REF_NAME}-$(COMMIT_HASH)-rk
 
-push-rk: version
+push-rk: build-rk
 	docker buildx bake --file=docker/rockchip/rk.hcl rk \
-		--set rk.tags=crzynik/frigate-rk \
+		--set rk.tags=$(IMAGE_REPO):${GITHUB_REF_NAME}-$(COMMIT_HASH)-rk \
 		--push

--- a/docker/rockchip/rk.mk
+++ b/docker/rockchip/rk.mk
@@ -9,7 +9,7 @@ build-rk: version
 	docker buildx bake --file=docker/rockchip/rk.hcl rk \
 		--set rk.tags=$(IMAGE_REPO):${GITHUB_REF_NAME}-$(COMMIT_HASH)-rk
 
-push-rk: build-rk
+push-rk: version
 	docker buildx bake --file=docker/rockchip/rk.hcl rk \
-		--set rk.tags=$(IMAGE_REPO):${GITHUB_REF_NAME}-$(COMMIT_HASH)-rk \
+		--set rk.tags=crzynik/frigate-rk \
 		--push

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -865,6 +865,7 @@ model: # required
   # - deci-fp16-yolonas_s
   # - deci-fp16-yolonas_m
   # - deci-fp16-yolonas_l
+  # your yolonas_model.rknn
   path: deci-fp16-yolonas_s
   model_type: yolonas
   width: 320
@@ -888,6 +889,7 @@ model: # required
   # possible values are:
   # - yolov9-t
   # - yolov9-s
+  # your yolo_model.rknn
   path: /config/model_cache/rknn_cache/yolov9-t.rknn
   model_type: yolo-generic
   width: 320
@@ -905,6 +907,7 @@ model: # required
   # possible values are:
   # - yolox_nano
   # - yolox_tiny
+  # your yolox_model.rknn
   path: yolox_tiny
   model_type: yolox
   width: 416

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -849,6 +849,7 @@ The inference time was determined on a rk3588 with 3 NPU cores.
 | deci-fp16-yolonas_s | 24         | 25                   |
 | deci-fp16-yolonas_m | 62         | 35                   |
 | deci-fp16-yolonas_l | 81         | 45                   |
+| yolov9_tiny         | 8          | 35                   |
 | yolox_nano          | 3          | 16                   |
 | yolox_tiny          | 6          | 20                   |
 
@@ -865,6 +866,7 @@ model: # required
   # - deci-fp16-yolonas_m
   # - deci-fp16-yolonas_l
   path: deci-fp16-yolonas_s
+  model_type: yolonas
   width: 320
   height: 320
   input_pixel_format: bgr
@@ -878,6 +880,23 @@ The pre-trained YOLO-NAS weights from DeciAI are subject to their license and ca
 
 :::
 
+#### YOLO (v9)
+
+```yaml
+model: # required
+  # name of model (will be automatically downloaded) or path to your own .rknn model file
+  # possible values are:
+  # - yolov9-t
+  # - yolov9-s
+  path: /config/model_cache/rknn_cache/yolov9-t.rknn
+  model_type: yolo-generic
+  width: 320
+  height: 320
+  input_tensor: nhwc
+  input_dtype: float
+  labelmap_path: /labelmap/coco-80.txt
+```
+
 #### YOLOx
 
 ```yaml
@@ -887,6 +906,7 @@ model: # required
   # - yolox_nano
   # - yolox_tiny
   path: yolox_tiny
+  model_type: yolox
   width: 416
   height: 416
   input_tensor: nhwc

--- a/docs/docs/frigate/hardware.md
+++ b/docs/docs/frigate/hardware.md
@@ -165,6 +165,12 @@ Frigate supports hardware video processing on all Rockchip boards. However, hard
 - RK3576
 - RK3588
 
+| Name            | YOLOv9 Inference Time | YOLO-NAS Inference Time     | YOLOx Inference Time      |
+| --------------- | --------------------- | --------------------------- | ------------------------- |
+| rk3588 3 cores  | ~ 35 ms               | small: ~ 20 ms med: ~ 30 ms | nano: 18 ms tiny: 20 ms   |
+| rk3566 1 core   |                       | small: ~ 96 ms              |                           |
+
+
 The inference time of a rk3588 with all 3 cores enabled is typically 25-30 ms for yolo-nas s.
 
 ## What does Frigate use the CPU for and what does it use a detector for? (ELI5 Version)

--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -11,6 +11,7 @@ from pydantic import Field
 from frigate.const import MODEL_CACHE_DIR
 from frigate.detectors.detection_api import DetectionApi
 from frigate.detectors.detector_config import BaseDetectorConfig, ModelTypeEnum
+from frigate.util.model import post_process_yolo
 
 logger = logging.getLogger(__name__)
 
@@ -284,6 +285,8 @@ class Rknn(DetectionApi):
     def post_process(self, output):
         if self.detector_config.model.model_type == ModelTypeEnum.yolonas:
             return self.post_process_yolonas(output)
+        elif self.detector_config.model.model_type == ModelTypeEnum.yologeneric:
+            return post_process_yolo(output, self.width, self.height)
         elif self.detector_config.model.model_type == ModelTypeEnum.yolox:
             return self.post_process_yolox(output, self.grids, self.expanded_strides)
         else:


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This PR adds support for running yolov9 rknn models. Currently the model will need to be downloaded and converted to rknn separately until they can be provided directly.

Was converted to rknn using this config:

```
soc: ["rk3588"]
quantization: false

output_name: "{input_basename}"

config: {}
```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
