### PR TITLE
Allow changing object detection via MQTT.

### DIFF
--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -68,6 +68,8 @@ class Dispatcher:
             "birdseye_mode": self._on_birdseye_mode_command,
             "review_alerts": self._on_alerts_command,
             "review_detections": self._on_detections_command,
+            "object_detection_enable": self._on_object_detection_enable_command,
+            "object_detection_disable": self._on_object_detection_disable_command,
         }
         self._global_settings_handlers: dict[str, Callable] = {
             "notifications": self._on_global_notification_command,
@@ -641,3 +643,27 @@ class Dispatcher:
 
         self.config_updater.publish(f"config/review/{camera_name}", review_settings)
         self.publish(f"{camera_name}/review_detections/state", payload, retain=True)
+
+    def _on_object_detection_enable_command(
+        self, camera_name: str, object_name: str
+    ) -> None:
+        """Callback for object detect topic."""
+        objects_settings = self.config.cameras[camera_name].objects
+
+        if object_name not in objects_settings.track:
+            logger.info(f"Turning on detection for {object_name} on {camera_name}")
+            objects_settings.track.append(object_name)
+
+        self.config_updater.publish(f"config/objects/{camera_name}", objects_settings)
+
+    def _on_object_detection_disable_command(
+        self, camera_name: str, object_name: str
+    ) -> None:
+        """Callback for object detect topic."""
+        objects_settings = self.config.cameras[camera_name].objects
+
+        if object_name in objects_settings.track:
+            logger.info(f"Turning off detection for {object_name} on {camera_name}")
+            objects_settings.track.remove(object_name)
+
+        self.config_updater.publish(f"config/objects/{camera_name}", objects_settings)

--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -197,9 +197,7 @@ class MqttClient(Communicator):  # type: ignore[misc]
             payload="offline",
             qos=1,
             retain=True,
-        )
-
-        # register callbacks
+        )  # register callbacks
         callback_types = [
             "enabled",
             "recordings",
@@ -215,6 +213,8 @@ class MqttClient(Communicator):  # type: ignore[misc]
             "birdseye_mode",
             "review_alerts",
             "review_detections",
+            "object_detection_enable",
+            "object_detection_disable",
         ]
 
         for name in self.config.cameras.keys():


### PR DESCRIPTION
## Proposed change
Allows changing the set of detected objects via MQTT.
As a user, I want different sets of detections when I'm home / away - for example, I always want to detect my dogs and cats, but I only want to detect people inside when I'm away. This change allows me to do that dynamically.

Let me know if this is not the right approach to the change.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #15570

## Checklist

make run_tests fails to assert recording, but unclear how that would be related to my change.

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
