### PR TITLE
Support Cloudflare Email Header

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/proxy_trusted_headers.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/proxy_trusted_headers.conf
@@ -9,6 +9,7 @@ proxy_set_header X-Proxy-Secret $http_x_proxy_secret;
 # - Traefik forward auth
 # - oauth2_proxy
 # - Authentik
+# - Cloudflare Access
 
 proxy_set_header Remote-User $http_remote_user;
 proxy_set_header Remote-Groups $http_remote_groups;
@@ -23,3 +24,4 @@ proxy_set_header X-authentik-groups $http_x_authentik_groups;
 proxy_set_header X-authentik-email $http_x_authentik_email;
 proxy_set_header X-authentik-name $http_x_authentik_name;
 proxy_set_header X-authentik-uid $http_x_authentik_uid;
+proxy_set_header Cf-Access-Authenticated-User-Email $http_cf_access_authenticated_user_email;

--- a/docs/docs/configuration/authentication.md
+++ b/docs/docs/configuration/authentication.md
@@ -166,6 +166,7 @@ X-authentik-groups
 X-authentik-email
 X-authentik-name
 X-authentik-uid
+Cf-Access-Authenticated-User-Email
 ```
 
 If you would like to add more options, you can overwrite the default file with a docker bind mount at `/usr/local/nginx/conf/proxy_trusted_headers.conf`. Reference the source code for the default file formatting.


### PR DESCRIPTION
## Proposed change

Proposing adding support for Cloudflare as supported default proxy. This PR merely adds `Cf-Access-Authenticated-User-Email` as a supported header.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update



## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
