### PR TITLE
Only import tensorflow-lite when used as a detector

### DIFF
--- a/frigate/data_processing/real_time/bird.py
+++ b/frigate/data_processing/real_time/bird.py
@@ -19,11 +19,6 @@ from frigate.util.object import calculate_region
 from ..types import DataProcessorMetrics
 from .api import RealTimeProcessorApi
 
-try:
-    from tflite_runtime.interpreter import Interpreter
-except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter
-
 logger = logging.getLogger(__name__)
 
 
@@ -35,7 +30,7 @@ class BirdRealTimeProcessor(RealTimeProcessorApi):
         metrics: DataProcessorMetrics,
     ):
         super().__init__(config, metrics)
-        self.interpreter: Interpreter = None
+        self.interpreter = None
         self.sub_label_publisher = sub_label_publisher
         self.tensor_input_details: dict[str, Any] = None
         self.tensor_output_details: dict[str, Any] = None
@@ -79,6 +74,11 @@ class BirdRealTimeProcessor(RealTimeProcessorApi):
 
     @redirect_output_to_logger(logger, logging.DEBUG)
     def __build_detector(self) -> None:
+        try:
+            from tflite_runtime.interpreter import Interpreter
+        except ModuleNotFoundError:
+            from tensorflow.lite.python.interpreter import Interpreter
+
         self.interpreter = Interpreter(
             model_path=os.path.join(MODEL_CACHE_DIR, "bird/bird.tflite"),
             num_threads=2,

--- a/frigate/data_processing/real_time/custom_classification.py
+++ b/frigate/data_processing/real_time/custom_classification.py
@@ -27,11 +27,6 @@ from frigate.util.object import box_overlaps, calculate_region
 from ..types import DataProcessorMetrics
 from .api import RealTimeProcessorApi
 
-try:
-    from tflite_runtime.interpreter import Interpreter
-except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter
-
 logger = logging.getLogger(__name__)
 
 
@@ -44,11 +39,12 @@ class CustomStateClassificationProcessor(RealTimeProcessorApi):
         metrics: DataProcessorMetrics,
     ):
         super().__init__(config, metrics)
+        
         self.model_config = model_config
         self.requestor = requestor
         self.model_dir = os.path.join(MODEL_CACHE_DIR, self.model_config.name)
         self.train_dir = os.path.join(CLIPS_DIR, self.model_config.name, "train")
-        self.interpreter: Interpreter = None
+        self.interpreter = None
         self.tensor_input_details: dict[str, Any] = None
         self.tensor_output_details: dict[str, Any] = None
         self.labelmap: dict[int, str] = {}
@@ -61,6 +57,11 @@ class CustomStateClassificationProcessor(RealTimeProcessorApi):
 
     @redirect_output_to_logger(logger, logging.DEBUG)
     def __build_detector(self) -> None:
