### PR TITLE
Fix deprecated listen...http2 documentation in nginx reverse proxy

### DIFF
--- a/docs/docs/guides/reverse_proxy.md
+++ b/docs/docs/guides/reverse_proxy.md
@@ -117,7 +117,8 @@ server {
   set $port           8971;
 
   listen 80;
-  listen 443 ssl http2;
+  listen 443 ssl;
+  http2 on;
 
   server_name frigate.domain.com;
 }


### PR DESCRIPTION
This is deprecated:

listen 443 ssl http2;

New syntax has a separate line:

http2 on;

See e.g. https://forum.hestiacp.com/t/nginx-1-25-1-listen-http2-directive-is-deprecated/9816

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
