### PR TITLE
Initial custom classification model config support

### DIFF
--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -34,16 +34,28 @@ class BirdClassificationConfig(FrigateBaseModel):
     )
 
 
-class TeachableMachineModelType(str, Enum):
-    object = "object"
-    state = "state"
+class TeachableMachineStateCameraConfig(FrigateBaseModel):
+    crop: list[int, int, int, int] = Field(
+        title="Crop of image frame on this camera to run classification on."
+    )
+
+
+class TeachableMachineStateConfig(FrigateBaseModel):
+    cameras: Dict[str, TeachableMachineStateCameraConfig] = Field(
+        title="Cameras to run classification on."
+    )
+
+
+class TeachableMachineObjectConfig(FrigateBaseModel):
+    objects: list[str] = Field(title="Object types to classify.")
 
 
 class TeachableMachineConfig(FrigateBaseModel):
     enabled: bool = Field(default=True, title="Enable running the model.")
     model_path: str = Field(title="Path to teachable machine tflite model.")
     labelmap_path: str = Field(title="Path to teachable machine labelmap.")
-    model_type: TeachableMachineModelType = Field(title="Type of model.")
+    object_config: TeachableMachineObjectConfig | None = Field(default=None)
+    state_config: TeachableMachineStateConfig | None = Field(default=None)
 
 
 class ClassificationConfig(FrigateBaseModel):
@@ -51,7 +63,7 @@ class ClassificationConfig(FrigateBaseModel):
         default_factory=BirdClassificationConfig, title="Bird classification config."
     )
     teachable_machine: Dict[str, TeachableMachineConfig] = Field(
-        title="Teachable Machine Model Configs."
+        default={}, title="Teachable Machine Model Configs."
     )
 
 

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -34,10 +34,16 @@ class BirdClassificationConfig(FrigateBaseModel):
     )
 
 
+class TeachableMachineModelType(str, Enum):
+    object = "object"
+    state = "state"
+
+
 class TeachableMachineConfig(FrigateBaseModel):
     enabled: bool = Field(default=True, title="Enable running the model.")
     model_path: str = Field(title="Path to teachable machine tflite model.")
     labelmap_path: str = Field(title="Path to teachable machine labelmap.")
+    model_type: TeachableMachineModelType = Field(title="Type of model.")
 
 
 class ClassificationConfig(FrigateBaseModel):

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -52,8 +52,8 @@ class CustomClassificationObjectConfig(FrigateBaseModel):
 
 class CustomClassificationConfig(FrigateBaseModel):
     enabled: bool = Field(default=True, title="Enable running the model.")
-    model_path: str = Field(title="Path to teachable machine tflite model.")
-    labelmap_path: str = Field(title="Path to teachable machine labelmap.")
+    model_path: str = Field(title="Path to custom classification tflite model.")
+    labelmap_path: str = Field(title="Path to custom classification model labelmap.")
     object_config: CustomClassificationObjectConfig | None = Field(default=None)
     state_config: CustomClassificationStateConfig | None = Field(default=None)
 
@@ -63,7 +63,7 @@ class ClassificationConfig(FrigateBaseModel):
         default_factory=BirdClassificationConfig, title="Bird classification config."
     )
     custom: Dict[str, CustomClassificationConfig] = Field(
-        default={}, title="Teachable Machine Model Configs."
+        default={}, title="Custom Classification Model Configs."
     )
 
 

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -34,35 +34,35 @@ class BirdClassificationConfig(FrigateBaseModel):
     )
 
 
-class TeachableMachineStateCameraConfig(FrigateBaseModel):
+class CustomClassificationStateCameraConfig(FrigateBaseModel):
     crop: list[int, int, int, int] = Field(
         title="Crop of image frame on this camera to run classification on."
     )
 
 
