### PR TITLE
Enhance mqtt reliability on stale connections

### DIFF
--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -162,7 +162,9 @@ class MqttClient(Communicator):
     def _reason_info(reason_code: object) -> str:
         """Return human_readable_name for a Paho reason code."""
         # Name string
-        if hasattr(reason_code, "getName") and callable(getattr(reason_code, "getName")):
+        if hasattr(reason_code, "getName") and callable(
+            getattr(reason_code, "getName")
+        ):
             try:
                 name = str(getattr(reason_code, "getName")())
             except Exception:
@@ -195,13 +197,19 @@ class MqttClient(Communicator):
         # Check for connection failure by comparing reason name
         if reason_name != "Success":
             if reason_name == "Server unavailable":
-                logger.error("Unable to connect to MQTT server: MQTT Server unavailable")
+                logger.error(
+                    "Unable to connect to MQTT server: MQTT Server unavailable"
+                )
             elif reason_name == "Bad user name or password":
-                logger.error("Unable to connect to MQTT server: MQTT Bad username or password")
+                logger.error(
+                    "Unable to connect to MQTT server: MQTT Bad username or password"
+                )
             elif reason_name == "Not authorized":
                 logger.error("Unable to connect to MQTT server: MQTT Not authorized")
             else:
-                logger.error(f"Unable to connect to MQTT server: Connection refused. Error: {reason_name}")
+                logger.error(
+                    f"Unable to connect to MQTT server: Connection refused. Error: {reason_name}"
+                )
             # Don't set connected = True on connection failure
             return
 
@@ -341,7 +349,7 @@ class MqttClient(Communicator):
         """Handle MQTT reconnection using fresh client creation, retrying every 10 seconds indefinitely."""
         logger.error("MQTT reconnection loop started")
         attempt = 0
-        
+
         while not self._stop_reconnect and not self.connected:
             attempt += 1
 

--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -24,6 +24,7 @@ class MqttClient(Communicator):
         self._reconnect_thread: Optional[threading.Thread] = None
         self._reconnect_delay = 10  # Retry every 10 seconds
         self._stop_reconnect: bool = False
+        self._cleanup_in_progress: bool = False
 
     def subscribe(self, receiver: Callable[[str, str], None]) -> None:
         """Wrapper for allowing dispatcher to subscribe."""
@@ -239,9 +240,13 @@ class MqttClient(Communicator):
             f"MQTT disconnected - reason: '{reason_name}', code: {reason_value}, type: {type(reason_code)}"
         )
 
-        # Don't attempt reconnection if we're stopping or if it was a clean disconnect
+        # Don't attempt reconnection if we're stopping, cleaning up, or if it was a clean disconnect
         if self._stop_reconnect:
             logger.error("MQTT not reconnecting - stop flag set")
+            return
+
+        if self._cleanup_in_progress:
+            logger.error("MQTT not reconnecting - cleanup in progress")
             return
 
         if reason_code == 0:
@@ -379,9 +384,12 @@ class MqttClient(Communicator):
                 # Clean up old client if it exists
                 if self.client is not None:
                     try:
+                        self._cleanup_in_progress = True
                         self.client.disconnect()
                         self.client.loop_stop()
+                        self._cleanup_in_progress = False
                     except Exception:
+                        self._cleanup_in_progress = False
                         pass  # Ignore cleanup errors
 
                 # Create completely fresh client and attempt connection


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Inspiration:
When frigate is using Mqtt behind a proxy and the proxy stops or frigate loses connection with the proxy. Mqtt disconnects and keeps retrying on a closed connection. When the proxy comes back frigate is never able to connect again. When this retry code is implemented which spawns a new connection entirely each retry frigate is then able to successfully reconnect.

These changes enhance Mqtt client to add indefinite retries every 10 seconds after the client has been come disconnected from the broker. With the goal of automatically reconnecting when the broker comes back online without requiring manual intervention within frigate.


Tested by having frigate connected through the proxy to Mqtt, then stopping the proxy. Waiting for a few retries, starting proxy and frigate reconnected to Mqtt.


```
2025-09-01 15:29:40.274353653  [2025-09-01 15:29:40] frigate.comms.mqtt
    ERROR   : MQTT disconnected - reason: 'Unspecified error', code: 128, type:
<class 'paho.mqtt.reasoncodes.ReasonCode'>
2025-09-01 15:29:40.274610357  [2025-09-01 15:29:40] frigate.comms.mqtt
    ERROR   : MQTT will attempt reconnection...
2025-09-01 15:29:40.275021844  [2025-09-01 15:29:40] frigate.comms.mqtt
    ERROR   : MQTT reconnection loop started
2025-09-01 15:29:40.275098914  [2025-09-01 15:29:40] frigate.comms.mqtt
    ERROR   : Will attempt MQTT reconnection in 10 seconds (attempt 1)
2025-09-01 15:29:50.276057439  [2025-09-01 15:29:50] frigate.comms.mqtt
    ERROR   : Creating fresh MQTT client for reconnection attempt 1...
2025-09-01 15:29:50.285930281  [2025-09-01 15:29:50] frigate.comms.mqtt
    ERROR   : MQTT disconnected - reason: 'Unspecified error', code: 128, type:
<class 'paho.mqtt.reasoncodes.ReasonCode'>
2025-09-01 15:29:50.286288156  [2025-09-01 15:29:50] frigate.comms.mqtt
    ERROR   : MQTT will attempt reconnection...
2025-09-01 15:29:55.280491525  [2025-09-01 15:29:55] frigate.comms.mqtt
    ERROR   : MQTT fresh connection attempt 1 timed out, will retry
2025-09-01 15:29:55.281046287  [2025-09-01 15:29:55] frigate.comms.mqtt
    ERROR   : Will attempt MQTT reconnection in 10 seconds (attempt 2)
2025-09-01 15:30:05.282132049  [2025-09-01 15:30:05] frigate.comms.mqtt
    ERROR   : Creating fresh MQTT client for reconnection attempt 2...
2025-09-01 15:30:06.290957824  [2025-09-01 15:30:06] frigate.comms.mqtt
    ERROR   : MQTT fresh connection successful on attempt 2!
```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
