### PR TITLE
Improve ffmpeg frame handling

### DIFF
--- a/frigate/video.py
+++ b/frigate/video.py
@@ -208,7 +208,35 @@ class CameraWatchdog(threading.Thread):
 
         return self.config.enabled
 
-    def run(self):
+    def reset_capture_thread(
+        self, terminate: bool = True, drain_output: bool = True
+    ) -> None:
+        if terminate:
+            self.ffmpeg_detect_process.terminate()
+            try:
+                self.logger.info("Waiting for ffmpeg to exit gracefully...")
+
+                if drain_output:
+                    self.ffmpeg_detect_process.communicate(timeout=30)
+                else:
+                    self.ffmpeg_detect_process.wait(timeout=30)
+            except sp.TimeoutExpired:
+                self.logger.info("FFmpeg did not exit. Force killing...")
+                self.ffmpeg_detect_process.kill()
+
+                if drain_output:
+                    self.ffmpeg_detect_process.communicate()
+                else:
+                    self.ffmpeg_detect_process.wait()
+
+        self.logger.error(
+            "The following ffmpeg logs include the last 100 lines prior to exit."
+        )
+        self.logpipe.dump()
+        self.logger.info("Restarting ffmpeg...")
+        self.start_ffmpeg_detect()
+
+    def run(self) -> None:
         if self._update_enabled_state():
             self.start_all_ffmpeg()
 
@@ -235,11 +263,7 @@ class CameraWatchdog(threading.Thread):
                 self.logger.error(
                     f"Ffmpeg process crashed unexpectedly for {self.camera_name}."
                 )
-                self.logger.error(
-                    "The following ffmpeg logs include the last 100 lines prior to exit."
-                )
-                self.logpipe.dump()
-                self.start_ffmpeg_detect()
+                self.reset_capture_thread(terminate=False)
             elif self.camera_fps.value >= (self.config.detect.fps + 10):
                 self.fps_overflow_count += 1
 
@@ -249,29 +273,13 @@ class CameraWatchdog(threading.Thread):
                     self.logger.info(
                         f"{self.camera_name} exceeded fps limit. Exiting ffmpeg..."
                     )
-                    self.ffmpeg_detect_process.terminate()
-                    try:
-                        # we don't want to communicate() here because we know that ffmpeg is
-                        # outputting a massive amount of frames
-                        self.logger.info("Waiting for ffmpeg to exit gracefully...")
-                        self.ffmpeg_detect_process.wait(timeout=30)
-                    except sp.TimeoutExpired:
-                        self.logger.info("FFmpeg did not exit. Force killing...")
-                        self.ffmpeg_detect_process.kill()
-                        self.ffmpeg_detect_process.wait()
+                    self.reset_capture_thread(drain_output=False)
             elif now - self.capture_thread.current_frame.value > 20:
                 self.camera_fps.value = 0
                 self.logger.info(
                     f"No frames received from {self.camera_name} in 20 seconds. Exiting ffmpeg..."
                 )
-                self.ffmpeg_detect_process.terminate()
-                try:
-                    self.logger.info("Waiting for ffmpeg to exit gracefully...")
-                    self.ffmpeg_detect_process.communicate(timeout=30)
-                except sp.TimeoutExpired:
-                    self.logger.info("FFmpeg did not exit. Force killing...")
-                    self.ffmpeg_detect_process.kill()
-                    self.ffmpeg_detect_process.communicate()
+                self.reset_capture_thread()
             else:
                 # process is running normally
                 self.fps_overflow_count = 0


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This PR:

- Removes the `communicate` from the ffmpeg fps exceeded case. This had the potential to lead to OOM due to ffmpeg creating hundreds of duplicate frames per second and the communicate call would load that into python's memory to clear the stdout pipe. We now use wait in this case
- Always restart ffmpeg immediately instead of waiting 10 seconds for an additional loop before starting a new ffmpeg process
- Simplify and reduce duplicated code
- Add additional logs to make behavior more clear

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
