### PR TITLE
Camera group url fixes

### DIFF
--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -109,7 +109,7 @@ export function CameraGroupSelector({ className }: CameraGroupSelectorProps) {
 
   // groups
 
-  const [group, setGroup, deleteGroup] = usePersistedOverlayState(
+  const [group, setGroup, , deleteGroup] = usePersistedOverlayState(
     "cameraGroup",
     "default" as string,
   );

--- a/web/src/hooks/use-overlay-state.tsx
+++ b/web/src/hooks/use-overlay-state.tsx
@@ -40,6 +40,7 @@ export function usePersistedOverlayState<S extends string>(
 ): [
   S | undefined,
   (value: S | undefined, replace?: boolean) => void,
+  boolean,
   () => void,
 ] {
   const location = useLocation();
@@ -55,7 +56,7 @@ export function usePersistedOverlayState<S extends string>(
 
   // saved value from previous session
 
-  const [persistedValue, setPersistedValue, , deletePersistedValue] =
+  const [persistedValue, setPersistedValue, loaded, deletePersistedValue] =
     usePersistence<S>(key, overlayStateValue);
 
   const setOverlayStateValue = useCallback(
@@ -73,6 +74,7 @@ export function usePersistedOverlayState<S extends string>(
   return [
     overlayStateValue ?? persistedValue ?? defaultValue,
     setOverlayStateValue,
+    loaded,
     deletePersistedValue,
   ];
 }

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -35,6 +35,10 @@ function Live() {
 
       if (group) {
         setCameraGroup(cameraGroup);
+        // return false so that url cleanup doesn't occur here
+        // will be cleaned up by usePersistedOverlayState in the
+        // camera group selector s that the icon switches correctly
+        return false;
       }
 
       return true;

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -35,9 +35,9 @@ function Live() {
 
       if (group) {
         setCameraGroup(cameraGroup);
-        // return false so that url cleanup doesn't occur here
+        // return false so that url cleanup doesn't occur here.
         // will be cleaned up by usePersistedOverlayState in the
-        // camera group selector s that the icon switches correctly
+        // camera group selector so that the icon switches correctly
         return false;
       }
 

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -24,13 +24,13 @@ function Live() {
   // selection
 
   const [selectedCameraName, setSelectedCameraName] = useHashState();
-  const [cameraGroup, setCameraGroup] = usePersistedOverlayState(
+  const [cameraGroup, setCameraGroup, loaded, ,] = usePersistedOverlayState(
     "cameraGroup",
     "default" as string,
   );
 
   useSearchEffect("group", (cameraGroup) => {
-    if (config && cameraGroup) {
+    if (config && cameraGroup && loaded) {
       const group = config.camera_groups[cameraGroup];
 
       if (group) {


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
When using the `?group=<group_name>` url parameter, a camera group was not always loaded. This is due to the async nature of loading from a browser's indexed db storage. This would create a race that was almost always won by the search hook. The fix was to ensure the loading state is obtained from the persisted overlay state hook before changing the camera group.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
