### PR TITLE
WIP: Add retain.max_size to clean up storage

### DIFF
--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -70,6 +70,8 @@ record:
 
 As of Frigate 0.12 if there is less than an hour left of storage, the oldest 2 hours of recordings will be deleted.
 
+Additionally, you can configure a maximum storage size limit for recordings using the `max_size` option. When the total size of recordings exceeds this limit, Frigate will automatically clean up the oldest recordings to stay within the specified size.
+
 ## Configuring Recording Retention
 
 Frigate supports both continuous and tracked object based recordings with separate retention modes and retention periods.
@@ -92,6 +94,20 @@ record:
 ```
 
 Continuous recording supports different retention modes [which are described below](#what-do-the-different-retain-modes-mean)
+
+### Storage Size Limit
+
+You can configure a maximum storage size limit for recordings. When the total size of recordings exceeds this limit, Frigate will automatically clean up the oldest recordings first.
+
+```yaml
+record:
+  enabled: True
+  retain:
+    days: 7
+    max_size: 5000 # <- maximum storage size in MB (5GB in this example)
+```
+
+The `max_size` parameter specifies the maximum total storage size in megabytes (MB) that recordings should consume. This works in addition to the time-based retention settings - recordings will be deleted when either the time limit OR the size limit is exceeded.
 
 ### Object Recording
 

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -452,6 +452,9 @@ record:
     #   active_objects - save all recording segments with active/moving objects
     # NOTE: this mode only applies when the days setting above is greater than 0
     mode: all
+    # Optional: Maximum storage size in MB for recordings (default: no limit)
+    # When total recording storage exceeds this limit, oldest recordings will be deleted
+    max_size: 5000
   # Optional: Recording Export Settings
   export:
     # Optional: Timelapse Output Args (default: shown below).

--- a/frigate/config/camera/record.py
+++ b/frigate/config/camera/record.py
@@ -31,6 +31,7 @@ class RetainModeEnum(str, Enum):
 class RecordRetainConfig(FrigateBaseModel):
     days: float = Field(default=0, title="Default retention period.")
     mode: RetainModeEnum = Field(default=RetainModeEnum.all, title="Retain mode.")
+    max_size: Optional[int] = Field(default=None, title="Maximum storage size in MB.")
 
 
 class ReviewRetainConfig(FrigateBaseModel):

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -1531,6 +1531,49 @@ class TestConfig(unittest.TestCase):
 
         self.assertRaises(ValueError, lambda: FrigateConfig(**config))
 
+    def test_record_retain_max_size(self):
+        config = {
+            "mqtt": {"host": "mqtt"},
+            "record": {"retain": {"max_size": 1000}},
+            "cameras": {
+                "back": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}
+                        ]
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
+                }
+            },
+        }
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.record.retain.max_size == 1000
+
+    def test_record_retain_max_size_default(self):
+        config = {
+            "mqtt": {"host": "mqtt"},
+            "cameras": {
+                "back": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}
+                        ]
+                    },
+                    "detect": {
+                        "height": 1080,
+                        "width": 1920,
+                        "fps": 5,
+                    },
+                }
+            },
+        }
+        frigate_config = FrigateConfig(**config)
+        assert frigate_config.record.retain.max_size is None
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed change
This change is per #9275 adds a new option to control the storage used.
This feature enables Frigate to be used (optionally) without consuming an entire volume (-1 hr)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR is related to issue: #9275 and #5847 

## Checklist

- [] The code change is tested and works locally.
- [] Local tests pass. **Your PR cannot be merged unless tests pass**
- [] There is no commented out code in this PR.
- [] UI changes including text have used i18n keys and have been added to the `en` locale.
- [] The code has been formatted using Ruff (`ruff format frigate`)
