### PR TITLE
Extend i18n

### DIFF
--- a/web/public/locales/en/views/system.json
+++ b/web/public/locales/en/views/system.json
@@ -129,7 +129,16 @@
       "detect": "detect",
       "skipped": "skipped",
       "ffmpeg": "ffmpeg",
-      "capture": "capture"
+      "capture": "capture",
+      "overallFramesPerSecond": "overall frames per second",
+      "overallDetectionsPerSecond": "overall detections per second",
+      "overallSkippedDetectionsPerSecond": "overall skipped detections per second",
+      "cameraFfmpeg": "{{camName}} ffmpeg",
+      "cameraCapture": "{{camName}} capture",
+      "cameraDetect": "{{camName}} detect",
+      "cameraFramesPerSecond": "{{camName}} frames per second",
+      "cameraDetectionsPerSecond": "{{camName}} detections per second",
+      "cameraSkippedDetectionsPerSecond": "{{camName}} skipped detections per second"
     },
     "toast": {
       "success": {

--- a/web/src/views/system/CameraMetrics.tsx
+++ b/web/src/views/system/CameraMetrics.tsx
@@ -79,9 +79,18 @@ export default function CameraMetrics({
       [key: string]: { name: string; data: { x: number; y: number }[] };
     } = {};
 
-    series["overall_fps"] = { name: t("cameras.label.overallFramesPerSecond"), data: [] };
-    series["overall_dps"] = { name: t("cameras.label.overallDetectionsPerSecond"), data: [] };
-    series["overall_skipped_dps"] = { name: t("cameras.label.overallSkippedDetectionsPerSecond"),data: [],};
+    series["overall_fps"] = {
+      name: t("cameras.label.overallFramesPerSecond"),
+      data: [],
+    };
+    series["overall_dps"] = {
+      name: t("cameras.label.overallDetectionsPerSecond"),
+      data: [],
+    };
+    series["overall_skipped_dps"] = {
+      name: t("cameras.label.overallSkippedDetectionsPerSecond"),
+      data: [],
+    };
 
     statsHistory.forEach((stats, statsIdx) => {
       if (!stats) {
@@ -114,7 +123,7 @@ export default function CameraMetrics({
       });
     });
     return Object.values(series);
-  }, [statsHistory]);
+  }, [statsHistory, t]);
 
   const cameraCpuSeries = useMemo(() => {
     if (!statsHistory || statsHistory.length == 0) {
@@ -140,9 +149,18 @@ export default function CameraMetrics({
         if (!(key in series)) {
           const camName = key.replaceAll("_", " ");
           series[key] = {};
-          series[key]["ffmpeg"] = { name: t("cameras.label.cameraFfmpeg", {camName: camName}), data: [] };
-          series[key]["capture"] = { name: t("cameras.label.cameraCapture", {camName: camName}), data: [] };
-          series[key]["detect"] = { name: t("cameras.label.cameraCapture", {camName: camName}), data: [] };
+          series[key]["ffmpeg"] = {
+            name: t("cameras.label.cameraFfmpeg", { camName: camName }),
+            data: [],
+          };
+          series[key]["capture"] = {
+            name: t("cameras.label.cameraCapture", { camName: camName }),
+            data: [],
+          };
+          series[key]["detect"] = {
+            name: t("cameras.label.cameraCapture", { camName: camName }),
+            data: [],
+          };
         }
 
         series[key]["ffmpeg"].data.push({
@@ -160,7 +178,7 @@ export default function CameraMetrics({
       });
     });
     return series;
-  }, [config, statsHistory]);
+  }, [config, statsHistory, t]);
 
   const cameraFpsSeries = useMemo(() => {
     if (!statsHistory) {
@@ -183,15 +201,21 @@ export default function CameraMetrics({
           const camName = key.replaceAll("_", " ");
           series[key] = {};
           series[key]["fps"] = {
-            name: t("cameras.label.cameraFramesPerSecond", {camName: camName}),
+            name: t("cameras.label.cameraFramesPerSecond", {
+              camName: camName,
+            }),
             data: [],
           };
           series[key]["det"] = {
-            name: t("cameras.label.cameraDetectionsPerSecond", {camName: camName}),
+            name: t("cameras.label.cameraDetectionsPerSecond", {
+              camName: camName,
+            }),
             data: [],
           };
           series[key]["skip"] = {
-            name: t("cameras.label.cameraSkippedDetectionsPerSecond", {camName: camName}),
+            name: t("cameras.label.cameraSkippedDetectionsPerSecond", {
+              camName: camName,
+            }),
             data: [],
           };
         }
@@ -211,7 +235,7 @@ export default function CameraMetrics({
       });
     });
     return series;
-  }, [statsHistory]);
+  }, [statsHistory, t]);
 
   useEffect(() => {
     if (!showCameraInfoDialog) {

--- a/web/src/views/system/CameraMetrics.tsx
+++ b/web/src/views/system/CameraMetrics.tsx
@@ -79,12 +79,9 @@ export default function CameraMetrics({
       [key: string]: { name: string; data: { x: number; y: number }[] };
     } = {};
 
-    series["overall_fps"] = { name: "overall frames per second", data: [] };
-    series["overall_dps"] = { name: "overall detections per second", data: [] };
-    series["overall_skipped_dps"] = {
-      name: "overall skipped detections per second",
-      data: [],
-    };
+    series["overall_fps"] = { name: t("cameras.label.overallFramesPerSecond"), data: [] };
+    series["overall_dps"] = { name: t("cameras.label.overallDetectionsPerSecond"), data: [] };
+    series["overall_skipped_dps"] = { name: t("cameras.label.overallSkippedDetectionsPerSecond"),data: [],};
 
     statsHistory.forEach((stats, statsIdx) => {
       if (!stats) {
@@ -143,9 +140,9 @@ export default function CameraMetrics({
         if (!(key in series)) {
           const camName = key.replaceAll("_", " ");
           series[key] = {};
-          series[key]["ffmpeg"] = { name: `${camName} ffmpeg`, data: [] };
-          series[key]["capture"] = { name: `${camName} capture`, data: [] };
-          series[key]["detect"] = { name: `${camName} detect`, data: [] };
+          series[key]["ffmpeg"] = { name: t("cameras.label.cameraFfmpeg", {camName: camName}), data: [] };
+          series[key]["capture"] = { name: t("cameras.label.cameraCapture", {camName: camName}), data: [] };
+          series[key]["detect"] = { name: t("cameras.label.cameraCapture", {camName: camName}), data: [] };
         }
 
         series[key]["ffmpeg"].data.push({
@@ -186,15 +183,15 @@ export default function CameraMetrics({
           const camName = key.replaceAll("_", " ");
           series[key] = {};
           series[key]["fps"] = {
-            name: `${camName} frames per second`,
+            name: t("cameras.label.cameraFramesPerSecond", {camName: camName}),
             data: [],
           };
           series[key]["det"] = {
-            name: `${camName} detections per second`,
+            name: t("cameras.label.cameraDetectionsPerSecond", {camName: camName}),
             data: [],
           };
           series[key]["skip"] = {
-            name: `${camName} skipped detections per second`,
+            name: t("cameras.label.cameraSkippedDetectionsPerSecond", {camName: camName}),
             data: [],
           };
         }


### PR DESCRIPTION
## Proposed change
After transferring the project to the use of Weblate for localizations and the appearance of new languages in the product, I noticed that on the camera metrics page, non-localized text graphics remained. I corrected it in this PR.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)