### PR TITLE
Go2rtc homekit config quick fix

### DIFF
--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
@@ -51,16 +51,16 @@ function set_libva_version() {
 }
 
 function setup_homekit_config() {
-    local homekit_config_path="$1"
+    local config_path="$1"
 
-    if [[ ! -f "${homekit_config_path}" ]]; then
+    if [[ ! -f "${config_path}" ]]; then
         echo "[INFO] Creating empty HomeKit config file..."
-        echo '{}' > "${homekit_config_path}"
+        echo '{}' > "${config_path}"
     fi
 
     # Convert YAML to JSON for jq processing
     local temp_json="/tmp/cache/homekit_config.json"
-    yq eval -o=json "${homekit_config_path}" > "${temp_json}" 2>/dev/null || {
+    yq eval -o=json "${config_path}" > "${temp_json}" 2>/dev/null || {
         echo "[WARNING] Failed to convert HomeKit config to JSON, skipping cleanup"
         return 0
     }
@@ -73,9 +73,9 @@ function setup_homekit_config() {
     ' "${temp_json}" > "${cleaned_json}" 2>/dev/null || echo '{"homekit": {}}' > "${cleaned_json}"
 
     # Convert back to YAML and write to the config file
-    yq eval -P "${cleaned_json}" > "${homekit_config_path}" 2>/dev/null || {
+    yq eval -P "${cleaned_json}" > "${config_path}" 2>/dev/null || {
         echo "[WARNING] Failed to convert cleaned config to YAML, creating minimal config"
-        echo '{"homekit": {}}' > "${homekit_config_path}"
+        echo '{"homekit": {}}' > "${config_path}"
     }
 
     # Clean up temp files


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Starting the Frigate container would fail with
```
2025-09-29 20:12:00.964620271  [INFO] Preparing new go2rtc config...
./run.user: line 54: local: homekit_config_path: readonly variable
```

The variable `homekit_config_path` was already declared in the script as `readonly`, and then it was used again in a function. In bash, you cannot redeclare a readonly variable as local, even within a function scope. The fix was just to rename the variable in the function.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
