### PR TITLE
Restrict desktop dropdown menu to grid view only.

### DIFF
--- a/web/src/components/settings/SearchSettings.tsx
+++ b/web/src/components/settings/SearchSettings.tsx
@@ -92,7 +92,7 @@ export default function ExploreSettings({
           </SelectContent>
         </Select>
       </div>
-      {!isMobileOnly && (
+      {!isMobileOnly && defaultView == "grid" && (
         <>
           <DropdownMenuSeparator />
           <div className="flex w-full flex-col space-y-4">


### PR DESCRIPTION
## Proposed change
Previously, the dropdown menu appeared on all desktop views, causing inconsistency. This update ensures it is displayed only when the default view is set to "grid".

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
