### PR TITLE
Avoid unhealthy container when Frigate is stopping

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -260,7 +260,7 @@ ENTRYPOINT ["/init"]
 CMD []
 
 HEALTHCHECK --start-period=300s --start-interval=5s --interval=15s --timeout=5s --retries=3 \
-    CMD curl --fail --silent --show-error http://127.0.0.1:5000/api/version || exit 1
+    CMD test -f /dev/shm/.frigate-is-stopping && exit 0; curl --fail --silent --show-error http://127.0.0.1:5000/api/version || exit 1
 
 # Frigate deps with Node.js and NPM for devcontainer
 FROM deps AS devcontainer

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate/finish
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate/finish
@@ -25,4 +25,7 @@ elif [[ "${exit_code_service}" -ne 0 ]]; then
   fi
 fi
 
+# used by the docker healthcheck
+touch /dev/shm/.frigate-is-stopping
+
 exec /run/s6/basedir/bin/halt

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/prepare/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/prepare/run
@@ -138,5 +138,9 @@ function migrate_db_from_media_to_config() {
     fi
 }
 
+# remove leftover from last run, not normally needed, but just in case
+# used by the docker healthcheck
+rm -f /dev/shm/.frigate-is-stopping
+
 migrate_addon_config_dir
 migrate_db_from_media_to_config


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Frigate takes some time to stop. It's annoying that the healthchecker some times marks it as unhealthy during that. This fixes it.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

N/A

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
