### PR TITLE
Bump HailoRT to 4.21.0 for HAOS 16 compatibility

### DIFF
--- a/docker/hailo8l/user_installation.sh
+++ b/docker/hailo8l/user_installation.sh
@@ -4,7 +4,7 @@
 sudo apt-get update
 sudo apt-get install -y build-essential cmake git wget
 
-hailo_version="4.20.1"
+hailo_version="4.21.0"
 arch=$(uname -m)
 
 if [[ $arch == "x86_64" ]]; then

--- a/docker/main/install_hailort.sh
+++ b/docker/main/install_hailort.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-hailo_version="4.20.1"
+hailo_version="4.21.0"
 
 if [[ "${TARGETARCH}" == "amd64" ]]; then
     arch="x86_64"


### PR DESCRIPTION
## Proposed change

Home Assistant OS 16.0.rc1 contains bump of Hailo driver and firmware to v4.21.0, update Frigate's userspace libraries to the same version to fix compatibility.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
