### PR TITLE
Improve Settings menu for mobile

### DIFF
--- a/web/src/components/mobile/MobileSettingsMenu.tsx
+++ b/web/src/components/mobile/MobileSettingsMenu.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import useOptimisticState from "@/hooks/use-optimistic-state";
+import { motion, AnimatePresence } from "framer-motion";
+import { Button } from "@/components/ui/button";
+import { LuChevronLeft, LuChevronRight } from "react-icons/lu";
+import Logo from "@/components/Logo";
+import { SettingsType } from "@/types/settings";
+
+type SettingsGroup = {
+  label: string;
+  items: { key: string }[];
+};
+
+type MobileSettingsMenuProps = {
+  settingsGroups: SettingsGroup[];
+  visibleSettingsViews: readonly string[];
+  onSelect: (key: string) => void;
+  isAdmin: boolean;
+  allowedViewsForViewer: readonly string[];
+  setPageToggle: (page: SettingsType) => void;
+};
+
+export default function MobileSettingsMenu({
+  settingsGroups,
+  visibleSettingsViews,
+  onSelect,
+  isAdmin,
+  allowedViewsForViewer,
+  setPageToggle,
+}: MobileSettingsMenuProps) {
+  const { t } = useTranslation(["views/settings"]);
+  const [currentGroup, setCurrentGroup] = useState<string | null>(null);
+  const [currentGroupToggle, setCurrentGroupToggle] = useOptimisticState(
+    currentGroup,
+    setCurrentGroup,
+    100,
+  );
+
+  useEffect(() => {
+    const handlePopState = (event: PopStateEvent) => {
+      // only handle the pop state for our submenu nav
+      // mobile pages are handled separately
+      if (currentGroupToggle && !event.state?.submenu) {
+        event.preventDefault();
+        setCurrentGroupToggle(null);
+        window.history.replaceState(null, "", window.location.pathname);
+      }
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [currentGroupToggle, setCurrentGroupToggle]);
+
+  const handleGroupClick = (group: SettingsGroup) => {
+    const filteredItems = group.items.filter((item) =>
+      visibleSettingsViews.includes(item.key),
+    );
+    if (filteredItems.length === 1) {
+      // Navigate directly
+      const key = filteredItems[0].key;
+      if (!isAdmin && !allowedViewsForViewer.includes(key)) {
+        setPageToggle("ui");
+      } else {
+        setPageToggle(key as SettingsType);
+      }
+      onSelect(key);
+    } else {
+      // Show submenu
+      window.history.pushState({ submenu: true }, "", window.location.pathname);
+      setCurrentGroupToggle(group.label);
+    }
+  };
+
+  const handleItemClick = (key: string) => {
+    if (!isAdmin && !allowedViewsForViewer.includes(key)) {
+      setPageToggle("ui");
+    } else {
+      setPageToggle(key as SettingsType);
+    }
+    onSelect(key);
+  };
+
+  return (
+    <div className="flex size-full flex-col">
+      <div className="sticky -top-2 z-50 mb-2 bg-background p-4">
+        <div className="flex items-center justify-center">
+          <Logo className="h-8" />
+        </div>
+        <div className="flex flex-row text-center">
+          {currentGroupToggle ? (
+            <button
+              className="ml-1 mt-4 flex items-center text-lg smart-capitalize hover:underline"
+              onClick={() => setCurrentGroupToggle(null)}
+            >
+              <LuChevronLeft className="mr-2 size-4" />
+              {t("menu." + currentGroupToggle.toLowerCase())}
+            </button>
+          ) : (
+            <h2 className="ml-1 mt-4 text-lg">
+              {t("menu.settings", { ns: "common" })}
+            </h2>
+          )}
+        </div>
+      </div>
+
+      <div className="relative flex-1">
+        <AnimatePresence>
+          {currentGroupToggle ? (
+            <motion.div
+              key="submenu"
+              initial={{ x: "100%" }}
+              animate={{ x: 0 }}
+              exit={{ x: "100%" }}
+              transition={{ type: "spring", damping: 25, stiffness: 200 }}
+              className="scrollbar-container absolute inset-0 overflow-y-auto px-1"
+            >
+              {(() => {
+                const group = settingsGroups.find(
+                  (g) => g.label === currentGroupToggle,
+                );
+                if (!group) return null;
+                const filteredItems = group.items.filter((item) =>
+                  visibleSettingsViews.includes(item.key),
+                );
+                return filteredItems.map((item) => (
+                  <Button
+                    key={item.key}
+                    variant="ghost"
+                    className="w-full justify-between hover:bg-transparent hover:text-muted-foreground"
+                    onClick={() => handleItemClick(item.key)}
+                  >
+                    <div className="smart-capitalize">
+                      {t("menu." + item.key)}
+                    </div>
+                    <LuChevronRight className="size-4" />
+                  </Button>
+                ));
+              })()}
+            </motion.div>
+          ) : (
+            <motion.div
+              key="main"
+              initial={{ x: "-100%" }}
+              animate={{ x: 0 }}
+              exit={{ x: "-100%" }}
+              transition={{ type: "spring", damping: 25, stiffness: 200 }}
+              className="scrollbar-container absolute inset-0 overflow-y-auto px-1"
+            >
+              {settingsGroups.map((group) => {
+                const filteredItems = group.items.filter((item) =>
+                  visibleSettingsViews.includes(item.key),
+                );
+                if (filteredItems.length === 0) return null;
+                return (
+                  <Button
+                    key={group.label}
+                    variant="ghost"
+                    className="mb-2 w-full justify-between hover:bg-transparent hover:text-muted-foreground"
+                    onClick={() => handleGroupClick(group)}
+                  >
+                    <div className="smart-capitalize">
+                      {t("menu." + group.label.toLowerCase())}
+                    </div>
+                    <LuChevronRight className="size-4" />
+                  </Button>
+                );
+              })}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -58,29 +58,14 @@ import {
 } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 import Heading from "@/components/ui/heading";
-import { LuChevronRight } from "react-icons/lu";
-import Logo from "@/components/Logo";
 import {
   MobilePage,
   MobilePageContent,
   MobilePageHeader,
   MobilePageTitle,
 } from "@/components/mobile/MobilePage";
-
-const allSettingsViews = [
-  "ui",
-  "enrichments",
-  "cameras",
-  "masksAndZones",
-  "motionTuner",
-  "triggers",
-  "debug",
-  "users",
-  "roles",
-  "notifications",
-  "frigateplus",
-] as const;
-type SettingsType = (typeof allSettingsViews)[number];
+import MobileSettingsMenu from "@/components/mobile/MobileSettingsMenu";
+import { allSettingsViews, SettingsType } from "@/types/settings";
 
 const settingsGroups = [
   {
@@ -129,34 +114,6 @@ const getCurrentComponent = (page: SettingsType) => {
   }
   return null;
 };
-
-function MobileMenuItem({
-  item,
-  onSelect,
-  onClose,
-  className,
-}: {
-  item: { key: string };
-  onSelect: (key: string) => void;
-  onClose?: () => void;
-  className?: string;
-}) {
-  const { t } = useTranslation(["views/settings"]);
-
-  return (
-    <Button
-      variant="ghost"
-      className={cn("w-full justify-between pr-2", className)}
-      onClick={() => {
-        onSelect(item.key);
-        onClose?.();
-      }}
-    >
-      <div className="smart-capitalize">{t("menu." + item.key)}</div>
-      <LuChevronRight className="size-4" />
-    </Button>
-  );
-}
 
 export default function Settings() {
   const { t } = useTranslation(["views/settings"]);
@@ -282,61 +239,29 @@ export default function Settings() {
     }
   }, [t, contentMobileOpen]);
 
+  // mobile
+
   if (isMobile) {
     return (
       <>
-        {!contentMobileOpen && (
-          <div className="flex size-full flex-col">
-            <div className="sticky -top-2 z-50 mb-2 bg-background p-4">
-              <div className="flex items-center justify-center">
-                <Logo className="h-8" />
-              </div>
-              <div className="flex flex-row text-center">
-                <h2 className="ml-2 text-lg font-semibold">
-                  {t("menu.settings", { ns: "common" })}
-                </h2>
-              </div>
-            </div>
-
-            <div className="scrollbar-container overflow-y-auto px-4">
-              {settingsGroups.map((group) => {
-                const filteredItems = group.items.filter((item) =>
-                  visibleSettingsViews.includes(item.key as SettingsType),
-                );
-                if (filteredItems.length === 0) return null;
-                return (
-                  <div key={group.label} className="mb-3">
-                    {filteredItems.length > 1 && (
-                      <h3 className="mb-2 ml-2 text-sm font-medium text-secondary-foreground">
-                        <div className="smart-capitalize">
-                          {t("menu." + group.label)}
-                        </div>
-                      </h3>
-                    )}
-                    {filteredItems.map((item) => (
-                      <MobileMenuItem
-                        key={item.key}
-                        item={item}
-                        className={cn(filteredItems.length == 1 && "pl-2")}
-                        onSelect={(key) => {
-                          if (
-                            !isAdmin &&
-                            !allowedViewsForViewer.includes(key as SettingsType)
-                          ) {
-                            setPageToggle("ui");
-                          } else {
-                            setPageToggle(key as SettingsType);
-                          }
-                          setContentMobileOpen(true);
-                        }}
-                      />
-                    ))}
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
+        <MobileSettingsMenu
+          settingsGroups={settingsGroups}
+          visibleSettingsViews={visibleSettingsViews}
+          onSelect={(key) => {
+            if (
+              !isAdmin &&
+              !allowedViewsForViewer.includes(key as SettingsType)
+            ) {
+              setPageToggle("ui");
+            } else {
+              setPageToggle(key as SettingsType);
+            }
+            setContentMobileOpen(true);
+          }}
+          isAdmin={isAdmin}
+          allowedViewsForViewer={allowedViewsForViewer}
+          setPageToggle={setPageToggle}
+        />
         <MobilePage
           open={contentMobileOpen}
           onOpenChange={setContentMobileOpen}
@@ -419,6 +344,8 @@ export default function Settings() {
       </>
     );
   }
+
+  // desktop
 
   return (
     <div className="flex h-full flex-col">

--- a/web/src/types/settings.ts
+++ b/web/src/types/settings.ts
@@ -1,0 +1,15 @@
+export const allSettingsViews = [
+  "ui",
+  "enrichments",
+  "cameras",
+  "masksAndZones",
+  "motionTuner",
+  "triggers",
+  "debug",
+  "users",
+  "roles",
+  "notifications",
+  "frigateplus",
+] as const;
+
+export type SettingsType = (typeof allSettingsViews)[number];


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
- Break the mobile submenu out into its own component 
- Render submenus separately to match Figma
- Add framer animation between main and submenu
- Support browser back button


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
