### PR TITLE
Listen on timeline ref instead of window

### DIFF
--- a/web/src/hooks/use-timeline-zoom.ts
+++ b/web/src/hooks/use-timeline-zoom.ts
@@ -159,16 +159,30 @@ export function useTimelineZoom({
   );
 
   useEffect(() => {
-    window.addEventListener("wheel", handleWheel, { passive: false });
-    window.addEventListener("touchstart", handleTouchStart, { passive: false });
-    window.addEventListener("touchmove", handleTouchMove, { passive: false });
+    const timelineElement = timelineRef.current;
+
+    if (timelineElement) {
+      timelineElement.addEventListener("wheel", handleWheel, {
+        passive: false,
+      });
+      timelineElement.addEventListener("touchstart", handleTouchStart, {
+        passive: false,
+      });
+      timelineElement.addEventListener("touchmove", handleTouchMove, {
+        passive: false,
+      });
+    }
 
     return () => {
-      window.removeEventListener("wheel", handleWheel);
-      window.removeEventListener("touchstart", handleTouchStart);
-      window.removeEventListener("touchmove", handleTouchMove);
+      if (timelineElement) {
+        timelineElement.removeEventListener("wheel", handleWheel);
+        timelineElement.removeEventListener("touchstart", handleTouchStart);
+        timelineElement.removeEventListener("touchmove", handleTouchMove);
+      }
     };
-  }, [handleWheel, handleTouchStart, handleTouchMove]);
+    // we know that these deps are correct
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [handleWheel, handleTouchStart, handleTouchMove, timelineRef.current]);
 
   return { zoomLevel, handleZoom, isZooming, zoomDirection };
 }


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
The timeline zooming listener was listening on `window` rather than a ref for the timeline div.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
