### PR TITLE
Optimize cuda execution to run in single stream

### DIFF
--- a/frigate/util/model.py
+++ b/frigate/util/model.py
@@ -306,6 +306,7 @@ def get_ort_providers(
             options.append(
                 {
                     "arena_extend_strategy": "kSameAsRequested",
+                    "use_ep_level_unified_stream": True,
                     "device_id": device_id,
                 }
             )


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

By default, CUDAExecutionProvider is configured to use multiple CUDA streams. This is helpful in cases where there are concurrent requests across multiple threads, but this is not relevant to Frigate's use case. Using a single stream provides the following benefits:
- Lower overall inference times
- Lower GPU memory usage (~30MB per model)
- Lower CPU usage

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
