### PR TITLE
Catch exception when regex in LPR format field is invalid

### DIFF
--- a/frigate/data_processing/common/license_plate/mixin.py
+++ b/frigate/data_processing/common/license_plate/mixin.py
@@ -385,11 +385,18 @@ class LicensePlateProcessingMixin:
                     )
                     continue
 
-                if self.lpr_config.format and not re.fullmatch(
-                    self.lpr_config.format, plate
-                ):
-                    logger.debug(f"Filtered out '{plate}' due to format mismatch")
-                    continue
+                if self.lpr_config.format:
+                    try:
+                        if not re.fullmatch(self.lpr_config.format, plate):
+                            logger.debug(
+                                f"Filtered out '{plate}' due to format mismatch"
+                            )
+                            continue
+                    except re.error:
+                        # Skip format filtering if regex is invalid
+                        logger.error(
+                            f"{camera}: Invalid regex in LPR format configuration: {self.lpr_config.format}"
+                        )
 
                 filtered_data.append((plate, conf_list, area))
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/20087
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
