### PR TITLE
Add ability to pass additional args to Ollama

### DIFF
--- a/frigate/config/camera/genai.py
+++ b/frigate/config/camera/genai.py
@@ -23,5 +23,6 @@ class GenAIConfig(FrigateBaseModel):
     base_url: Optional[str] = Field(default=None, title="Provider base url.")
     model: str = Field(default="gpt-4o", title="GenAI model.")
     provider: GenAIProviderEnum | None = Field(default=None, title="GenAI provider.")
-    keep_alive: int | str | None = Field(default="1h", title="Ollama keep_alive.")
-    extra_options: dict[str, Any] = Field(default={}, title="Ollama extra options.")
+    provider_options: dict[str, Any] = Field(
+        default={}, title="GenAI Provider extra options."
+    )

--- a/frigate/config/camera/genai.py
+++ b/frigate/config/camera/genai.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import Field
 
@@ -23,3 +23,5 @@ class GenAIConfig(FrigateBaseModel):
     base_url: Optional[str] = Field(default=None, title="Provider base url.")
     model: str = Field(default="gpt-4o", title="GenAI model.")
     provider: GenAIProviderEnum | None = Field(default=None, title="GenAI provider.")
+    keep_alive: int | str | None = Field(default="1h", title="Ollama keep_alive.")
+    extra_options: dict[str, Any] = Field(default={}, title="Ollama extra options.")

--- a/frigate/data_processing/post/review_descriptions.py
+++ b/frigate/data_processing/post/review_descriptions.py
@@ -209,7 +209,9 @@ def run_analysis(
         {
             "id": final_data["id"],
             "camera": camera,
-            "objects": final_data["data"]["objects"],
+            "objects": list(
+                filter(lambda o: "-verified" not in o, final_data["data"]["objects"])
+            ),
             "recognized_objects": final_data["data"]["sub_labels"],
             "zones": final_data["data"]["zones"],
             "timestamp": datetime.datetime.fromtimestamp(final_data["end_time"]),

--- a/frigate/genai/__init__.py
+++ b/frigate/genai/__init__.py
@@ -52,22 +52,9 @@ class GenAIClient:
                 concern_list = "\n    - ".join(concerns)
                 return f"""
 - `other_concerns` (list of strings): Include a list of any of the following concerns that are occurring:
-    - {concern_list}
-"""
+    - {concern_list}"""
             else:
                 return ""
-
-        def get_recognized_objects_prompt() -> str:
-            if not review_data["recognized_objects"]:
-                return ""
-
-            return f"""
-Recognized Objects:
-- These are people, vehicles, or other entities that the system has positively identified.
-- Always use these names or labels directly in the scene description instead of generic terms.
-
-Recognized objects: {list(set(review_data["recognized_objects"]))}
-"""
 
         def get_language_prompt() -> str:
             if preferred_language:
@@ -91,8 +78,6 @@ When forming your description:
 - Focus on behaviors that are uncharacteristic of innocent activity: loitering without clear purpose, avoiding cameras, inspecting vehicles/doors, changing behavior when lights activate, scanning surroundings without an apparent benign reason.
 - **Benign context override**: If scanning or looking around is clearly part of an innocent activity (such as playing with a dog, gardening, supervising children, or watching for a pet), do not treat it as suspicious.
 
-{get_recognized_objects_prompt()}
-
 Your response MUST be a flat JSON object with:
 - `scene` (string): A full description including setting, entities, actions, and any plausible supported inferences.
 - `confidence` (float): 0-1 confidence in the analysis.
@@ -108,6 +93,7 @@ Sequence details:
 - Frame 1 = earliest, Frame 10 = latest
 - Activity occurred at {review_data["timestamp"].strftime("%I:%M %p")}
 - Detected objects: {list(set(review_data["objects"]))}
+- Recognized objects: {list(set(review_data["recognized_objects"])) or "None"}
 - Zones involved: {review_data["zones"]}
 
 **IMPORTANT:**

--- a/frigate/genai/gemini.py
+++ b/frigate/genai/gemini.py
@@ -21,7 +21,9 @@ class GeminiClient(GenAIClient):
     def _init_provider(self):
         """Initialize the client."""
         genai.configure(api_key=self.genai_config.api_key)
-        return genai.GenerativeModel(self.genai_config.model)
+        return genai.GenerativeModel(
+            self.genai_config.model, **self.genai_config.provider_options
+        )
 
     def _send(self, prompt: str, images: list[bytes]) -> Optional[str]:
         """Submit a request to Gemini."""

--- a/frigate/genai/ollama.py
+++ b/frigate/genai/ollama.py
@@ -48,8 +48,7 @@ class OllamaClient(GenAIClient):
                 self.genai_config.model,
                 prompt,
                 images=images if images else None,
-                keep_alive=self.genai_config.keep_alive,
-                options=self.genai_config.extra_options,
+                **self.genai_config.provider_options,
             )
             return result["response"].strip()
         except (TimeoutException, ResponseError) as e:

--- a/frigate/genai/ollama.py
+++ b/frigate/genai/ollama.py
@@ -48,7 +48,8 @@ class OllamaClient(GenAIClient):
                 self.genai_config.model,
                 prompt,
                 images=images if images else None,
-                keep_alive="1h",
+                keep_alive=self.genai_config.keep_alive,
+                options=self.genai_config.extra_options,
             )
             return result["response"].strip()
         except (TimeoutException, ResponseError) as e:

--- a/frigate/genai/openai.py
+++ b/frigate/genai/openai.py
@@ -21,7 +21,9 @@ class OpenAIClient(GenAIClient):
 
     def _init_provider(self):
         """Initialize the client."""
-        return OpenAI(api_key=self.genai_config.api_key)
+        return OpenAI(
+            api_key=self.genai_config.api_key, **self.genai_config.provider_options
+        )
 
     def _send(self, prompt: str, images: list[bytes]) -> Optional[str]:
         """Submit a request to OpenAI."""


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This makes it so the `keep_alive` and `options` can be passed. For now it is only used for Ollama but likely can be used for other genai providers if there are options that need to be set. 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
