### PR TITLE
Catch invalid key in genai prompt

### DIFF
--- a/frigate/genai/__init__.py
+++ b/frigate/genai/__init__.py
@@ -40,10 +40,15 @@ class GenAIClient:
         event: Event,
     ) -> Optional[str]:
         """Generate a description for the frame."""
-        prompt = camera_config.genai.object_prompts.get(
-            event.label,
-            camera_config.genai.prompt,
-        ).format(**model_to_dict(event))
+        try:
+            prompt = camera_config.genai.object_prompts.get(
+                event.label,
+                camera_config.genai.prompt,
+            ).format(**model_to_dict(event))
+        except KeyError as e:
+            logger.error(f"Invalid key in GenAI prompt: {e}")
+            return None
+
         logger.debug(f"Sending images to genai provider with prompt: {prompt}")
         return self._send(prompt, thumbnails)
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Catch invalid keys in genai prompts instead of crashing the embeddings maintainer.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/19649
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
