### PR TITLE
Min face configuration option

### DIFF
--- a/docs/docs/configuration/face_recognition.md
+++ b/docs/docs/configuration/face_recognition.md
@@ -65,6 +65,8 @@ Fine-tune face recognition with these optional parameters at the global level of
   - Default: `0.8`.
 - `recognition_threshold`: Recognition confidence score required to add the face to the object as a sub label.
   - Default: `0.9`.
+- `min_faces`: Min face attempts for the sub label to be applied to the person object.
+  - Default: `1`
 - `save_attempts`: Number of images of recognized faces to save for training.
   - Default: `100`.
 - `blur_confidence_filter`: Enables a filter that calculates how blurry the face is and adjusts the confidence based on this.

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -559,6 +559,8 @@ face_recognition:
   recognition_threshold: 0.9
   # Optional: Min area of detected face box to consider running face recognition (default: shown below)
   min_area: 500
+  # Optional: Min face attempts for the sub label to be applied to the person object (default: shown below)
+  min_faces: 1
   # Optional: Number of images of recognized faces to save for training (default: shown below)
   save_attempts: 100
   # Optional: Apply a blur quality filter to adjust confidence based on the blur level of the image (default: shown below)

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -80,6 +80,11 @@ class FaceRecognitionConfig(FrigateBaseModel):
     min_area: int = Field(
         default=750, title="Min area of face box to consider running face recognition."
     )
+    min_faces: int = Field(
+        default=1,
+        gt=0,
+        title="Min face attempts for the sub label to be applied to the person object.",
+    )
     save_attempts: int = Field(
         default=100, ge=0, title="Number of face attempts to save in the train tab."
     )

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -83,6 +83,7 @@ class FaceRecognitionConfig(FrigateBaseModel):
     min_faces: int = Field(
         default=1,
         gt=0,
+        le=6,
         title="Min face attempts for the sub label to be applied to the person object.",
     )
     save_attempts: int = Field(

--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -302,6 +302,9 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
             self.person_face_history[id]
         )
 
+        if len(self.person_face_history[id]) < self.face_config.min_faces:
+            weighted_sub_label = "unknown"
+
         self.requestor.send_data(
             "tracked_object_update",
             json.dumps(


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This PR adds a config option for the minimum number of face attempts for a given person before a sub label can be assigned.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
