### PR TITLE
Rocm 9070 mesa upgrade

### DIFF
--- a/docker/rocm/Dockerfile
+++ b/docker/rocm/Dockerfile
@@ -33,7 +33,10 @@ RUN echo /opt/rocm/lib|tee /opt/rocm-dist/etc/ld.so.conf.d/rocm.conf
 #######################################################################
 FROM deps AS deps-prelim
 
-RUN apt-get update && apt-get install -y libnuma1
+COPY docker/rocm/debian-backports.sources /etc/apt/sources.list.d/debian-backports.sources
+RUN apt-get update && \
+    apt-get install -y libnuma1 && \
+    apt-get install -qq -y -t bookworm-backports mesa-va-drivers mesa-vulkan-drivers
 
 WORKDIR /opt/frigate
 COPY --from=rootfs / /

--- a/docker/rocm/debian-backports.sources
+++ b/docker/rocm/debian-backports.sources
@@ -1,0 +1,6 @@
+Types: deb
+URIs: http://deb.debian.org/debian
+Suites: bookworm-backports
+Components: main
+Enabled: yes
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This PR adds backports to the frigate-rocm image and installs the necessary packages to upgrade mesa to a version that supports RDNA4.

On the 0.17 branch I'm getting the following errors when using `hwaccel_args: preset-vaapi` and `LIBVA_DRIVER_NAME=radeonsi` on an  RX 9070; it looks like the GPU is unrecognised by the current library.

```
2025-07-29 10:51:50.961688781  [2025-07-29 10:51:50] watchdog.gatecam               ERROR   : Ffmpeg process crashed unexpectedly for gatecam.
2025-07-29 10:51:50.961865272  [2025-07-29 10:51:50] watchdog.gatecam               ERROR   : The following ffmpeg logs include the last 100 lines prior to exit.
2025-07-29 10:51:50.961948723  [2025-07-29 10:51:50] ffmpeg.gatecam.detect          ERROR   : amdgpu: unknown (family_id, chip_external_rev): (152, 81)
2025-07-29 10:51:50.961998243  [2025-07-29 10:51:50] ffmpeg.gatecam.detect          ERROR   : [AVHWDeviceContext @ 0x55facd61d3c0] libva: /usr/lib/x86_64-linux-gnu/dri/radeonsi_drv_video.so init failed
2025-07-29 10:51:50.962061973  [2025-07-29 10:51:50] ffmpeg.gatecam.detect          ERROR   : [AVHWDeviceContext @ 0x55facd61d3c0] Failed to initialise VAAPI connection: 2 (resource allocation failed).
2025-07-29 10:51:50.962107504  [2025-07-29 10:51:50] ffmpeg.gatecam.detect          ERROR   : Device creation failed: -5.
2025-07-29 10:51:50.962146704  [2025-07-29 10:51:50] ffmpeg.gatecam.detect          ERROR   : [vist#0:0/h264 @ 0x55facd55a1c0] [dec:h264 @ 0x55facd568f80] No device available for decoder: device type vaapi needed for codec h264.
2025-07-29 10:51:50.962179234  [2025-07-29 10:51:50] ffmpeg.gatecam.detect          ERROR   : [vist#0:0/h264 @ 0x55facd55a1c0] [dec:h264 @ 0x55facd568f80] Hardware device setup failed for decoder: Input/output error
2025-07-29 10:51:50.962213194  [2025-07-29 10:51:50] ffmpeg.gatecam.detect          ERROR   : [vost#0:0/rawvideo @ 0x55facd56b540] Error initializing a simple filtergraph
2025-07-29 10:51:50.962243434  [2025-07-29 10:51:50] ffmpeg.gatecam.detect          ERROR   : Error opening output file pipe:.
2025-07-29 10:51:50.962276835  [2025-07-29 10:51:50] ffmpeg.gatecam.detect          ERROR   : Error opening output files: Input/output error
2025-07-29 10:51:50.962309765  [2025-07-29 10:51:50] watchdog.gatecam               INFO    : Restarting ffmpeg...
2025-07-29 10:51:53.995194852  [2025-07-29 10:51:53] frigate.video                  ERROR   : gatecam: Unable to read frames from ffmpeg process.
2025-07-29 10:51:53.995305833  [2025-07-29 10:51:53] frigate.video                  ERROR   : gatecam: ffmpeg process is not running. exiting capture thread...
```

This makes sense as the RX 9070 cards are were known to require Mesa, kernel and firmware updates on launch. Installing  mesa-va-drivers from `bookworm-backports` (22.3.6 to 25.0.7) fixes this error. 


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
