### PR TITLE
Install non-free i965 driver

### DIFF
--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -58,7 +58,7 @@ fi
 # arch specific packages
 if [[ "${TARGETARCH}" == "amd64" ]]; then
   # Install non-free version of i965 driver
-  CODENAME=$(grep VERSION_CODENAME= /etc/os-release | cut -d= -f2) \ 
+  CODENAME=$(grep VERSION_CODENAME= /etc/os-release | cut -d= -f2) \
       && sed -i -E "s/^(deb http:\/\/deb\.debian\.org\/debian ${CODENAME} main)(.*)$/\1 contrib non-free non-free-firmware\2/" /etc/apt/sources.list \
       && apt-get -qq update \
       && apt-get install --no-install-recommends --no-install-suggests -y i965-va-driver-shaders \

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -57,9 +57,13 @@ fi
 
 # arch specific packages
 if [[ "${TARGETARCH}" == "amd64" ]]; then
-    # use debian bookworm for amd / intel-i965 driver packages, non-free required for video encoding using i965 driver
-    echo 'deb https://deb.debian.org/debian bookworm main contrib non-free' >/etc/apt/sources.list.d/debian-bookworm.list
-    apt-get -qq update
+# Install non-free version of i965 driver
+CODENAME=$(grep VERSION_CODENAME= /etc/os-release | cut -d= -f2) \
+    && echo "deb http://deb.debian.org/debian $CODENAME main contrib non-free" > /etc/apt/sources.list.d/va-driver.list \
+    && apt update \
+    && apt install -y i965-va-driver-shaders \
+    && rm /etc/apt/sources.list.d/va-driver.list \
+    && apt update
     # install amd / intel-i965 driver packages
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
         i965-va-driver-shaders intel-gpu-tools onevpl-tools \

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -57,9 +57,12 @@ fi
 
 # arch specific packages
 if [[ "${TARGETARCH}" == "amd64" ]]; then
+    # use debian bookworm for amd / intel-i965 driver packages, non-free required for video encoding using i965 driver
+    echo 'deb https://deb.debian.org/debian bookworm main contrib non-free' >/etc/apt/sources.list.d/debian-bookworm.list
+    apt-get -qq update
     # install amd / intel-i965 driver packages
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
-        i965-va-driver intel-gpu-tools onevpl-tools \
+        i965-va-driver-shaders intel-gpu-tools onevpl-tools \
         libva-drm2 \
         mesa-va-drivers radeontop
 

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -66,7 +66,7 @@ CODENAME=$(grep VERSION_CODENAME= /etc/os-release | cut -d= -f2) \
     && apt update
     # install amd / intel-i965 driver packages
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
-        i965-va-driver-shaders intel-gpu-tools onevpl-tools \
+        intel-gpu-tools onevpl-tools \
         libva-drm2 \
         mesa-va-drivers radeontop
 

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -59,11 +59,12 @@ fi
 if [[ "${TARGETARCH}" == "amd64" ]]; then
   # Install non-free version of i965 driver
   CODENAME=$(grep VERSION_CODENAME= /etc/os-release | cut -d= -f2) \
-      && echo "deb http://deb.debian.org/debian $CODENAME main contrib non-free" > /etc/apt/sources.list.d/va-driver.list \
-      && apt update \
-      && apt install -y i965-va-driver-shaders \
+      && echo "deb http://deb.debian.org/debian $CODENAME main contrib non-free non-free-firmware" > /etc/apt/sources.list.d/va-driver.list \
+      && apt-get -qq update \
+      && apt-get install -y i965-va-driver-shaders \
       && rm /etc/apt/sources.list.d/va-driver.list \
-      && apt update
+      && apt-get update
+
     # install amd / intel-i965 driver packages
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
         intel-gpu-tools onevpl-tools \

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -61,9 +61,9 @@ if [[ "${TARGETARCH}" == "amd64" ]]; then
   CODENAME=$(grep VERSION_CODENAME= /etc/os-release | cut -d= -f2) \
       && echo "deb http://deb.debian.org/debian $CODENAME main contrib non-free" > /etc/apt/sources.list.d/va-driver.list \
       && apt update \
