### PR TITLE
Support automatic language selection based on system language

### DIFF
--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -120,7 +120,7 @@ class EmbeddingMaintainer(threading.Thread):
         if self.config.face_recognition.enabled:
             self.realtime_processors.append(
                 FaceRealTimeProcessor(
-                    self.config, self.event_metadata_publisher, metrics
+                    self.config, self.requestor, self.event_metadata_publisher, metrics
                 )
             )
 

--- a/web/src/components/menu/GeneralSettings.tsx
+++ b/web/src/components/menu/GeneralSettings.tsx
@@ -79,8 +79,9 @@ export default function GeneralSettings({ className }: GeneralSettingsProps) {
   const languages = useMemo(() => {
     // Handle language keys that aren't directly used for translation key
     const specialKeyMap: { [key: string]: string } = {
-      "zh-CN": "zhCN",
+      "nb-NO": "nb",
       "yue-Hant": "yue",
+      "zh-CN": "zhCN",
     };
 
     return supportedLanguageKeys.map((key) => {

--- a/web/src/components/menu/GeneralSettings.tsx
+++ b/web/src/components/menu/GeneralSettings.tsx
@@ -34,7 +34,7 @@ import {
   useTheme,
 } from "@/context/theme-provider";
 import { IoColorPalette } from "react-icons/io5";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRestart } from "@/api/ws";
 import {
   Tooltip,
@@ -62,6 +62,7 @@ import { toast } from "sonner";
 import axios from "axios";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { useTranslation } from "react-i18next";
+import { supportedLanguageKeys } from "@/lib/const";
 
 type GeneralSettingsProps = {
   className?: string;
@@ -75,20 +76,13 @@ export default function GeneralSettings({ className }: GeneralSettingsProps) {
 
   // languages
 
-  const languages = [
-    { code: "en", label: t("menu.language.en") },
-    { code: "es", label: t("menu.language.es") },
-    { code: "fr", label: t("menu.language.fr") },
-    { code: "de", label: t("menu.language.de") },
-    { code: "it", label: t("menu.language.it") },
-    { code: "nl", label: t("menu.language.nl") },
-    { code: "nb-NO", label: t("menu.language.nb") },
-    { code: "tr", label: t("menu.language.tr") },
-    { code: "pl", label: t("menu.language.pl") },
-    { code: "zh-CN", label: t("menu.language.zhCN") },
-    { code: "yue-Hant", label: t("menu.language.yue") },
-    { code: "ru", label: t("menu.language.ru") },
-  ];
+  const languages = useMemo(
+    () =>
+      supportedLanguageKeys.map((key) => {
+        return { code: key, label: t(`menu.language.${key}`) };
+      }),
+    [t],
+  );
 
   // settings
 

--- a/web/src/components/menu/GeneralSettings.tsx
+++ b/web/src/components/menu/GeneralSettings.tsx
@@ -76,13 +76,20 @@ export default function GeneralSettings({ className }: GeneralSettingsProps) {
 
   // languages
 
-  const languages = useMemo(
-    () =>
-      supportedLanguageKeys.map((key) => {
-        return { code: key, label: t(`menu.language.${key}`) };
-      }),
-    [t],
-  );
+  const languages = useMemo(() => {
+    // Handle language keys that aren't directly used for translation key
+    const specialKeyMap: { [key: string]: string } = {
+      "zh-CN": "zhCN",
+      "yue-Hant": "yue",
+    };
+
+    return supportedLanguageKeys.map((key) => {
+      return {
+        code: key,
+        label: t(`menu.language.${specialKeyMap[key] || key}`),
+      };
+    });
+  }, [t]);
 
   // settings
 

--- a/web/src/context/language-provider.tsx
+++ b/web/src/context/language-provider.tsx
@@ -34,6 +34,15 @@ export function LanguageProvider({
       return systemLanguage;
     }
 
+    // browser languages may include a -REGION (ex: en-US)
+    if (systemLanguage.includes("-")) {
+      const shortenedSystemLanguage = systemLanguage.split("-")[0];
+
+      if (supportedLanguageKeys.includes(shortenedSystemLanguage)) {
+        return shortenedSystemLanguage;
+      }
+    }
+
     return defaultLanguage;
   }, [defaultLanguage]);
 

--- a/web/src/context/language-provider.tsx
+++ b/web/src/context/language-provider.tsx
@@ -1,15 +1,14 @@
 import { createContext, useContext, useState, useEffect, useMemo } from "react";
 import i18next from "i18next";
+import { supportedLanguageKeys } from "@/lib/const";
 
 type LanguageProviderState = {
   language: string;
-  systemLanguage: string;
   setLanguage: (language: string) => void;
 };
 
 const initialState: LanguageProviderState = {
   language: i18next.language || "en",
-  systemLanguage: "en",
   setLanguage: () => null,
 };
 
@@ -26,10 +25,22 @@ export function LanguageProvider({
   defaultLanguage?: string;
   storageKey?: string;
 }) {
+  const systemLanguage = useMemo<string>(() => {
+    if (typeof window === "undefined") return defaultLanguage;
+
+    const systemLanguage = window.navigator.language;
+
+    if (supportedLanguageKeys.includes(systemLanguage)) {
+      return systemLanguage;
+    }
+
+    return defaultLanguage;
+  }, [defaultLanguage]);
+
   const [language, setLanguage] = useState<string>(() => {
     try {
       const storedData = localStorage.getItem(storageKey);
-      const newLanguage = storedData || defaultLanguage;
+      const newLanguage = storedData || systemLanguage;
       i18next.changeLanguage(newLanguage);
       return newLanguage;
     } catch (error) {
@@ -38,11 +49,6 @@ export function LanguageProvider({
       return defaultLanguage;
     }
   });
-
-  const systemLanguage = useMemo<string>(() => {
-    if (typeof window === "undefined") return "en";
-    return window.navigator.language;
-  }, []);
 
   useEffect(() => {
     // set document lang for smart capitalization
@@ -54,7 +60,6 @@ export function LanguageProvider({
 
   const value = {
     language,
-    systemLanguage,
     setLanguage: (language: string) => {
       localStorage.setItem(storageKey, language);
       setLanguage(language);

--- a/web/src/lib/const.ts
+++ b/web/src/lib/const.ts
@@ -1,0 +1,14 @@
+export const supportedLanguageKeys = [
+  "en",
+  "es",
+  "fr",
+  "de",
+  "it",
+  "nl",
+  "nb-NO",
+  "tr",
+  "pl",
+  "zh-CN",
+  "yue-Hant",
+  "ru",
+];


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This PR cleans up the list of supported language keys and will use the system language if it is included in that list, falling back to the default language when it is not. This means there is no "system" option in the dropdown, just that the default selected language will be the system language unless the user overrides that choice by selecting a different language.

Also fixes bug with face processor

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/issues/17951
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
