### PR TITLE
Update localization files

### DIFF
--- a/web/public/locales/de/components/dialog.json
+++ b/web/public/locales/de/components/dialog.json
@@ -10,24 +10,18 @@
   },
   "explore": {
     "plus": {
-      "review": {
-        "true": {
-          "label": "Bestätigen Sie das Label für Frigate Plus",
-          "true_one": "Das ist ein/eine {{label}}",
-          "true_other": "Dies sind {{label}}"
-        },
-        "state": {
-          "submitted": "Übermittelt"
-        },
-        "false": {
-          "false_one": "Das ist kein(e) {{label}}",
-          "false_other": "Das sind kein(e) {{label}}",
-          "label": "Bestätige dieses Label nicht für Frigate Plus"
-        }
-      },
       "submitToPlus": {
         "label": "An Frigate+ übermitteln",
         "desc": "Objekte an Orten die du vermeiden möchtest, sind keine Fehlalarme. Wenn du sie als Fehlalarme meldest, verwirrst du das Modell."
+      },
+      "review": {
+        "question": {
+          "label": "Bestätigen Sie das Label für Frigate Plus",
+          "ask_full": "Dies sind <code>{{untranslatedLabel}}</code> ({{translatedLabel}})?"
+        },
+        "state": {
+          "submitted": "Übermittelt"
+        }
       }
     },
     "video": {

--- a/web/public/locales/es/components/dialog.json
+++ b/web/public/locales/es/components/dialog.json
@@ -15,17 +15,9 @@
         "desc": "Los objetos en ubicaciones que deseas evitar no son falsos positivos. Enviarlos como falsos positivos confundirá al modelo."
       },
       "review": {
-        "false": {
-          "label": "No confirmar esta etiqueta para Frigate Plus",
-          "false_one": "Esto no es un {{label}}",
-          "false_many": "Esto no es un {{label}}",
-          "false_other": "Esto no es un {{label}}"
-        },
-        "true": {
-          "true_one": "Esto es un {{label}}",
-          "true_many": "Esto es un {{label}}",
-          "true_other": "Esto es un {{label}}",
-          "label": "Confirmar esta etiqueta para Frigate+"
+        "question": {
+          "label": "Confirmar esta etiqueta para Frigate+",
+          "ask_full": "Esto es un <code>{{untranslatedLabel}}</code> ({{translatedLabel}})?"
         },
         "state": {
           "submitted": "Enviado"

--- a/web/public/locales/fr/components/dialog.json
+++ b/web/public/locales/fr/components/dialog.json
@@ -15,17 +15,9 @@
         "desc": "Les objets situés dans des endroits que vous souhaitez éviter ne sont pas des faux positifs. Les soumettre comme faux positifs perturberait le modèle."
       },
       "review": {
-        "true": {
+        "question": {
           "label": "Confirmez cette étiquette pour Frigate Plus",
-          "true_one": "C'est un {{label}}",
-          "true_many": "Ce sont des {{label}}",
-          "true_other": "Ce sont des {{label}}"
-        },
-        "false": {
-          "false_one": "Ceci n'est pas un {{label}}",
-          "false_many": "Ceux-ci ne sont pas des {{label}}",
-          "false_other": "Ceux-ci ne sont pas des {{label}}",
-          "label": "Ne pas confirmer cette étiquette pour Frigate Plus"
+          "ask_full": "Ce sont des <code>{{untranslatedLabel}}</code> ({{translatedLabel}})?"
         },
         "state": {
           "submitted": "Soumis"

--- a/web/public/locales/it/components/dialog.json
+++ b/web/public/locales/it/components/dialog.json
@@ -15,17 +15,9 @@
         "desc": "Gli oggetti in posizioni che si desidera evitare non sono falsi positivi. Inviarli come falsi positivi confonderà il modello."
       },
       "review": {
-        "false": {
-          "label": "Non confermare questa etichetta per Frigate Plus",
-          "false_one": "Questo non è un {{label}}",
-          "false_many": "Questi non sono un {{label}}",
-          "false_other": "Questi non sono un {{label}}"
-        },
-        "true": {
+        "question": {
           "label": "Conferma questa etichetta per Frigate Plus",
-          "true_one": "Questo è un {{label}}",
-          "true_many": "Questi sono {{label}}",
-          "true_other": "Questi sono {{label}}"
+          "ask_full": "Questi sono <code>{{untranslatedLabel}}</code> ({{translatedLabel}})?"
         },
         "state": {
           "submitted": "Inviato"

--- a/web/public/locales/nb-NO/components/dialog.json
+++ b/web/public/locales/nb-NO/components/dialog.json
@@ -15,18 +15,12 @@
         "desc": "Objekter på steder du vil unngå er ikke falske positiver. Å sende dem som falske positiver vil forvirre modellen."
       },
       "review": {
-        "true": {
+        "question": {
           "label": "Bekreft denne merkelappen for Frigate Plus",
-          "true_one": "Dette er en {{label}}",
-          "true_other": "Dette er en {{label}}"
+          "ask_full": "Dette er en <code>{{untranslatedLabel}}</code> ({{translatedLabel}})?"
         },
         "state": {
           "submitted": "Sendt inn"
-        },
-        "false": {
-          "label": "Ikke bekreft denne merkelappen for Frigate Plus",
-          "false_one": "Dette er ikke en {{label}}",
-          "false_other": "Dette er ikke en {{label}}"
         }
       }
     },

--- a/web/public/locales/nl/components/dialog.json
+++ b/web/public/locales/nl/components/dialog.json
@@ -15,15 +15,9 @@
         "desc": "Objecten op locaties die je wilt vermijden, zijn geen valspositieven. Als je ze als valspositieven indient, brengt dit het model in verwarring."
       },
       "review": {
-        "true": {
-          "true_one": "Dit is een {{label}}",
-          "true_other": "Dit zijn {{label}}",
-          "label": "Bevestig dit label voor Frigate Plus"
-        },
-        "false": {
-          "false_one": "Dit is geen {{label}}",
-          "false_other": "Dit zijn geen {{label}}",
-          "label": "Bevestig dit label niet voor Frigate Plus"
+        "question": {
+          "label": "Bevestig dit label voor Frigate Plus",
+          "ask_full": "Dit zijn <code>{{untranslatedLabel}}</code> ({{translatedLabel}})?"
         },
         "state": {
           "submitted": "Ingediend"

--- a/web/public/locales/pl/components/dialog.json
+++ b/web/public/locales/pl/components/dialog.json
@@ -15,17 +15,9 @@
         "desc": "Obiekty w miejscach, których chcesz unikać, nie są fałszywymi alarmami. Zgłaszanie ich jako fałszywe alarmy zdezorientuje model."
       },
       "review": {
-        "true": {
+        "question": {
           "label": "Potwierdź tę etykietę dla Frigate Plus",
-          "true_one": "To jest {{label}}",
-          "true_few": "To są {{label}}",
-          "true_many": "To są {{label}}"
-        },
-        "false": {
-          "label": "Nie potwierdzaj tej etykiety dla Frigate Plus",
-          "false_one": "To nie jest {{label}}",
-          "false_few": "To nie są {{label}}",
-          "false_many": "To nie są {{label}}"
+          "ask_full": "To są <code>{{untranslatedLabel}}</code> ({{translatedLabel}})?"
         },
         "state": {
           "submitted": "Przesłano"

--- a/web/public/locales/pt/components/dialog.json
+++ b/web/public/locales/pt/components/dialog.json
@@ -15,20 +15,12 @@
         "desc": "Objetos em locais que você quer evitar não são falsos positivos. Enviá-los como falsos positivos confundirá o modelo."
       },
       "review": {
-        "true": {
+        "question": {
           "label": "Confirme esta etiqueta para Frigate Plus",
-          "true_one": "Este é um {{label}}",
-          "true_many": "Estes são muitos {{label}}",
-          "true_other": "Estão são {{label}}"
+          "ask_full": "Estão são <code>{{untranslatedLabel}}</code> ({{translatedLabel}})?"
         },
         "state": {
           "submitted": "Enviado"
-        },
-        "false": {
-          "label": "Não confirmar esta etiqueta para Frigate Plus",
-          "false_one": "Este não é um {{label}}",
-          "false_many": "Estes não são muitos {{label}}",
-          "false_other": "Estes não são {{label}}"
         }
       }
     },

--- a/web/public/locales/ro/components/dialog.json
+++ b/web/public/locales/ro/components/dialog.json
@@ -11,17 +11,9 @@
   "explore": {
     "plus": {
       "review": {
-        "true": {
+        "question": {
           "label": "Confirma aceasta eticheta pentru Frigate Plus",
-          "true_one": "Asta e o {{label}}",
-          "true_few": "Astea sunt {{label}}",
-          "true_other": "Astea sunt {{label}}"
-        },
-        "false": {
-          "label": "Nu confirma aceasta eticheta pentru Frigate Plus",
-          "false_one": "Asta nu este  {{label}}",
-          "false_few": "Astea nu sunt {{label}}",
-          "false_other": "Astea nu sunt {{label}}"
+          "ask_full": "Astea sunt <code>{{untranslatedLabel}}</code> ({{translatedLabel}})?"
         },
         "state": {
           "submitted": "Trimis"

--- a/web/public/locales/ru/components/dialog.json
+++ b/web/public/locales/ru/components/dialog.json
@@ -15,17 +15,9 @@
         "desc": "Объекты в местах, которых вы хотите избежать, не являются ложными срабатываниями. Отправка их как ложных срабатываний запутает модель."
       },
       "review": {
-        "true": {
+        "question": {
           "label": "Подтвердите метку для Frigate Plus",
-          "true_one": "Это {{label}}",
-          "true_few": "Это {{label}}",
-          "true_many": "Это {{label}}"
-        },
-        "false": {
-          "label": "Не подтверждать эту метку для Frigate Plus",
-          "false_one": "Это не {{label}}",
-          "false_few": "Это не {{label}}",
-          "false_many": "Это не {{label}}"
+          "ask_full": "Это <code>{{untranslatedLabel}}</code> ({{translatedLabel}})?"
         },
         "state": {
           "submitted": "Отправлено"

--- a/web/public/locales/tr/components/dialog.json
+++ b/web/public/locales/tr/components/dialog.json
@@ -10,24 +10,18 @@
   },
   "explore": {
     "plus": {
-      "review": {
-        "state": {
-          "submitted": "Gönderildi"
-        },
-        "true": {
-          "true_one": "Bu bir {{label}}",
-          "true_other": "Bu bir {{label}}",
-          "label": "Frigate+ için bu etiketi onaylayın"
-        },
-        "false": {
-          "label": "Bu etiketi Frigate+ için onaylamaktan vazgeç",
-          "false_one": "Bu bir {{label}} değil",
-          "false_other": "Bu bir {{label}} değil"
-        }
-      },
       "submitToPlus": {
         "label": "Frigate+'ya Gönder",
         "desc": "Görülmesini istemediğiniz yerlerdeki nesneler yanlış pozitif değildir. Bunları yanlış pozitif olarak göndermek modeli yanıltacaktır."
+      },
+      "review": {
+        "question": {
+          "label": "Frigate+ için bu etiketi onaylayın",
+          "ask_full": "Bu bir <code>{{untranslatedLabel}}</code> ({{translatedLabel}})?"
+        },
+        "state": {
+          "submitted": "Gönderildi"
+        }
       }
     },
     "video": {

--- a/web/public/locales/zh-CN/components/dialog.json
+++ b/web/public/locales/zh-CN/components/dialog.json
@@ -15,15 +15,9 @@
         "desc": "您希望避开的地点中的物体不应被视为误报。若将其作为误报提交，可能会导致AI模型容易混淆相关物体的识别。"
       },
       "review": {
-        "true": {
+        "question": {
           "label": "为 Frigate Plus 确认此标签",
-          "true_one": "这是 {{label}}",
-          "true_other": "这是 {{label}}"
-        },
-        "false": {
-          "label": "不为 Frigate Plus 确认此标签",
-          "false_one": "这不是 {{label}}",
-          "false_other": "这不是 {{label}}"
+          "ask_full": "这是 <code>{{untranslatedLabel}}</code> ({{translatedLabel}})?"
         },
         "state": {
           "submitted": "已提交"


### PR DESCRIPTION
Refactor review prompts for Frigate Plus across multiple languages

## Proposed change

In the recent PR #17725, the structure of the information message for Frigate+ was changed for 'en' localization, but not supported in the rest. Because of this, the information message in all localizations was displayed in English.
The order was also put in order in accordance with the file for 'en' localization.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
