### PR TITLE
i18n updates

### DIFF
--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -153,6 +153,7 @@
       "fi": "Suomi (Finnish)",
       "da": "Dansk (Danish)",
       "sk": "Slovenčina (Slovak)",
+      "yue": "粵語 (Cantonese)",
       "withSystem": {
         "label": "Use the system settings for language"
       }

--- a/web/src/components/menu/GeneralSettings.tsx
+++ b/web/src/components/menu/GeneralSettings.tsx
@@ -79,11 +79,14 @@ export default function GeneralSettings({ className }: GeneralSettingsProps) {
     { code: "en", label: t("menu.language.en") },
     { code: "es", label: t("menu.language.es") },
     { code: "fr", label: t("menu.language.fr") },
-    { code: "zh-CN", label: t("menu.language.zhCN") },
-    { code: "tr", label: t("menu.language.tr") },
+    { code: "de", label: t("menu.language.de") },
+    { code: "it", label: t("menu.language.it") },
     { code: "nl", label: t("menu.language.nl") },
     { code: "nb-NO", label: t("menu.language.nb") },
+    { code: "tr", label: t("menu.language.tr") },
     { code: "pl", label: t("menu.language.pl") },
+    { code: "zh-CN", label: t("menu.language.zhCN") },
+    { code: "yue-Hant", label: t("menu.language.yue") },
     { code: "ru", label: t("menu.language.ru") },
   ];
 

--- a/web/src/hooks/use-date-locale.ts
+++ b/web/src/hooks/use-date-locale.ts
@@ -31,6 +31,8 @@ const localeMap: Record<string, () => Promise<Locale>> = {
   fi: () => import("date-fns/locale/fi").then((module) => module.fi),
   da: () => import("date-fns/locale/da").then((module) => module.da),
   sk: () => import("date-fns/locale/sk").then((module) => module.sk),
+  "yue-Hant": () =>
+    import("date-fns/locale/zh-HK").then((module) => module.zhHK),
 };
 
 export function useDateLocale(): Locale {


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
- Add Italian, Cantonese, and German to languages menu
- `date-fns` doesn't have Cantonese available, but Gemini suggested using `zhHK`. This only affects `react-day-picker` calendar month and day names.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
