### PR TITLE
HLS Playback Startup Time Optimization

### DIFF
--- a/web/src/components/player/GenericVideoPlayer.tsx
+++ b/web/src/components/player/GenericVideoPlayer.tsx
@@ -109,7 +109,6 @@ export function GenericVideoPlayer({
                 videoRef={videoRef}
                 currentSource={{
                   playlist: source,
-                  startPosition: 0,
                 }}
                 hotKeys
                 visible

--- a/web/src/components/player/GenericVideoPlayer.tsx
+++ b/web/src/components/player/GenericVideoPlayer.tsx
@@ -107,7 +107,10 @@ export function GenericVideoPlayer({
             >
               <HlsVideoPlayer
                 videoRef={videoRef}
-                currentSource={source}
+                currentSource={{
+                  playlist: source,
+                  startPosition: 0,
+                }}
                 hotKeys
                 visible
                 frigateControls={false}

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -30,7 +30,7 @@ const unsupportedErrorCodes = [
 
 export interface HlsSource {
   playlist: string;
-  startPosition: number;
+  startPosition?: number;
 }
 
 type HlsVideoPlayerProps = {

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -43,7 +43,7 @@ type HlsVideoPlayerProps = {
   fullscreen: boolean;
   frigateControls?: boolean;
   inpointOffset?: number;
-  onClipEnded?: () => void;
+  onClipEnded?: (currentTime: number) => void;
   onPlayerLoaded?: () => void;
   onTimeUpdate?: (time: number) => void;
   onPlaying?: () => void;
@@ -387,7 +387,11 @@ export default function HlsVideoPlayer({
               }
             }
           }}
-          onEnded={onClipEnded}
+          onEnded={() => {
+            if (onClipEnded) {
+              onClipEnded(getVideoTime() ?? 0);
+            }
+          }}
           onError={(e) => {
             if (
               !hlsRef.current &&

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -185,9 +185,16 @@ export default function DynamicVideoPlayer({
       playerRef.current.autoplay = !isScrubbing;
     }
 
+    const inpointOffset = calculateInpointOffset(
+      recordingParams.after,
+      (recordings || [])[0],
+    );
+
     setSource({
       playlist: `${apiHost}vod/${camera}/start/${recordingParams.after}/end/${recordingParams.before}/master.m3u8`,
-      startPosition: startTimestamp ? startTimestamp - timeRange.after : 0,
+      startPosition: startTimestamp
+        ? Math.max(0, startTimestamp - timeRange.after - inpointOffset)
+        : 0,
     });
 
     setLoadingTimeout(setTimeout(() => setIsLoading(true), 1000));

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -185,16 +185,26 @@ export default function DynamicVideoPlayer({
       playerRef.current.autoplay = !isScrubbing;
     }
 
-    const inpointOffset = calculateInpointOffset(
-      recordingParams.after,
-      (recordings || [])[0],
-    );
+    let startPosition = undefined;
+
+    if (startTimestamp) {
+      const inpointOffset = calculateInpointOffset(
+        recordingParams.after,
+        (recordings || [])[0],
+      );
+      const idealStartPosition = Math.max(
+        0,
+        startTimestamp - timeRange.after - inpointOffset,
+      );
+
+      if (idealStartPosition >= recordings[0].start_time - timeRange.after) {
+        startPosition = idealStartPosition;
+      }
+    }
 
     setSource({
       playlist: `${apiHost}vod/${camera}/start/${recordingParams.after}/end/${recordingParams.before}/master.m3u8`,
-      startPosition: startTimestamp
-        ? Math.max(0, startTimestamp - timeRange.after - inpointOffset)
-        : 0,
+      startPosition,
     });
 
     setLoadingTimeout(setTimeout(() => setIsLoading(true), 1000));

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -6,7 +6,7 @@ import { Recording } from "@/types/record";
 import { Preview } from "@/types/preview";
 import PreviewPlayer, { PreviewController } from "../PreviewPlayer";
 import { DynamicVideoController } from "./DynamicVideoController";
-import HlsVideoPlayer from "../HlsVideoPlayer";
+import HlsVideoPlayer, { HlsSource } from "../HlsVideoPlayer";
 import { TimeRange } from "@/types/timeline";
 import ActivityIndicator from "@/components/indicators/activity-indicator";
 import { VideoResolutionType } from "@/types/live";
@@ -98,9 +98,10 @@ export default function DynamicVideoPlayer({
   const [isLoading, setIsLoading] = useState(false);
   const [isBuffering, setIsBuffering] = useState(false);
   const [loadingTimeout, setLoadingTimeout] = useState<NodeJS.Timeout>();
-  const [source, setSource] = useState(
-    `${apiHost}vod/${camera}/start/${timeRange.after}/end/${timeRange.before}/master.m3u8`,
-  );
+  const [source, setSource] = useState<HlsSource>({
+    playlist: `${apiHost}vod/${camera}/start/${timeRange.after}/end/${timeRange.before}/master.m3u8`,
+    startPosition: startTimestamp ? timeRange.after - startTimestamp : 0,
+  });
 
   // start at correct time
 
@@ -184,9 +185,16 @@ export default function DynamicVideoPlayer({
       playerRef.current.autoplay = !isScrubbing;
     }
 
-    setSource(
-      `${apiHost}vod/${camera}/start/${recordingParams.after}/end/${recordingParams.before}/master.m3u8`,
-    );
+    setSource({
+      playlist: `${apiHost}vod/${camera}/start/${recordingParams.after}/end/${recordingParams.before}/master.m3u8`,
+      startPosition: startTimestamp ? startTimestamp - timeRange.after : 0,
+    });
+    if (startTimestamp) {
+      console.log(
+        `start timestamp is ${startTimestamp} which is ${startTimestamp - recordingParams.after} seconds from start of playlist`,
+      );
+    }
+
     setLoadingTimeout(setTimeout(() => setIsLoading(true), 1000));
 
     controller.newPlayback({

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -189,11 +189,6 @@ export default function DynamicVideoPlayer({
       playlist: `${apiHost}vod/${camera}/start/${recordingParams.after}/end/${recordingParams.before}/master.m3u8`,
       startPosition: startTimestamp ? startTimestamp - timeRange.after : 0,
     });
-    if (startTimestamp) {
-      console.log(
-        `start timestamp is ${startTimestamp} which is ${startTimestamp - recordingParams.after} seconds from start of playlist`,
-      );
-    }
 
     setLoadingTimeout(setTimeout(() => setIsLoading(true), 1000));
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

By default the HLS player would have a startPosition of 0 set. For example, if a review item at 30 minutes into the hour was opened the HLS player would first load the 0seconds segment and then seek into the playlist to load the relevant segment.

This PR adjusts the source calculation to use existing data to calculate the desired start position within the playlist, which allows the HLS player to start by immediately loading the relevant segment. In testing with a forcefully throttled connection via browser tools, it sped up playback start time from 30 seconds to 8 seconds. 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
