### PR TITLE
Add support for newer Authentik "entitlements" header

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/proxy_trusted_headers.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/proxy_trusted_headers.conf
@@ -23,3 +23,4 @@ proxy_set_header X-authentik-groups $http_x_authentik_groups;
 proxy_set_header X-authentik-email $http_x_authentik_email;
 proxy_set_header X-authentik-name $http_x_authentik_name;
 proxy_set_header X-authentik-uid $http_x_authentik_uid;
+proxy_set_header X-authentik-entitlements $http_x_authentik_entitlements;


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Hi there. This adds default support for a new header that Authentik sends for the entitlements feature. 

**Example:**
You can add an entitlement named "admin" to an Authentik application, bind that entitlement to any group you desire, and Authentik will send:

```
X-Authentik-Entitlements: admin
```

This can then be used a clean role header for Frigate auth

**Documentation:**

https://docs.goauthentik.io/add-secure-apps/providers/proxy/#x-authentik-entitlements
https://docs.goauthentik.io/add-secure-apps/applications/manage_apps/#application-entitlements

This has not been run through full tests because it is not a change to the Authentik code itself. I don't have a full Authentik development environment set up at this time.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
