### PR TITLE
Replaces sriov flag with explicit path to the Intel GPU device

### DIFF
--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -176,15 +176,25 @@ For more information on the various values across different distributions, see h
 
 Depending on your OS and kernel configuration, you may need to change the `/proc/sys/kernel/perf_event_paranoid` kernel tunable. You can test the change by running `sudo sh -c 'echo 2 >/proc/sys/kernel/perf_event_paranoid'` which will persist until a reboot. Make it permanent by running `sudo sh -c 'echo kernel.perf_event_paranoid=2 >> /etc/sysctl.d/local.conf'`
 
-#### Stats for SR-IOV devices
+#### Stats for SR-IOV or other devices
 
-When using virtualized GPUs via SR-IOV, additional args are needed for GPU stats to function. This can be enabled with the following config:
+When using virtualized GPUs via SR-IOV, you need to specify the device path to use to gather stats from `intel_gpu_top`. This example may work for some systems using SR-IOV:
 
 ```yaml
 telemetry:
   stats:
-    sriov: True
+    intel_gpu_device: "sriov"
 ```
+
+For other virtualized GPUs, try specifying the direct path to the device instead:
+
+```yaml
+telemetry:
+  stats:
+    intel_gpu_device: "drm:/dev/dri/card0"
+```
+
+If you are passing in a device path, make sure you've passed the device through to the container.
 
 ## AMD/ATI GPUs (Radeon HD 2000 and newer GPUs) via libva-mesa-driver
 

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -903,7 +903,7 @@ telemetry:
     # Optional: Enable Intel GPU stats (default: shown below)
     intel_gpu_stats: True
     # Optional: Treat GPU as SR-IOV to fix GPU stats (default: shown below)
-    sriov: False
+    intel_gpu_device: None
     # Optional: Enable network bandwidth stats monitoring for camera ffmpeg processes, go2rtc, and object detectors. (default: shown below)
     # NOTE: The container must either be privileged or have cap_net_admin, cap_net_raw capabilities enabled.
     network_bandwidth: False

--- a/frigate/config/telemetry.py
+++ b/frigate/config/telemetry.py
@@ -1,4 +1,5 @@
 from pydantic import Field
+from typing import Optional
 
 from .base import FrigateBaseModel
 
@@ -11,8 +12,8 @@ class StatsConfig(FrigateBaseModel):
     network_bandwidth: bool = Field(
         default=False, title="Enable network bandwidth for ffmpeg processes."
     )
-    sriov: bool = Field(
-        default=False, title="Treat device as SR-IOV to support GPU stats."
+    intel_gpu_device: Optional[str] = Field(
+        default=None, title="Define the device to use when gathering SR-IOV stats."
     )
 
 

--- a/frigate/config/telemetry.py
+++ b/frigate/config/telemetry.py
@@ -1,5 +1,6 @@
-from pydantic import Field
 from typing import Optional
+
+from pydantic import Field
 
 from .base import FrigateBaseModel
 

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -201,7 +201,7 @@ async def set_gpu_stats(
                 continue
 
             # intel QSV GPU
-            intel_usage = get_intel_gpu_stats(config.telemetry.stats.sriov)
+            intel_usage = get_intel_gpu_stats(config.telemetry.stats.intel_gpu_device)
 
             if intel_usage is not None:
                 stats["intel-qsv"] = intel_usage or {"gpu": "", "mem": ""}
@@ -226,7 +226,9 @@ async def set_gpu_stats(
                     continue
 
                 # intel VAAPI GPU
-                intel_usage = get_intel_gpu_stats(config.telemetry.stats.sriov)
+                intel_usage = get_intel_gpu_stats(
+                    config.telemetry.stats.intel_gpu_device
+                )
 
                 if intel_usage is not None:
                     stats["intel-vaapi"] = intel_usage or {"gpu": "", "mem": ""}

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -257,7 +257,7 @@ def get_amd_gpu_stats() -> Optional[dict[str, str]]:
         return results
 
 
-def get_intel_gpu_stats(sriov: bool) -> Optional[dict[str, str]]:
+def get_intel_gpu_stats(intel_gpu_device: Optional[str]) -> Optional[dict[str, str]]:
     """Get stats using intel_gpu_top."""
 
     def get_stats_manually(output: str) -> dict[str, str]:
@@ -304,8 +304,8 @@ def get_intel_gpu_stats(sriov: bool) -> Optional[dict[str, str]]:
         "1",
     ]
 
-    if sriov:
-        intel_gpu_top_command += ["-d", "sriov"]
+    if intel_gpu_device:
+        intel_gpu_top_command += ["-d", intel_gpu_device]
 
     try:
         p = sp.run(


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This was discussed in https://github.com/blakeblackshear/frigate/discussions/14356, unfortunately the change that introduced the `sriov` flag worked for some people but not for others. There are a few other such examples in the issue tracker, e.g. https://github.com/blakeblackshear/frigate/issues/14840#issuecomment-2511760936. Instead of introducing more booleans or other flags, this change just allows users to specify the device they need directly, whether that's `sriov`, `drm:/dev/dri/card0`, `sys:/sys/devices/pci0000:00/0000:00:1e.0/0000:05:01.0/0000:06:10.0`, or something else. 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

I'm not sure what the policy is on this project for what counts as "breaking change" vs. "bug fix", this is technically only a breaking change against earlier 0.16 betas since as far as I know the `sriov` flag was introduced in 0.16.

## Additional information

- This PR fixes or closes issue: None that are currently open
- This PR is related to issue: None that are currently open 

There are a few discussions, like the ones I linked above or https://github.com/blakeblackshear/frigate/discussions/16090#discussioncomment-11924185. Seaching for `intel_gpu_top` or `Failed to detect engines!` in the issue tracker brings up many results.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
