### PR TITLE
Add docker metadata - fixes #19618

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,6 +8,8 @@ outputs:
     value: ${{ steps.meta.outputs.tags }}
   image-labels:
     value: ${{ steps.meta.outputs.labels }}
+  bake-file:
+    value: ${{ steps.meta.outputs.bake-file }}
   cache-name:
     value: ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:cache
 runs:
@@ -54,6 +56,7 @@ runs:
       id: meta
       uses: docker/metadata-action@v5
       with:
+        bake-target: docker-metadata-action
         # list of Docker images to use as base name for tags
         images: ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}
         tags: type=raw,value=${{ steps.create-short-sha.outputs.SHORT_SHA }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,9 @@ inputs:
     required: true
 outputs:
   image-name:
-    value: ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ steps.create-short-sha.outputs.SHORT_SHA }}
+    value: ${{ steps.meta.outputs.tags }}
+  image-labels:
+    value: ${{ steps.meta.outputs.labels }}
   cache-name:
     value: ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:cache
 runs:
@@ -48,3 +50,10 @@ runs:
     - id: create-short-sha
       run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
       shell: bash
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        # list of Docker images to use as base name for tags
+        images: ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}
+        tags: type=raw,value=${{ steps.create-short-sha.outputs.SHORT_SHA }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,9 @@ jobs:
           source: .
           push: true
           targets: rpi
-          files: docker/rpi/rpi.hcl
+          files: |
+            docker/rpi/rpi.hcl
+            ${{ steps.setup.outputs.bake-file }}
           set: |
             rpi.tags=${{ steps.setup.outputs.image-name }}-rpi
             *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-arm64
@@ -102,7 +104,9 @@ jobs:
           source: .
           push: true
           targets: tensorrt
-          files: docker/tensorrt/trt.hcl
+          files: |
+            docker/tensorrt/trt.hcl
+            ${{ steps.setup.outputs.bake-file }}
           set: |
             tensorrt.tags=${{ steps.setup.outputs.image-name }}-tensorrt-jp6
             *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-jp6
@@ -130,7 +134,9 @@ jobs:
           source: .
           push: true
           targets: tensorrt
-          files: docker/tensorrt/trt.hcl
+          files: |
+            docker/tensorrt/trt.hcl
+            ${{ steps.setup.outputs.bake-file }}
           set: |
             tensorrt.tags=${{ steps.setup.outputs.image-name }}-tensorrt
             *.cache-from=type=registry,ref=${{ steps.setup.outputs.cache-name }}-tensorrt
@@ -144,7 +150,9 @@ jobs:
           source: .
           push: true
           targets: rocm
-          files: docker/rocm/rocm.hcl
+          files: |
+            docker/rocm/rocm.hcl
+            ${{ steps.setup.outputs.bake-file }}
           set: |
             rocm.tags=${{ steps.setup.outputs.image-name }}-rocm
             *.cache-to=type=registry,ref=${{ steps.setup.outputs.cache-name }}-rocm,mode=max
@@ -170,7 +178,9 @@ jobs:
           source: .
           push: true
           targets: rk
-          files: docker/rockchip/rk.hcl
+          files: |
+            docker/rockchip/rk.hcl
+            ${{ steps.setup.outputs.bake-file }}
           set: |
             rk.tags=${{ steps.setup.outputs.image-name }}-rk
             *.cache-from=type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           push: true
           platforms: linux/amd64
           target: frigate
+          labels: ${{ steps.setup.outputs.image-labels }}
           tags: ${{ steps.setup.outputs.image-name }}-amd64
           cache-from: type=registry,ref=${{ steps.setup.outputs.cache-name }}-amd64
           cache-to: type=registry,ref=${{ steps.setup.outputs.cache-name }}-amd64,mode=max
@@ -63,8 +64,8 @@ jobs:
           push: true
           platforms: linux/arm64
           target: frigate
-          tags: |
-            ${{ steps.setup.outputs.image-name }}-standard-arm64
+          labels: ${{ steps.setup.outputs.image-labels }}
+          tags: ${{ steps.setup.outputs.image-name }}-standard-arm64
           cache-from: type=registry,ref=${{ steps.setup.outputs.cache-name }}-arm64
       - name: Build and push RPi build
         uses: docker/bake-action@v6
@@ -194,9 +195,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create short sha
         run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+      - uses: docker/metadata-action@v5
+        id: metadata
+        with:
+          images: ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}
+          tags: type=raw,value=${{ env.SHORT_SHA }}
       - uses: int128/docker-manifest-create-action@v2
         with:
-          tags: ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ env.SHORT_SHA }}
+          index-annotations: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
           sources: |
             ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ env.SHORT_SHA }}-amd64
             ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ env.SHORT_SHA }}-rpi

--- a/docker/rockchip/rk.hcl
+++ b/docker/rockchip/rk.hcl
@@ -1,3 +1,5 @@
+target "docker-metadata-action" {}
+
 target wheels {
   dockerfile = "docker/main/Dockerfile"
   platforms = ["linux/arm64"]
@@ -18,6 +20,7 @@ target rootfs {
 
 target rk {
   dockerfile = "docker/rockchip/Dockerfile"
+  inherits = ["docker-metadata-action"]
   contexts = {
     wheels = "target:wheels",
     deps = "target:deps",

--- a/docker/rocm/rocm.hcl
+++ b/docker/rocm/rocm.hcl
@@ -11,6 +11,8 @@ variable "HSA_OVERRIDE" {
   default = "1"
 }
 
+target "docker-metadata-action" {}
+
 target wget {
   dockerfile = "docker/main/Dockerfile"
   platforms = ["linux/amd64"]
@@ -31,6 +33,7 @@ target rootfs {
 
 target rocm {
   dockerfile = "docker/rocm/Dockerfile"
+  inherits = ["docker-metadata-action"]
   contexts = {
     deps = "target:deps",
     wget = "target:wget",

--- a/docker/rpi/rpi.hcl
+++ b/docker/rpi/rpi.hcl
@@ -1,3 +1,5 @@
+target "docker-metadata-action" {}
+
 target deps {
   dockerfile = "docker/main/Dockerfile"
   platforms = ["linux/arm64"]
@@ -12,6 +14,7 @@ target rootfs {
 
 target rpi {
   dockerfile = "docker/rpi/Dockerfile"
+  inherits = ["docker-metadata-action"]
   contexts = {
     deps = "target:deps",
     rootfs = "target:rootfs"

--- a/docker/tensorrt/trt.hcl
+++ b/docker/tensorrt/trt.hcl
@@ -29,6 +29,8 @@ fi
 EOT
 }
 
+target "docker-metadata-action" {}
+
 target "_build_args" {
   args = {
     BASE_IMAGE = BASE_IMAGE,
@@ -81,6 +83,7 @@ target "trt-deps" {
 
 target "tensorrt" {
   dockerfile = "docker/tensorrt/Dockerfile.${ARCH}"
+  inherits = ["docker-metadata-action", "_build_args"]
   context = "."
   contexts = {
     wget = "target:wget",
@@ -89,7 +92,6 @@ target "tensorrt" {
     rootfs = "target:rootfs"
   }
   target = "frigate-tensorrt"
-  inherits = ["_build_args"]
 }
 
 target "devcontainer-trt" {


### PR DESCRIPTION
## Proposed change

Adds common docker / opencontainer labels to docker image.

My specific use case is that renovate will pull release notes into the update PR

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #19618
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
