### PR TITLE
OpenVINO: Don't force hard-coded input tensor shapes

### DIFF
--- a/frigate/detectors/plugins/openvino.py
+++ b/frigate/detectors/plugins/openvino.py
@@ -59,7 +59,6 @@ class OvDetector(DetectionApi):
             )
             self.model_invalid = True
 
-        # Ensure the SSD model has the right input and output shapes
         if self.ov_model_type == ModelTypeEnum.ssd:
             model_inputs = self.interpreter.inputs
             model_outputs = self.interpreter.outputs
@@ -72,12 +71,6 @@ class OvDetector(DetectionApi):
             if len(model_outputs) != 1:
                 logger.error(
                     f"SSD models must only have 1 output. Found {len(model_outputs)}."
-                )
-                self.model_invalid = True
-
-            if model_inputs[0].get_shape() != ov.Shape([1, self.w, self.h, 3]):
-                logger.error(
-                    f"SSD model input doesn't match. Found {model_inputs[0].get_shape()}."
                 )
                 self.model_invalid = True
 
@@ -100,13 +93,6 @@ class OvDetector(DetectionApi):
                     f"YoloNAS models must be exported in flat format and only have 1 output. Found {len(model_outputs)}."
                 )
                 self.model_invalid = True
-
-            if model_inputs[0].get_shape() != ov.Shape([1, 3, self.w, self.h]):
-                logger.error(
-                    f"YoloNAS model input doesn't match. Found {model_inputs[0].get_shape()}, but expected {[1, 3, self.w, self.h]}."
-                )
-                self.model_invalid = True
-
             output_shape = model_outputs[0].partial_shape
             if output_shape[-1] != 7:
                 logger.error(


### PR DESCRIPTION
## Proposed change

This changeset relaxes the requirements when using the YOLO-NAS model with OpenVINO backend. Model can be converted to the more efficient NHWC form offline thus avoiding an unnecessary transpose on the CPU for every single detection.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)

## Additional info

I have tested these instructions on my own frigate instance and detections continue working perfectly well after the conversion. I have not updated the documentation to recommend the converted model, however, as I don't really have the means to 100% verify whether models operate identically.

That said I did update the notebook for obtaining the model to produce the different variations of the model in both onnx and openvino formats so people who know what they're doing can experiment with this.