+        try:
+            from tflite_runtime.interpreter import Interpreter
+        except ModuleNotFoundError:
+            from tensorflow.lite.python.interpreter import Interpreter
+
         self.interpreter = Interpreter(
             model_path=os.path.join(self.model_dir, "model.tflite"),
             num_threads=2,
@@ -197,7 +198,7 @@ class CustomObjectClassificationProcessor(RealTimeProcessorApi):
         self.model_config = model_config
         self.model_dir = os.path.join(MODEL_CACHE_DIR, self.model_config.name)
         self.train_dir = os.path.join(CLIPS_DIR, self.model_config.name, "train")
-        self.interpreter: Interpreter = None
+        self.interpreter = None
         self.sub_label_publisher = sub_label_publisher
         self.tensor_input_details: dict[str, Any] = None
         self.tensor_output_details: dict[str, Any] = None
@@ -211,6 +212,11 @@ class CustomObjectClassificationProcessor(RealTimeProcessorApi):
 
     @redirect_output_to_logger(logger, logging.DEBUG)
     def __build_detector(self) -> None:
+        try:
+            from tflite_runtime.interpreter import Interpreter
+        except ModuleNotFoundError:
+            from tensorflow.lite.python.interpreter import Interpreter
+
         self.interpreter = Interpreter(
             model_path=os.path.join(self.model_dir, "model.tflite"),
             num_threads=2,

--- a/frigate/data_processing/real_time/custom_classification.py
+++ b/frigate/data_processing/real_time/custom_classification.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import cv2
 import numpy as np
+from tflite_runtime.interpreter import Interpreter
 
 from frigate.comms.embeddings_updater import EmbeddingsRequestEnum
 from frigate.comms.event_metadata_updater import (
@@ -39,12 +40,11 @@ class CustomStateClassificationProcessor(RealTimeProcessorApi):
         metrics: DataProcessorMetrics,
     ):
         super().__init__(config, metrics)
-
         self.model_config = model_config
         self.requestor = requestor
         self.model_dir = os.path.join(MODEL_CACHE_DIR, self.model_config.name)
         self.train_dir = os.path.join(CLIPS_DIR, self.model_config.name, "train")
-        self.interpreter = None
+        self.interpreter: Interpreter = None
         self.tensor_input_details: dict[str, Any] = None
         self.tensor_output_details: dict[str, Any] = None
         self.labelmap: dict[int, str] = {}
@@ -57,11 +57,6 @@ class CustomStateClassificationProcessor(RealTimeProcessorApi):
 
     @redirect_output_to_logger(logger, logging.DEBUG)
     def __build_detector(self) -> None:
-        try:
-            from tflite_runtime.interpreter import Interpreter
-        except ModuleNotFoundError:
-            from tensorflow.lite.python.interpreter import Interpreter
-
         self.interpreter = Interpreter(
             model_path=os.path.join(self.model_dir, "model.tflite"),
             num_threads=2,
@@ -198,7 +193,7 @@ class CustomObjectClassificationProcessor(RealTimeProcessorApi):
         self.model_config = model_config
         self.model_dir = os.path.join(MODEL_CACHE_DIR, self.model_config.name)
         self.train_dir = os.path.join(CLIPS_DIR, self.model_config.name, "train")
-        self.interpreter = None
+        self.interpreter: Interpreter = None
         self.sub_label_publisher = sub_label_publisher
         self.tensor_input_details: dict[str, Any] = None
         self.tensor_output_details: dict[str, Any] = None
@@ -212,11 +207,6 @@ class CustomObjectClassificationProcessor(RealTimeProcessorApi):
 
     @redirect_output_to_logger(logger, logging.DEBUG)
     def __build_detector(self) -> None:
-        try:
-            from tflite_runtime.interpreter import Interpreter
-        except ModuleNotFoundError:
-            from tensorflow.lite.python.interpreter import Interpreter
-
         self.interpreter = Interpreter(
             model_path=os.path.join(self.model_dir, "model.tflite"),
             num_threads=2,

--- a/frigate/data_processing/real_time/custom_classification.py
+++ b/frigate/data_processing/real_time/custom_classification.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import cv2
 import numpy as np
-from tflite_runtime.interpreter import Interpreter
 
 from frigate.comms.embeddings_updater import EmbeddingsRequestEnum
 from frigate.comms.event_metadata_updater import (
@@ -44,7 +43,7 @@ class CustomStateClassificationProcessor(RealTimeProcessorApi):
         self.requestor = requestor
         self.model_dir = os.path.join(MODEL_CACHE_DIR, self.model_config.name)
         self.train_dir = os.path.join(CLIPS_DIR, self.model_config.name, "train")
-        self.interpreter: Interpreter = None
+        self.interpreter = None
         self.tensor_input_details: dict[str, Any] = None
         self.tensor_output_details: dict[str, Any] = None
         self.labelmap: dict[int, str] = {}
@@ -57,6 +56,11 @@ class CustomStateClassificationProcessor(RealTimeProcessorApi):
 
     @redirect_output_to_logger(logger, logging.DEBUG)
     def __build_detector(self) -> None:
+        try:
+            from tflite_runtime.interpreter import Interpreter
+        except ModuleNotFoundError:
+            from tensorflow.lite.python.interpreter import Interpreter
+
         self.interpreter = Interpreter(
             model_path=os.path.join(self.model_dir, "model.tflite"),
             num_threads=2,
@@ -193,7 +197,7 @@ class CustomObjectClassificationProcessor(RealTimeProcessorApi):
         self.model_config = model_config
         self.model_dir = os.path.join(MODEL_CACHE_DIR, self.model_config.name)
         self.train_dir = os.path.join(CLIPS_DIR, self.model_config.name, "train")
-        self.interpreter: Interpreter = None
+        self.interpreter = None
         self.sub_label_publisher = sub_label_publisher
         self.tensor_input_details: dict[str, Any] = None
         self.tensor_output_details: dict[str, Any] = None
@@ -207,6 +211,11 @@ class CustomObjectClassificationProcessor(RealTimeProcessorApi):
 
     @redirect_output_to_logger(logger, logging.DEBUG)
     def __build_detector(self) -> None:
+        try:
+            from tflite_runtime.interpreter import Interpreter
+        except ModuleNotFoundError:
+            from tensorflow.lite.python.interpreter import Interpreter
+
         self.interpreter = Interpreter(
             model_path=os.path.join(self.model_dir, "model.tflite"),
             num_threads=2,

--- a/frigate/data_processing/real_time/custom_classification.py
+++ b/frigate/data_processing/real_time/custom_classification.py
@@ -39,7 +39,7 @@ class CustomStateClassificationProcessor(RealTimeProcessorApi):
         metrics: DataProcessorMetrics,
     ):
         super().__init__(config, metrics)
-        
+
         self.model_config = model_config
         self.requestor = requestor
         self.model_dir = os.path.join(MODEL_CACHE_DIR, self.model_config.name)

--- a/frigate/detectors/detector_utils.py
+++ b/frigate/detectors/detector_utils.py
@@ -3,7 +3,6 @@ import os
 
 import numpy as np
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/frigate/detectors/detector_utils.py
+++ b/frigate/detectors/detector_utils.py
@@ -3,11 +3,6 @@ import os
 
 import numpy as np
 
-try:
-    from tflite_runtime.interpreter import Interpreter, load_delegate
-except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter, load_delegate
-
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +45,11 @@ def tflite_detect_raw(self, tensor_input):
 def tflite_load_delegate_interpreter(
     delegate_library: str, detector_config, device_config
 ):
+    try:
+        from tflite_runtime.interpreter import Interpreter, load_delegate
+    except ModuleNotFoundError:
+        from tensorflow.lite.python.interpreter import Interpreter, load_delegate
+
     try:
         logger.info("Attempting to load NPU")
         tf_delegate = load_delegate(delegate_library, device_config)

--- a/frigate/detectors/plugins/cpu_tfl.py
+++ b/frigate/detectors/plugins/cpu_tfl.py
@@ -9,7 +9,6 @@ from frigate.log import redirect_output_to_logger
 
 from ..detector_utils import tflite_detect_raw, tflite_init
 
-
 logger = logging.getLogger(__name__)
 
 DETECTOR_KEY = "cpu"

--- a/frigate/detectors/plugins/cpu_tfl.py
+++ b/frigate/detectors/plugins/cpu_tfl.py
@@ -9,11 +9,6 @@ from frigate.log import redirect_output_to_logger
 
 from ..detector_utils import tflite_detect_raw, tflite_init
 
-try:
-    from tflite_runtime.interpreter import Interpreter
-except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter
-
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +25,12 @@ class CpuTfl(DetectionApi):
 
     @redirect_output_to_logger(logger, logging.DEBUG)
     def __init__(self, detector_config: CpuDetectorConfig):
+        # Import TensorFlow Lite only when this detector is actually used
+        try:
+            from tflite_runtime.interpreter import Interpreter
+        except ModuleNotFoundError:
+            from tensorflow.lite.python.interpreter import Interpreter
+
         interpreter = Interpreter(
             model_path=detector_config.model.path,
             num_threads=detector_config.num_threads or 3,

--- a/frigate/detectors/plugins/edgetpu_tfl.py
+++ b/frigate/detectors/plugins/edgetpu_tfl.py
@@ -8,12 +8,6 @@ from typing_extensions import Literal
 from frigate.detectors.detection_api import DetectionApi
 from frigate.detectors.detector_config import BaseDetectorConfig
 
-try:
-    from tflite_runtime.interpreter import Interpreter, load_delegate
-except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter, load_delegate
-
-
 logger = logging.getLogger(__name__)
 
 DETECTOR_KEY = "edgetpu"
@@ -28,6 +22,12 @@ class EdgeTpuTfl(DetectionApi):
     type_key = DETECTOR_KEY
 
     def __init__(self, detector_config: EdgeTpuDetectorConfig):
+        # Import TensorFlow Lite only when this detector is actually used
+        try:
+            from tflite_runtime.interpreter import Interpreter, load_delegate
+        except ModuleNotFoundError:
+            from tensorflow.lite.python.interpreter import Interpreter, load_delegate
+
         device_config = {}
         if detector_config.device is not None:
             device_config = {"device": detector_config.device}

--- a/frigate/embeddings/onnx/face_embedding.py
+++ b/frigate/embeddings/onnx/face_embedding.py
@@ -14,11 +14,6 @@ from frigate.util.downloader import ModelDownloader
 from ...config import FaceRecognitionConfig
 from .base_embedding import BaseEmbedding
 
-try:
-    from tflite_runtime.interpreter import Interpreter
-except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter
-
 logger = logging.getLogger(__name__)
 
 ARCFACE_INPUT_SIZE = 112
@@ -61,6 +56,11 @@ class FaceNetEmbedding(BaseEmbedding):
         if self.runner is None:
             if self.downloader:
                 self.downloader.wait_for_download()
+
+            try:
+                from tflite_runtime.interpreter import Interpreter
+            except ModuleNotFoundError:
+                from tensorflow.lite.python.interpreter import Interpreter
 
             self.runner = Interpreter(
                 model_path=os.path.join(MODEL_CACHE_DIR, "facedet/facenet.tflite"),

--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -40,12 +40,6 @@ from frigate.util.builtin import get_ffmpeg_arg_list
 from frigate.util.process import FrigateProcess
 from frigate.video import start_or_restart_ffmpeg, stop_ffmpeg
 
-try:
-    from tflite_runtime.interpreter import Interpreter
-except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -369,6 +363,11 @@ class AudioEventMaintainer(threading.Thread):
 class AudioTfl:
     @redirect_output_to_logger(logger, logging.DEBUG)
     def __init__(self, stop_event: threading.Event, num_threads=2):
+        try:
+            from tflite_runtime.interpreter import Interpreter
+        except ModuleNotFoundError:
+            from tensorflow.lite.python.interpreter import Interpreter
+
         self.stop_event = stop_event
         self.num_threads = num_threads
         self.labels = load_labels("/audio-labelmap.txt", prefill=521)


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

When using the `-tensorrt` image, logs would complain that CUdnn was already registered. This is caused by the fallback `tensorflow.lite` import happening in the tflite detectors. This PR fixes this by only importing that when the detector is actually configured.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
