### PR TITLE
Adjust loitering behavior based on object type

### DIFF
--- a/docs/docs/configuration/zones.md
+++ b/docs/docs/configuration/zones.md
@@ -88,7 +88,9 @@ Sometimes objects are expected to be passing through a zone, but an object loite
 
 :::note
 
-When using loitering zones, a review item will remain active until the object leaves. Loitering zones are only meant to be used in areas where loitering is not expected behavior.
+When using loitering zones, a review item will remain behave in the following way:
+- When a person is in a loitering zone, the review item will remain active until the person leaves the loitering zone, regardless of if they are stationary.
+- When any other object is in a loitering zone, the review item will remain active until the loitering time is met. Then if the object is stationary the review item will end.
 
 :::
 

--- a/docs/docs/configuration/zones.md
+++ b/docs/docs/configuration/zones.md
@@ -88,7 +88,7 @@ Sometimes objects are expected to be passing through a zone, but an object loite
 
 :::note
 
-When using loitering zones, a review item will remain behave in the following way:
+When using loitering zones, a review item will behave in the following way:
 - When a person is in a loitering zone, the review item will remain active until the person leaves the loitering zone, regardless of if they are stationary.
 - When any other object is in a loitering zone, the review item will remain active until the loitering time is met. Then if the object is stationary the review item will end.
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

In most cases objects that loiter in a loitering zone should alert,
but can still be expected to stay stationary for extended periods of time
(ex: car loitering on the street vs when a known person parks on the street)
person is the main object that should keep alerts going as long as they loiter
even if they are stationary.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
