### PR TITLE
[Fix] Always Instantiate GenAI Client if GenAI is enabled in config

### DIFF
--- a/frigate/genai/__init__.py
+++ b/frigate/genai/__init__.py
@@ -63,7 +63,7 @@ def get_genai_client(config: FrigateConfig) -> Optional[GenAIClient]:
         c for c in config.cameras.values() if c.enabled and c.genai.enabled
     ]
 
-    if genai_cameras:
+    if genai_cameras or genai_config.enabled:
         load_providers()
         provider = PROVIDERS.get(genai_config.provider)
         if provider:


### PR DESCRIPTION
## Proposed change

Following #18616, update the logic to instantiate the GenAI client not only when any camera has GenAI enabled, but also if the global `genai.enabled` setting is true.
This ensures that on-demand GenAI analysis can still be triggered even if all individual cameras have GenAI disabled.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
