### PR TITLE
Deprecate API field include_thumbnails

### DIFF
--- a/frigate/api/defs/query/events_query_parameters.py
+++ b/frigate/api/defs/query/events_query_parameters.py
@@ -47,7 +47,14 @@ class EventsSearchQueryParams(BaseModel):
     query: Optional[str] = None
     event_id: Optional[str] = None
     search_type: Optional[str] = "thumbnail"
-    include_thumbnails: Optional[int] = 1
+    include_thumbnails: Optional[int] = Field(
+        1,
+        description=(
+            "Deprecated. Thumbnail data is no longer included in the response. "
+            "Use the /api/events/:event_id/thumbnail.:extension endpoint instead."
+        ),
+        deprecated=True,
+    )
     limit: Optional[int] = 50
     cameras: Optional[str] = "all"
     labels: Optional[str] = "all"

--- a/frigate/api/defs/query/events_query_parameters.py
+++ b/frigate/api/defs/query/events_query_parameters.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 DEFAULT_TIME_RANGE = "00:00,24:00"
 
@@ -21,7 +21,14 @@ class EventsQueryParams(BaseModel):
     has_clip: Optional[int] = None
     has_snapshot: Optional[int] = None
     in_progress: Optional[int] = None
-    include_thumbnails: Optional[int] = 1
+    include_thumbnails: Optional[int] = Field(
+        1,
+        description=(
+            "Deprecated. Thumbnail data is no longer included in the response. "
+            "Use the /api/events/:event_id/thumbnail.:extension endpoint instead."
+        ),
+        deprecated=True,
+    )
     favorites: Optional[int] = None
     min_score: Optional[float] = None
     max_score: Optional[float] = None


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
https://github.com/blakeblackshear/frigate/pull/16647 removed thumbnails from the database. This PR adds a deprecation note to the API documentation for the `include_thumbnails` field.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/19580
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
