### PR TITLE
Fix model selection type in Frigate+ settings pane

### DIFF
--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -139,7 +139,7 @@ export default function HlsVideoPlayer({
       if (hlsRef.current) {
         hlsRef.current.destroy();
       }
-    }
+    };
   }, [videoRef, hlsRef, useHlsCompat, currentSource]);
 
   // state handling

--- a/web/src/views/settings/FrigatePlusSettingsView.tsx
+++ b/web/src/views/settings/FrigatePlusSettingsView.tsx
@@ -390,7 +390,6 @@ export default function FrigatePlusSettingsView({
                                       className="cursor-pointer"
                                       value={id}
                                       disabled={
-                                        model.type != config.model.model_type ||
                                         !model.supportedDetectors.includes(
                                           Object.values(config.detectors)[0]
                                             .type,


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
If a user was running a YOLO-NAS model (type `yolonas`), they are unable to choose a YOLOv9 model (type `yolo-generic`) from the dropdown in the Frigate+ settings page. The plus model type does not need to match config model type. As long as a model is supported by a detector, it should be available in the list. 

Also, fix a missing semicolon in HlsVideoPlayer. The web linter has been complaining for a while.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
