### PR TITLE
Timezone fix

### DIFF
--- a/web/src/components/overlay/ReviewActivityCalendar.tsx
+++ b/web/src/components/overlay/ReviewActivityCalendar.tsx
@@ -50,7 +50,7 @@ export default function ReviewActivityCalendar({
         }
 
         const parts = date.split("-");
-        const cal = new TZDate(date, timezone);
+        const cal = new TZDate(date + "T00:00:00", timezone);
 
         cal.setFullYear(
           parseInt(parts[0]),
@@ -70,7 +70,7 @@ export default function ReviewActivityCalendar({
         }
 
         const parts = date.split("-");
-        const cal = new TZDate(date, timezone);
+        const cal = new TZDate(date + "T00:00:00", timezone);
 
         cal.setFullYear(
           parseInt(parts[0]),

--- a/web/src/views/system/StorageMetrics.tsx
+++ b/web/src/views/system/StorageMetrics.tsx
@@ -80,7 +80,7 @@ export default function StorageMetrics({
   const formattedEarliestDate = useFormattedTimestamp(
     earliestDate || 0,
     format,
-    timezone,
+    "UTC", // timezone is already converted from recordings summary endpoint
   );
 
   if (!cameraStorage || !stats || !totalStorage || !config) {

--- a/web/src/views/system/StorageMetrics.tsx
+++ b/web/src/views/system/StorageMetrics.tsx
@@ -13,6 +13,7 @@ import { FrigateConfig } from "@/types/frigateConfig";
 import { useFormattedTimestamp, useTimezone } from "@/hooks/use-date-utils";
 import { RecordingsSummary } from "@/types/review";
 import { useTranslation } from "react-i18next";
+import { TZDate } from "react-day-picker";
 
 type CameraStorage = {
   [key: string]: {
@@ -66,9 +67,10 @@ export default function StorageMetrics({
   const earliestDate = useMemo(() => {
     const keys = Object.keys(recordingsSummary || {});
     return keys.length
-      ? new Date(keys[keys.length - 1]).getTime() / 1000
+      ? new TZDate(keys[keys.length - 1] + "T00:00:00", timezone).getTime() /
+          1000
       : null;
-  }, [recordingsSummary]);
+  }, [recordingsSummary, timezone]);
 
   const timeFormat = config?.ui.time_format === "24hour" ? "24hour" : "12hour";
   const format = useMemo(() => {
@@ -80,7 +82,7 @@ export default function StorageMetrics({
   const formattedEarliestDate = useFormattedTimestamp(
     earliestDate || 0,
     format,
-    "UTC", // timezone is already converted from recordings summary endpoint
+    timezone,
   );
 
   if (!cameraStorage || !stats || !totalStorage || !config) {


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
JavaScript's `Date` constructor always treats "YYYY-MM-DD" as UTC. The values being returned from the recordings/summary endpoint don't include hours/minutes/seconds, so the earliest recording date in Storage metrics could be off by 1 day. This fix ensures a valid date string is passed to `TZDate()`, the timezone-aware version of `Date()` provided by `react-day-picker`.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
