### PR TITLE
Add ability to rename faces in the Face Library

### DIFF
--- a/frigate/api/classification.py
+++ b/frigate/api/classification.py
@@ -14,6 +14,7 @@ from peewee import DoesNotExist
 from playhouse.shortcuts import model_to_dict
 
 from frigate.api.auth import require_role
+from frigate.api.defs.request.classification_body import RenameFaceBody
 from frigate.api.defs.tags import Tags
 from frigate.config.camera import DetectConfig
 from frigate.const import FACE_DIR
@@ -258,6 +259,31 @@ def deregister_faces(request: Request, name: str, body: dict = None):
         content=({"success": True, "message": "Successfully deleted faces."}),
         status_code=200,
     )
+
+
+@router.put("/faces/{old_name}/rename", dependencies=[Depends(require_role(["admin"]))])
+def rename_face(request: Request, old_name: str, body: RenameFaceBody):
+    if not request.app.frigate_config.face_recognition.enabled:
+        return JSONResponse(
+            status_code=400,
+            content={"message": "Face recognition is not enabled.", "success": False},
+        )
+
+    context: EmbeddingsContext = request.app.embeddings
+    try:
+        context.rename_face(old_name, body.new_name)
+        return JSONResponse(
+            content={
+                "success": True,
+                "message": f"Successfully renamed face to {body.new_name}.",
+            },
+            status_code=200,
+        )
+    except ValueError as e:
+        return JSONResponse(
+            status_code=400,
+            content={"message": str(e), "success": False},
+        )
 
 
 @router.put("/lpr/reprocess")

--- a/frigate/api/classification.py
+++ b/frigate/api/classification.py
@@ -280,9 +280,13 @@ def rename_face(request: Request, old_name: str, body: RenameFaceBody):
             status_code=200,
         )
     except ValueError as e:
+        logger.error(e)
         return JSONResponse(
             status_code=400,
-            content={"message": str(e), "success": False},
+            content={
+                "message": "Error renaming face. Check Frigate logs.",
+                "success": False,
+            },
         )
 
 

--- a/frigate/api/defs/request/classification_body.py
+++ b/frigate/api/defs/request/classification_body.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class RenameFaceBody(BaseModel):
+    new_name: str

--- a/web/public/locales/en/views/faceLibrary.json
+++ b/web/public/locales/en/views/faceLibrary.json
@@ -36,9 +36,15 @@
     "title": "Delete Name",
     "desc": "Are you sure you want to delete the collection {{name}}? This will permanently delete all associated faces."
   },
+  "renameFace": {
+    "title": "Rename Face",
+    "desc": "Enter a new name for {{name}}"
+  },
   "button": {
     "deleteFaceAttempts": "Delete Face Attempts",
     "addFace": "Add Face",
+    "renameFace": "Rename Face",
+    "deleteFace": "Delete Face",
     "uploadImage": "Upload Image",
     "reprocessFace": "Reprocess Face"
   },
@@ -62,6 +68,7 @@
       "deletedName_zero": "Empty collection deleted successfully.",
       "deletedName_one": "{{count}} face has been successfully deleted.",
       "deletedName_other": "{{count}} faces have been successfully deleted.",
+      "renamedFace": "Successfully renamed face to {{name}}",
       "trainedFace": "Successfully trained face.",
       "updatedFaceScore": "Successfully updated face score."
     },
@@ -70,6 +77,7 @@
       "addFaceLibraryFailed": "Failed to set face name: {{errorMessage}}",
       "deleteFaceFailed": "Failed to delete: {{errorMessage}}",
       "deleteNameFailed": "Failed to delete name: {{errorMessage}}",
+      "renameFaceFailed": "Failed to rename face: {{errorMessage}}",
       "trainFailed": "Failed to train: {{errorMessage}}",
       "updateFaceScoreFailed": "Failed to update face score: {{errorMessage}}"
     }

--- a/web/src/pages/FaceLibrary.tsx
+++ b/web/src/pages/FaceLibrary.tsx
@@ -3,6 +3,7 @@ import TimeAgo from "@/components/dynamic/TimeAgo";
 import AddFaceIcon from "@/components/icons/AddFaceIcon";
 import ActivityIndicator from "@/components/indicators/activity-indicator";
 import CreateFaceWizardDialog from "@/components/overlay/detail/FaceCreateWizardDialog";
+import TextEntryDialog from "@/components/overlay/dialog/TextEntryDialog";
 import UploadImageDialog from "@/components/overlay/dialog/UploadImageDialog";
 import FaceSelectionDialog from "@/components/overlay/FaceSelectionDialog";
 import { Button } from "@/components/ui/button";
