### PR TITLE
fix(web): handle undefined screen.orientation

### DIFF
--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -401,7 +401,7 @@ export default function LiveCameraView({
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const screenOrientation = screen.orientation as any;
-    if (!screenOrientation.lock || !screenOrientation.unlock) {
+    if (!screenOrientation?.lock || !screenOrientation?.unlock) {
       // Browser does not support ScreenOrientation APIs that we need
       return;
     }


### PR DESCRIPTION
## Proposed change
In older browsers `screen.orientation` property can be `undefined` resulting in a crash. I came across it in iOS 15.7.2 and in [surf 2.1](https://surf.suckless.org/), both uses WebKit.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass** (got "No test files found")
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using ESlint (`npm run lint`)
