### PR TITLE
Update edgetpu.md

### DIFF
--- a/docs/docs/troubleshooting/edgetpu.md
+++ b/docs/docs/troubleshooting/edgetpu.md
@@ -40,6 +40,17 @@ Some users have reported that this older device runs an older kernel causing iss
 6. Open the control panel - info scree. The coral TPU will now be recognised as a USB Device - google inc
 7. Start the frigate container. Everything should work now!
 
+### QNAP NAS
+
+QNAP NAS devices, such as the TS-253A, may use connected Coral TPU devices if [QuMagie](https://www.qnap.com/en/software/qumagie) is installed along with its QNAP AI Core extension. If any of the features—`facial recognition`, `object recognition`, or `similar photo recognition`—are enabled, Container Station applications such as `Frigate` or `CodeProject.AI Server` will be unable to initialize the TPU device in use.
+To allow the Coral TPU device to be discovered, the you must either:
+
+1. [Disable the AI recognition features in QuMagie](https://docs.qnap.com/application/qumagie/2.x/en-us/configuring-qnap-ai-core-settings-FB13CE03.html),
+2. Remove the QNAP AI Core extension or
+3. Manually start the QNAP AI Core extension after Frigate has fully started (not recommended).
+
+It is also recommended to restart the NAS once the changes have been made.
+
 ## USB Coral Detection Appears to be Stuck
 
 The USB Coral can become stuck and need to be restarted, this can happen for a number of reasons depending on hardware and software setup. Some common reasons are:


### PR DESCRIPTION
Updated "USB Coral Not Detected" section with troubleshooting steps for QNAP NAS devices.

## Proposed change

Added [Coral TPU troubleshooting](https://docs.frigate.video/troubleshooting/edgetpu) steps for QNAP NAS devices after trial and error with my own setup. These troubleshooting steps should also apply to most QNAP NAS devices that are compatible with coral TPUs.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update

## Additional information
- none

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
