### PR TITLE
Add RKNN support for Radxa RK3588S (#20440)

### DIFF
--- a/frigate/detectors/plugins/rknn.py
+++ b/frigate/detectors/plugins/rknn.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 DETECTOR_KEY = "rknn"
 
-supported_socs = ["rk3562", "rk3566", "rk3568", "rk3576", "rk3588"]
+supported_socs = ["rk3562", "rk3566", "rk3568", "rk3576", "rk3588", "rk3588s"]
 
 supported_models = {
     ModelTypeEnum.yologeneric: "^frigate-fp16-yolov9-[cemst]$",


### PR DESCRIPTION
## Summary
- add `rk3588s` to the RKNN `supported_socs` list so Radxa RK3588S variants pass the detector check

## Testing
- no runtime tests (constant whitelist change only)

Fixes #20440
