### PR TITLE
Map verified objects to their sub label directly

### DIFF
--- a/frigate/data_processing/post/review_descriptions.py
+++ b/frigate/data_processing/post/review_descriptions.py
@@ -255,19 +255,20 @@ def run_analysis(
     }
 
     objects = []
-    verified_objects = []
     named_objects = []
 
-    for label in set(final_data["data"]["objects"] + final_data["data"]["sub_labels"]):
+    objects_list = final_data["data"]["objects"]
+    sub_labels_list = final_data["data"]["sub_labels"]
+    verified_index = 0
+
+    for label in objects_list:
         if "-verified" in label:
-            verified_objects.append(label)
-            continue
-
-        if label in labelmap_objects:
+            named_objects.append(
+                f"{sub_labels_list[verified_index].replace('_', ' ').title()} ({label.replace('-verified', '')})"
+            )
+            verified_index += 1
+        elif label in labelmap_objects:
             objects.append(label.replace("_", " ").title())
-
-    for label in verified_objects:
-        named_objects.append(f'{label.replace("_", " ").title()} ({label.replace("-verified", "")})')
 
     analytics_data["objects"] = objects
     analytics_data["recognized_objects"] = named_objects

--- a/frigate/data_processing/post/review_descriptions.py
+++ b/frigate/data_processing/post/review_descriptions.py
@@ -259,19 +259,17 @@ def run_analysis(
 
     objects_list = final_data["data"]["objects"]
     sub_labels_list = final_data["data"]["sub_labels"]
-    verified_index = 0
 
     for label in objects_list:
         if "-verified" in label:
-            try:
-                named_objects.append(
-                    f"{sub_labels_list[verified_index].replace('_', ' ').title()} ({label.replace('-verified', '')})"
-                )
-                verified_index += 1
-            except IndexError:
-                continue
+            continue
         elif label in labelmap_objects:
             objects.append(label.replace("_", " ").title())
+
+    for i, verified_label in enumerate(final_data["data"]["verified_objects"]):
+        named_objects.append(
+            f"{sub_labels_list[i].replace('_', ' ').title()} ({verified_label.replace('-verified', '')})"
+        )
 
     analytics_data["objects"] = objects
     analytics_data["recognized_objects"] = named_objects

--- a/frigate/data_processing/post/review_descriptions.py
+++ b/frigate/data_processing/post/review_descriptions.py
@@ -256,18 +256,21 @@ def run_analysis(
 
     objects = []
     verified_objects = []
+    named_objects = []
 
     for label in set(final_data["data"]["objects"] + final_data["data"]["sub_labels"]):
         if "-verified" in label:
+            verified_objects.append(label)
             continue
 
         if label in labelmap_objects:
             objects.append(label.replace("_", " ").title())
-        else:
-            verified_objects.append(label.replace("_", " ").title())
+
+    for label in verified_objects:
+        named_objects.append(f'{label.replace("_", " ").title()} ({label.replace("-verified", "")})')
 
     analytics_data["objects"] = objects
-    analytics_data["recognized_objects"] = verified_objects
+    analytics_data["recognized_objects"] = named_objects
 
     metadata = genai_client.generate_review_description(
         analytics_data,

--- a/frigate/data_processing/post/review_descriptions.py
+++ b/frigate/data_processing/post/review_descriptions.py
@@ -263,10 +263,13 @@ def run_analysis(
 
     for label in objects_list:
         if "-verified" in label:
-            named_objects.append(
-                f"{sub_labels_list[verified_index].replace('_', ' ').title()} ({label.replace('-verified', '')})"
-            )
-            verified_index += 1
+            try:
+                named_objects.append(
+                    f"{sub_labels_list[verified_index].replace('_', ' ').title()} ({label.replace('-verified', '')})"
+                )
+                verified_index += 1
+            except IndexError:
+                continue
         elif label in labelmap_objects:
             objects.append(label.replace("_", " ").title())
 

--- a/frigate/genai/__init__.py
+++ b/frigate/genai/__init__.py
@@ -65,7 +65,7 @@ class GenAIClient:
 
         def get_verified_objects() -> str:
             if review_data["recognized_objects"]:
-                return "\n  - " + "\n  - ".join(review_data["recognized_objects"])
+                return "  - " + "\n  - ".join(review_data["recognized_objects"])
             else:
                 return "  None"
 

--- a/frigate/genai/__init__.py
+++ b/frigate/genai/__init__.py
@@ -63,6 +63,12 @@ class GenAIClient:
             else:
                 return ""
 
+        def get_verified_objects() -> str:
+            if review_data["recognized_objects"]:
+                return "\n  - " + "\n  - ".join(review_data["recognized_objects"])
+            else:
+                return "  None"
+
         context_prompt = f"""
 Please analyze the sequence of images ({len(thumbnails)} total) taken in chronological order from the perspective of the {review_data["camera"].replace("_", " ")} security camera.
 
@@ -102,7 +108,8 @@ Sequence details:
 - Frame 1 = earliest, Frame {len(thumbnails)} = latest
 - Activity started at {review_data["start"]} and lasted {review_data["duration"]} seconds
 - Detected objects: {", ".join(review_data["objects"])}
-- Verified recognized objects: {", ".join(review_data["recognized_objects"]) or "None"}
+- Verified recognized objects (use these names when describing these objects):
+{get_verified_objects()}
 - Zones involved: {", ".join(z.replace("_", " ").title() for z in review_data["zones"]) or "None"}
 
 **IMPORTANT:**

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -147,6 +147,9 @@ class PendingReviewSegment:
                 ReviewSegment.data.name: {
                     "detections": list(set(self.detections.keys())),
                     "objects": list(set(self.detections.values())),
+                    "verified_objects": [
+                        o for o in self.detections.values() if "-verified" in o
+                    ],
                     "sub_labels": list(self.sub_labels.values()),
                     "zones": self.zones,
                     "audio": list(self.audio),


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Depending on the sub label, GenAI had a hard time associating that to a particular object, so it would not always use it in the title / description.

With adding a list of all verified objects, we can directly match the sub labeled objects to the sub labels, allowing a more clear representation (example below)

```
- Verified recognized objects (use these names when describing these objects):
  - Bob (Person)
  - Bob's F150 (Car)
```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
