### PR TITLE
Ensure birdseye is enabled before trying to grab a frame from it

### DIFF
--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -201,7 +201,11 @@ def latest_frame(
                 else "private, max-age=60",
             },
         )
-    elif camera_name == "birdseye" and request.app.frigate_config.birdseye.restream:
+    elif (
+        camera_name == "birdseye"
+        and request.app.frigate_config.birdseye.enabled
+        and request.app.frigate_config.birdseye.restream
+    ):
         frame = cv2.cvtColor(
             frame_processor.get_current_frame(camera_name),
             cv2.COLOR_YUV2BGR_I420,


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
When users misconfigure birdseye (`enabled: false` and `restream: true`), the API returns a 500 when trying to grab the latest frame. This PR adds a check to ensure birdseye is enabled. If not, 404/"camera not found" is returned.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/19572
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
