### PR TITLE
Set ulimit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default_target: local
 
 COMMIT_HASH := $(shell git log -1 --pretty=format:"%h"|tail -1)
-VERSION = 0.15.0
+VERSION = 0.15.2
 IMAGE_REPO ?= ghcr.io/blakeblackshear/frigate
 GITHUB_REF_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
 BOARDS= #Initialized empty

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate/run
@@ -50,6 +50,7 @@ function set_libva_version() {
 echo "[INFO] Preparing Frigate..."
 migrate_db_path
 set_libva_version
+/usr/local/ulimit/set_ulimit.sh
 echo "[INFO] Starting Frigate..."
 
 cd /opt/frigate || echo "[ERROR] Failed to change working directory to /opt/frigate"

--- a/docker/main/rootfs/usr/local/ulimit/set_ulimit.sh
+++ b/docker/main/rootfs/usr/local/ulimit/set_ulimit.sh
@@ -11,7 +11,7 @@ current_hard_limit=$(ulimit -Hn)
 TARGET_SOFT_LIMIT=65536
 TARGET_HARD_LIMIT=65536
 
-if [ "$current_soft_limit" -eq 1024 ]; then
+if [ "$current_soft_limit" -lt "$TARGET_SOFT_LIMIT" ]; then
     # Attempt to set both soft and hard limits to the new value
     # This requires sufficient privileges (e.g., running as root in the container)
     if ulimit -n "$TARGET_SOFT_LIMIT:$TARGET_HARD_LIMIT"; then

--- a/docker/main/rootfs/usr/local/ulimit/set_ulimit.sh
+++ b/docker/main/rootfs/usr/local/ulimit/set_ulimit.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Newer versions of containerd 2.X+ impose a very low soft file limit of 1024
+# This applies to OSs like HA OS (see https://github.com/home-assistant/operating-system/issues/4110)
+# Attempt to increase this limit
+
+# Get current soft and hard nofile limits
+current_soft_limit=$(ulimit -Sn)
+current_hard_limit=$(ulimit -Hn)
+
+TARGET_SOFT_LIMIT=65536
+TARGET_HARD_LIMIT=65536
+
+if [ "$current_soft_limit" -eq 1024 ]; then
+    # Attempt to set both soft and hard limits to the new value
+    # This requires sufficient privileges (e.g., running as root in the container)
+    if ulimit -n "$TARGET_SOFT_LIMIT:$TARGET_HARD_LIMIT"; then
+        new_soft_limit=$(ulimit -Sn)
+        new_hard_limit=$(ulimit -Hn)
+
+        if [ "$new_soft_limit" -ne "$TARGET_SOFT_LIMIT" ] || [ "$new_hard_limit" -ne "$TARGET_HARD_LIMIT" ]; then
+            echo "Warning: Limits were set, but not to the exact target values. Check system constraints."
+        fi
+    else
+        echo "Error: Failed to set new nofile limits."
+    fi
+fi


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

HA OS 16 uses a newer containerd 2.X which sets a low soft limit for open files, causing a crash in many cases. This PR implements a script to set a more reasonable value on startup to avoid failing in this way.

https://github.com/home-assistant/operating-system/issues/4110

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
