### PR TITLE
Stationary bug fixes

### DIFF
--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -614,7 +614,11 @@ class NorfairTracker(ObjectTracker):
                     self.tracked_objects[id]["estimate"] = new_obj["estimate"]
             # else update it
             else:
-                self.update(str(t.global_id), new_obj, yuv_frame)
+                self.update(
+                    str(t.global_id),
+                    new_obj,
+                    yuv_frame if new_obj["label"] == "car" else None,
+                )
 
         # clear expired tracks
         expired_ids = [k for k in self.track_id_map.keys() if k not in active_ids]

--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -410,7 +410,7 @@ class NorfairTracker(ObjectTracker):
 
         # if there are more than 5 and less than 10 entries for the position, add the bounding box
         # and recompute the position box
-        if 5 <= len(position["xmins"]) < 10:
+        if len(position["xmins"]) < 10:
             position["xmins"].append(xmin)
             position["ymins"].append(ymin)
             position["xmaxs"].append(xmax)


### PR DESCRIPTION
# Proposed Changes

This PR fixes 2 different bugs:
- yuv_frame sent for all objects instead of just car
- In https://github.com/blakeblackshear/frigate/pull/17671 object tracking was improved, but the 5 <= constraint meant that any object that was active (and had its position replaced with a single entry) would then never be able to build up a position history again, so the average and median were always that single position.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
