### PR TITLE
Ensure logging config is propagated to forked processes

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -386,6 +386,7 @@ class FrigateApp:
                 self.detection_queue,
                 list(self.config.cameras.keys()),
                 detector_config,
+                self.config,
             )
 
     def start_ptz_autotracker(self) -> None:

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -385,8 +385,8 @@ class FrigateApp:
                 name,
                 self.detection_queue,
                 list(self.config.cameras.keys()),
-                detector_config,
                 self.config,
+                detector_config,
             )
 
     def start_ptz_autotracker(self) -> None:

--- a/frigate/config/logger.py
+++ b/frigate/config/logger.py
@@ -1,20 +1,12 @@
-import logging
-from enum import Enum
 
 from pydantic import Field, ValidationInfo, model_validator
 from typing_extensions import Self
 
+from frigate.log import LogLevel, apply_log_levels
+
 from .base import FrigateBaseModel
 
-__all__ = ["LoggerConfig", "LogLevel"]
-
-
-class LogLevel(str, Enum):
-    debug = "debug"
-    info = "info"
-    warning = "warning"
-    error = "error"
-    critical = "critical"
+__all__ = ["LoggerConfig"]
 
 
 class LoggerConfig(FrigateBaseModel):
@@ -26,18 +18,6 @@ class LoggerConfig(FrigateBaseModel):
     @model_validator(mode="after")
     def post_validation(self, info: ValidationInfo) -> Self:
         if isinstance(info.context, dict) and info.context.get("install", False):
-            logging.getLogger().setLevel(self.default.value.upper())
-
-            log_levels = {
-                "absl": LogLevel.error,
-                "httpx": LogLevel.error,
-                "tensorflow": LogLevel.error,
-                "werkzeug": LogLevel.error,
-                "ws4py": LogLevel.error,
-                **self.logs,
-            }
-
-            for log, level in log_levels.items():
-                logging.getLogger(log).setLevel(level.value.upper())
+            apply_log_levels(self.default.value.upper(), self.logs)
 
         return self

--- a/frigate/config/logger.py
+++ b/frigate/config/logger.py
@@ -1,4 +1,3 @@
-
 from pydantic import Field, ValidationInfo, model_validator
 from typing_extensions import Self
 

--- a/frigate/embeddings/__init__.py
+++ b/frigate/embeddings/__init__.py
@@ -35,7 +35,7 @@ class EmbeddingProcess(FrigateProcess):
         self.metrics = metrics
 
     def run(self) -> None:
-        self.pre_run_setup()
+        self.pre_run_setup(self.config.logger)
         maintainer = EmbeddingMaintainer(
             self.config,
             self.metrics,

--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -105,7 +105,7 @@ class AudioProcessor(util.Process):
             self.transcription_model_runner = None
 
     def run(self) -> None:
-        self.pre_run_setup()
+        self.pre_run_setup(self.config.logger)
         audio_threads: list[AudioEventMaintainer] = []
 
         threading.current_thread().name = "process:audio_manager"

--- a/frigate/object_detection/base.py
+++ b/frigate/object_detection/base.py
@@ -12,6 +12,7 @@ from frigate.comms.object_detector_signaler import (
     ObjectDetectorPublisher,
     ObjectDetectorSubscriber,
 )
+from frigate.config import FrigateConfig
 from frigate.detectors import create_detector
 from frigate.detectors.detector_config import (
     BaseDetectorConfig,
@@ -92,6 +93,7 @@ class DetectorRunner(util.Process):
         cameras: list[str],
         avg_speed: Value,
         start_time: Value,
+        config: FrigateConfig,
         detector_config: BaseDetectorConfig,
     ) -> None:
         super().__init__(name=name, daemon=True)
@@ -99,6 +101,7 @@ class DetectorRunner(util.Process):
         self.cameras = cameras
         self.avg_speed = avg_speed
         self.start_time = start_time
+        self.config = config
         self.detector_config = detector_config
         self.outputs: dict = {}
 
@@ -108,7 +111,7 @@ class DetectorRunner(util.Process):
         self.outputs[name] = {"shm": out_shm, "np": out_np}
 
     def run(self) -> None:
-        self.pre_run_setup()
+        self.pre_run_setup(self.config.logger)
 
         frame_manager = SharedMemoryFrameManager()
         object_detector = LocalObjectDetector(detector_config=self.detector_config)
@@ -161,6 +164,7 @@ class ObjectDetectProcess:
         name: str,
         detection_queue: Queue,
         cameras: list[str],
+        config: FrigateConfig,
         detector_config: BaseDetectorConfig,
     ):
         self.name = name
