### PR TITLE
Ensure proxy group claim uses the configured separator character

### DIFF
--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -357,7 +357,7 @@ def auth(request: Request):
             else "anonymous"
         )
 
-        # parse header and
+        # parse header and resolve a valid role
         role = resolve_role(request.headers, proxy_config)
 
         success_response.headers["remote-role"] = role

--- a/frigate/test/test_proxy_auth.py
+++ b/frigate/test/test_proxy_auth.py
@@ -1,0 +1,79 @@
+import unittest
+
+from frigate.api.auth import resolve_role
+from frigate.config import HeaderMappingConfig, ProxyConfig
+
+
+class TestProxyRoleResolution(unittest.TestCase):
+    def setUp(self):
+        self.proxy_config = ProxyConfig(
+            auth_secret=None,
+            default_role="viewer",
+            separator="|",
+            header_map=HeaderMappingConfig(
+                user="x-remote-user",
+                role="x-remote-role",
+                role_map={
+                    "admin": ["group_admin"],
+                    "viewer": ["group_viewer"],
+                },
+            ),
+        )
+
+    def test_role_map_single_group_match(self):
+        headers = {"x-remote-role": "group_admin"}
+        role = resolve_role(headers, self.proxy_config)
+        self.assertEqual(role, "admin")
+
+    def test_role_map_multiple_groups(self):
+        headers = {"x-remote-role": "group_viewer|group_admin"}
+        role = resolve_role(headers, self.proxy_config)
+        # admin should win since VALID_ROLES priority puts it before viewer
+        self.assertEqual(role, "admin")
+
+    def test_direct_role_header_with_separator(self):
+        config = self.proxy_config
+        config.header_map.role_map = None  # disable role_map
+        headers = {"x-remote-role": "viewer|admin"}
+        role = resolve_role(headers, config)
+        # admin should be chosen since it appears in VALID_ROLES
+        self.assertEqual(role, "admin")
+
+    def test_invalid_role_header(self):
+        config = self.proxy_config
+        config.header_map.role_map = None
+        headers = {"x-remote-role": "notarole"}
+        role = resolve_role(headers, config)
+        self.assertEqual(role, config.default_role)
+
+    def test_missing_role_header(self):
+        headers = {}
+        role = resolve_role(headers, self.proxy_config)
+        self.assertEqual(role, self.proxy_config.default_role)
+
+    def test_empty_role_header(self):
+        headers = {"x-remote-role": ""}
+        role = resolve_role(headers, self.proxy_config)
+        self.assertEqual(role, self.proxy_config.default_role)
+
+    def test_whitespace_groups(self):
+        headers = {"x-remote-role": "   | group_admin |   "}
+        role = resolve_role(headers, self.proxy_config)
+        self.assertEqual(role, "admin")
+
+    def test_mixed_valid_and_invalid_groups(self):
+        headers = {"x-remote-role": "bogus|group_viewer"}
+        role = resolve_role(headers, self.proxy_config)
+        self.assertEqual(role, "viewer")
+
+    def test_case_insensitive_role_direct(self):
+        config = self.proxy_config
+        config.header_map.role_map = None
+        headers = {"x-remote-role": "AdMiN"}
+        role = resolve_role(headers, config)
+        self.assertEqual(role, "admin")
+
+    def test_role_map_no_match_falls_back(self):
+        headers = {"x-remote-role": "group_unknown"}
+        role = resolve_role(headers, self.proxy_config)
+        self.assertEqual(role, self.proxy_config.default_role)


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR improves on the original changes made for role mapping in https://github.com/blakeblackshear/frigate/pull/19758 by using the separator character for group claims as well as the legacy role header. A number of tests were also added.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
