### PR TITLE
Add average_estimated_speed to mqtt docs

### DIFF
--- a/docs/docs/integrations/mqtt.md
+++ b/docs/docs/integrations/mqtt.md
@@ -29,12 +29,12 @@ Message published for each changed tracked object. The first message is publishe
     "camera": "front_door",
     "frame_time": 1607123961.837752,
     "snapshot": {
-        "frame_time": 1607123965.975463,
-        "box": [415, 489, 528, 700],
-        "area": 12728,
-        "region": [260, 446, 660, 846],
-        "score": 0.77546,
-        "attributes": [],
+      "frame_time": 1607123965.975463,
+      "box": [415, 489, 528, 700],
+      "area": 12728,
+      "region": [260, 446, 660, 846],
+      "score": 0.77546,
+      "attributes": []
     },
     "label": "person",
     "sub_label": null,
@@ -61,6 +61,7 @@ Message published for each changed tracked object. The first message is publishe
     }, // attributes with top score that have been identified on the object at any point
     "current_attributes": [], // detailed data about the current attributes in this frame
     "current_estimated_speed": 0.71, // current estimated speed (mph or kph) for objects moving through zones with speed estimation enabled
+    "average_estimated_speed": 14.3, // average estimated speed (mph or kph) for objects moving through zones with speed estimation enabled
     "velocity_angle": 180, // direction of travel relative to the frame for objects moving through zones with speed estimation enabled
     "recognized_license_plate": "ABC12345", // a recognized license plate for car objects
     "recognized_license_plate_score": 0.933451
@@ -70,12 +71,12 @@ Message published for each changed tracked object. The first message is publishe
     "camera": "front_door",
     "frame_time": 1607123962.082975,
     "snapshot": {
-        "frame_time": 1607123965.975463,
-        "box": [415, 489, 528, 700],
-        "area": 12728,
-        "region": [260, 446, 660, 846],
-        "score": 0.77546,
-        "attributes": [],
+      "frame_time": 1607123965.975463,
+      "box": [415, 489, 528, 700],
+      "area": 12728,
+      "region": [260, 446, 660, 846],
+      "score": 0.77546,
+      "attributes": []
     },
     "label": "person",
     "sub_label": ["John Smith", 0.79],
@@ -109,6 +110,7 @@ Message published for each changed tracked object. The first message is publishe
       }
     ],
     "current_estimated_speed": 0.77, // current estimated speed (mph or kph) for objects moving through zones with speed estimation enabled
+    "average_estimated_speed": 14.31, // average estimated speed (mph or kph) for objects moving through zones with speed estimation enabled
     "velocity_angle": 180, // direction of travel relative to the frame for objects moving through zones with speed estimation enabled
     "recognized_license_plate": "ABC12345", // a recognized license plate for car objects
     "recognized_license_plate_score": 0.933451
@@ -139,7 +141,7 @@ Message published for updates to tracked object metadata, for example:
   "name": "John",
   "score": 0.95,
   "camera": "front_door_cam",
-  "timestamp": 1607123958.748393,
+  "timestamp": 1607123958.748393
 }
 ```
 
@@ -153,7 +155,7 @@ Message published for updates to tracked object metadata, for example:
   "plate": "123ABC",
   "score": 0.95,
   "camera": "driveway_cam",
-  "timestamp": 1607123958.748393,
+  "timestamp": 1607123958.748393
 }
 ```
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Linter also did some cleaning up

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
