### PR TITLE
Improve recognized license plate filter

### DIFF
--- a/web/src/components/overlay/dialog/SearchFilterDialog.tsx
+++ b/web/src/components/overlay/dialog/SearchFilterDialog.tsx
@@ -42,6 +42,7 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { LuCheck } from "react-icons/lu";
+import ActivityIndicator from "@/components/indicators/activity-indicator";
 
 type SearchFilterDialogProps = {
   config?: FrigateConfig;
@@ -947,7 +948,8 @@ export function RecognizedLicensePlatesFilterContent({
       <DropdownMenuSeparator className="mb-3" />
       <div className="mb-3 text-lg">{t("recognizedLicensePlates.title")}</div>
       {allRecognizedLicensePlates == undefined ? (
-        <p className="text-sm text-muted-foreground">
+        <p className="flex items-center text-sm text-muted-foreground">
+          <ActivityIndicator className="mr-2 size-5" />
           {t("recognizedLicensePlates.loading")}
         </p>
       ) : allRecognizedLicensePlates.length === 0 ? null : (

--- a/web/src/components/overlay/dialog/SearchFilterDialog.tsx
+++ b/web/src/components/overlay/dialog/SearchFilterDialog.tsx
@@ -64,6 +64,9 @@ export default function SearchFilterDialog({
   const { t } = useTranslation(["components/filter"]);
   const [currentFilter, setCurrentFilter] = useState(filter ?? {});
   const { data: allSubLabels } = useSWR(["sub_labels", { split_joined: 1 }]);
+  const { data: allRecognizedLicensePlates } = useSWR<string[]>(
+    "recognized_license_plates",
+  );
 
   useEffect(() => {
     if (filter) {
@@ -130,6 +133,7 @@ export default function SearchFilterDialog({
         }
       />
       <RecognizedLicensePlatesFilterContent
+        allRecognizedLicensePlates={allRecognizedLicensePlates}
         recognizedLicensePlates={currentFilter.recognized_license_plate}
         setRecognizedLicensePlates={(plate) =>
           setCurrentFilter({
@@ -875,6 +879,7 @@ export function SnapshotClipFilterContent({
 }
 
 type RecognizedLicensePlatesFilterContentProps = {
+  allRecognizedLicensePlates: string[] | undefined;
   recognizedLicensePlates: string[] | undefined;
   setRecognizedLicensePlates: (
     recognizedLicensePlates: string[] | undefined,
@@ -882,17 +887,11 @@ type RecognizedLicensePlatesFilterContentProps = {
 };
 
 export function RecognizedLicensePlatesFilterContent({
+  allRecognizedLicensePlates,
   recognizedLicensePlates,
   setRecognizedLicensePlates,
 }: RecognizedLicensePlatesFilterContentProps) {
   const { t } = useTranslation(["components/filter"]);
-
-  const { data: allRecognizedLicensePlates, error } = useSWR<string[]>(
-    "recognized_license_plates",
-    {
-      revalidateOnFocus: false,
-    },
-  );
 
   const [selectedRecognizedLicensePlates, setSelectedRecognizedLicensePlates] =
     useState<string[]>(recognizedLicensePlates || []);
@@ -923,7 +922,7 @@ export function RecognizedLicensePlatesFilterContent({
     }
   };
 
-  if (!allRecognizedLicensePlates || allRecognizedLicensePlates.length === 0) {
+  if (allRecognizedLicensePlates && allRecognizedLicensePlates.length === 0) {
     return null;
   }
 
@@ -947,15 +946,11 @@ export function RecognizedLicensePlatesFilterContent({
     <div className="overflow-x-hidden">
       <DropdownMenuSeparator className="mb-3" />
       <div className="mb-3 text-lg">{t("recognizedLicensePlates.title")}</div>
-      {error ? (
-        <p className="text-sm text-red-500">
-          {t("recognizedLicensePlates.loadFailed")}
-        </p>
-      ) : !allRecognizedLicensePlates ? (
+      {allRecognizedLicensePlates == undefined ? (
         <p className="text-sm text-muted-foreground">
           {t("recognizedLicensePlates.loading")}
         </p>
-      ) : (
+      ) : allRecognizedLicensePlates.length === 0 ? null : (
         <>
           <Command
             className="border border-input bg-background"

--- a/web/src/components/overlay/dialog/SearchFilterDialog.tsx
+++ b/web/src/components/overlay/dialog/SearchFilterDialog.tsx
@@ -948,11 +948,11 @@ export function RecognizedLicensePlatesFilterContent({
       <DropdownMenuSeparator className="mb-3" />
       <div className="mb-3 text-lg">{t("recognizedLicensePlates.title")}</div>
       {allRecognizedLicensePlates == undefined ? (
-        <p className="flex items-center text-sm text-muted-foreground">
-          <ActivityIndicator className="mr-2 size-5" />
-          {t("recognizedLicensePlates.loading")}
-        </p>
-      ) : allRecognizedLicensePlates.length === 0 ? null : (
+        <div className="flex flex-col items-center justify-center text-sm text-muted-foreground">
+          <ActivityIndicator className="mb-3 mr-2 size-5" />
+          <p>{t("recognizedLicensePlates.loading")}</p>
+        </div>
+      ) : allRecognizedLicensePlates.length == 0 ? null : (
         <>
           <Command
             className="border border-input bg-background"
@@ -1007,11 +1007,11 @@ export function RecognizedLicensePlatesFilterContent({
               ))}
             </div>
           )}
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t("recognizedLicensePlates.selectPlatesFromList")}
+          </p>
         </>
       )}
-      <p className="mt-1 text-sm text-muted-foreground">
-        {t("recognizedLicensePlates.selectPlatesFromList")}
-      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
If the swr call to retrieve recognized license plates took a while, the component may not render due to a null check. This PR improves the UI by moving the fetch to the parent and improves the backend query by using the database to filter rather than selecting all rows and filtering in Python.

A workaround to this issue is to select `car` or `motorcycle` from the filters list in Explore *before* opening the More Filters pane.

https://github.com/blakeblackshear/frigate/discussions/19287#discussioncomment-14096207


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
