### PR TITLE
Add stationary scan for LPR

### DIFF
--- a/docs/docs/configuration/license_plate_recognition.md
+++ b/docs/docs/configuration/license_plate_recognition.md
@@ -5,7 +5,7 @@ title: License Plate Recognition (LPR)
 
 Frigate can recognize license plates on vehicles and automatically add the detected characters to the `recognized_license_plate` field or a known name as a `sub_label` to tracked objects of type `car` or `motorcycle`. A common use case may be to read the license plates of cars pulling into a driveway or cars passing by on a street.
 
-LPR works best when the license plate is clearly visible to the camera. For moving vehicles, Frigate continuously refines the recognition process, keeping the most confident result. However, LPR does not run on stationary vehicles.
+LPR works best when the license plate is clearly visible to the camera. For moving vehicles, Frigate continuously refines the recognition process, keeping the most confident result. When a vehicle becomes stationary, LPR continues to run for a short time after to attempt recognition.
 
 When a plate is recognized, the details are:
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
With the introduction of LPR in 0.16, Frigate would not run LPR on stationary vehicles. Even though the LPR models themselves are relatively lightweight, running them continuously on stationary vehicles would still waste resources. Once a vehicle stops moving, its image (and the license plate region) doesn’t change between frames. Continuously reprocessing that same region provides no new information but still consumes inference time and bandwidth in the detection pipeline. However, there may be several reasons why this is not ideal - on Frigate startup or when disabling and re-enabling object detection, a non-moving car/motorcycle with a detected license plate would never be run through LPR as it would never report any position changes, and then move into stationary status.

This PR tweaks that behavior slightly. Now, vehicles that move from active to stationary with a detected license plate will have LPR run on them for 5 seconds (calculated based on frame rate). Once stationary for 5 seconds, LPR will stop.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