-class TeachableMachineStateConfig(FrigateBaseModel):
-    cameras: Dict[str, TeachableMachineStateCameraConfig] = Field(
+class CustomClassificationStateConfig(FrigateBaseModel):
+    cameras: Dict[str, CustomClassificationStateCameraConfig] = Field(
         title="Cameras to run classification on."
     )
 
 
-class TeachableMachineObjectConfig(FrigateBaseModel):
+class CustomClassificationObjectConfig(FrigateBaseModel):
     objects: list[str] = Field(title="Object types to classify.")
 
 
-class TeachableMachineConfig(FrigateBaseModel):
+class CustomClassificationConfig(FrigateBaseModel):
     enabled: bool = Field(default=True, title="Enable running the model.")
     model_path: str = Field(title="Path to teachable machine tflite model.")
     labelmap_path: str = Field(title="Path to teachable machine labelmap.")
-    object_config: TeachableMachineObjectConfig | None = Field(default=None)
-    state_config: TeachableMachineStateConfig | None = Field(default=None)
+    object_config: CustomClassificationObjectConfig | None = Field(default=None)
+    state_config: CustomClassificationStateConfig | None = Field(default=None)
 
 
 class ClassificationConfig(FrigateBaseModel):
     bird: BirdClassificationConfig = Field(
         default_factory=BirdClassificationConfig, title="Bird classification config."
     )
-    teachable_machine: Dict[str, TeachableMachineConfig] = Field(
+    custom: Dict[str, CustomClassificationConfig] = Field(
         default={}, title="Teachable Machine Model Configs."
     )
 

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -34,9 +34,18 @@ class BirdClassificationConfig(FrigateBaseModel):
     )
 
 
+class TeachableMachineConfig(FrigateBaseModel):
+    enabled: bool = Field(default=True, title="Enable running the model.")
+    model_path: str = Field(title="Path to teachable machine tflite model.")
+    labelmap_path: str = Field(title="Path to teachable machine labelmap.")
+
+
 class ClassificationConfig(FrigateBaseModel):
     bird: BirdClassificationConfig = Field(
         default_factory=BirdClassificationConfig, title="Bird classification config."
+    )
+    teachable_machine: Dict[str, TeachableMachineConfig] = Field(
+        title="Teachable Machine Model Configs."
     )
 
 

--- a/frigate/data_processing/real_time/custom_classification.py
+++ b/frigate/data_processing/real_time/custom_classification.py
@@ -1,4 +1,4 @@
-"""Real time processor that works with teachable machine tflite models."""
+"""Real time processor that works with classification tflite models."""
 
 import logging
 from typing import Any

--- a/frigate/data_processing/real_time/custom_classification.py
+++ b/frigate/data_processing/real_time/custom_classification.py
@@ -11,7 +11,7 @@ from frigate.comms.event_metadata_updater import (
     EventMetadataTypeEnum,
 )
 from frigate.config import FrigateConfig
-from frigate.config.classification import TeachableMachineConfig
+from frigate.config.classification import CustomClassificationConfig
 from frigate.util.builtin import load_labels
 from frigate.util.object import calculate_region
 
@@ -26,11 +26,11 @@ except ModuleNotFoundError:
 logger = logging.getLogger(__name__)
 
 
-class TeachableMachineStateProcessor(RealTimeProcessorApi):
+class CustomStateClassificationProcessor(RealTimeProcessorApi):
     def __init__(
         self,
         config: FrigateConfig,
-        model_config: TeachableMachineConfig,
+        model_config: CustomClassificationConfig,
         metrics: DataProcessorMetrics,
     ):
         super().__init__(config, metrics)
@@ -96,11 +96,11 @@ class TeachableMachineStateProcessor(RealTimeProcessorApi):
         pass
 
 
-class TeachableMachineObjectProcessor(RealTimeProcessorApi):
+class CustomObjectClassificationProcessor(RealTimeProcessorApi):
     def __init__(
         self,
         config: FrigateConfig,
-        model_config: TeachableMachineConfig,
+        model_config: CustomClassificationConfig,
         sub_label_publisher: EventMetadataPublisher,
         metrics: DataProcessorMetrics,
     ):

--- a/frigate/data_processing/real_time/teachable_machine.py
+++ b/frigate/data_processing/real_time/teachable_machine.py
@@ -127,7 +127,7 @@ class TeachableMachineObjectProcessor(RealTimeProcessorApi):
         self.labelmap = load_labels(self.model_config.labelmap_path, prefill=0)
 
     def process_frame(self, obj_data, frame):
-        if obj_data["label"] != "object":
+        if obj_data["label"] not in self.model_config.object_config.objects:
             return
 
         x, y, x2, y2 = calculate_region(

--- a/frigate/data_processing/real_time/teachable_machine.py
+++ b/frigate/data_processing/real_time/teachable_machine.py
@@ -76,8 +76,6 @@ class TeachableMachineStateProcessor(RealTimeProcessorApi):
         if input.shape != (224, 224):
             input = cv2.resize(input, (224, 224))
 
-        cv2.imwrite("/media/frigate/frames/gate.jpg", input)
-
         input = np.expand_dims(input, axis=0)
         self.interpreter.set_tensor(self.tensor_input_details[0]["index"], input)
         self.interpreter.invoke()

--- a/frigate/data_processing/real_time/teachable_machine.py
+++ b/frigate/data_processing/real_time/teachable_machine.py
@@ -1,0 +1,172 @@
+"""Real time processor that works with teachable machine tflite models."""
+
+import logging
+from typing import Any
+
+import cv2
+import numpy as np
+
+from frigate.comms.event_metadata_updater import (
+    EventMetadataPublisher,
+    EventMetadataTypeEnum,
+)
+from frigate.config import FrigateConfig
+from frigate.config.classification import TeachableMachineConfig
+from frigate.util.builtin import load_labels
+from frigate.util.object import calculate_region
+
+from ..types import DataProcessorMetrics
+from .api import RealTimeProcessorApi
+
+try:
+    from tflite_runtime.interpreter import Interpreter
+except ModuleNotFoundError:
+    from tensorflow.lite.python.interpreter import Interpreter
+
+logger = logging.getLogger(__name__)
+
+
+class TeachableMachineStateProcessor(RealTimeProcessorApi):
+    def __init__(
+        self,
+        config: FrigateConfig,
+        model_config: TeachableMachineConfig,
+        metrics: DataProcessorMetrics,
+    ):
+        super().__init__(config, metrics)
+        self.model_config = model_config
+        self.interpreter: Interpreter = None
+        self.tensor_input_details: dict[str, Any] = None
+        self.tensor_output_details: dict[str, Any] = None
+        self.labelmap: dict[int, str] = {}
+        self.__build_detector()
+
+    def __build_detector(self) -> None:
+        self.interpreter = Interpreter(
+            model_path=self.model_config.model_path,
+            num_threads=2,
+        )
+        self.interpreter.allocate_tensors()
+        self.tensor_input_details = self.interpreter.get_input_details()
+        self.tensor_output_details = self.interpreter.get_output_details()
+        self.labelmap = load_labels(self.model_config.labelmap_path, prefill=0)
+
+    def process_frame(self, obj_data, frame):
+        x, y, x2, y2 = calculate_region(
+            frame.shape,
+            obj_data["box"][0],
+            obj_data["box"][1],
+            obj_data["box"][2],
+            obj_data["box"][3],
+            224,
+            1.0,
+        )
+
+        rgb = cv2.cvtColor(frame, cv2.COLOR_YUV2RGB_I420)
+        input = rgb[
+            y:y2,
+            x:x2,
+        ]
+
+        if input.shape != (224, 224):
+            input = cv2.resize(input, (224, 224))
+
+        input = np.expand_dims(input, axis=0)
+        self.interpreter.set_tensor(self.tensor_input_details[0]["index"], input)
+        self.interpreter.invoke()
+        res: np.ndarray = self.interpreter.get_tensor(
+            self.tensor_output_details[0]["index"]
+        )[0]
+        probs = res / res.sum(axis=0)
+        best_id = np.argmax(probs)
+        score = round(probs[best_id], 2)
+
+        print(f"got ID of {best_id} with score {score}")
+
+    def handle_request(self, topic, request_data):
+        return None
+
+    def expire_object(self, object_id, camera):
+        pass
+
+
+class TeachableMachineObjectProcessor(RealTimeProcessorApi):
+    def __init__(
+        self,
+        config: FrigateConfig,
+        model_config: TeachableMachineConfig,
+        sub_label_publisher: EventMetadataPublisher,
+        metrics: DataProcessorMetrics,
+    ):
+        super().__init__(config, metrics)
+        self.model_config = model_config
+        self.interpreter: Interpreter = None
+        self.sub_label_publisher = sub_label_publisher
+        self.tensor_input_details: dict[str, Any] = None
+        self.tensor_output_details: dict[str, Any] = None
+        self.detected_objects: dict[str, float] = {}
+        self.labelmap: dict[int, str] = {}
+        self.__build_detector()
+
+    def __build_detector(self) -> None:
+        self.interpreter = Interpreter(
+            model_path=self.model_config.model_path,
+            num_threads=2,
+        )
+        self.interpreter.allocate_tensors()
+        self.tensor_input_details = self.interpreter.get_input_details()
+        self.tensor_output_details = self.interpreter.get_output_details()
+        self.labelmap = load_labels(self.model_config.labelmap_path, prefill=0)
+
+    def process_frame(self, obj_data, frame):
+        if obj_data["label"] != "object":
+            return
+
+        x, y, x2, y2 = calculate_region(
+            frame.shape,
+            obj_data["box"][0],
+            obj_data["box"][1],
+            obj_data["box"][2],
+            obj_data["box"][3],
+            224,
+            1.0,
+        )
+
+        rgb = cv2.cvtColor(frame, cv2.COLOR_YUV2RGB_I420)
+        input = rgb[
+            y:y2,
+            x:x2,
+        ]
+
+        if input.shape != (224, 224):
+            input = cv2.resize(input, (224, 224))
+
+        input = np.expand_dims(input, axis=0)
+        self.interpreter.set_tensor(self.tensor_input_details[0]["index"], input)
+        self.interpreter.invoke()
+        res: np.ndarray = self.interpreter.get_tensor(
+            self.tensor_output_details[0]["index"]
+        )[0]
+        probs = res / res.sum(axis=0)
+        best_id = np.argmax(probs)
+
+        score = round(probs[best_id], 2)
+
+        previous_score = self.detected_objects.get(obj_data["id"], 0.0)
+
+        if score <= previous_score:
+            logger.debug(f"Score {score} is worse than previous score {previous_score}")
+            return
+
+        self.sub_label_publisher.publish(
+            EventMetadataTypeEnum.sub_label,
+            (obj_data["id"], self.labelmap[best_id], score),
+        )
+        self.detected_objects[obj_data["id"]] = score
+
+    def handle_request(self, topic, request_data):
+        return None
+
+    def expire_object(self, object_id, camera):
+        if object_id in self.detected_objects:
+            self.detected_objects.pop(object_id)

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -42,13 +42,13 @@ from frigate.data_processing.post.license_plate import (
 )
 from frigate.data_processing.real_time.api import RealTimeProcessorApi
 from frigate.data_processing.real_time.bird import BirdRealTimeProcessor
+from frigate.data_processing.real_time.custom_classification import (
+    CustomObjectClassificationProcessor,
+    CustomStateClassificationProcessor,
+)
 from frigate.data_processing.real_time.face import FaceRealTimeProcessor
 from frigate.data_processing.real_time.license_plate import (
     LicensePlateRealTimeProcessor,
-)
-from frigate.data_processing.real_time.teachable_machine import (
-    TeachableMachineObjectProcessor,
-    TeachableMachineStateProcessor,
 )
 from frigate.data_processing.types import DataProcessorMetrics, PostProcessDataEnum
 from frigate.events.types import EventTypeEnum, RegenerateDescriptionEnum
@@ -149,9 +149,9 @@ class EmbeddingMaintainer(threading.Thread):
 
         for model in self.config.classification.teachable_machine.values():
             self.realtime_processors.append(
-                TeachableMachineStateProcessor(self.config, model, self.metrics)
+                CustomStateClassificationProcessor(self.config, model, self.metrics)
                 if model.state_config != None
-                else TeachableMachineObjectProcessor(
+                else CustomObjectClassificationProcessor(
                     self.config,
                     model,
                     self.event_metadata_publisher,
@@ -503,7 +503,7 @@ class EmbeddingMaintainer(threading.Thread):
             if isinstance(processor, LicensePlateRealTimeProcessor):
                 processor.process_frame(camera, yuv_frame, True)
 
-            if isinstance(processor, TeachableMachineStateProcessor):
+            if isinstance(processor, CustomStateClassificationProcessor):
                 processor.process_frame({"camera": camera}, yuv_frame)
 
         self.frame_manager.close(frame_name)

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -503,9 +503,7 @@ class EmbeddingMaintainer(threading.Thread):
             if isinstance(processor, LicensePlateRealTimeProcessor):
                 processor.process_frame(camera, yuv_frame, True)
 
-            if isinstance(processor, TeachableMachineObjectProcessor) or isinstance(
-                processor, TeachableMachineStateProcessor
-            ):
+            if isinstance(processor, TeachableMachineStateProcessor):
                 processor.process_frame({"camera": camera}, yuv_frame)
 
         self.frame_manager.close(frame_name)

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -147,7 +147,7 @@ class EmbeddingMaintainer(threading.Thread):
                 )
             )
 
-        for model in self.config.classification.teachable_machine.values():
+        for model in self.config.classification.custom.values():
             self.realtime_processors.append(
                 CustomStateClassificationProcessor(self.config, model, self.metrics)
                 if model.state_config != None
@@ -482,7 +482,7 @@ class EmbeddingMaintainer(threading.Thread):
         if (
             camera_config.type != CameraTypeEnum.lpr
             or "license_plate" in camera_config.objects.track
-        ) and len(self.config.classification.teachable_machine) == 0:
+        ) and len(self.config.classification.custom) == 0:
             # no active features that use this data
             return
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This PR implements the ability to create custom classification models using resnet models generated via tools like [Teachable Machine](https://teachablemachine.withgoogle.com/), and to implement those models in Frigate. Currently the config is quite barebones, but this allows a starting point to experiment with these models.

I trained a model to tell if my gate is open or closed and it works surprisingly well. Below is the config that was used

```
classification:
  custom:
    gate:
      model_path: /config/model_cache/gate_model.tflite
      labelmap_path: /config/model_cache/gate_labels.txt
      state_config:
        cameras:
          back_deck_cam:
            crop: [0, 180, 180, 360]
```

and an example of running on a video of me opening the gate

```
got Gate Closed with score 0.61
got Gate Closed with score 0.61
got Gate Closed with score 0.73
got Gate Closed with score 0.59
got Gate Open with score 0.5
got Gate Open with score 0.69
got Gate Open with score 0.59
got Gate Open with score 0.81
got Gate Open with score 0.75
```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
