### PR TITLE
Fix HLS video initial aspect on Chrome

### DIFF
--- a/web/src/hooks/use-video-dimensions.ts
+++ b/web/src/hooks/use-video-dimensions.ts
@@ -26,7 +26,7 @@ export function useVideoDimensions(
 
   const videoDimensions = useMemo(() => {
     if (!containerWidth || !containerHeight)
-      return { width: "100%", height: "100%" };
+      return { aspectRatio: "16 / 9", width: "100%" };
     if (containerAspectRatio > videoAspectRatio) {
       const height = containerHeight;
       const width = height * videoAspectRatio;


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Explore videos are very small on Chrome specifically, this has something to do with how the latest version of Chrome loads video metadata. This change provides a default aspect ratio instead of a default height when the container ref is not defined yet

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
