### PR TITLE
Refactor async ONVIF

### DIFF
--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -1,5 +1,6 @@
 """Image and video apis."""
 
+import asyncio
 import glob
 import logging
 import math
@@ -110,9 +111,12 @@ def imagestream(
 @router.get("/{camera_name}/ptz/info")
 async def camera_ptz_info(request: Request, camera_name: str):
     if camera_name in request.app.frigate_config.cameras:
-        return JSONResponse(
-            content=request.app.onvif.get_camera_info(camera_name),
+        # Schedule get_camera_info in the OnvifController's event loop
+        future = asyncio.run_coroutine_threadsafe(
+            request.app.onvif.get_camera_info(camera_name), request.app.onvif.loop
         )
+        result = future.result()
+        return JSONResponse(content=result)
     else:
         return JSONResponse(
             content={"success": False, "message": "Camera not found"},

--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -111,7 +111,7 @@ def imagestream(
 async def camera_ptz_info(request: Request, camera_name: str):
     if camera_name in request.app.frigate_config.cameras:
         return JSONResponse(
-            content=await request.app.onvif.get_camera_info(camera_name),
+            content=request.app.onvif.get_camera_info(camera_name),
         )
     else:
         return JSONResponse(

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -699,6 +699,10 @@ class FrigateApp:
             self.audio_process.terminate()
             self.audio_process.join()
 
+        # stop the onvif controller
+        if self.onvif_controller:
+            self.onvif_controller.close()
+
         # ensure the capture processes are done
         for camera, metrics in self.camera_metrics.items():
             capture_process = metrics.capture_process

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -334,7 +334,7 @@ class PtzAutoTracker:
                     )
 
             if camera_config.onvif.autotracking.calibrate_on_startup:
-                self._calibrate_camera(camera)
+                await self._calibrate_camera(camera)
 
         self.ptz_metrics[camera].tracking_active.clear()
         self.dispatcher.publish(f"{camera}/ptz_autotracker/active", "OFF", retain=False)
@@ -377,7 +377,7 @@ class PtzAutoTracker:
 
             for i in range(2):
                 # absolute move to 0 - fully zoomed out
-                self.onvif._zoom_absolute(
+                await self.onvif._zoom_absolute(
                     camera,
                     self.onvif.cams[camera]["absolute_zoom_range"]["XRange"]["Min"],
                     1,
@@ -388,7 +388,7 @@ class PtzAutoTracker:
 
                 zoom_out_values.append(self.ptz_metrics[camera].zoom_level.value)
 
-                self.onvif._zoom_absolute(
+                await self.onvif._zoom_absolute(
                     camera,
                     self.onvif.cams[camera]["absolute_zoom_range"]["XRange"]["Max"],
                     1,
@@ -475,7 +475,7 @@ class PtzAutoTracker:
             self.ptz_metrics[camera].max_zoom.value = 1
             self.ptz_metrics[camera].min_zoom.value = 0
 
-        self.onvif._move_to_preset(
+        await self.onvif._move_to_preset(
             camera,
             self.config.cameras[camera].onvif.autotracking.return_preset.lower(),
         )

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -580,6 +580,12 @@ class OnvifController:
     ) -> None:
         """Handle ONVIF commands asynchronously"""
         # logger.debug(f"handling async: {camera_name}, {command}, {param}")
+        current_loop = asyncio.get_running_loop()
+        expected_loop = self.loop
+        if current_loop is not expected_loop:
+            logger.error(
+                f"Wrong event loop in _move! Expected {expected_loop}, got {current_loop}"
+            )
         if camera_name not in self.cams.keys():
             logger.error(f"ONVIF is not configured for {camera_name}")
             return

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -48,7 +48,7 @@ class OnvifController:
         self.ptz_metrics = ptz_metrics
 
         # Create a dedicated event loop and run it in a separate thread
-        self.loop = asyncio.new_event_loop()
+        self.loop = asyncio.get_event_loop()
         self.loop_thread = threading.Thread(target=self._run_event_loop, daemon=True)
         self.loop_thread.start()
 
@@ -63,7 +63,7 @@ class OnvifController:
 
     def _run_event_loop(self) -> None:
         """Run the event loop in a separate thread."""
-        asyncio.set_event_loop(self.loop)
+        # asyncio.set_event_loop(self.loop)
         try:
             self.loop.run_forever()
         except Exception as e:

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import threading
 import time
 from enum import Enum
 from importlib.util import find_spec
@@ -39,22 +40,33 @@ class OnvifController:
     def __init__(
         self, config: FrigateConfig, ptz_metrics: dict[str, PTZMetrics]
     ) -> None:
-        self.cams: dict[str, ONVIFCamera] = {}
+        self.cams: dict[str, dict] = {}
         self.failed_cams: dict[str, dict] = {}
         self.max_retries = 5
         self.reset_timeout = 900  # 15 minutes
-
         self.config = config
         self.ptz_metrics = ptz_metrics
+
+        # Create a dedicated event loop and run it in a separate thread
+        self.loop = asyncio.new_event_loop()
+        self.loop_thread = threading.Thread(target=self._run_event_loop, daemon=True)
+        self.loop_thread.start()
 
         for cam_name, cam in config.cameras.items():
             if not cam.enabled:
                 continue
-
             if cam.onvif.host:
                 result = self._create_onvif_camera(cam_name, cam)
                 if result:
                     self.cams[cam_name] = result
+
+    def _run_event_loop(self) -> None:
+        """Run the event loop in a separate thread."""
+        asyncio.set_event_loop(self.loop)
+        try:
+            self.loop.run_forever()
+        except Exception as e:
+            logger.error(f"Onvif event loop terminated unexpectedly: {e}")
 
     def _create_onvif_camera(self, cam_name: str, cam) -> dict | None:
         """Create an ONVIF camera instance and handle failures."""
@@ -344,25 +356,23 @@ class OnvifController:
         self.cams[camera_name]["init"] = True
         return True
 
-    def _stop(self, camera_name: str) -> None:
+    async def _stop(self, camera_name: str) -> None:
         move_request = self.cams[camera_name]["move_request"]
-        asyncio.run(
-            self.cams[camera_name]["ptz"].Stop(
-                {
-                    "ProfileToken": move_request.ProfileToken,
-                    "PanTilt": True,
-                    "Zoom": True,
-                }
-            )
+        await self.cams[camera_name]["ptz"].Stop(
+            {
+                "ProfileToken": move_request.ProfileToken,
+                "PanTilt": True,
+                "Zoom": True,
+            }
         )
         self.cams[camera_name]["active"] = False
 
-    def _move(self, camera_name: str, command: OnvifCommandEnum) -> None:
+    async def _move(self, camera_name: str, command: OnvifCommandEnum) -> None:
         if self.cams[camera_name]["active"]:
             logger.warning(
                 f"{camera_name} is already performing an action, stopping..."
             )
-            self._stop(camera_name)
+            await self._stop(camera_name)
 
         if "pt" not in self.cams[camera_name]["features"]:
             logger.error(f"{camera_name} does not support ONVIF pan/tilt movement.")
@@ -391,11 +401,11 @@ class OnvifController:
             }
 
         try:
-            asyncio.run(self.cams[camera_name]["ptz"].ContinuousMove(move_request))
+            await self.cams[camera_name]["ptz"].ContinuousMove(move_request)
         except (Fault, ONVIFError, TransportError, Exception) as e:
             logger.warning(f"Onvif sending move request to {camera_name} failed: {e}")
 
-    def _move_relative(self, camera_name: str, pan, tilt, zoom, speed) -> None:
+    async def _move_relative(self, camera_name: str, pan, tilt, zoom, speed) -> None:
         if "pt-r-fov" not in self.cams[camera_name]["features"]:
             logger.error(f"{camera_name} does not support ONVIF RelativeMove (FOV).")
             return
@@ -464,7 +474,7 @@ class OnvifController:
             }
             move_request.Translation.Zoom.x = zoom
 
-        asyncio.run(self.cams[camera_name]["ptz"].RelativeMove(move_request))
+        await self.cams[camera_name]["ptz"].RelativeMove(move_request)
 
         # reset after the move request
         move_request.Translation.PanTilt.x = 0
@@ -479,7 +489,7 @@ class OnvifController:
 
         self.cams[camera_name]["active"] = False
 
-    def _move_to_preset(self, camera_name: str, preset: str) -> None:
+    async def _move_to_preset(self, camera_name: str, preset: str) -> None:
         if preset not in self.cams[camera_name]["presets"]:
             logger.error(f"{preset} is not a valid preset for {camera_name}")
             return
@@ -489,23 +499,22 @@ class OnvifController:
         self.ptz_metrics[camera_name].stop_time.value = 0
         move_request = self.cams[camera_name]["move_request"]
         preset_token = self.cams[camera_name]["presets"][preset]
-        asyncio.run(
-            self.cams[camera_name]["ptz"].GotoPreset(
-                {
-                    "ProfileToken": move_request.ProfileToken,
-                    "PresetToken": preset_token,
-                }
-            )
+
+        await self.cams[camera_name]["ptz"].GotoPreset(
+            {
+                "ProfileToken": move_request.ProfileToken,
+                "PresetToken": preset_token,
+            }
         )
 
         self.cams[camera_name]["active"] = False
 
-    def _zoom(self, camera_name: str, command: OnvifCommandEnum) -> None:
+    async def _zoom(self, camera_name: str, command: OnvifCommandEnum) -> None:
         if self.cams[camera_name]["active"]:
             logger.warning(
                 f"{camera_name} is already performing an action, stopping..."
             )
-            self._stop(camera_name)
+            await self._stop(camera_name)
 
         if "zoom" not in self.cams[camera_name]["features"]:
             logger.error(f"{camera_name} does not support ONVIF zooming.")
@@ -519,9 +528,9 @@ class OnvifController:
         elif command == OnvifCommandEnum.zoom_out:
             move_request.Velocity = {"Zoom": {"x": -0.5}}
 
-        asyncio.run(self.cams[camera_name]["ptz"].ContinuousMove(move_request))
+        await self.cams[camera_name]["ptz"].ContinuousMove(move_request)
 
-    def _zoom_absolute(self, camera_name: str, zoom, speed) -> None:
+    async def _zoom_absolute(self, camera_name: str, zoom, speed) -> None:
         if "zoom-a" not in self.cams[camera_name]["features"]:
             logger.error(f"{camera_name} does not support ONVIF AbsoluteMove zooming.")
             return
@@ -560,19 +569,21 @@ class OnvifController:
 
         logger.debug(f"{camera_name}: Absolute zoom: {zoom}")
 
-        asyncio.run(self.cams[camera_name]["ptz"].AbsoluteMove(move_request))
+        await self.cams[camera_name]["ptz"].AbsoluteMove(move_request)
 
         self.cams[camera_name]["active"] = False
 
-    def handle_command(
+    async def handle_command_async(
         self, camera_name: str, command: OnvifCommandEnum, param: str = ""
     ) -> None:
+        """Handle ONVIF commands asynchronously"""
+        # logger.debug(f"handling async: {camera_name}, {command}, {param}")
         if camera_name not in self.cams.keys():
             logger.error(f"ONVIF is not configured for {camera_name}")
             return
 
         if not self.cams[camera_name]["init"]:
-            if not asyncio.run(self._init_onvif(camera_name)):
+            if not await self._init_onvif(camera_name):
                 return
 
         try:
@@ -580,21 +591,47 @@ class OnvifController:
                 # already init
                 return
             elif command == OnvifCommandEnum.stop:
-                self._stop(camera_name)
+                await self._stop(camera_name)
             elif command == OnvifCommandEnum.preset:
-                self._move_to_preset(camera_name, param)
+                await self._move_to_preset(camera_name, param)
             elif command == OnvifCommandEnum.move_relative:
                 _, pan, tilt = param.split("_")
-                self._move_relative(camera_name, float(pan), float(tilt), 0, 1)
+                await self._move_relative(camera_name, float(pan), float(tilt), 0, 1)
             elif (
                 command == OnvifCommandEnum.zoom_in
                 or command == OnvifCommandEnum.zoom_out
             ):
-                self._zoom(camera_name, command)
+                await self._zoom(camera_name, command)
             else:
-                self._move(camera_name, command)
+                await self._move(camera_name, command)
         except (Fault, ONVIFError, TransportError, Exception) as e:
             logger.error(f"Unable to handle onvif command: {e}")
+
+    def handle_command(
+        self, camera_name: str, command: OnvifCommandEnum, param: str = ""
+    ) -> None:
+        """
+        Handle ONVIF commands by scheduling them in the event loop.
+        This is the synchronous interface that schedules async work.
+        """
+        # Run the async command in the event loop
+        # logger.debug(
+        #     f"Scheduling handle_command_async for {camera_name} with command {command}. {self.loop}"
+        # )
+        future = asyncio.run_coroutine_threadsafe(
+            self.handle_command_async(camera_name, command, param), self.loop
+        )
+        # logger.debug(f"Scheduled handle_command_async for {camera_name}")
+
+        try:
+            # Wait with a timeout to prevent blocking indefinitely
+            future.result(timeout=10)
+        except asyncio.TimeoutError:
+            logger.error(f"Command {command} timed out for camera {camera_name}")
+        except Exception as e:
+            logger.error(
+                f"Error executing command {command} for camera {camera_name}: {e}"
+            )
 
     async def get_camera_info(self, camera_name: str) -> dict[str, any]:
         """
@@ -681,23 +718,21 @@ class OnvifController:
         logger.debug(f"Could not initialize ONVIF for {camera_name}")
         return {}
 
-    def get_service_capabilities(self, camera_name: str) -> None:
+    async def get_service_capabilities(self, camera_name: str) -> None:
         if camera_name not in self.cams.keys():
             logger.error(f"ONVIF is not configured for {camera_name}")
             return {}
 
         if not self.cams[camera_name]["init"]:
-            asyncio.run(self._init_onvif(camera_name))
+            await self._init_onvif(camera_name)
 
         service_capabilities_request = self.cams[camera_name][
             "service_capabilities_request"
         ]
         try:
-            service_capabilities = asyncio.run(
-                self.cams[camera_name]["ptz"].GetServiceCapabilities(
-                    service_capabilities_request
-                )
-            )
+            service_capabilities = await self.cams[camera_name][
+                "ptz"
+            ].GetServiceCapabilities(service_capabilities_request)
 
             logger.debug(
                 f"Onvif service capabilities for {camera_name}: {service_capabilities}"
@@ -711,19 +746,18 @@ class OnvifController:
             )
             return False
 
-    def get_camera_status(self, camera_name: str) -> None:
+    async def get_camera_status(self, camera_name: str) -> None:
         if camera_name not in self.cams.keys():
             logger.error(f"ONVIF is not configured for {camera_name}")
-            return {}
+            return
 
         if not self.cams[camera_name]["init"]:
-            asyncio.run(self._init_onvif(camera_name))
+            if not await self._init_onvif(camera_name):
+                return
 
         status_request = self.cams[camera_name]["status_request"]
         try:
-            status = asyncio.run(
-                self.cams[camera_name]["ptz"].GetStatus(status_request)
-            )
+            status = await self.cams[camera_name]["ptz"].GetStatus(status_request)
         except Exception:
             pass  # We're unsupported, that'll be reported in the next check.
 
@@ -807,3 +841,22 @@ class OnvifController:
                 camera_name
             ].frame_time.value
             logger.warning(f"Camera {camera_name} is still in ONVIF 'MOVING' status.")
+
+    def close(self) -> None:
+        """Gracefully shut down the ONVIF controller."""
+        if not hasattr(self, "loop") or self.loop.is_closed():
+            logger.debug("ONVIF controller already closed")
+            return
+
+        logger.info("Exiting ONVIF controller...")
+
+        def stop_and_cleanup():
+            try:
+                self.loop.stop()
+            except Exception as e:
+                logger.error(f"Error during loop cleanup: {e}")
+
+        # Schedule stop and cleanup in the loop thread
+        self.loop.call_soon_threadsafe(stop_and_cleanup)
+
+        self.loop_thread.join()

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -271,12 +271,12 @@ class OnvifController:
                     logger.debug(
                         f"{camera_name}: Relative move request after deleting zoom: {move_request}"
                     )
-            except Exception:
+            except Exception as e:
                 self.config.cameras[
                     camera_name
                 ].onvif.autotracking.zooming = ZoomingModeEnum.disabled
                 logger.warning(
-                    f"Disabling autotracking zooming for {camera_name}: Relative zoom not supported"
+                    f"Disabling autotracking zooming for {camera_name}: Relative zoom not supported. Exception: {e}"
                 )
 
             if move_request.Speed is None:
@@ -326,7 +326,7 @@ class OnvifController:
                     self.cams[camera_name]["relative_zoom_range"] = (
                         ptz_config.Spaces.RelativeZoomTranslationSpace[0]
                     )
-                except Exception:
+                except Exception as e:
                     if (
                         self.config.cameras[camera_name].onvif.autotracking.zooming
                         == ZoomingModeEnum.relative
@@ -335,7 +335,7 @@ class OnvifController:
                             camera_name
                         ].onvif.autotracking.zooming = ZoomingModeEnum.disabled
                         logger.warning(
-                            f"Disabling autotracking zooming for {camera_name}: Relative zoom not supported"
+                            f"Disabling autotracking zooming for {camera_name}: Relative zoom not supported. Exception: {e}"
                         )
 
         if configs.DefaultAbsoluteZoomPositionSpace:
@@ -350,13 +350,13 @@ class OnvifController:
                         ptz_config.Spaces.AbsoluteZoomPositionSpace[0]
                     )
                     self.cams[camera_name]["zoom_limits"] = configs.ZoomLimits
-                except Exception:
+                except Exception as e:
                     if self.config.cameras[camera_name].onvif.autotracking.zooming:
                         self.config.cameras[
                             camera_name
                         ].onvif.autotracking.zooming = ZoomingModeEnum.disabled
                         logger.warning(
-                            f"Disabling autotracking zooming for {camera_name}: Absolute zoom not supported"
+                            f"Disabling autotracking zooming for {camera_name}: Absolute zoom not supported. Exception: {e}"
                         )
 
         # set relative pan/tilt space for autotracker
@@ -750,9 +750,9 @@ class OnvifController:
 
             # MoveStatus is required for autotracking - should return "true" if supported
             return find_by_key(vars(service_capabilities), "MoveStatus")
-        except Exception:
+        except Exception as e:
             logger.warning(
-                f"Camera {camera_name} does not support the ONVIF GetServiceCapabilities method. Autotracking will not function correctly and must be disabled in your config."
+                f"Camera {camera_name} does not support the ONVIF GetServiceCapabilities method. Autotracking will not function correctly and must be disabled in your config. Exception: {e}"
             )
             return False
 

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -638,14 +638,9 @@ class OnvifController:
         Handle ONVIF commands by scheduling them in the event loop.
         This is the synchronous interface that schedules async work.
         """
-        # Run the async command in the event loop
-        # logger.debug(
-        #     f"Scheduling handle_command_async for {camera_name} with command {command}. {self.loop}"
-        # )
         future = asyncio.run_coroutine_threadsafe(
             self.handle_command_async(camera_name, command, param), self.loop
         )
-        # logger.debug(f"Scheduled handle_command_async for {camera_name}")
 
         try:
             # Wait with a timeout to prevent blocking indefinitely
@@ -657,7 +652,7 @@ class OnvifController:
                 f"Error executing command {command} for camera {camera_name}: {e}"
             )
 
-    def get_camera_info(self, camera_name: str) -> dict[str, any]:
+    async def get_camera_info(self, camera_name: str) -> dict[str, any]:
         """
         Get ptz capabilities and presets, attempting to reconnect if ONVIF is configured
         but not initialized.
@@ -685,21 +680,8 @@ class OnvifController:
             }
 
         if camera_name not in self.cams.keys() and camera_name in self.config.cameras:
-            # Schedule _init_single_camera in the OnvifController's event loop
-            future = asyncio.run_coroutine_threadsafe(
-                self._init_single_camera(camera_name), self.loop
-            )
-            try:
-                success = future.result(timeout=10)
-                if not success:
-                    return {}
-            except asyncio.TimeoutError:
-                logger.error(f"_init_single_camera timed out for camera {camera_name}")
-                return {}
-            except Exception as e:
-                logger.error(
-                    f"Error in _init_single_camera for camera {camera_name}: {e}"
-                )
+            success = await self._init_single_camera(camera_name)
+            if not success:
                 return {}
 
         # Reset retry count after timeout
@@ -717,12 +699,7 @@ class OnvifController:
                 f"Attempting ONVIF initialization for {camera_name} (retry {attempts + 1}/{self.max_retries})"
             )
             try:
-                # Schedule _init_onvif in the OnvifController's event loop
-                future = asyncio.run_coroutine_threadsafe(
-                    self._init_onvif(camera_name), self.loop
-                )
-                success = future.result(timeout=10)
-                if success:
+                if await self._init_onvif(camera_name):
                     if camera_name in self.failed_cams:
                         del self.failed_cams[camera_name]
                     return {
@@ -732,8 +709,6 @@ class OnvifController:
                     }
                 else:
                     logger.warning(f"ONVIF initialization failed for {camera_name}")
-            except asyncio.TimeoutError:
-                logger.error(f"_init_onvif timed out for camera {camera_name}")
             except Exception as e:
                 logger.error(
                     f"Error during ONVIF initialization for {camera_name}: {e}"

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -595,7 +595,6 @@ class OnvifController:
         self, camera_name: str, command: OnvifCommandEnum, param: str = ""
     ) -> None:
         """Handle ONVIF commands asynchronously"""
-        # logger.debug(f"handling async: {camera_name}, {command}, {param}")
         current_loop = asyncio.get_running_loop()
         expected_loop = self.loop
         if current_loop is not expected_loop:

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -107,6 +107,7 @@ class OnvifController:
             return True
         except (Fault, ONVIFError, TransportError, Exception) as e:
             logger.error(f"Failed to create ONVIF camera instance for {cam_name}: {e}")
+            # track initial failures
             self.failed_cams[cam_name] = {
                 "retry_attempts": 0,
                 "last_error": str(e),
@@ -595,12 +596,6 @@ class OnvifController:
         self, camera_name: str, command: OnvifCommandEnum, param: str = ""
     ) -> None:
         """Handle ONVIF commands asynchronously"""
-        current_loop = asyncio.get_running_loop()
-        expected_loop = self.loop
-        if current_loop is not expected_loop:
-            logger.error(
-                f"Wrong event loop in _move! Expected {expected_loop}, got {current_loop}"
-            )
         if camera_name not in self.cams.keys():
             logger.error(f"ONVIF is not configured for {camera_name}")
             return

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -48,7 +48,7 @@ class OnvifController:
         self.ptz_metrics = ptz_metrics
 
         # Create a dedicated event loop and run it in a separate thread
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.new_event_loop()
         self.loop_thread = threading.Thread(target=self._run_event_loop, daemon=True)
         self.loop_thread.start()
 
@@ -63,7 +63,7 @@ class OnvifController:
 
     def _run_event_loop(self) -> None:
         """Run the event loop in a separate thread."""
-        # asyncio.set_event_loop(self.loop)
+        asyncio.set_event_loop(self.loop)
         try:
             self.loop.run_forever()
         except Exception as e:
@@ -88,7 +88,7 @@ class OnvifController:
                     "features": [],
                     "presets": {},
                 }
-            except (Fault, ONVIFError, TransportError, Exception) as e:
+            except (Fault, ONVIFError, Exception, TransportError) as e:
                 logger.error(
                     f"Failed to create ONVIF camera instance for {cam_name}: {e}"
                 )


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
With the upgrade to `onvif-zeep-async` for 0.16, some beta users were encountering issues related to asyncio loops (https://github.com/blakeblackshear/frigate/discussions/18054, https://github.com/blakeblackshear/frigate/discussions/18084). This PR refactors the onvif module to use `async`/`await` rather than `asyncio.run()`. 
- The onvif module now creates its own asyncio loop in a thread to run onvif commands in.
- The API endpoint used to get ptz info was changed to run the async onvif call with the new loop.
- Autotracking now uses the onvif asyncio loop and asyncio queues and locks rather than its own threads for non-blocking relative movement commands.
- Catch additional exceptions and improve logging.

These changes were tested by users in the linked discussions above and found to be working well.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