-    && apt install -y i965-va-driver-shaders \
-    && rm /etc/apt/sources.list.d/va-driver.list \
-    && apt update
+      && apt install -y i965-va-driver-shaders \
+      && rm /etc/apt/sources.list.d/va-driver.list \
+      && apt update
     # install amd / intel-i965 driver packages
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
         intel-gpu-tools onevpl-tools \

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -57,10 +57,10 @@ fi
 
 # arch specific packages
 if [[ "${TARGETARCH}" == "amd64" ]]; then
-# Install non-free version of i965 driver
-CODENAME=$(grep VERSION_CODENAME= /etc/os-release | cut -d= -f2) \
-    && echo "deb http://deb.debian.org/debian $CODENAME main contrib non-free" > /etc/apt/sources.list.d/va-driver.list \
-    && apt update \
+  # Install non-free version of i965 driver
+  CODENAME=$(grep VERSION_CODENAME= /etc/os-release | cut -d= -f2) \
+      && echo "deb http://deb.debian.org/debian $CODENAME main contrib non-free" > /etc/apt/sources.list.d/va-driver.list \
+      && apt update \
     && apt install -y i965-va-driver-shaders \
     && rm /etc/apt/sources.list.d/va-driver.list \
     && apt update

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -58,7 +58,8 @@ fi
 # arch specific packages
 if [[ "${TARGETARCH}" == "amd64" ]]; then
   # Install non-free version of i965 driver
-  sed -i -E "s/^(deb http:\/\/deb\.debian\.org\/debian ${CODENAME} main)(.*)$/\1 contrib non-free non-free-firmware\2/" /etc/apt/sources.list \
+  CODENAME=$(grep VERSION_CODENAME= /etc/os-release | cut -d= -f2) \ 
+      && sed -i -E "s/^(deb http:\/\/deb\.debian\.org\/debian ${CODENAME} main)(.*)$/\1 contrib non-free non-free-firmware\2/" /etc/apt/sources.list \
       && apt-get -qq update \
       && apt-get install --no-install-recommends --no-install-suggests -y i965-va-driver-shaders \
       && sed -i -E "s/(deb http:\/\/deb\.debian\.org\/debian ${CODENAME} main) contrib non-free non-free-firmware/\1/" /etc/apt/sources.list \

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -58,11 +58,10 @@ fi
 # arch specific packages
 if [[ "${TARGETARCH}" == "amd64" ]]; then
   # Install non-free version of i965 driver
-  CODENAME=$(grep VERSION_CODENAME= /etc/os-release | cut -d= -f2) \
-      && echo "deb http://deb.debian.org/debian $CODENAME main contrib non-free non-free-firmware" > /etc/apt/sources.list.d/va-driver.list \
+  sed -i -E "s/^(deb http:\/\/deb\.debian\.org\/debian ${CODENAME} main)(.*)$/\1 contrib non-free non-free-firmware\2/" /etc/apt/sources.list \
       && apt-get -qq update \
-      && apt-get install -y i965-va-driver-shaders \
-      && rm /etc/apt/sources.list.d/va-driver.list \
+      && apt-get install --no-install-recommends --no-install-suggests -y i965-va-driver-shaders \
+      && sed -i -E "s/(deb http:\/\/deb\.debian\.org\/debian ${CODENAME} main) contrib non-free non-free-firmware/\1/" /etc/apt/sources.list \
       && apt-get update
 
     # install amd / intel-i965 driver packages


### PR DESCRIPTION
Fix old i965 driver issue
Second attempt as i seem to have messed up the previous one

## Proposed change
in the update to 0.16.0, the non-free area of debian was omitted and this breaks the encoding functionality of the i965 driver. This patch fixes that issue

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #19550

## Checklist


- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
