### PR TITLE
Read secrets dir from CREDENTIALS_DIRECTORY

### DIFF
--- a/docs/docs/configuration/authentication.md
+++ b/docs/docs/configuration/authentication.md
@@ -81,7 +81,7 @@ python3 -c 'import secrets; print(secrets.token_hex(64))'
 Frigate looks for a JWT token secret in the following order:
 
 1. An environment variable named `FRIGATE_JWT_SECRET`
-2. A docker secret named `FRIGATE_JWT_SECRET` in `/run/secrets/`
+2. A file named `FRIGATE_JWT_SECRET` in the directory specified by the `CREDENTIALS_DIRECTORY` environment variable (defaults to the Docker Secrets directory: `/run/secrets/`)
 3. A `jwt_secret` option from the Home Assistant Add-on options
 4. A `.jwt_secret` file in the config directory
 

--- a/frigate/config/env.py
+++ b/frigate/config/env.py
@@ -5,12 +5,13 @@ from typing import Annotated
 from pydantic import AfterValidator, ValidationInfo
 
 FRIGATE_ENV_VARS = {k: v for k, v in os.environ.items() if k.startswith("FRIGATE_")}
-# read docker secret files as env vars too
-if os.path.isdir("/run/secrets") and os.access("/run/secrets", os.R_OK):
-    for secret_file in os.listdir("/run/secrets"):
+secrets_dir = os.environ.get("CREDENTIALS_DIRECTORY", "/run/secrets")
+# read secret files as env vars too
+if os.path.isdir(secrets_dir) and os.access(secrets_dir, os.R_OK):
+    for secret_file in os.listdir(secrets_dir):
         if secret_file.startswith("FRIGATE_"):
             FRIGATE_ENV_VARS[secret_file] = (
-                Path(os.path.join("/run/secrets", secret_file)).read_text().strip()
+                Path(os.path.join(secrets_dir, secret_file)).read_text().strip()
             )
 
 


### PR DESCRIPTION
This supports systemd credentials, see https://systemd.io/CREDENTIALS/. Default to `/run/secrets` (the Docker Secrets dir) for backwards compatibility.

## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
