### PR TITLE
Watchdog enhancements

### DIFF
--- a/frigate/comms/recordings_updater.py
+++ b/frigate/comms/recordings_updater.py
@@ -11,11 +11,13 @@ logger = logging.getLogger(__name__)
 
 class RecordingsDataTypeEnum(str, Enum):
     all = ""
-    recordings_available_through = "recordings_available_through"
-    latest_valid_segment = "latest_valid_segment"
+    saved = "saved"  # segment has been saved to db
+    latest = "latest"  # segment is in cache
+    valid = "valid"  # segment is valid
+    invalid = "invalid"  # segment is invalid
 
 
-class RecordingsDataPublisher(Publisher[tuple[str, float]]):
+class RecordingsDataPublisher(Publisher[Any]):
     """Publishes latest recording data."""
 
     topic_base = "recordings/"

--- a/frigate/comms/recordings_updater.py
+++ b/frigate/comms/recordings_updater.py
@@ -2,6 +2,7 @@
 
 import logging
 from enum import Enum
+from typing import Any
 
 from .zmq_proxy import Publisher, Subscriber
 
@@ -11,6 +12,7 @@ logger = logging.getLogger(__name__)
 class RecordingsDataTypeEnum(str, Enum):
     all = ""
     recordings_available_through = "recordings_available_through"
+    latest_valid_segment = "latest_valid_segment"
 
 
 class RecordingsDataPublisher(Publisher[tuple[str, float]]):
@@ -18,10 +20,10 @@ class RecordingsDataPublisher(Publisher[tuple[str, float]]):
 
     topic_base = "recordings/"
 
-    def __init__(self, topic: RecordingsDataTypeEnum) -> None:
-        super().__init__(topic.value)
+    def __init__(self) -> None:
+        super().__init__()
 
-    def publish(self, payload: tuple[str, float], sub_topic: str = "") -> None:
+    def publish(self, payload: Any, sub_topic: str = "") -> None:
         super().publish(payload, sub_topic)
 
 
@@ -32,3 +34,11 @@ class RecordingsDataSubscriber(Subscriber):
 
     def __init__(self, topic: RecordingsDataTypeEnum) -> None:
         super().__init__(topic.value)
+
+    def _return_object(
+        self, topic: str, payload: tuple | None
+    ) -> tuple[str, Any] | tuple[None, None]:
+        if payload is None:
+            return (None, None)
+
+        return (topic, payload)

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -524,20 +524,30 @@ class EmbeddingMaintainer(threading.Thread):
     def _process_recordings_updates(self) -> None:
         """Process recordings updates."""
         while True:
-            recordings_data = self.recordings_subscriber.check_for_update()
+            update = self.recordings_subscriber.check_for_update()
 
-            if recordings_data == None:
+            if not update:
                 break
 
-            camera, recordings_available_through_timestamp = recordings_data
+            (raw_topic, payload) = update
 
-            self.recordings_available_through[camera] = (
-                recordings_available_through_timestamp
-            )
+            if not raw_topic or not payload:
+                break
 
-            logger.debug(
-                f"{camera} now has recordings available through {recordings_available_through_timestamp}"
-            )
+            topic = str(raw_topic)
+
+            if topic.endswith(
+                RecordingsDataTypeEnum.recordings_available_through.value
+            ):
+                camera, recordings_available_through_timestamp = payload
+
+                self.recordings_available_through[camera] = (
+                    recordings_available_through_timestamp
+                )
+
+                logger.debug(
+                    f"{camera} now has recordings available through {recordings_available_through_timestamp}"
+                )
 
     def _process_review_updates(self) -> None:
         """Process review updates."""

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -144,7 +144,7 @@ class EmbeddingMaintainer(threading.Thread):
             EventMetadataTypeEnum.regenerate_description
         )
         self.recordings_subscriber = RecordingsDataSubscriber(
-            RecordingsDataTypeEnum.recordings_available_through
+            RecordingsDataTypeEnum.saved
         )
         self.review_subscriber = ReviewDataSubscriber("")
         self.detection_subscriber = DetectionSubscriber(DetectionTypeEnum.video.value)
@@ -536,10 +536,8 @@ class EmbeddingMaintainer(threading.Thread):
 
             topic = str(raw_topic)
 
