### PR TITLE
Decode proxy http headers

### DIFF
--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -12,6 +12,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import List
+from urllib.parse import unquote
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -397,7 +398,7 @@ def profile(request: Request):
     username = request.headers.get("remote-user", "anonymous")
     role = request.headers.get("remote-role", "viewer")
 
-    return JSONResponse(content={"username": username, "role": role})
+    return JSONResponse(content={"username": unquote(username), "role": role})
 
 
 @router.get("/logout")


### PR DESCRIPTION
## Proposed change

I'm using Authentik as a proxy to the Frigate. However my first name contains diacritical marks which are displayed incorrectly because HTTP headers can only contain ASCII. In order to correctly display UTF-8 characters they must be decoded.

Before
 
<img width="312" height="187" alt="before" src="https://github.com/user-attachments/assets/39feb6c1-6442-45c3-ac3f-efcc4bdc2c8c" />

After

<img width="300" height="181" alt="after" src="https://github.com/user-attachments/assets/c39d6344-7e35-40ec-b425-b0d4b5ad7736" />



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information
- 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
