### PR TITLE
Fix bird link in EnrichmentsSettingsView.tsx

### DIFF
--- a/web/src/views/settings/EnrichmentsSettingsView.tsx
+++ b/web/src/views/settings/EnrichmentsSettingsView.tsx
@@ -553,7 +553,7 @@ export default function EnrichmentsSettingsView({
 
               <div className="flex items-center text-primary">
                 <Link
-                  to={getLocaleDocUrl(
+                  to={getLocaleDocUrl("configuration/bird_classification")}
                   )}
                   target="_blank"
                   rel="noopener noreferrer"

--- a/web/src/views/settings/EnrichmentsSettingsView.tsx
+++ b/web/src/views/settings/EnrichmentsSettingsView.tsx
@@ -554,7 +554,6 @@ export default function EnrichmentsSettingsView({
               <div className="flex items-center text-primary">
                 <Link
                   to={getLocaleDocUrl("configuration/bird_classification")}
-                  )}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline"

--- a/web/src/views/settings/EnrichmentsSettingsView.tsx
+++ b/web/src/views/settings/EnrichmentsSettingsView.tsx
@@ -554,7 +554,6 @@ export default function EnrichmentsSettingsView({
               <div className="flex items-center text-primary">
                 <Link
                   to={getLocaleDocUrl(
-                    "configuration/bird_classification",
                   )}
                   target="_blank"
                   rel="noopener noreferrer"

--- a/web/src/views/settings/EnrichmentsSettingsView.tsx
+++ b/web/src/views/settings/EnrichmentsSettingsView.tsx
@@ -554,7 +554,7 @@ export default function EnrichmentsSettingsView({
               <div className="flex items-center text-primary">
                 <Link
                   to={getLocaleDocUrl(
-                    "configuration/license_plate_recognition",
+                    "configuration/bird_classification",
                   )}
                   target="_blank"
                   rel="noopener noreferrer"


### PR DESCRIPTION
This trivial PR fixes what looks like a a copy/paste bug for the bird classification docs URL.
`license_plate_recognition` -> `bird_classification`

## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
