### PR TITLE
Add low shm warning to bottom bar

### DIFF
--- a/web/public/locales/en/views/system.json
+++ b/web/public/locales/en/views/system.json
@@ -162,7 +162,8 @@
     "reindexingEmbeddings": "Reindexing embeddings ({{processed}}% complete)",
     "cameraIsOffline": "{{camera}} is offline",
     "detectIsSlow": "{{detect}} is slow ({{speed}} ms)",
-    "detectIsVerySlow": "{{detect}} is very slow ({{speed}} ms)"
+    "detectIsVerySlow": "{{detect}} is very slow ({{speed}} ms)",
+    "shmTooLow": "/dev/shm allocation ({{total}} MB) should be increased to at least {{min}} MB."
   },
   "enrichments": {
     "title": "Enrichments",

--- a/web/src/hooks/use-stats.ts
+++ b/web/src/hooks/use-stats.ts
@@ -41,7 +41,7 @@ export default function useStats(stats: FrigateStats | undefined) {
           min: shm.min_shm,
         }),
         color: "text-danger",
-        relevantLink: "/system#general",
+        relevantLink: "/system#storage",
       });
     }
 

--- a/web/src/hooks/use-stats.ts
+++ b/web/src/hooks/use-stats.ts
@@ -32,6 +32,19 @@ export default function useStats(stats: FrigateStats | undefined) {
       return problems;
     }
 
+    // check shm level
+    const shm = memoizedStats.service.storage["/dev/shm"];
+    if (shm?.total && shm?.min_shm && shm.total < shm.min_shm) {
+      problems.push({
+        text: t("stats.shmTooLow", {
+          total: shm.total,
+          min: shm.min_shm,
+        }),
+        color: "text-danger",
+        relevantLink: "/system#general",
+      });
+    }
+
     // check detectors for high inference speeds
     Object.entries(memoizedStats["detectors"]).forEach(([key, det]) => {
       if (det["inference_speed"] > InferenceThreshold.error) {


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
As a follow up to #19712, this PR adds a warning to the status bar if shm is set too low.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
