### PR TITLE
Only try to import memryx SDK when memry detector is used

### DIFF
--- a/frigate/detectors/plugins/memryx.py
+++ b/frigate/detectors/plugins/memryx.py
@@ -9,15 +9,6 @@ from queue import Queue
 
 import cv2
 import numpy as np
-
-try:
-    # from memryx import AsyncAccl  # Import MemryX SDK
-    from memryx import AsyncAccl
-except ModuleNotFoundError:
-    raise ImportError(
-        "MemryX SDK is not installed. Install it and set up MIX environment."
-    )
-
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
@@ -55,6 +46,14 @@ class MemryXDetector(DetectionApi):
 
     def __init__(self, detector_config):
         """Initialize MemryX detector with the provided configuration."""
+        try:
+            # Import MemryX SDK
+            from memryx import AsyncAccl
+        except ModuleNotFoundError:
+            raise ImportError(
+                "MemryX SDK is not installed. Install it and set up MIX environment."
+            )
+            return
 
         model_cfg = getattr(detector_config, "model", None)
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Even when the memryx detector was not used, the module was still attempting to be imported so irrelevant log messages were being displayed. This PR moves the import to the detector init.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
