### PR TITLE
Improve LPR regex support

### DIFF
--- a/web/public/locales/en/components/filter.json
+++ b/web/public/locales/en/components/filter.json
@@ -127,6 +127,8 @@
     "loading": "Loading recognized license plates…",
     "placeholder": "Type to search license plates…",
     "noLicensePlatesFound": "No license plates found.",
-    "selectPlatesFromList": "Select one or more plates from the list."
+    "selectPlatesFromList": "Select one or more plates from the list.",
+    "selectAll": "Select all",
+    "clearAll": "Clear all"
   }
 }


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR adds the ability to use regexes in the events API and frontend when looking for recognized license plates.

- Add regex support to sqlite 
- Users can specify regexes in `/api/events` and `/api/events/search` HTTP API calls, eg: 
   ```
   /api/events?recognized_license_plate=ABC123
   /api/events?recognized_license_plate=ABC.*
   /api/events?recognized_license_plate=^XYZ[0-9]{3}$
   ```
- Add support for regexes in recognized license plates input in More Filters in Explore. Users can use wildcards `?` or `*` or a full regex by surrounding the string with `/.../`.
- Add Select All and Clear All links below the box in More Filters in Explore

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: closes https://github.com/blakeblackshear/frigate/issues/19528
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