@@ -169,6 +173,7 @@ class ObjectDetectProcess:
         self.avg_inference_speed = Value("d", 0.01)
         self.detection_start = Value("d", 0.0)
         self.detect_process: util.Process | None = None
+        self.config = config
         self.detector_config = detector_config
         self.start_or_restart()
 
@@ -195,6 +200,7 @@ class ObjectDetectProcess:
             self.cameras,
             self.avg_inference_speed,
             self.detection_start,
+            self.config,
             self.detector_config,
         )
         self.detect_process.start()

--- a/frigate/output/output.py
+++ b/frigate/output/output.py
@@ -77,7 +77,7 @@ class OutputProcess(util.Process):
         self.config = config
 
     def run(self) -> None:
-        self.pre_run_setup()
+        self.pre_run_setup(self.config.logger)
 
         frame_manager = SharedMemoryFrameManager()
 

--- a/frigate/record/record.py
+++ b/frigate/record/record.py
@@ -18,7 +18,7 @@ class RecordProcess(FrigateProcess):
         self.config = config
 
     def run(self) -> None:
-        self.pre_run_setup()
+        self.pre_run_setup(self.config.logger)
         db = SqliteQueueDatabase(
             self.config.database.path,
             pragmas={

--- a/frigate/review/review.py
+++ b/frigate/review/review.py
@@ -15,7 +15,7 @@ class ReviewProcess(util.Process):
         self.config = config
 
     def run(self) -> None:
-        self.pre_run_setup()
+        self.pre_run_setup(self.config.logger)
         maintainer = ReviewSegmentMaintainer(
             self.config,
             self.stop_event,

--- a/frigate/util/process.py
+++ b/frigate/util/process.py
@@ -7,6 +7,8 @@ import threading
 from logging.handlers import QueueHandler
 from typing import Callable, Optional
 
+from setproctitle import setproctitle
+
 import frigate.log
 from frigate.config.logger import LoggerConfig
 
@@ -52,6 +54,8 @@ class Process(BaseProcess):
         self.__log_queue = frigate.log.log_listener.queue
 
     def pre_run_setup(self, logConfig: LoggerConfig | None = None) -> None:
+        setproctitle(self.name)
+        threading.current_thread().name = f"process:{self.name}"
         faulthandler.enable()
 
         def receiveSignal(signalNumber, frame):

--- a/frigate/util/process.py
+++ b/frigate/util/process.py
@@ -8,6 +8,7 @@ from logging.handlers import QueueHandler
 from typing import Callable, Optional
 
 import frigate.log
+from frigate.config.logger import LoggerConfig
 
 
 class BaseProcess(mp.Process):
@@ -50,7 +51,7 @@ class Process(BaseProcess):
     def before_start(self) -> None:
         self.__log_queue = frigate.log.log_listener.queue
 
-    def pre_run_setup(self) -> None:
+    def pre_run_setup(self, logConfig: LoggerConfig | None = None) -> None:
         faulthandler.enable()
 
         def receiveSignal(signalNumber, frame):
@@ -68,3 +69,8 @@ class Process(BaseProcess):
         self.logger = logging.getLogger(self.name)
         logging.basicConfig(handlers=[], force=True)
         logging.getLogger().addHandler(QueueHandler(self.__log_queue))
+
+        if logConfig:
+            frigate.log.apply_log_levels(
+                logConfig.default.value.upper(), logConfig.logs
+            )


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Python’s multiprocessing module creates new Python interpreters for child processes when using the `forkserver` start method. This prevents the logging config for specific processes from being propagated as they used to be. 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
