### PR TITLE
Fix camera label translation from 'cameraCapture' to 'cameraDetect'

### DIFF
--- a/web/src/views/system/CameraMetrics.tsx
+++ b/web/src/views/system/CameraMetrics.tsx
@@ -158,7 +158,7 @@ export default function CameraMetrics({
             data: [],
           };
           series[key]["detect"] = {
-            name: t("cameras.label.cameraCapture", { camName: camName }),
+            name: t("cameras.label.cameraDetect", { camName: camName }),
             data: [],
           };
         }


### PR DESCRIPTION
## Proposed change
In #17969, an error was made in the chart label. This PR fixes the error.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
