### PR TITLE
Change default zmq timeout

### DIFF
--- a/frigate/comms/event_metadata_updater.py
+++ b/frigate/comms/event_metadata_updater.py
@@ -39,9 +39,6 @@ class EventMetadataSubscriber(Subscriber):
     def __init__(self, topic: EventMetadataTypeEnum) -> None:
         super().__init__(topic.value)
 
-    def check_for_update(self, timeout: float) -> tuple | None:
-        return super().check_for_update(timeout)
-
     def _return_object(self, topic: str, payload: tuple) -> tuple:
         if payload is None:
             return (None, None)

--- a/frigate/comms/event_metadata_updater.py
+++ b/frigate/comms/event_metadata_updater.py
@@ -39,7 +39,7 @@ class EventMetadataSubscriber(Subscriber):
     def __init__(self, topic: EventMetadataTypeEnum) -> None:
         super().__init__(topic.value)
 
-    def check_for_update(self, timeout: float = 1) -> tuple | None:
+    def check_for_update(self, timeout: float) -> tuple | None:
         return super().check_for_update(timeout)
 
     def _return_object(self, topic: str, payload: tuple) -> tuple:

--- a/frigate/comms/zmq_proxy.py
+++ b/frigate/comms/zmq_proxy.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 import zmq
 
+from frigate.const import FAST_QUEUE_TIMEOUT
+
 SOCKET_PUB = "ipc:///tmp/cache/proxy_pub"
 SOCKET_SUB = "ipc:///tmp/cache/proxy_sub"
 
@@ -77,7 +79,9 @@ class Subscriber:
         self.socket.setsockopt_string(zmq.SUBSCRIBE, self.topic)
         self.socket.connect(SOCKET_SUB)
 
-    def check_for_update(self, timeout: float = 1) -> Optional[tuple[str, any]]:
+    def check_for_update(
+        self, timeout: float = FAST_QUEUE_TIMEOUT
+    ) -> Optional[tuple[str, any]]:
         """Returns message or None if no update."""
         try:
             has_update, _, _ = zmq.select([self.socket], [], [], timeout)

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -231,7 +231,7 @@ class EmbeddingMaintainer(threading.Thread):
 
     def _process_updates(self) -> None:
         """Process event updates"""
-        update = self.event_subscriber.check_for_update(timeout=0.01)
+        update = self.event_subscriber.check_for_update()
 
         if update is None:
             return
@@ -324,7 +324,7 @@ class EmbeddingMaintainer(threading.Thread):
     def _process_finalized(self) -> None:
         """Process the end of an event."""
         while True:
-            ended = self.event_end_subscriber.check_for_update(timeout=0.01)
+            ended = self.event_end_subscriber.check_for_update()
 
             if ended == None:
                 break
@@ -420,7 +420,7 @@ class EmbeddingMaintainer(threading.Thread):
     def _process_recordings_updates(self) -> None:
         """Process recordings updates."""
         while True:
-            recordings_data = self.recordings_subscriber.check_for_update(timeout=0.01)
+            recordings_data = self.recordings_subscriber.check_for_update()
 
             if recordings_data == None:
                 break
@@ -437,7 +437,7 @@ class EmbeddingMaintainer(threading.Thread):
 
     def _process_event_metadata(self):
         # Check for regenerate description requests
-        (topic, payload) = self.event_metadata_subscriber.check_for_update(timeout=0.01)
+        (topic, payload) = self.event_metadata_subscriber.check_for_update()
 
         if topic is None:
             return
@@ -451,7 +451,7 @@ class EmbeddingMaintainer(threading.Thread):
 
     def _process_dedicated_lpr(self) -> None:
         """Process event updates"""
-        (topic, data) = self.detection_subscriber.check_for_update(timeout=0.01)
+        (topic, data) = self.detection_subscriber.check_for_update()
 
         if topic is None:
             return

--- a/frigate/events/maintainer.py
+++ b/frigate/events/maintainer.py
@@ -75,7 +75,7 @@ class EventProcessor(threading.Thread):
         ).execute()
 
         while not self.stop_event.is_set():
-            update = self.event_receiver.check_for_update()
+            update = self.event_receiver.check_for_update(timeout=1)
 
             if update == None:
                 continue


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Lower the default ZMQ timeout so that threads and processes with multiple loops are not waiting around as much. This should improve performance especially in the embeddings maintainer for users with larger numbers of cameras and tracked objects.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
