### PR TITLE
fix: set preset-record-generic as default output args

### DIFF
--- a/frigate/config/camera/ffmpeg.py
+++ b/frigate/config/camera/ffmpeg.py
@@ -21,7 +21,7 @@ __all__ = [
 FFMPEG_GLOBAL_ARGS_DEFAULT = ["-hide_banner", "-loglevel", "warning", "-threads", "2"]
 FFMPEG_INPUT_ARGS_DEFAULT = "preset-rtsp-generic"
 
-RECORD_FFMPEG_OUTPUT_ARGS_DEFAULT = "preset-record-generic-audio-aac"
+RECORD_FFMPEG_OUTPUT_ARGS_DEFAULT = "preset-record-generic"
 DETECT_FFMPEG_OUTPUT_ARGS_DEFAULT = [
     "-threads",
     "2",


### PR DESCRIPTION
According to [docs](https://deploy-preview-16390--frigate-docs.netlify.app/configuration/ffmpeg_presets#output-args-presets), `preset-record-generic` should be set as default on the output args.

However that isn't the case: https://github.com/blakeblackshear/frigate/blob/178117183ed0b43e9d7e6705ce0fbb1d5619d7c4/frigate/config/camera/ffmpeg.py#L24

This PR changes it to `preset-record-generic`