### PR TITLE
Logging bugfix

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -44,6 +44,7 @@ from frigate.embeddings import EmbeddingsContext, manage_embeddings
 from frigate.events.audio import AudioProcessor
 from frigate.events.cleanup import EventCleanup
 from frigate.events.maintainer import EventProcessor
+from frigate.log import _stop_logging
 from frigate.models import (
     Event,
     Export,
@@ -770,5 +771,8 @@ class FrigateApp:
             shm = self.detection_shms.pop()
             shm.close()
             shm.unlink()
+
+        # exit the mp Manager process
+        _stop_logging()
 
         os._exit(os.EX_OK)

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -7,6 +7,7 @@ import sys
 import threading
 from collections import deque
 from logging.handlers import QueueHandler, QueueListener
+from queue import Queue
 from typing import Deque, Optional
 
 from frigate.util.builtin import clean_camera_user_pass
@@ -33,7 +34,7 @@ LOG_HANDLER.addFilter(
 )
 
 log_listener: Optional[QueueListener] = None
-log_queue: Optional[mp.Queue] = None
+log_queue: Optional[Queue] = None
 manager = None
 
 

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -1,3 +1,4 @@
+# In log.py
 import atexit
 import logging
 import multiprocessing as mp
@@ -6,6 +7,7 @@ import sys
 import threading
 from collections import deque
 from logging.handlers import QueueHandler, QueueListener
+from multiprocessing import Manager
 from typing import Deque, Optional
 
 from frigate.util.builtin import clean_camera_user_pass
@@ -32,12 +34,14 @@ LOG_HANDLER.addFilter(
 )
 
 log_listener: Optional[QueueListener] = None
+log_queue: Optional[mp.Queue] = None
+manager = None
 
 
 def setup_logging() -> None:
-    global log_listener
-
-    log_queue: mp.Queue = mp.Queue()
+    global log_listener, log_queue, manager
+    manager = Manager()
+    log_queue = manager.Queue()
     log_listener = QueueListener(log_queue, LOG_HANDLER, respect_handler_level=True)
 
     atexit.register(_stop_logging)
@@ -53,11 +57,13 @@ def setup_logging() -> None:
 
 
 def _stop_logging() -> None:
-    global log_listener
-
+    global log_listener, manager
     if log_listener is not None:
         log_listener.stop()
         log_listener = None
+    if manager is not None:
+        manager.shutdown()
+        manager = None
 
 
 # When a multiprocessing.Process exits, python tries to flush stdout and stderr. However, if the

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -7,7 +7,6 @@ import sys
 import threading
 from collections import deque
 from logging.handlers import QueueHandler, QueueListener
-from multiprocessing import Manager
 from typing import Deque, Optional
 
 from frigate.util.builtin import clean_camera_user_pass
@@ -40,7 +39,7 @@ manager = None
 
 def setup_logging() -> None:
     global log_listener, log_queue, manager
-    manager = Manager()
+    manager = mp.Manager()
     log_queue = manager.Queue()
     log_listener = QueueListener(log_queue, LOG_HANDLER, respect_handler_level=True)
 


### PR DESCRIPTION


## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
A Python bug (https://github.com/python/cpython/issues/91555) was preventing logs from the embeddings maintainer process (and possibly other subprocesses) from printing. The bug is fixed in Python 3.14, but a viable workaround is to use the multiprocessing `Manager`, which better manages mp queues and causes the logging to work correctly.

The `Manager.Queue` is created by the `SyncManager` before any child processes are spawned, ensuring that the queue is fully initialized and accessible when the child process (e.g., `embedding_process`) starts logging.

With a standard `multiprocessing.Queue`, the queue is created in the main process and passed to the child process. If the child process attempts to use the queue (via `QueueHandler`) before it’s fully set up or before the `QueueListener` in the main process is ready to consume messages, it can lead to failures, such as messages being dropped or the queue becoming unresponsive. This is likely what caused the logging in the embeddings maintainer's `__init__` call to disrupt subsequent logging.

The `Manager.Queue` mitigates this by handling queue creation and management in a separate process, which is less sensitive to the timing of process initialization in the child process.

Though there is an `atexit.register()` call to exit the `Manager` subprocess in `log.py`, we explicitly call `os._exit()` at the end of `stop()`, which prevents `atexit` calls from running. So we also need to make an explicit call to stop it at the end.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
