### PR TITLE
Fix motion timeline for offset timezones

### DIFF
--- a/web/src/utils/timelineUtil.tsx
+++ b/web/src/utils/timelineUtil.tsx
@@ -46,7 +46,7 @@ export function getChunkedTimeRange(
   endOfThisHour.setHours(endOfThisHour.getHours() + 1, 0, 0, 0);
   const data: TimeRange[] = [];
   const startDay = new Date(startTimestamp * 1000);
-  startDay.setMinutes(0, 0, 0);
+  startDay.setUTCMinutes(0, 0, 0);
   let start = startDay.getTime() / 1000;
   let end = 0;
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

The motion timeline uses a different function for chunking the time range than the recording view, and it was not correctly setting the minutes to UTC as is necessary for offset timezones

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
