### PR TITLE
Use devcontainer build to run tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     paths-ignore:
       - "docs/**"
-      - ".github/**"
+      - ".github/*.yml"
+      - ".github/DISCUSSION_TEMPLATE/**"
+      - ".github/ISSUE_TEMPLATE/**"
 
 env:
   DEFAULT_PYTHON: 3.11

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,32 +10,6 @@ env:
   DEFAULT_PYTHON: 3.11
 
 jobs:
-  build_devcontainer:
-    runs-on: ubuntu-latest
-    name: Build Devcontainer
-    # The Dockerfile contains features that requires buildkit, and since the
-    # devcontainer cli uses docker-compose to build the image, the only way to
-    # ensure docker-compose uses buildkit is to explicitly enable it.
-    env:
-      DOCKER_BUILDKIT: "1"
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@master
-        with:
-          node-version: 20.x
-      - name: Install devcontainer cli
-        run: npm install --global @devcontainers/cli
-      - name: Build devcontainer
-        run: devcontainer build --workspace-folder .
-      # It would be nice to also test the following commands, but for some
-      # reason they don't work even though in VS Code devcontainer works.
-      # - name: Start devcontainer
-      #   run: devcontainer up --workspace-folder .
-      # - name: Run devcontainer scripts
-      #   run: devcontainer run-user-commands --workspace-folder .
-
   web_lint:
     name: Web - Lint
     runs-on: ubuntu-latest
@@ -102,13 +76,18 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build
-        run: make debug
-      - name: Run mypy
-        run: docker run --rm --entrypoint=python3 frigate:latest -u -m mypy --config-file frigate/mypy.ini frigate
-      - name: Run tests
-        run: docker run --rm --entrypoint=python3 frigate:latest -u -m unittest
+      - uses: actions/setup-node@master
+        with:
+          node-version: 20.x
+      - name: Install devcontainer cli
+        run: npm install --global @devcontainers/cli
+      - name: Build devcontainer
+        env:
+          DOCKER_BUILDKIT: "1"
+        run: devcontainer build --workspace-folder .
+      - name: Start devcontainer
+        run: devcontainer up --workspace-folder .
+      - name: Run mypy in devcontainer
+        run: devcontainer exec --workspace-folder . bash -lc "python3 -u -m mypy --config-file frigate/mypy.ini frigate"
+      - name: Run unit tests in devcontainer
+        run: devcontainer exec --workspace-folder . bash -lc "python3 -u -m unittest"


### PR DESCRIPTION
Instead of running a docker build for python tests (which is now failing due to out of space errors) alongside a dev container build - best to just run the devcontainer build and run the tests on top of that

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
