### PR TITLE
Autotracking improvements

### DIFF
--- a/frigate/config/camera/onvif.py
+++ b/frigate/config/camera/onvif.py
@@ -63,9 +63,9 @@ class PtzAutotrackConfig(FrigateBaseModel):
         else:
             raise ValueError("Invalid type for movement_weights")
 
-        if len(weights) != 5:
+        if len(weights) != 6:
             raise ValueError(
-                "movement_weights must have exactly 5 floats, remove this line from your config and run autotracking calibration"
+                "movement_weights must have exactly 6 floats, remove this line from your config and run autotracking calibration"
             )
 
         return weights

--- a/frigate/embeddings/__init__.py
+++ b/frigate/embeddings/__init__.py
@@ -243,7 +243,7 @@ class EmbeddingsContext:
         )
 
     def rename_face(self, old_name: str, new_name: str) -> None:
-        valid_name_pattern = r"^[a-zA-Z0-9_-]{1,50}$"
+        valid_name_pattern = r"^[a-zA-Z0-9\s_-]{1,50}$"
 
         try:
             sanitized_old_name = sanitize_filename(old_name, replacement_text="_")

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -273,7 +273,12 @@ class PtzAutoTracker:
 
             move_status_supported = self.onvif.get_service_capabilities(camera)
 
-            if move_status_supported is None or move_status_supported.lower() != "true":
+            if not (
+                isinstance(move_status_supported, bool) and move_status_supported
+            ) and not (
+                isinstance(move_status_supported, str)
+                and move_status_supported.lower() == "true"
+            ):
                 logger.warning(
                     f"Disabling autotracking for {camera}: ONVIF MoveStatus not supported"
                 )

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -1143,7 +1143,7 @@ class PtzAutoTracker:
             tilt = (0.5 - (centroid_y / camera_height)) * 2
 
             logger.debug(
-                f"{camera}: Zoom predicted time: {zoom_predicted_movement_time}, zoom predicted box: {tuple(zoom_predicted_box)}"
+                f"{camera}: Zoom amount: {zoom}, zoom predicted time: {zoom_predicted_movement_time}, zoom predicted box: {tuple(zoom_predicted_box)}"
             )
 
         self._enqueue_move(camera, obj.obj_data["frame_time"], pan, tilt, zoom)

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -1491,7 +1491,9 @@ class TestConfig(unittest.TestCase):
                         "fps": 5,
                     },
                     "onvif": {
-                        "autotracking": {"movement_weights": "0, 1, 1.23, 2.34, 0.50"}
+                        "autotracking": {
+                            "movement_weights": "0, 1, 1.23, 2.34, 0.50, 1"
+                        }
                     },
                 }
             },
@@ -1504,6 +1506,7 @@ class TestConfig(unittest.TestCase):
             "1.23",
             "2.34",
             "0.5",
+            "1.0",
         ]
 
     def test_fails_invalid_movement_weights(self):

--- a/frigate/util/config.py
+++ b/frigate/util/config.py
@@ -330,7 +330,7 @@ def migrate_016_0(config: dict[str, dict[str, any]]) -> dict[str, dict[str, any]
 
             if movement_weights and len(movement_weights.split(",")) == 5:
                 onvif_config["autotracking"]["movement_weights"] = (
-                    movement_weights + ", 1"
+                    movement_weights + ", 0"
                 )
             camera_config["onvif"] = onvif_config
 

--- a/frigate/util/config.py
+++ b/frigate/util/config.py
@@ -319,6 +319,21 @@ def migrate_016_0(config: dict[str, dict[str, any]]) -> dict[str, dict[str, any]
 
             camera_config["live"] = live_config
 
+        # add another value to movement_weights for autotracking cams
+        onvif_config = camera_config.get("onvif", {})
+        if "autotracking" in onvif_config:
+            movement_weights = (
+                camera_config.get("onvif", {})
+                .get("autotracking")
+                .get("movement_weights", {})
+            )
+
+            if movement_weights and len(movement_weights.split(",")) == 5:
+                onvif_config["autotracking"]["movement_weights"] = (
+                    movement_weights + ", 1"
+                )
+            camera_config["onvif"] = onvif_config
+
         new_config["cameras"][name] = camera_config
 
     new_config["version"] = "0.16-0"


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR makes some minor changes and fixes to autotracking.
- Add zoom time to predictions when using relative zooming (absolute zooming is unchanged and not needed in this case). This requires a re-calibration and will take the time the zoom motor moves into account (not just the pan/tilt motor) when predicting the position of a tracked object when moving.
- Add a config migrator to add a new value to the end of any defined `movement_weights` in the config. **Users already running the 0.16 builds will need to add `, 0` to the end of their movement weights list, or just delete the `movement_weights` line in their config and recalibrate (set `calibrate_on_startup: true`).**
- Update test to check for the correct number of floats.
- Fix initial check on a new object to look for `active` rather than manually checking `motionless_count`.
- Fix check for ONVIF `MoveStatus` - apparently sometimes this is returned as a boolean (https://github.com/blakeblackshear/frigate/discussions/17504#discussioncomment-12982434) - perhaps this is new with the upgrade to `onvif-zeep-async`.

This PR also includes a small change when renaming a face in the Face Library, adding whitespace as a valid character.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
