### PR TITLE
Fix submitting false positives

### DIFF
--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -1021,7 +1021,7 @@ async def false_positive(request: Request, event_id: str):
         )
 
     if not event.plus_id:
-        plus_response = send_to_plus(request, event_id)
+        plus_response = await send_to_plus(request, event_id)
         if plus_response.status_code != 200:
             return plus_response
         # need to refetch the event now that it has a plus_id


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR fixes an issue introduced with the viewer roles changes that would cause submitting false positives to Frigate+ to fail. The `false_positive` endpoint needs to await `send_to_plus` call. 



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
