### PR TITLE
Ensure alertVideos persistence is loaded before displaying thumb or preview

### DIFF
--- a/web/src/components/card/AnimatedEventCard.tsx
+++ b/web/src/components/card/AnimatedEventCard.tsx
@@ -91,7 +91,10 @@ export function AnimatedEventCard({
 
   // image behavior
 
-  const [alertVideos] = usePersistence("alertVideos", true);
+  const [alertVideos, _, alertVideosLoaded] = usePersistence(
+    "alertVideos",
+    true,
+  );
 
   const aspectRatio = useMemo(() => {
     if (
@@ -135,7 +138,7 @@ export function AnimatedEventCard({
               <TooltipContent>{t("markAsReviewed")}</TooltipContent>
             </Tooltip>
           )}
-          {previews != undefined && (
+          {previews != undefined && alertVideosLoaded && (
             <div
               className="size-full cursor-pointer"
               onClick={onOpenReview}


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
The default value of true would cause previews to be loaded in the background in the filmstrip even if the local storage value was false.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/19429
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
