### PR TITLE
feat: add github mirror download endpoint

### DIFF
--- a/frigate/data_processing/real_time/bird.py
+++ b/frigate/data_processing/real_time/bird.py
@@ -41,10 +41,13 @@ class BirdRealTimeProcessor(RealTimeProcessorApi):
         self.detected_birds: dict[str, float] = {}
         self.labelmap: dict[int, str] = {}
 
+        GITHUB_RAW_ENDPOINT = os.environ.get(
+            "GITHUB_RAW_ENDPOINT", "raw.githubusercontent.com"
+        )
         download_path = os.path.join(MODEL_CACHE_DIR, "bird")
         self.model_files = {
-            "bird.tflite": "https://raw.githubusercontent.com/google-coral/test_data/master/mobilenet_v2_1.0_224_inat_bird_quant.tflite",
-            "birdmap.txt": "https://raw.githubusercontent.com/google-coral/test_data/master/inat_bird_labels.txt",
+            "bird.tflite": f"{GITHUB_RAW_ENDPOINT}/google-coral/test_data/master/mobilenet_v2_1.0_224_inat_bird_quant.tflite",
+            "birdmap.txt": f"{GITHUB_RAW_ENDPOINT}/google-coral/test_data/master/inat_bird_labels.txt",
         }
 
         if not all(

--- a/frigate/data_processing/real_time/bird.py
+++ b/frigate/data_processing/real_time/bird.py
@@ -42,7 +42,7 @@ class BirdRealTimeProcessor(RealTimeProcessorApi):
         self.labelmap: dict[int, str] = {}
 
         GITHUB_RAW_ENDPOINT = os.environ.get(
-            "GITHUB_RAW_ENDPOINT", "raw.githubusercontent.com"
+            "GITHUB_RAW_ENDPOINT", "https://raw.githubusercontent.com"
         )
         download_path = os.path.join(MODEL_CACHE_DIR, "bird")
         self.model_files = {

--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -60,10 +60,12 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
         self.faces_per_second = EventsPerSecond()
         self.inference_speed = InferenceSpeed(self.metrics.face_rec_speed)
 
+        GITHUB_ENDPOINT = os.environ.get("GITHUB_ENDPOINT", "https://github.com")
+
         download_path = os.path.join(MODEL_CACHE_DIR, "facedet")
         self.model_files = {
-            "facedet.onnx": "https://github.com/NickM-27/facenet-onnx/releases/download/v1.0/facedet.onnx",
-            "landmarkdet.yaml": "https://github.com/NickM-27/facenet-onnx/releases/download/v1.0/landmarkdet.yaml",
+            "facedet.onnx": f"{GITHUB_ENDPOINT}/NickM-27/facenet-onnx/releases/download/v1.0/facedet.onnx",
+            "landmarkdet.yaml": f"{GITHUB_ENDPOINT}/NickM-27/facenet-onnx/releases/download/v1.0/landmarkdet.yaml",
         }
 
         if not all(

--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -139,8 +139,9 @@ class Rknn(DetectionApi):
         if not os.path.isdir(model_cache_dir):
             os.mkdir(model_cache_dir)
 
+        GITHUB_ENDPOINT = os.environ.get("GITHUB_ENDPOINT", "https://github.com")
         urllib.request.urlretrieve(
-            f"https://github.com/MarcA711/rknn-models/releases/download/v2.3.2-2/{filename}",
+            f"{GITHUB_ENDPOINT}/MarcA711/rknn-models/releases/download/v2.3.2-2/{filename}",
             model_cache_dir + filename,
         )
 

--- a/frigate/embeddings/onnx/face_embedding.py
+++ b/frigate/embeddings/onnx/face_embedding.py
@@ -24,11 +24,12 @@ FACENET_INPUT_SIZE = 160
 
 class FaceNetEmbedding(BaseEmbedding):
     def __init__(self):
+        GITHUB_ENDPOINT = os.environ.get("GITHUB_ENDPOINT", "https://github.com")
         super().__init__(
             model_name="facedet",
             model_file="facenet.tflite",
             download_urls={
-                "facenet.tflite": "https://github.com/NickM-27/facenet-onnx/releases/download/v1.0/facenet.tflite",
+                "facenet.tflite": f"{GITHUB_ENDPOINT}/NickM-27/facenet-onnx/releases/download/v1.0/facenet.tflite",
             },
         )
         self.download_path = os.path.join(MODEL_CACHE_DIR, self.model_name)
@@ -109,12 +110,14 @@ class FaceNetEmbedding(BaseEmbedding):
 
 
 class ArcfaceEmbedding(BaseEmbedding):
+    GITHUB_ENDPOINT = os.environ.get("GITHUB_ENDPOINT", "https://github.com")
+
     def __init__(self):
         super().__init__(
             model_name="facedet",
             model_file="arcface.onnx",
             download_urls={
-                "arcface.onnx": "https://github.com/NickM-27/facenet-onnx/releases/download/v1.0/arcface.onnx",
+                "arcface.onnx": f"{GITHUB_ENDPOINT}/NickM-27/facenet-onnx/releases/download/v1.0/arcface.onnx",
             },
         )
         self.download_path = os.path.join(MODEL_CACHE_DIR, self.model_name)

--- a/frigate/embeddings/onnx/face_embedding.py
+++ b/frigate/embeddings/onnx/face_embedding.py
@@ -110,9 +110,8 @@ class FaceNetEmbedding(BaseEmbedding):
 
 
 class ArcfaceEmbedding(BaseEmbedding):
-    GITHUB_ENDPOINT = os.environ.get("GITHUB_ENDPOINT", "https://github.com")
-
     def __init__(self):
+        GITHUB_ENDPOINT = os.environ.get("GITHUB_ENDPOINT", "https://github.com")
         super().__init__(
             model_name="facedet",
             model_file="arcface.onnx",

--- a/frigate/embeddings/onnx/lpr_embedding.py
+++ b/frigate/embeddings/onnx/lpr_embedding.py
@@ -34,11 +34,12 @@ class PaddleOCRDetection(BaseEmbedding):
         model_file = (
             "detection-large.onnx" if model_size == "large" else "detection-small.onnx"
         )
+        GITHUB_ENDPOINT = os.environ.get("GITHUB_ENDPOINT", "https://github.com")
         super().__init__(
             model_name="paddleocr-onnx",
             model_file=model_file,
             download_urls={
-                model_file: f"https://github.com/hawkeye217/paddleocr-onnx/raw/refs/heads/master/models/{model_file}"
+                model_file: f"{GITHUB_ENDPOINT}/hawkeye217/paddleocr-onnx/raw/refs/heads/master/models/{model_file}"
             },
         )
         self.requestor = requestor
@@ -94,11 +95,12 @@ class PaddleOCRClassification(BaseEmbedding):
         requestor: InterProcessRequestor,
         device: str = "AUTO",
     ):
+        GITHUB_ENDPOINT = os.environ.get("GITHUB_ENDPOINT", "https://github.com")
         super().__init__(
             model_name="paddleocr-onnx",
             model_file="classification.onnx",
             download_urls={
-                "classification.onnx": "https://github.com/hawkeye217/paddleocr-onnx/raw/refs/heads/master/models/classification.onnx"
+                "classification.onnx": f"{GITHUB_ENDPOINT}/hawkeye217/paddleocr-onnx/raw/refs/heads/master/models/classification.onnx"
             },
         )
         self.requestor = requestor
@@ -154,11 +156,12 @@ class PaddleOCRRecognition(BaseEmbedding):
         requestor: InterProcessRequestor,
         device: str = "AUTO",
     ):
+        GITHUB_ENDPOINT = os.environ.get("GITHUB_ENDPOINT", "https://github.com")
         super().__init__(
             model_name="paddleocr-onnx",
             model_file="recognition.onnx",
             download_urls={
-                "recognition.onnx": "https://github.com/hawkeye217/paddleocr-onnx/raw/refs/heads/master/models/recognition.onnx"
+                "recognition.onnx": f"{GITHUB_ENDPOINT}/hawkeye217/paddleocr-onnx/raw/refs/heads/master/models/recognition.onnx"
             },
         )
         self.requestor = requestor
@@ -214,11 +217,12 @@ class LicensePlateDetector(BaseEmbedding):
         requestor: InterProcessRequestor,
         device: str = "AUTO",
     ):
+        GITHUB_ENDPOINT = os.environ.get("GITHUB_ENDPOINT", "https://github.com")
         super().__init__(
             model_name="yolov9_license_plate",
             model_file="yolov9-256-license-plates.onnx",
             download_urls={
-                "yolov9-256-license-plates.onnx": "https://github.com/hawkeye217/yolov9-license-plates/raw/refs/heads/master/models/yolov9-256-license-plates.onnx"
+                "yolov9-256-license-plates.onnx": f"{GITHUB_ENDPOINT}/hawkeye217/yolov9-license-plates/raw/refs/heads/master/models/yolov9-256-license-plates.onnx"
             },
         )
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Add github download mirrors.
The system will automatically switch to mirror sources at the optimal time—this is determined by pinging both the mirror source and the original address, and using the mirror source if the latency difference is significant. Since GitHub and Hugging Face do not have server nodes in mainland China, their latency will inevitably be higher compared to mirror sites that do have nodes in China.
Additionally, if the download from the mirror source fails, the system will automatically fall back to the original address for re-download

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
