### PR TITLE
Log ffmpeg version at startup

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -75,7 +75,7 @@ from frigate.timeline import TimelineProcessor
 from frigate.track.object_processing import TrackedObjectProcessor
 from frigate.util.builtin import empty_and_close_queue
 from frigate.util.image import UntrackedSharedMemory
-from frigate.util.services import set_file_limit, get_ffmpeg_version
+from frigate.util.services import get_ffmpeg_version, set_file_limit
 from frigate.version import VERSION
 from frigate.watchdog import FrigateWatchdog
 

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -75,7 +75,7 @@ from frigate.timeline import TimelineProcessor
 from frigate.track.object_processing import TrackedObjectProcessor
 from frigate.util.builtin import empty_and_close_queue
 from frigate.util.image import UntrackedSharedMemory
-from frigate.util.services import set_file_limit
+from frigate.util.services import set_file_limit, get_ffmpeg_version
 from frigate.version import VERSION
 from frigate.watchdog import FrigateWatchdog
 
@@ -551,6 +551,10 @@ class FrigateApp:
         self.start_event_cleanup()
         self.start_record_cleanup()
         self.start_watchdog()
+
+        # Log ffmpeg version
+        ffmpeg_version = get_ffmpeg_version(self.config.ffmpeg.ffmpeg_path)
+        logger.info(f"Using ffmpeg: {ffmpeg_version}")
 
         self.init_auth()
 

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -782,6 +782,29 @@ def get_fs_type(path: str) -> str:
     return fsType
 
 
+def get_ffmpeg_version(ffmpeg_path: str) -> str:
+    """Get ffmpeg version."""
+    try:
+        result = sp.run(
+            [ffmpeg_path, "-version"], 
+            capture_output=True, 
+            text=True, 
+            timeout=5
+        )
+        if result.returncode == 0:
+            # Extract version from output (first line contains version info)
+            first_line = result.stdout.split('\n')[0]
+            return first_line.strip()
+        else:
+            return f"Unknown (ffmpeg returned code {result.returncode})"
+    except FileNotFoundError:
+        return f"Not found at path: {ffmpeg_path}"
+    except sp.TimeoutExpired:
+        return "Timeout getting version"
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
 def calculate_shm_requirements(config) -> dict:
     try:
         storage_stats = shutil.disk_usage("/dev/shm")

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -786,14 +786,11 @@ def get_ffmpeg_version(ffmpeg_path: str) -> str:
     """Get ffmpeg version."""
     try:
         result = sp.run(
-            [ffmpeg_path, "-version"], 
-            capture_output=True, 
-            text=True, 
-            timeout=5
+            [ffmpeg_path, "-version"], capture_output=True, text=True, timeout=5
         )
         if result.returncode == 0:
             # Extract version from output (first line contains version info)
-            first_line = result.stdout.split('\n')[0]
+            first_line = result.stdout.split("\n")[0]
             return first_line.strip()
         else:
             return f"Unknown (ffmpeg returned code {result.returncode})"


### PR DESCRIPTION
## Proposed change
Added a utility function to retrieve the ffmpeg version and log it during application startup. This helps with diagnostics and ensures the correct ffmpeg binary is being used.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ X ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ X ] The code change is tested and works locally.
- [ X ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ X ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ X ] The code has been formatted using Ruff (`ruff format frigate`)
