### PR TITLE
Implement automatic go2rtc homekit config

### DIFF
--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
@@ -50,6 +50,38 @@ function set_libva_version() {
     export LIBAVFORMAT_VERSION_MAJOR
 }
 
+function setup_homekit_config() {
+    local homekit_config_path="$1"
+
+    if [[ ! -f "${homekit_config_path}" ]]; then
+        echo "[INFO] Creating empty HomeKit config file..."
+        echo '{}' > "${homekit_config_path}"
+    fi
+
+    # Convert YAML to JSON for jq processing
+    local temp_json="/tmp/cache/homekit_config.json"
+    yq eval -o=json "${homekit_config_path}" > "${temp_json}" 2>/dev/null || {
+        echo "[WARNING] Failed to convert HomeKit config to JSON, skipping cleanup"
+        return 0
+    }
+
+    # Use jq to filter and keep only the homekit section
+    local cleaned_json="/tmp/cache/homekit_cleaned.json"
+    jq '
+        # Keep only the homekit section if it exists, otherwise empty object
+        if has("homekit") then {homekit: .homekit} else {homekit: {}} end
+    ' "${temp_json}" > "${cleaned_json}" 2>/dev/null || echo '{"homekit": {}}' > "${cleaned_json}"
+
+    # Convert back to YAML and write to the config file
+    yq eval -P "${cleaned_json}" > "${homekit_config_path}" 2>/dev/null || {
+        echo "[WARNING] Failed to convert cleaned config to YAML, creating minimal config"
+        echo '{"homekit": {}}' > "${homekit_config_path}"
+    }
+
+    # Clean up temp files
+    rm -f "${temp_json}" "${cleaned_json}"
+}
+
 set_libva_version
 
 if [[ -f "/dev/shm/go2rtc.yaml" ]]; then
@@ -70,6 +102,10 @@ else
     echo "[WARNING] Unable to remove existing go2rtc config. Changes made to your frigate config file may not be recognized. Please remove the /dev/shm/go2rtc.yaml from your docker host manually."
 fi
 
+# HomeKit configuration persistence setup
+readonly homekit_config_path="/config/go2rtc_homekit.yml"
+setup_homekit_config "${homekit_config_path}"
+
 readonly config_path="/config"
 
 if [[ -x "${config_path}/go2rtc" ]]; then
@@ -82,5 +118,7 @@ fi
 echo "[INFO] Starting go2rtc..."
 
 # Replace the bash process with the go2rtc process, redirecting stderr to stdout
+# Use HomeKit config as the primary config so writebacks go there
+# The main config from Frigate will be loaded as a secondary config
 exec 2>&1
-exec "${binary_path}" -config=/dev/shm/go2rtc.yaml
+exec "${binary_path}" -config="${homekit_config_path}" -config=/dev/shm/go2rtc.yaml

--- a/docs/docs/guides/configuring_go2rtc.md
+++ b/docs/docs/guides/configuring_go2rtc.md
@@ -3,15 +3,13 @@ id: configuring_go2rtc
 title: Configuring go2rtc
 ---
 
-# Configuring go2rtc
-
 Use of the bundled go2rtc is optional. You can still configure FFmpeg to connect directly to your cameras. However, adding go2rtc to your configuration is required for the following features:
 
 - WebRTC or MSE for live viewing with audio, higher resolutions and frame rates than the jsmpeg stream which is limited to the detect stream and does not support audio
 - Live stream support for cameras in Home Assistant Integration
 - RTSP relay for use with other consumers to reduce the number of connections to your camera streams
 
-# Setup a go2rtc stream
+## Setup a go2rtc stream
 
 First, you will want to configure go2rtc to connect to your camera stream by adding the stream you want to use for live view in your Frigate config file. Avoid changing any other parts of your config at this step. Note that go2rtc supports [many different stream types](https://github.com/AlexxIT/go2rtc/tree/v1.9.10#module-streams), not just rtsp.
 
@@ -111,11 +109,11 @@ section.
 
 :::
 
-## Next steps
+### Next steps
 
 1. If the stream you added to go2rtc is also used by Frigate for the `record` or `detect` role, you can migrate your config to pull from the RTSP restream to reduce the number of connections to your camera as shown [here](/configuration/restream#reduce-connections-to-camera).
 2. You can [set up WebRTC](/configuration/live#webrtc-extra-configuration) if your camera supports two-way talk. Note that WebRTC only supports specific audio formats and may require opening ports on your router.
 
-## Important considerations
+## Homekit Configuration
 
-If you are configuring go2rtc to publish HomeKit camera streams, on pairing the configuration is written to the `/dev/shm/go2rtc.yaml` file inside the container. These changes must be manually copied across to the `go2rtc` section of your Frigate configuration in order to persist through restarts.
+To add camera streams to Homekit Frigate must be configured in docker to use `host` networking mode. Once that is done, you can use the go2rtc WebUI (accessed via port 1984, which is disabled by default) to share export a camera to Homekit. Any changes made will automatically be saved to `/config/go2rtc_homekit.yml`.


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

go2rtc automatically writes to the config when using the UI / API. However, Frigate uses a temporary file in order to have a clean space to write a config that combines user and required / recommended configurations. This leads to the homekit config being written and then lost. 

go2rtc automatically writes to the _first_ config that is specified. We can use this to have a persisted `/config/go2rtc_homekit.yml` used as the main config so that homekit changes are saved. The go2rtc service will cleanup non homekit configs to provide a clear intention and ensure we don't have erroneous user configs that are causing incorrect behavior. 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
