### PR TITLE
Update camera_specific.md to fix 2 way audio example for Reolink

### DIFF
--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -213,7 +213,7 @@ go2rtc:
   streams:
     your_reolink_doorbell:
       - "ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=username&password=password#video=copy#audio=copy#audio=opus"
-      - rtsp://reolink_ip/Preview_01_sub
+      - rtsp://username:password@reolink_ip/Preview_01_sub
     your_reolink_doorbell_sub:
       - "ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user=username&password=password"
 ```


### PR DESCRIPTION
Update camera_specific.md to fix 2 way audio example for Reolink Doorbell camera's.

## Proposed change
Updating documentation example to include username and password on the rtsp stream.   The given example does not include username and password, which the Reolink Doorbell camera requires.

I was going to create a Discussion, but this is so minor I figured I'd just submit it.

## Type of change

- [X] Documentation Update

## Additional information

## Checklist
