### PR TITLE
Fixes

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -792,6 +792,10 @@ class OnvifController:
             )
             return
 
+        logger.debug(
+            f"{camera_name}: Pan/tilt status: {pan_tilt_status}, Zoom status: {zoom_status}"
+        )
+
         if pan_tilt_status == "IDLE" and (zoom_status is None or zoom_status == "IDLE"):
             self.cams[camera_name]["active"] = False
             if not self.ptz_metrics[camera_name].motor_stopped.is_set():

--- a/frigate/track/object_processing.py
+++ b/frigate/track/object_processing.py
@@ -156,7 +156,7 @@ class TrackedObjectProcessor(threading.Thread):
                 )
             )
 
-        def snapshot(camera, obj: TrackedObject, frame_name: str):
+        def snapshot(camera: str, obj: TrackedObject) -> bool:
             mqtt_config: CameraMqttConfig = self.config.cameras[camera].mqtt
             if mqtt_config.enabled and self.should_mqtt_snapshot(camera, obj):
                 jpg_bytes = obj.get_img_bytes(
@@ -188,6 +188,10 @@ class TrackedObjectProcessor(threading.Thread):
                                 jpg_bytes,
                                 retain=True,
                             )
+
+                    return True
+
+            return False
 
         def camera_activity(camera, activity):
             last_activity = self.camera_activity.get(camera)

--- a/frigate/track/object_processing.py
+++ b/frigate/track/object_processing.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import cv2
 import numpy as np
-from peewee import DoesNotExist
+from peewee import SQL, DoesNotExist
 
 from frigate.camera.state import CameraState
 from frigate.comms.config_updater import ConfigSubscriber
@@ -29,9 +29,13 @@ from frigate.config import (
     RecordConfig,
     SnapshotsConfig,
 )
-from frigate.const import FAST_QUEUE_TIMEOUT, UPDATE_CAMERA_ACTIVITY
+from frigate.const import (
+    FAST_QUEUE_TIMEOUT,
+    UPDATE_CAMERA_ACTIVITY,
+    UPSERT_REVIEW_SEGMENT,
+)
 from frigate.events.types import EventStateEnum, EventTypeEnum
-from frigate.models import Event, Timeline
+from frigate.models import Event, ReviewSegment, Timeline
 from frigate.track.tracked_object import TrackedObject
 from frigate.util.image import SharedMemoryFrameManager
 
@@ -356,6 +360,71 @@ class TrackedObjectProcessor(threading.Thread):
             Timeline.update(
                 data=Timeline.data.update({"sub_label": (sub_label, score)})
             ).where(Timeline.source_id == event_id).execute()
+
+            # only update ended review segments
+            # manually updating a sub_label from the UI is only possible for ended tracked objects
+            try:
+                review_segment = ReviewSegment.get(
+                    (
+                        SQL(
+                            "json_extract(data, '$.detections') LIKE ?",
+                            [f'%"{event_id}"%'],
+                        )
+                    )
+                    & (ReviewSegment.end_time.is_null(False))
+                )
+
+                segment_data = review_segment.data
+                detection_ids = segment_data.get("detections", [])
+                objects_set = set(segment_data.get("objects", []))
+
+                # if sub_label is None, update objects set to remove -verified
+                if sub_label is None:
+                    try:
+                        target_event = Event.get(Event.id == event_id)
+                        base_label = target_event.label  # eg, "bird"
+                        verified_label = f"{base_label}-verified"  # eg, "bird-verified"
+                        if verified_label in objects_set:
+                            objects_set.remove(verified_label)
+                            objects_set.add(base_label)
+                    except DoesNotExist:
+                        logger.debug(
+                            f"No event found for event ID {event_id} when updating review item objects"
+                        )
+
+                sub_labels = set()
+                for det_id in detection_ids:
+                    try:
+                        det_event = Event.get(Event.id == det_id)
+                        if det_event.sub_label:
+                            sub_labels.add(det_event.sub_label)
+                    except DoesNotExist:
+                        logger.debug(
+                            f"No event found for review segment detection {det_id}"
+                        )
+
+                segment_data["objects"] = list(objects_set)
+                segment_data["sub_labels"] = list(sub_labels)
+
+                updated_data = {
+                    ReviewSegment.id.name: review_segment.id,
+                    ReviewSegment.camera.name: review_segment.camera,
+                    ReviewSegment.start_time.name: review_segment.start_time,
+                    ReviewSegment.end_time.name: review_segment.end_time,
+                    ReviewSegment.severity.name: review_segment.severity,
+                    ReviewSegment.thumb_path.name: review_segment.thumb_path,
+                    ReviewSegment.data.name: segment_data,
+                }
+
+                self.requestor.send_data(UPSERT_REVIEW_SEGMENT, updated_data)
+                logger.debug(
+                    f"Updated sub_label for event {event_id} in review segment {review_segment.id}"
+                )
+
+            except ReviewSegment.DoesNotExist:
+                logger.debug(
+                    f"No review segment found with event ID {event_id} when updating sub_label"
+                )
 
         return True
 

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -721,7 +721,7 @@ function ObjectDetailsTab({
                 ns: "objects",
               })}
               {search.sub_label && ` (${search.sub_label})`}
-              {isAdmin && (
+              {isAdmin && search.end_time && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span>

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -1242,13 +1242,13 @@ export function VideoTab({ search }: VideoTabProps) {
     <>
       <span tabIndex={0} className="sr-only" />
       <GenericVideoPlayer source={source}>
-        {reviewItem && (
-          <div
-            className={cn(
-              "absolute top-2 z-10 flex items-center gap-2",
-              isIOS ? "right-8" : "right-2",
-            )}
-          >
+        <div
+          className={cn(
+            "absolute top-2 z-10 flex items-center gap-2",
+            isIOS ? "right-8" : "right-2",
+          )}
+        >
+          {reviewItem && (
             <Tooltip>
               <TooltipTrigger>
                 <Chip
@@ -1271,25 +1271,25 @@ export function VideoTab({ search }: VideoTabProps) {
                 </TooltipContent>
               </TooltipPortal>
             </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <a
-                  download
-                  href={`${baseUrl}api/${search.camera}/${clipTimeRange}/clip.mp4`}
-                >
-                  <Chip className="cursor-pointer rounded-md bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500">
-                    <FaDownload className="size-4 text-white" />
-                  </Chip>
-                </a>
-              </TooltipTrigger>
-              <TooltipPortal>
-                <TooltipContent>
-                  {t("button.download", { ns: "common" })}
-                </TooltipContent>
-              </TooltipPortal>
-            </Tooltip>
-          </div>
-        )}
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <a
+                download
+                href={`${baseUrl}api/${search.camera}/${clipTimeRange}/clip.mp4`}
+              >
+                <Chip className="cursor-pointer rounded-md bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500">
+                  <FaDownload className="size-4 text-white" />
+                </Chip>
+              </a>
+            </TooltipTrigger>
+            <TooltipPortal>
+              <TooltipContent>
+                {t("button.download", { ns: "common" })}
+              </TooltipContent>
+            </TooltipPortal>
+          </Tooltip>
+        </div>
       </GenericVideoPlayer>
     </>
   );


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
- Don't allow editing of sub label until object lifecycle has ended
- Update sub labels in ended review segments. When manually editing a sub label for a tracked object from the UI, any review segments containing that tracked object did not have their sub_labels and objects values altered, leaving a data inconsistency.
- Additional onvif debug log
- Fix issue where mqtt snapshot for object is not sent when required_zones is configured
- Don't hide download button in video tab when a review item does not exist

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/18832
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
