### PR TITLE
Rockchip: add FFmpeg 7.1 to image

### DIFF
--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -30,5 +30,7 @@ ADD https://github.com/MarcA711/rknn-toolkit2/releases/download/v2.3.2/librknnrt
 
 ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-11/ffmpeg /usr/lib/ffmpeg/6.0/bin/
 ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-11/ffprobe /usr/lib/ffmpeg/6.0/bin/
+ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/7.1-1/ffmpeg /usr/lib/ffmpeg/7.0/bin/
+ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/7.1-1/ffprobe /usr/lib/ffmpeg/7.0/bin/
 ENV DEFAULT_FFMPEG_VERSION="6.0"
-ENV INCLUDED_FFMPEG_VERSIONS="${DEFAULT_FFMPEG_VERSION}:${INCLUDED_FFMPEG_VERSIONS}"
+ENV INCLUDED_FFMPEG_VERSIONS="${DEFAULT_FFMPEG_VERSION}:7.0:${INCLUDED_FFMPEG_VERSIONS}"

--- a/docker/rockchip/Dockerfile
+++ b/docker/rockchip/Dockerfile
@@ -33,4 +33,4 @@ ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/down
 ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/7.1-1/ffmpeg /usr/lib/ffmpeg/7.0/bin/
 ADD --chmod=111 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/7.1-1/ffprobe /usr/lib/ffmpeg/7.0/bin/
 ENV DEFAULT_FFMPEG_VERSION="6.0"
-ENV INCLUDED_FFMPEG_VERSIONS="${DEFAULT_FFMPEG_VERSION}:7.0:${INCLUDED_FFMPEG_VERSIONS}"
+ENV INCLUDED_FFMPEG_VERSIONS="${DEFAULT_FFMPEG_VERSION}:${INCLUDED_FFMPEG_VERSIONS}"

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -386,17 +386,45 @@ Make sure to follow the [Rockchip specific installation instructions](/frigate/i
 Add one of the following FFmpeg presets to your `config.yml` to enable hardware video processing:
 
 ```yaml
-# if you try to decode a h264 encoded stream
 ffmpeg:
-  hwaccel_args: preset-rk-h264
-
-# if you try to decode a h265 (hevc) encoded stream
-ffmpeg:
-  hwaccel_args: preset-rk-h265
+  hwaccel_args: preset-rkmpp
 ```
 
 :::note
 
 Make sure that your SoC supports hardware acceleration for your input stream. For example, if your camera streams with h265 encoding and a 4k resolution, your SoC must be able to de- and encode h265 with a 4k resolution or higher. If you are unsure whether your SoC meets the requirements, take a look at the datasheet.
+
+:::
+
+:::warning
+
+If one or more of your cameras are not properly processed and this error is shown in the logs:
+
+```
+[segment @ 0xaaaaff694790] Timestamps are unset in a packet for stream 0. This is deprecated and will stop working in the future. Fix your code to set the timestamps properly
+[Parsed_scale_rkrga_0 @ 0xaaaaff819070] No hw context provided on input
+[Parsed_scale_rkrga_0 @ 0xaaaaff819070] Failed to configure output pad on Parsed_scale_rkrga_0
+Error initializing filters!
+Error marking filters as finished
+[out#1/rawvideo @ 0xaaaaff3d8730] Nothing was written into output file, because at least one of its streams received no packets.
+Restarting ffmpeg...
+```
+
+you should try to uprade to FFmpeg 7. This can be done using this config option:
+
+```
+ffmpeg:
+  path: "7.0"
+```
+
+You can set this option globally to use FFmpeg 7 for all cameras or on camera level to use it only for specific cameras. Do not confuse this option with:
+
+```
+cameras:
+  name:
+    ffmpeg:
+      inputs:
+        - path: rtsp://viewer:{FRIGATE_RTSP_PASSWORD}@10.0.10.10:554/cam/realmonitor?channel=1&subtype=2
+```
 
 :::

--- a/frigate/const.py
+++ b/frigate/const.py
@@ -72,6 +72,7 @@ LIBAVFORMAT_VERSION_MAJOR = int(os.environ.get("LIBAVFORMAT_VERSION_MAJOR", "59"
 FFMPEG_HWACCEL_NVIDIA = "preset-nvidia"
 FFMPEG_HWACCEL_VAAPI = "preset-vaapi"
 FFMPEG_HWACCEL_VULKAN = "preset-vulkan"
+FFMPEG_HWACCEL_RKMPP = "preset-rkmpp"
 FFMPEG_HVC1_ARGS = ["-tag:v", "hvc1"]
 
 # Regex constants


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Depending on the rtsp source, the sequence header might be passed through sdp only and might not be present in the video stream. However, the rkmpp decoder gets stuck if the sequence header is not present in the video stream. In this case the option `dump_extra` must be used. See https://github.com/nyanmisaka/ffmpeg-rockchip/issues/155#issuecomment-2648157574 and https://github.com/nyanmisaka/ffmpeg-rockchip/commit/04f5eaa11c713577e41f201552ff8183af6508bf for details.

In FFmpeg 6.1.7 (that was used up to beta 3) the option `dump_extra` was used by default. This created issues for some users: https://github.com/nyanmisaka/ffmpeg-rockchip/issues/155.

That's why this option was removed in FFmpeg 6.1-11 (which we use since beta 4). However, this might be the reason for these issues: https://github.com/blakeblackshear/frigate/discussions/19169 and https://github.com/blakeblackshear/frigate/discussions/19114#discussioncomment-13757431

FFmpeg 7.1 allows the user to add the option `-bsf:v dump_extra` on command line level, so users that need this option can enable it. However, even though FFmpeg 7.1 should be stable it was not really tested and we are already in beta 4, so I don't want to use 7.1 as the default version. So we we include this binary but keep 6.1 the default for now. Users who have problems can manually switch the version and apply the command line option.

However, I have two questions:
1. What is the recommended way to make Frigate use the version FFmpeg 7.1? Should the user set the environment variable `DEFAULT_FFMPEG_VERSION="7.0"`? Is there a way to use FFmpeg 7.1 just for specific cameras and use the default (FFmpeg 6.1) for the other cameras?
2. Is there a way to add the option `-bsf:v dump_extra` to the args from the input preset in the config? Like in this example (that is not working) `input_args: preset-rtsp-generic -bsf:v dump_extra`. Or will the user need to manually specify all options from the `preset-rtsp-generic`?

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: mentioned in the introductory text
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
