### PR TITLE
Disable autoCorrect, autoCapitalize and spellCheck on username input in auth form.

### DIFF
--- a/web/src/components/auth/AuthForm.tsx
+++ b/web/src/components/auth/AuthForm.tsx
@@ -99,6 +99,9 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
                   <Input
                     className="text-md w-full border border-input bg-background p-2 hover:bg-accent hover:text-accent-foreground dark:[color-scheme:dark]"
                     autoFocus
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    spellCheck="false"
                     {...field}
                   />
                 </FormControl>


### PR DESCRIPTION
Some combinations of browsers/OS have them enabled by default, and this is not convenient for username input.
