### PR TITLE
Remove deprecated 'version' attribute

### DIFF
--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -187,7 +187,6 @@ Next, you should configure [hardware object detection](/configuration/object_det
 Running in Docker with compose is the recommended install method.
 
 ```yaml
-version: "3.9"
 services:
   frigate:
     container_name: frigate


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Removing the 'version' attribute from the sample docker compose file. This has been deprecated for a long time now.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
