### PR TITLE
Remove incorrect newlines from pipeline flowchart

### DIFF
--- a/docs/docs/frigate/video_pipeline.md
+++ b/docs/docs/frigate/video_pipeline.md
@@ -15,10 +15,10 @@ At a high level, there are five processing steps that could be applied to a came
 %%{init: {"themeVariables": {"edgeLabelBackground": "transparent"}}}%%
 
 flowchart LR
-    Feed(Feed\nacquisition) --> Decode(Video\ndecoding)
-    Decode --> Motion(Motion\ndetection)
-    Motion --> Object(Object\ndetection)
-    Feed --> Recording(Recording\nand\nvisualization)
+    Feed(Feed acquisition) --> Decode(Video decoding)
+    Decode --> Motion(Motion detection)
+    Motion --> Object(Object detection)
+    Feed --> Recording(Recording and visualization)
     Motion --> Recording
     Object --> Recording
 ```


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Newline characters (`\n`) were being incorrectly rendered in the video pipeline flowchart.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/19665
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
