### PR TITLE
Use HF_ENDPOINT env instead of hardcoding https://huggingface.co

### DIFF
--- a/frigate/embeddings/onnx/jina_v1_embedding.py
+++ b/frigate/embeddings/onnx/jina_v1_embedding.py
@@ -36,11 +36,12 @@ class JinaV1TextEmbedding(BaseEmbedding):
         requestor: InterProcessRequestor,
         device: str = "AUTO",
     ):
+        HF_ENDPOINT = os.environ.get("HF_ENDPOINT", "https://huggingface.co")
         super().__init__(
             model_name="jinaai/jina-clip-v1",
             model_file="text_model_fp16.onnx",
             download_urls={
-                "text_model_fp16.onnx": "https://huggingface.co/jinaai/jina-clip-v1/resolve/main/onnx/text_model_fp16.onnx",
+                "text_model_fp16.onnx": f"{HF_ENDPOINT}/jinaai/jina-clip-v1/resolve/main/onnx/text_model_fp16.onnx",
             },
         )
         self.tokenizer_file = "tokenizer"
@@ -156,12 +157,13 @@ class JinaV1ImageEmbedding(BaseEmbedding):
             if model_size == "large"
             else "vision_model_quantized.onnx"
         )
+        HF_ENDPOINT = os.environ.get("HF_ENDPOINT", "https://huggingface.co")
         super().__init__(
             model_name="jinaai/jina-clip-v1",
             model_file=model_file,
             download_urls={
-                model_file: f"https://huggingface.co/jinaai/jina-clip-v1/resolve/main/onnx/{model_file}",
-                "preprocessor_config.json": "https://huggingface.co/jinaai/jina-clip-v1/resolve/main/preprocessor_config.json",
+                model_file: f"{HF_ENDPOINT}/jinaai/jina-clip-v1/resolve/main/onnx/{model_file}",
+                "preprocessor_config.json": f"{HF_ENDPOINT}/jinaai/jina-clip-v1/resolve/main/preprocessor_config.json",
             },
         )
         self.requestor = requestor

--- a/frigate/embeddings/onnx/jina_v2_embedding.py
+++ b/frigate/embeddings/onnx/jina_v2_embedding.py
@@ -34,12 +34,13 @@ class JinaV2Embedding(BaseEmbedding):
         model_file = (
             "model_fp16.onnx" if model_size == "large" else "model_quantized.onnx"
         )
+        HF_ENDPOINT = os.environ.get("HF_ENDPOINT", "https://huggingface.co")
         super().__init__(
             model_name="jinaai/jina-clip-v2",
             model_file=model_file,
             download_urls={
-                model_file: f"https://huggingface.co/jinaai/jina-clip-v2/resolve/main/onnx/{model_file}",
-                "preprocessor_config.json": "https://huggingface.co/jinaai/jina-clip-v2/resolve/main/preprocessor_config.json",
+                model_file: f"{HF_ENDPOINT}/jinaai/jina-clip-v2/resolve/main/onnx/{model_file}",
+                "preprocessor_config.json": f"{HF_ENDPOINT}/jinaai/jina-clip-v2/resolve/main/preprocessor_config.json",
             },
         )
         self.tokenizer_file = "tokenizer"


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Huggingface supports the HF_ENDPOINT environment variable if your organization is using a [Private Hub](https://huggingface.co/platform).

The huggingface transformers.AutoTokenizer used by frigate will then follow this env to download the tokenizer, but that's not enough because frigate is hardcoded to download models from huggingface.co.

To solve this,
- Change the hardcoded huggingface.co to use HF_ENDPOINT so frigate can download from a private hub.

I've made similar changes on the 0.15.1 version locally and it works without problem.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
