### PR TITLE
Improve review segmentation behavior

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -390,6 +390,8 @@ review:
     labels:
       - car
       - person
+    # Time to cutoff alerts after no alert-causing activity has occurred (default: shown below)
+    cutoff_time: 40
     # Optional: required zones for an object to be marked as an alert (default: none)
     # NOTE: when settings required zones globally, this zone must exist on all cameras
     #       or the config will be considered invalid. In that case the required_zones
@@ -404,6 +406,8 @@ review:
     labels:
       - car
       - person
+    # Time to cutoff detections after no detection-causing activity has occurred (default: shown below)
+    cutoff_time: 30
     # Optional: required zones for an object to be marked as a detection (default: none)
     # NOTE: when settings required zones globally, this zone must exist on all cameras
     #       or the config will be considered invalid. In that case the required_zones

--- a/frigate/config/camera/review.py
+++ b/frigate/config/camera/review.py
@@ -26,6 +26,10 @@ class AlertsConfig(FrigateBaseModel):
     enabled_in_config: Optional[bool] = Field(
         default=None, title="Keep track of original state of alerts."
     )
+    cutoff_time: int = Field(
+        default=40,
+        title="Time to cutoff alerts after no alert-causing activity has occurred.",
+    )
 
     @field_validator("required_zones", mode="before")
     @classmethod
@@ -47,6 +51,10 @@ class DetectionsConfig(FrigateBaseModel):
     required_zones: Union[str, list[str]] = Field(
         default_factory=list,
         title="List of required zones to be entered in order to save the event as a detection.",
+    )
+    cutoff_time: int = Field(
+        default=30,
+        title="Time to cutoff detection after no detection-causing activity has occurred.",
     )
 
     enabled_in_config: Optional[bool] = Field(

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -659,15 +659,13 @@ class ReviewSegmentMaintainer(threading.Thread):
                         ):
                             current_segment.audio.add(audio)
                             current_segment.severity = SeverityEnum.alert
-                            current_segment.update_time(frame_time, SeverityEnum.alert)
+                            current_segment.last_alert_time = frame_time
                         elif (
                             camera_config.review.detections.labels is None
                             or audio in camera_config.review.detections.labels
                         ) and camera_config.review.detections.enabled:
                             current_segment.audio.add(audio)
-                            current_segment.update_time(
-                                frame_time, SeverityEnum.detection
-                            )
+                            current_segment.last_detection_time = frame_time
                 elif topic == DetectionTypeEnum.api or topic == DetectionTypeEnum.lpr:
                     if manual_info["state"] == ManualEventState.complete:
                         current_segment.detections[manual_info["event_id"]] = (

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 THUMB_HEIGHT = 180
 THUMB_WIDTH = 320
 
-THRESHOLD_ALERT_ACTIVITY = 120
+THRESHOLD_ALERT_ACTIVITY = 40
 THRESHOLD_DETECTION_ACTIVITY = 30
 
 
@@ -504,7 +504,7 @@ class ReviewSegmentMaintainer(threading.Thread):
                     self._publish_segment_start(
                         self.active_review_segments[activity.camera_config.name]
                     )
-            elif frame_time > (
+            elif segment.severity == SeverityEnum.detection and frame_time > (
                 segment.last_detection_time + THRESHOLD_DETECTION_ACTIVITY
             ):
                 self._publish_segment_end(segment, prev_data)

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -40,9 +40,6 @@ logger = logging.getLogger(__name__)
 THUMB_HEIGHT = 180
 THUMB_WIDTH = 320
 
-THRESHOLD_ALERT_ACTIVITY = 40
-THRESHOLD_DETECTION_ACTIVITY = 30
-
 
 class PendingReviewSegment:
     def __init__(
@@ -472,11 +469,14 @@ class ReviewSegmentMaintainer(threading.Thread):
                     return
 
             if segment.severity == SeverityEnum.alert and frame_time > (
-                segment.last_alert_time + THRESHOLD_ALERT_ACTIVITY
+                segment.last_alert_time + camera_config.review.alerts.cutoff_time
             ):
                 needs_new_detection = (
                     segment.last_detection_time > segment.last_alert_time
-                    and (segment.last_detection_time + THRESHOLD_DETECTION_ACTIVITY)
+                    and (
+                        segment.last_detection_time
+                        + camera_config.review.detections.cutoff_time
+                    )
                     > frame_time
                 )
                 last_detection_time = segment.last_detection_time
@@ -510,7 +510,8 @@ class ReviewSegmentMaintainer(threading.Thread):
                             activity.camera_config.name
                         ].last_detection_time = last_detection_time
             elif segment.severity == SeverityEnum.detection and frame_time > (
-                segment.last_detection_time + THRESHOLD_DETECTION_ACTIVITY
+                segment.last_detection_time
+                + camera_config.review.detections.cutoff_time
             ):
                 self._publish_segment_end(segment, prev_data)
 

--- a/web/src/components/preview/ScrubbablePreview.tsx
+++ b/web/src/components/preview/ScrubbablePreview.tsx
@@ -315,9 +315,9 @@ export function InProgressPreview({
   const apiHost = useApiHost();
   const sliderRef = useRef<HTMLDivElement | null>(null);
   const { data: previewFrames } = useSWR<string[]>(
-    `preview/${camera}/start/${Math.floor(startTime) - PREVIEW_PADDING}/end/${
-      Math.ceil(endTime ?? timeRange.before) + PREVIEW_PADDING
-    }/frames`,
+    `preview/${camera}/start/${Math.floor(startTime) - PREVIEW_PADDING}/end/${Math.ceil(
+      endTime ?? timeRange.before,
+    )}/frames`,
     { revalidateOnFocus: false },
   );
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Currently, if a review item is marked as an alert any activity will keep that review item going. For example: you can arrive home and go inside but vehicles driving by the street will keep that review item going. This behavior poses multiple problems:
- More difficult for the GenerativeAI to accurately summarize the activity
- More recording segments are retained for activity that is generally unrelated to what actually caused the review

This PR primarily reworks the review logic to keep track of alert and detection frame times separately, so when an alert has expired we can start a detection at the end of the alert, making review items accurately reflect the activity while still properly segmenting them.

Along with that, a few bugs / inconsistent behaviors have been fixed:
- Previously, the in-progress review items were given an end time padding but the video preview was not. Realistically, and end time padding is not needed as we have the time built into the review item itself to make sure no additional important activity happened.
- Previously the review checking for ending a segment on alert was not done correctly, so the 120 second time was not used. With this in mind, 120 seconds is significantly too long to wait with this new behavior so this time has been changed to 40 second to be close to detection but also be a bit more forgiving for longer alert time that is spread out (like unloading a vehicle).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
