### PR TITLE
Remove hardcoded usage of /dev/dri/card0 in call to intel_gpu_top

### DIFF
--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -304,7 +304,7 @@ def get_intel_gpu_stats(sriov: bool) -> Optional[dict[str, str]]:
     ]
 
     if sriov:
-        intel_gpu_top_command += ["-d", "drm:/dev/dri/card0"]
+        intel_gpu_top_command += ["-d", "sriov"]
 
     p = sp.run(
         intel_gpu_top_command,


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
-    https://github.com/blakeblackshear/frigate/issues/14840#issuecomment-2879874018

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
