### PR TITLE
Fix record motion config

### DIFF
--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -308,7 +308,10 @@ class RecordingCleanup(threading.Thread):
                 now - datetime.timedelta(days=config.record.continuous.days)
             ).timestamp()
             motion_expire_date = (
-                now - datetime.timedelta(days=config.record.motion.days)
+                now
+                - datetime.timedelta(
+                    days=max(config.record.motion.days, config.record.continuous.days)  # can't keep motion for less than continuous
+                )
             ).timestamp()
 
             # Get all the reviews to check against

--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -310,7 +310,9 @@ class RecordingCleanup(threading.Thread):
             motion_expire_date = (
                 now
                 - datetime.timedelta(
-                    days=max(config.record.motion.days, config.record.continuous.days)  # can't keep motion for less than continuous
+                    days=max(
+                        config.record.motion.days, config.record.continuous.days
+                    )  # can't keep motion for less than continuous
                 )
             ).timestamp()
 

--- a/frigate/util/config.py
+++ b/frigate/util/config.py
@@ -363,6 +363,10 @@ def migrate_017_0(config: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]
         if days:
             if mode == "all":
                 continuous["days"] = days
+
+                # if a user was keeping all for number of days
+                # we need to keep motion and all for that number of days
+                motion["days"] = days
             else:
                 motion["days"] = days
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

The config incorrectly set motion to 0 days when the user previously had mode set to `all`. However it is illogical for `motion.days` to be less than `continuous.days` so the migrator is fixed and also there is a logic in record cleanup to ensure motion does not cause unnecessary cleanups

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
