### PR TITLE
Rocm 9070 hipblaslt support

### DIFF
--- a/docker/rocm/Dockerfile
+++ b/docker/rocm/Dockerfile
@@ -20,9 +20,11 @@ RUN apt update && \
     apt update && \
     apt install -y rocm
 
-RUN mkdir -p /opt/rocm-dist/opt/rocm-$ROCM/lib
+RUN mkdir -p /opt/rocm-dist/opt/rocm-$ROCM/lib/hipblaslt/library
 RUN cd /opt/rocm-$ROCM/lib && \
     cp -dpr libMIOpen*.so* libamd*.so* libhip*.so* libhsa*.so* libmigraphx*.so* librocm*.so* librocblas*.so* libroctracer*.so* librocsolver*.so* librocfft*.so* librocprofiler*.so* libroctx*.so* /opt/rocm-dist/opt/rocm-$ROCM/lib/ && \
+    mkdir -p /opt/rocm-dist/opt/rocm-$ROCM/lib/hipblaslt/library && \
+    cp -dpr hipblaslt /opt/rocm-dist/opt/rocm-$ROCM/lib/ && \
     mkdir -p /opt/rocm-dist/opt/rocm-$ROCM/lib/migraphx/lib && \
     cp -dpr migraphx/lib/* /opt/rocm-dist/opt/rocm-$ROCM/lib/migraphx/lib
 RUN cd /opt/rocm-dist/opt/ && ln -s rocm-$ROCM rocm
@@ -57,6 +59,7 @@ COPY --from=rocm /opt/rocm-$ROCM/bin/rocminfo /opt/rocm-$ROCM/bin/migraphx-drive
 COPY --from=rocm /opt/rocm-$ROCM/share/miopen/db/*$AMDGPU* /opt/rocm-$ROCM/share/miopen/db/
 COPY --from=rocm /opt/rocm-$ROCM/share/miopen/db/*gfx908* /opt/rocm-$ROCM/share/miopen/db/
 COPY --from=rocm /opt/rocm-$ROCM/lib/rocblas/library/*$AMDGPU* /opt/rocm-$ROCM/lib/rocblas/library/
+COPY --from=rocm /opt/rocm-$ROCM/lib/hipblaslt/library/*$AMDGPU* /opt/rocm-$ROCM/lib/hipblaslt/library/
 COPY --from=rocm /opt/rocm-dist/ /
 
 #######################################################################

--- a/docker/rocm/Dockerfile
+++ b/docker/rocm/Dockerfile
@@ -15,7 +15,7 @@ ARG AMDGPU
 
 RUN apt update && \
     apt install -y wget gpg && \
-    wget -O rocm.deb https://repo.radeon.com/amdgpu-install/$ROCM/ubuntu/jammy/amdgpu-install_6.3.60303-1_all.deb && \
+    wget -O rocm.deb https://repo.radeon.com/amdgpu-install/$ROCM/ubuntu/jammy/amdgpu-install_6.4.60401-1_all.deb && \
     apt install -y ./rocm.deb && \
     apt update && \
     apt install -y rocm

--- a/docker/rocm/rocm.hcl
+++ b/docker/rocm/rocm.hcl
@@ -2,7 +2,7 @@ variable "AMDGPU" {
   default = "gfx900"
 }
 variable "ROCM" {
-  default = "6.3.3"
+  default = "6.4.1"
 }
 variable "HSA_OVERRIDE_GFX_VERSION" {
   default = ""

--- a/docker/rocm/rocm.mk
+++ b/docker/rocm/rocm.mk
@@ -1,7 +1,7 @@
 BOARDS += rocm
 
 # AMD/ROCm is chunky so we build couple of smaller images for specific chipsets
-ROCM_CHIPSETS:=gfx900:9.0.0 gfx1030:10.3.0 gfx1100:11.0.0
+ROCM_CHIPSETS:=gfx900:9.0.0 gfx1030:10.3.0 gfx1100:11.0.0 gfx1201:11.0.0
 
 local-rocm: version
 	$(foreach chipset,$(ROCM_CHIPSETS), \

--- a/docker/rocm/rocm.mk
+++ b/docker/rocm/rocm.mk
@@ -12,7 +12,7 @@ local-rocm: version
 			--set rocm.tags=frigate:latest-rocm-$(word 1,$(subst :, ,$(chipset))) \
 			--load \
 	&&) true
-	
+
 	unset HSA_OVERRIDE_GFX_VERSION && \
 	HSA_OVERRIDE=0 \
 	AMDGPU=gfx \


### PR DESCRIPTION
## Proposed change

The image `ghcr.io/blakeblackshear/frigate:0.16.0-rc1-rocm` fails on RX 9070 with the following errors:

```
2025-07-28 16:34:56.066574647  rocblaslt error: Cannot read /opt/rocm/lib/hipblaslt/library/TensileLibrary_lazy_gfx1201.dat: No such file or directory
2025-07-28 16:34:56.066583267  
2025-07-28 16:34:56.066583967  rocblaslt error: Could not load /opt/rocm/lib/hipblaslt/library/TensileLibrary_lazy_gfx1201.dat
2025-07-28 16:34:56.108597926  hipBLASLt error: Heuristic Fetch Failed!
2025-07-28 16:34:56.108599786  This message will be only be displayed once, unless the ROCBLAS_VERBOSE_HIPBLASLT_ERROR environment variable is set.
2025-07-28 16:34:56.108608376  
2025-07-28 16:34:56.108609076  rocBLAS warning: hipBlasLT failed, falling back to tensile. 
2025-07-28 16:34:56.108609786  This message will be only be displayed once, unless the ROCBLAS_VERBOSE_TENSILE_ERROR environment variable is set.
2025-07-28 16:34:56.115722329  Fatal Python error: Segmentation fault
2025-07-28 16:34:56.115726029  
2025-07-28 16:34:56.115727209  Current thread 0x00007f152719f040 (most recent call first):
2025-07-28 16:34:56.115728289    File "/usr/local/lib/python3.11/dist-packages/onnxruntime/capi/onnxruntime_inference_collection.py", line 266 in run
2025-07-28 16:34:56.115732039    File "/opt/frigate/frigate/detectors/plugins/onnx.py", line 81 in detect_raw
2025-07-28 16:34:56.115755769    File "/opt/frigate/frigate/object_detection/base.py", line 86 in detect_raw
2025-07-28 16:34:56.115757229    File "/opt/frigate/frigate/object_detection/base.py", line 136 in run_detector
2025-07-28 16:34:56.115758619    File "/usr/lib/python3.11/multiprocessing/process.py", line 108 in run
2025-07-28 16:34:56.115759559    File "/opt/frigate/frigate/util/process.py", line 41 in run_wrapper
2025-07-28 16:34:56.115778249    File "/usr/lib/python3.11/multiprocessing/process.py", line 314 in _bootstrap
2025-07-28 16:34:56.115779329    File "/usr/lib/python3.11/multiprocessing/popen_fork.py", line 71 in _launch
2025-07-28 16:34:56.115780199    File "/usr/lib/python3.11/multiprocessing/popen_fork.py", line 19 in __init__
2025-07-28 16:34:56.115781099    File "/usr/lib/python3.11/multiprocessing/context.py", line 281 in _Popen
2025-07-28 16:34:56.115781989    File "/usr/lib/python3.11/multiprocessing/context.py", line 224 in _Popen
2025-07-28 16:34:56.115782799    File "/usr/lib/python3.11/multiprocessing/process.py", line 121 in start
2025-07-28 16:34:56.115783629    File "/opt/frigate/frigate/util/process.py", line 30 in start
2025-07-28 16:34:56.115784519    File "/opt/frigate/frigate/object_detection/base.py", line 195 in start_or_restart
2025-07-28 16:34:56.115785449    File "/opt/frigate/frigate/object_detection/base.py", line 163 in __init__
2025-07-28 16:34:56.115815199    File "/opt/frigate/frigate/app.py", line 390 in start_detectors
2025-07-28 16:34:56.115816049    File "/opt/frigate/frigate/app.py", line 647 in start
2025-07-28 16:34:56.115817289    File "/opt/frigate/frigate/__main__.py", line 104 in main
2025-07-28 16:34:56.115818089    File "/opt/frigate/frigate/__main__.py", line 108 in <module>
2025-07-28 16:34:56.115827159    File "<frozen runpy>", line 88 in _run_code
2025-07-28 16:34:56.115827959    File "<frozen runpy>", line 198 in _run_module_as_main
2025-07-28 16:34:56.115832469  
```

This appears to be due to the hipblaslt libraries not being copied into the image. The PR fixes this, and a
adds support for RX 9070 by updating to the latest ROCm and adding `gfx1201` as a sub-image.

## Type of change

- [ ] Dependency upgrade
- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [] UI changes including text have used i18n keys and have been added to the `en` locale.
- [] The code has been formatted using Ruff (`ruff format frigate`)