@@ -41,6 +42,7 @@ import { isDesktop, isMobile } from "react-device-detect";
 import { useTranslation } from "react-i18next";
 import {
   LuImagePlus,
+  LuPencil,
   LuRefreshCw,
   LuScanFace,
   LuSearch,
@@ -221,6 +223,32 @@ export default function FaceLibrary() {
     [faceImages, refreshFaces, setPageToggle, t],
   );
 
+  const onRename = useCallback(
+    (oldName: string, newName: string) => {
+      axios
+        .put(`/faces/${oldName}/rename`, { new_name: newName })
+        .then((resp) => {
+          if (resp.status === 200) {
+            toast.success(t("toast.success.renamedFace", { name: newName }), {
+              position: "top-center",
+            });
+            setPageToggle("train");
+            refreshFaces();
+          }
+        })
+        .catch((error) => {
+          const errorMessage =
+            error.response?.data?.message ||
+            error.response?.data?.detail ||
+            "Unknown error";
+          toast.error(t("toast.error.renameFaceFailed", { errorMessage }), {
+            position: "top-center",
+          });
+        });
+    },
+    [setPageToggle, refreshFaces, t],
+  );
+
   // keyboard
 
   useKeyboardListener(["a", "Escape"], (key, modifiers) => {
@@ -274,6 +302,7 @@ export default function FaceLibrary() {
           trainImages={trainImages}
           setPageToggle={setPageToggle}
           onDelete={onDelete}
+          onRename={onRename}
         />
         {selectedFaces?.length > 0 ? (
           <div className="flex items-center justify-center gap-2">
@@ -338,6 +367,7 @@ type LibrarySelectorProps = {
   trainImages: string[];
   setPageToggle: (toggle: string | undefined) => void;
   onDelete: (name: string, ids: string[], isName: boolean) => void;
+  onRename: (old_name: string, new_name: string) => void;
 };
 function LibrarySelector({
   pageToggle,
@@ -346,9 +376,11 @@ function LibrarySelector({
   trainImages,
   setPageToggle,
   onDelete,
+  onRename,
 }: LibrarySelectorProps) {
   const { t } = useTranslation(["views/faceLibrary"]);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [renameFace, setRenameFace] = useState<string | null>(null);
 
   const handleDeleteFace = useCallback(
     (faceName: string) => {
@@ -359,6 +391,13 @@ function LibrarySelector({
       setPageToggle("train");
     },
     [faceData, onDelete, setPageToggle],
+  );
+
+  const handleSetOpen = useCallback(
+    (open: boolean) => {
+      setRenameFace(open ? renameFace : null);
+    },
+    [renameFace],
   );
 
   return (
@@ -392,6 +431,18 @@ function LibrarySelector({
           </div>
         </DialogContent>
       </Dialog>
+
+      <TextEntryDialog
+        open={!!renameFace}
+        setOpen={handleSetOpen}
+        title={t("renameFace.title")}
+        description={t("renameFace.desc", { name: renameFace })}
+        onSave={(newName) => {
+          onRename(renameFace!, newName);
+          setRenameFace(null);
+        }}
+        defaultValue={renameFace || ""}
+      />
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -440,17 +491,44 @@ function LibrarySelector({
                   ({faceData?.[face].length})
                 </span>
               </div>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-7 opacity-0 transition-opacity group-hover:opacity-100"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setConfirmDelete(face);
-                }}
-              >
-                <LuTrash2 className="size-4 text-destructive" />
-              </Button>
+              <div className="flex gap-0.5">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-7 opacity-0 transition-opacity group-hover:opacity-100"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setRenameFace(face);
+                      }}
+                    >
+                      <LuPencil className="size-4 text-primary" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipPortal>
+                    <TooltipContent>{t("button.renameFace")}</TooltipContent>
+                  </TooltipPortal>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-7 opacity-0 transition-opacity group-hover:opacity-100"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setConfirmDelete(face);
+                      }}
+                    >
+                      <LuTrash2 className="size-4 text-destructive" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipPortal>
+                    <TooltipContent>{t("button.deleteFace")}</TooltipContent>
+                  </TooltipPortal>
+                </Tooltip>
+              </div>
             </DropdownMenuItem>
           ))}
         </DropdownMenuContent>

--- a/web/src/pages/FaceLibrary.tsx
+++ b/web/src/pages/FaceLibrary.tsx
@@ -662,6 +662,7 @@ function TrainingGrid({
           </div>
           <img
             className="w-full"
+            loading="lazy"
             src={`${baseUrl}api/events/${selectedEvent?.id}/${selectedEvent?.has_snapshot ? "snapshot.jpg" : "thumbnail.jpg"}`}
           />
         </DialogContent>


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR adds an API endpoint and a small icon and dialog in the Face UI to rename a face. The underlying code just renames the directory and does not rename any classified faces in the Train tab.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
