### PR TITLE
feat: add login pages forgot password tips

### DIFF
--- a/web/public/locales/en/components/auth.json
+++ b/web/public/locales/en/components/auth.json
@@ -3,6 +3,10 @@
     "user": "Username",
     "password": "Password",
     "login": "Login",
+    "forgotPassword": {
+      "label": "Forgot password?",
+      "tips": "If you forgot your password, please refer to the following documentation to modify the configuration file and reset your password."
+    },
     "errors": {
       "usernameRequired": "Username is required",
       "passwordRequired": "Password is required",

--- a/web/src/components/auth/AuthForm.tsx
+++ b/web/src/components/auth/AuthForm.tsx
@@ -17,16 +17,24 @@ import {
   FormItem,
   FormLabel,
 } from "@/components/ui/form";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { AuthContext } from "@/context/auth-context";
 import { useTranslation } from "react-i18next";
+import { useDocDomain } from "@/hooks/use-doc-domain";
+import { LuExternalLink } from "react-icons/lu";
 
 interface UserAuthFormProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
   const { t } = useTranslation(["components/auth"]);
+  const { getLocaleDocUrl } = useDocDomain();
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const { login } = React.useContext(AuthContext);
 
@@ -120,6 +128,32 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
                     {...field}
                   />
                 </FormControl>
+
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <div className="cursor-pointer p-0 text-right">
+                      <span className="text-sm">
+                        {t("form.forgotPassword.label")}
+                      </span>
+                    </div>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-80 text-sm">
+                    {t("form.forgotPassword.tips")}
+                    <div className="mt-2 flex items-center text-primary">
+                      <a
+                        href={getLocaleDocUrl(
+                          "configuration/authentication/#resetting-admin-password",
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline"
+                      >
+                        {t("readTheDocumentation", { ns: "common" })}
+                        <LuExternalLink className="ml-2 inline-flex size-3" />
+                      </a>
+                    </div>
+                  </PopoverContent>
+                </Popover>
               </FormItem>
             )}
           />


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

<img width="589" height="463" alt="image" src="https://github.com/user-attachments/assets/64f8c0ed-f1c7-47d2-8f00-846ed044d9f6" />

Add password recovery instructions on the login page to prevent users from getting confused when they first use the system or forget their passwords.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
