### PR TITLE
Check for existence of model.path & model.labelmap_path on config save.

### DIFF
--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -511,6 +511,10 @@ class FrigateConfig(FrigateBaseModel):
                 elif detector_config.type == "edgetpu":
                     model_config["path"] = "/edgetpu_model.tflite"
 
+            # Verify that the model path points to an existing file.
+            if not os.path.exists(model_config["path"]):
+                raise ValueError(f"Model path '{model_config['path']}' does not exist.")
+
             model = ModelConfig.model_validate(model_config)
             model.check_and_load_plus_model(self.plus_api, detector_config.type)
             model.compute_model_hash()

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -511,9 +511,10 @@ class FrigateConfig(FrigateBaseModel):
                 elif detector_config.type == "edgetpu":
                     model_config["path"] = "/edgetpu_model.tflite"
 
-            # Verify that the model path points to an existing file.
-            if not os.path.exists(model_config["path"]):
-                raise ValueError(f"Model path '{model_config['path']}' does not exist.")
+            # If using a local file, verify that the model path points to an existing file.
+            if not model_config["path"].startswith("plus://"):
+                if not os.path.exists(model_config["path"]):
+                    raise ValueError(f"Model path '{model_config['path']}' does not exist.")
 
             model = ModelConfig.model_validate(model_config)
             model.check_and_load_plus_model(self.plus_api, detector_config.type)

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -514,7 +514,9 @@ class FrigateConfig(FrigateBaseModel):
             # If using a local file, verify that the model path points to an existing file.
             if not model_config["path"].startswith("plus://"):
                 if not os.path.exists(model_config["path"]):
-                    raise ValueError(f"Model path '{model_config['path']}' does not exist.")
+                    raise ValueError(
+                        f"Model path '{model_config['path']}' does not exist."
+                    )
 
             model = ModelConfig.model_validate(model_config)
             model.check_and_load_plus_model(self.plus_api, detector_config.type)

--- a/frigate/detectors/detector_config.py
+++ b/frigate/detectors/detector_config.py
@@ -108,9 +108,7 @@ class ModelConfig(BaseModel):
         # If using a local file, verify that the labelmap path points to an existing file.
         if not path.startswith("plus://"):
             if not os.path.exists(path):
-                raise ValueError(
-                    f"Model labelmap_path '{path}' does not exist."
-                )
+                raise ValueError(f"Model labelmap_path '{path}' does not exist.")
 
         self._merged_labelmap = {
             **load_labels(path),

--- a/frigate/detectors/detector_config.py
+++ b/frigate/detectors/detector_config.py
@@ -103,14 +103,17 @@ class ModelConfig(BaseModel):
     def __init__(self, **config):
         super().__init__(**config)
 
-        # Verify that the labelmap path points to an existing file.
-        if not os.path.exists(config.get("labelmap_path", "/labelmap.txt")):
-            raise ValueError(
-                f"Model labelmap_path '{config.get('labelmap_path', '/labelmap.txt')}' does not exist."
-            )
+        path = config.get("labelmap_path", "/labelmap.txt")
+
+        # If using a local file, verify that the labelmap path points to an existing file.
+        if not path.startswith("plus://"):
+            if not os.path.exists(path):
+                raise ValueError(
+                    f"Model labelmap_path '{path}' does not exist."
+                )
 
         self._merged_labelmap = {
-            **load_labels(config.get("labelmap_path", "/labelmap.txt")),
+            **load_labels(path),
             **config.get("labelmap", {}),
         }
         self._colormap = {}

--- a/frigate/detectors/detector_config.py
+++ b/frigate/detectors/detector_config.py
@@ -103,6 +103,12 @@ class ModelConfig(BaseModel):
     def __init__(self, **config):
         super().__init__(**config)
 
+        # Verify that the labelmap path points to an existing file.
+        if not os.path.exists(config.get("labelmap_path", "/labelmap.txt")):
+            raise ValueError(
+                f"Model labelmap_path '{config.get('labelmap_path', '/labelmap.txt')}' does not exist."
+            )
+
         self._merged_labelmap = {
             **load_labels(config.get("labelmap_path", "/labelmap.txt")),
             **config.get("labelmap", {}),


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Check on save if the paths entered under model.path and model.labelmap_path exist.

I've experimented a bit with different YOLO/YOLO-NAS models and frequently ran into issues, where this check would have helped me. Previously, the model would throw an error when frigate is restarting so I had to go through the logs to see this issue.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- None

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
