### PR TITLE
Fix IPv6 addresses with IPv4 trusted proxies

### DIFF
--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -71,7 +71,7 @@ def get_remote_addr(request: Request):
             )
             if trusted_proxy.version == 4:
                 ipv4 = ip.ipv4_mapped if ip.version == 6 else ip
-                if ipv4 in trusted_proxy:
+                if ipv4 is not None and ipv4 in trusted_proxy:
                     trusted = True
                     logger.debug(f"Trusted: {str(ip)} by {str(trusted_proxy)}")
                     break


### PR DESCRIPTION


## Proposed change

Fixes a bug when using checking an IPv6 address against IPv4 trusted_proxies. When an IPv6 address that doesn't map to an IPv4 address was checked against an IPv4 trusted proxy, we'd hit an exception because ip.ipv4_mapped was None:
`AttributeError: 'NoneType' object has no attribute '_version'`

Fix this by verifying ipv4_mapped is not None


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- The discussion here describes the issue and has repro logs: https://github.com/blakeblackshear/frigate/discussions/18573

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
