### PR TITLE
[Feature] Enable GenAI Description Generation via API for Non-Enabled Cameras

### DIFF
--- a/docs/docs/configuration/genai.md
+++ b/docs/docs/configuration/genai.md
@@ -9,7 +9,7 @@ Requests for a description are sent off automatically to your AI provider at the
 
 ## Configuration
 
-Generative AI can be enabled for all cameras or only for specific cameras. There are currently 3 native providers available to integrate with Frigate. Other providers that support the OpenAI standard API can also be used. See the OpenAI section below.
+Generative AI can be enabled for all cameras or only for specific cameras. If GenAI is disabled for a camera, you can still manually generate descriptions for events using the HTTP API. There are currently 3 native providers available to integrate with Frigate. Other providers that support the OpenAI standard API can also be used. See the OpenAI section below.
 
 To use Generative AI, you must define a single provider at the global level of your Frigate configuration. If the provider you choose requires an API key, you may either directly paste it in your configuration, or store it in an environment variable prefixed with `FRIGATE_`.
 

--- a/frigate/api/defs/query/regenerate_query_parameters.py
+++ b/frigate/api/defs/query/regenerate_query_parameters.py
@@ -1,9 +1,13 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from frigate.events.types import RegenerateDescriptionEnum
 
 
 class RegenerateQueryParameters(BaseModel):
     source: Optional[RegenerateDescriptionEnum] = RegenerateDescriptionEnum.thumbnails
+    force: Optional[bool] = Field(
+        default=False,
+        description="Force (re)generating the description even if GenAI is disabled for this camera.",
+    )

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -1225,9 +1225,10 @@ def regenerate_description(
 
     camera_config = request.app.frigate_config.cameras[event.camera]
 
-    if camera_config.genai.enabled:
+    if camera_config.genai.enabled or params.force:
         request.app.event_metadata_updater.publish(
-            EventMetadataTypeEnum.regenerate_description, (event.id, params.source)
+            EventMetadataTypeEnum.regenerate_description,
+            (event.id, params.source, params.force),
         )
 
         return JSONResponse(


### PR DESCRIPTION
## Proposed change

This PR introduces a new optional `force` parameter (default: `false`) when triggering description generation via the API. When force is set to `true`, the system will generate a description even if GenAI is not enabled for the associated camera.

**Key Benefits**
- Delayed processing: Generate descriptions at a later time instead of in real time — useful when real-time event processing exceeds hardware capacity.
- Selective usage: Generate descriptions only for specific events based on custom logic (e.g., object size, confidence level) to save resources.

**Note**
The [UI](https://github.com/blakeblackshear/frigate/blob/ed43df9c13e7d0d67c11080101b4da1439c95cf3/web/src/components/overlay/detail/SearchDetailDialog.tsx#L937) remains unchanged — the "Regenerate Description" button is still hidden for cameras without GenAI enabled to avoid confusing users.

This feature is intended for advanced users who require fine-grained control and typically interact with the system via the API.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
