### PR TITLE
Display warning in frontend if shm size is too low

### DIFF
--- a/frigate/camera/maintainer.py
+++ b/frigate/camera/maintainer.py
@@ -84,7 +84,7 @@ class CameraMaintainer(threading.Thread):
             f"frames for each camera in SHM"
         )
 
-        if shm_stats["min_shm"]:
+        if shm_stats["shm_frame_count"] < 20:
             logger.warning(
                 f"The current SHM size of {shm_stats['total']}MB is too small, "
                 f"recommend increasing it to at least {shm_stats['min_shm']}MB."

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -380,7 +380,7 @@ def stats_snapshot(
         "last_updated": int(time.time()),
     }
 
-    for path in [RECORD_DIR, CLIPS_DIR, CACHE_DIR, "/dev/shm"]:
+    for path in [RECORD_DIR, CLIPS_DIR, CACHE_DIR]:
         try:
             storage_stats = shutil.disk_usage(path)
         except (FileNotFoundError, OSError):

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -8,7 +8,6 @@ from json import JSONDecodeError
 from multiprocessing.managers import DictProxy
 from typing import Any, Optional
 
-import psutil
 import requests
 from requests.exceptions import RequestException
 
@@ -18,9 +17,11 @@ from frigate.data_processing.types import DataProcessorMetrics
 from frigate.object_detection.base import ObjectDetectProcess
 from frigate.types import StatsTrackingTypes
 from frigate.util.services import (
+    calculate_shm_requirements,
     get_amd_gpu_stats,
     get_bandwidth_stats,
     get_cpu_stats,
+    get_fs_type,
     get_intel_gpu_stats,
     get_jetson_stats,
     get_nvidia_gpu_stats,
@@ -68,16 +69,6 @@ def stats_init(
         "processes": processes,
     }
     return stats_tracking
-
-
-def get_fs_type(path: str) -> str:
-    bestMatch = ""
-    fsType = ""
-    for part in psutil.disk_partitions(all=True):
-        if path.startswith(part.mountpoint) and len(bestMatch) < len(part.mountpoint):
-            fsType = part.fstype
-            bestMatch = part.mountpoint
-    return fsType
 
 
 def read_temperature(path: str) -> Optional[float]:
@@ -402,6 +393,8 @@ def stats_snapshot(
             "free": round(storage_stats.free / pow(2, 20), 1),
             "mount_type": get_fs_type(path),
         }
+
+    stats["service"]["storage"]["/dev/shm"] = calculate_shm_requirements(config)
 
     stats["processes"] = {}
     for name, pid in stats_tracking["processes"].items():

--- a/web/public/locales/en/views/system.json
+++ b/web/public/locales/en/views/system.json
@@ -91,6 +91,11 @@
       "tips": "This value represents the total storage used by the recordings in Frigate's database. Frigate does not track storage usage for all files on your disk.",
       "earliestRecording": "Earliest recording available:"
     },
+    "shm": {
+      "title": "SHM (shared memory) allocation",
+      "warning": "The current SHM size of {{total}}MB is too small, recommend increasing to {{min_shm}}MB.",
+      "readTheDocumentation": "Read the documentation"
+    },
     "cameraStorage": {
       "title": "Camera Storage",
       "camera": "Camera",

--- a/web/public/locales/en/views/system.json
+++ b/web/public/locales/en/views/system.json
@@ -93,7 +93,7 @@
     },
     "shm": {
       "title": "SHM (shared memory) allocation",
-      "warning": "The current SHM size of {{total}}MB is too small, recommend increasing to {{min_shm}}MB.",
+      "warning": "The current SHM size of {{total}}MB is too small. Increase it to at least {{min_shm}}MB.",
       "readTheDocumentation": "Read the documentation"
     },
     "cameraStorage": {

--- a/web/src/types/stats.ts
+++ b/web/src/types/stats.ts
@@ -79,6 +79,7 @@ export type StorageStats = {
   total: number;
   used: number;
   mount_type: string;
+  min_shm?: number;
 };
 
 export type PotentialProblem = {

--- a/web/src/views/system/StorageMetrics.tsx
+++ b/web/src/views/system/StorageMetrics.tsx
@@ -14,6 +14,10 @@ import { useFormattedTimestamp, useTimezone } from "@/hooks/use-date-utils";
 import { RecordingsSummary } from "@/types/review";
 import { useTranslation } from "react-i18next";
 import { TZDate } from "react-day-picker";
+import { Link } from "react-router-dom";
+import { useDocDomain } from "@/hooks/use-doc-domain";
+import { LuExternalLink } from "react-icons/lu";
+import { FaExclamationTriangle } from "react-icons/fa";
 
 type CameraStorage = {
   [key: string]: {
@@ -36,6 +40,7 @@ export default function StorageMetrics({
   });
   const { t } = useTranslation(["views/system"]);
   const timezone = useTimezone(config);
+  const { getLocaleDocUrl } = useDocDomain();
 
   const totalStorage = useMemo(() => {
     if (!cameraStorage || !stats) {
@@ -142,7 +147,46 @@ export default function StorageMetrics({
           />
         </div>
         <div className="flex-col rounded-lg bg-background_alt p-2.5 md:rounded-2xl">
-          <div className="mb-5">/dev/shm</div>
+          <div className="mb-5 flex flex-row items-center justify-between">
+            /dev/shm
+            {stats.service.storage["/dev/shm"]["total"] <
+              (stats.service.storage["/dev/shm"]["min_shm"] ?? 0) && (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <button
+                    className="focus:outline-none"
+                    aria-label={t("storage.shm.title")}
+                  >
+                    <FaExclamationTriangle
+                      className="size-5 text-danger"
+                      aria-label={t("storage.shm.title")}
+                    />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent className="w-80">
+                  <div className="space-y-2">
+                    {t("storage.shm.warning", {
+                      total: stats.service.storage["/dev/shm"]["total"],
+                      min_shm: stats.service.storage["/dev/shm"]["min_shm"],
+                    })}
+                    <div className="mt-2 flex items-center text-primary">
+                      <Link
+                        to={getLocaleDocUrl(
+                          "frigate/installation#calculating-required-shm-size",
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline"
+                      >
+                        {t("storage.shm.readTheDocumentation")}
+                        <LuExternalLink className="ml-2 inline-flex size-3" />
+                      </Link>
+                    </div>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            )}
+          </div>
           <StorageGraph
             graphId="general-shared-memory"
             used={stats.service.storage["/dev/shm"]["used"]}


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR displays a warning in the Storage metrics pane of the UI if `shm_size` is too low.

- Refactor calculation to common function.
- Send calc output to stats API endpoint. This will be helpful to use for other warning messages as users dynamically add cameras from the UI.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: closes https://github.com/blakeblackshear/frigate/issues/19622
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
