### PR TITLE
Fix content type for latest image API endpoint

### DIFF
--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -217,7 +217,6 @@ def latest_frame(
             content=img.tobytes(),
             media_type=f"image/{extension.value}",
             headers={
-                "Content-Type": f"image/{extension.value}",
                 "Cache-Control": "no-store"
                 if not params.store
                 else "private, max-age=60",

--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -142,15 +142,13 @@ def latest_frame(
         "regions": params.regions,
     }
     quality = params.quality
-    mime_type = extension
 
-    if extension == "png":
+    if extension == Extension.png:
         quality_params = None
-    elif extension == "webp":
+    elif extension == Extension.webp:
         quality_params = [int(cv2.IMWRITE_WEBP_QUALITY), quality]
-    else:
+    else:  # jpg or jpeg
         quality_params = [int(cv2.IMWRITE_JPEG_QUALITY), quality]
-        mime_type = "jpeg"
 
     if camera_name in request.app.frigate_config.cameras:
         frame = frame_processor.get_current_frame(camera_name, draw_options)
@@ -193,12 +191,11 @@ def latest_frame(
 
         frame = cv2.resize(frame, dsize=(width, height), interpolation=cv2.INTER_AREA)
 
-        _, img = cv2.imencode(f".{extension}", frame, quality_params)
+        _, img = cv2.imencode(f".{extension.value}", frame, quality_params)
         return Response(
             content=img.tobytes(),
-            media_type=f"image/{mime_type}",
+            media_type=f"image/{extension.value}",
             headers={
-                "Content-Type": f"image/{mime_type}",
                 "Cache-Control": "no-store"
                 if not params.store
                 else "private, max-age=60",
@@ -215,12 +212,12 @@ def latest_frame(
 
         frame = cv2.resize(frame, dsize=(width, height), interpolation=cv2.INTER_AREA)
 
-        _, img = cv2.imencode(f".{extension}", frame, quality_params)
+        _, img = cv2.imencode(f".{extension.value}", frame, quality_params)
         return Response(
             content=img.tobytes(),
-            media_type=f"image/{mime_type}",
+            media_type=f"image/{extension.value}",
             headers={
-                "Content-Type": f"image/{mime_type}",
+                "Content-Type": f"image/{extension.value}",
                 "Cache-Control": "no-store"
                 if not params.store
                 else "private, max-age=60",


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Extension is an enum and .value needed to be appended. Additionally, fastapi's Response() automatically sets the content type when media_type is specified, so a Content-Type in the headers was redundant.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/19553
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
