### PR TITLE
Remove score sorting constraint

### DIFF
--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -724,15 +724,24 @@ def events_search(request: Request, params: EventsSearchQueryParams = Depends())
 
     if (sort is None or sort == "relevance") and search_results:
         processed_events.sort(key=lambda x: x.get("search_distance", float("inf")))
-    elif min_score is not None and max_score is not None and sort == "score_asc":
+    elif sort == "score_asc":
         processed_events.sort(key=lambda x: x["data"]["score"])
-    elif min_score is not None and max_score is not None and sort == "score_desc":
+    elif sort == "score_desc":
         processed_events.sort(key=lambda x: x["data"]["score"], reverse=True)
-    elif min_speed is not None and max_speed is not None and sort == "speed_asc":
-        processed_events.sort(key=lambda x: x["data"]["average_estimated_speed"])
-    elif min_speed is not None and max_speed is not None and sort == "speed_desc":
+    elif sort == "speed_asc":
         processed_events.sort(
-            key=lambda x: x["data"]["average_estimated_speed"], reverse=True
+            key=lambda x: (
+                x["data"].get("average_estimated_speed") is None,
+                x["data"].get("average_estimated_speed"),
+            )
+        )
+    elif sort == "speed_desc":
+        processed_events.sort(
+            key=lambda x: (
+                x["data"].get("average_estimated_speed") is None,
+                x["data"].get("average_estimated_speed", float("-inf")),
+            ),
+            reverse=True,
         )
     elif sort == "date_asc":
         processed_events.sort(key=lambda x: x["start_time"])

--- a/web/src/components/filter/SearchFilterGroup.tsx
+++ b/web/src/components/filter/SearchFilterGroup.tsx
@@ -131,10 +131,7 @@ export default function SearchFilterGroup({
   );
 
   const availableSortTypes = useMemo(() => {
-    const sortTypes = ["date_asc", "date_desc"];
-    if (filter?.min_score || filter?.max_score) {
-      sortTypes.push("score_desc", "score_asc");
-    }
+    const sortTypes = ["date_asc", "date_desc", "score_desc", "score_asc"];
     if (filter?.min_speed || filter?.max_speed) {
       sortTypes.push("speed_desc", "speed_asc");
     }


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR:
- removes the constraint to require first filtering by score in order to sort by score in Explore
- guards against sort errors when estimated speed is not defined on a tracked object in the sorting lambda
- still require filtering by estimated speed in order to sort by it as not all objects will have estimated speed


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