-            if topic.endswith(
-                RecordingsDataTypeEnum.recordings_available_through.value
-            ):
-                camera, recordings_available_through_timestamp = payload
+            if topic.endswith(RecordingsDataTypeEnum.saved.value):
+                camera, recordings_available_through_timestamp, _ = payload
 
                 self.recordings_available_through[camera] = (
                     recordings_available_through_timestamp

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -80,9 +80,7 @@ class RecordingMaintainer(threading.Thread):
             [CameraConfigUpdateEnum.add, CameraConfigUpdateEnum.record],
         )
         self.detection_subscriber = DetectionSubscriber(DetectionTypeEnum.all.value)
-        self.recordings_publisher = RecordingsDataPublisher(
-            RecordingsDataTypeEnum.recordings_available_through
-        )
+        self.recordings_publisher = RecordingsDataPublisher()
 
         self.stop_event = stop_event
         self.object_recordings_info: dict[str, list] = defaultdict(list)
@@ -233,7 +231,8 @@ class RecordingMaintainer(threading.Thread):
                     recordings[0]["start_time"].timestamp()
                     if self.config.cameras[camera].record.enabled
                     else None,
-                )
+                ),
+                RecordingsDataTypeEnum.recordings_available_through.value,
             )
 
         recordings_to_insert: list[Optional[Recordings]] = await asyncio.gather(*tasks)
@@ -250,7 +249,7 @@ class RecordingMaintainer(threading.Thread):
 
     async def validate_and_move_segment(
         self, camera: str, reviews: list[ReviewSegment], recording: dict[str, Any]
-    ) -> None:
+    ) -> Optional[Recordings]:
         cache_path: str = recording["cache_path"]
         start_time: datetime.datetime = recording["start_time"]
         record_config = self.config.cameras[camera].record
@@ -261,7 +260,7 @@ class RecordingMaintainer(threading.Thread):
             or not self.config.cameras[camera].record.enabled
         ):
             self.drop_segment(cache_path)
-            return
+            return None
 
         if cache_path in self.end_time_cache:
             end_time, duration = self.end_time_cache[cache_path]
@@ -270,10 +269,14 @@ class RecordingMaintainer(threading.Thread):
                 self.config.ffmpeg, cache_path, get_duration=True
             )
 
-            if segment_info["duration"]:
-                duration = float(segment_info["duration"])
-            else:
-                duration = -1
+            if not segment_info.get("has_valid_video", False):
+                logger.warning(
+                    f"Invalid or missing video stream in segment {cache_path}. Discarding."
+                )
+                self.drop_segment(cache_path)
+                return None
+
+            duration = float(segment_info.get("duration", -1))
 
             # ensure duration is within expected length
             if 0 < duration < MAX_SEGMENT_DURATION:
@@ -284,8 +287,14 @@ class RecordingMaintainer(threading.Thread):
                     logger.warning(f"Failed to probe corrupt segment {cache_path}")
 
                 logger.warning(f"Discarding a corrupt recording segment: {cache_path}")
-                Path(cache_path).unlink(missing_ok=True)
-                return
+                self.drop_segment(cache_path)
+                return None
+
+            # this segment has a valid duration and has video data, so publish an update
+            self.recordings_publisher.publish(
+                (camera, start_time.timestamp(), cache_path),
+                RecordingsDataTypeEnum.latest_valid_segment.value,
+            )
 
         record_config = self.config.cameras[camera].record
         highest = None

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -694,7 +694,7 @@ def process_frames(
     camera_metrics: CameraMetrics,
     stop_event: MpEvent,
     ptz_metrics: PTZMetrics,
-    region_grid: list[list, Any],
+    region_grid: list[list[dict[str, Any]]],
     exit_on_empty: bool = False,
 ):
     next_region_update = get_tomorrow_at_time(2)

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -286,7 +286,7 @@ class CameraWatchdog(threading.Thread):
                         continue
 
                     if topic.endswith(RecordingsDataTypeEnum.valid.value):
-                        self.logger.info(
+                        self.logger.debug(
                             f"Latest valid recording segment time on {camera}: {segment_time}"
                         )
                         self.latest_valid_segment_time = segment_time


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR improves the recording watchdog to restart ffmpeg if recording segments have been processed from a camera but have no video data.

Backend changes:
- Improve ZMQ pubsub for recordings data
- Refactor `get_video_properties()` and use json output from ffprobe

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: closes https://github.com/blakeblackshear/frigate/issues/19964
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
