### PR TITLE
Fix autotracking calibration crash when zooming is disabled

### DIFF
--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -369,12 +369,13 @@ class PtzAutoTracker:
         logger.info(f"Camera calibration for {camera} in progress")
 
         # zoom levels test
+        self.zoom_time[camera] = 0
+
         if (
             self.config.cameras[camera].onvif.autotracking.zooming
             != ZoomingModeEnum.disabled
         ):
             logger.info(f"Calibration for {camera} in progress: 0% complete")
-            self.zoom_time[camera] = 0
 
             for i in range(2):
                 # absolute move to 0 - fully zoomed out


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Fix autotracking calibration crash when zooming is disabled


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
