### PR TITLE
Add optional idle heartbeat for Birdseye

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -241,7 +241,7 @@ birdseye:
     # Optional: Maximum number of cameras to show at one time, showing the most recent (default: show all cameras)
     max_cameras: 1
   # Optional: Frames-per-second to re-send the last composed Birdseye frame when idle (no motion or active updates). (default: shown below)
-  idle_heartbeat_fps: 10.0
+  idle_heartbeat_fps: 0.0
 
 # Optional: ffmpeg configuration
 # More information about presets at https://docs.frigate.video/configuration/ffmpeg_presets

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -240,6 +240,8 @@ birdseye:
     scaling_factor: 2.0
     # Optional: Maximum number of cameras to show at one time, showing the most recent (default: show all cameras)
     max_cameras: 1
+  # Optional: Frames-per-second to re-send the last composed Birdseye frame when idle (no motion or active updates). (default: shown below)
+  idle_heartbeat_fps: 10.0
 
 # Optional: ffmpeg configuration
 # More information about presets at https://docs.frigate.video/configuration/ffmpeg_presets

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -24,12 +24,11 @@ birdseye:
   restream: True
 ```
 
-**Tip:** To improve connection speed when using Birdseye via RTSP or WebRTC,
- you can enable a small idle heartbeat by setting `birdseye.idle_heartbeat_fps`
- to a low value (e.g. `1–2`).  
- This makes Frigate periodically push the last frame even when no motion
- is detected, reducing initial connection latency.
+:::tip 
 
+To improve connection speed when using Birdseye via restream you can enable a small idle heartbeat by setting `birdseye.idle_heartbeat_fps` to a low value (e.g. `1–2`).  This makes Frigate periodically push the last frame even when no motion is detected, reducing initial connection latency.
+
+:::
 ### Securing Restream With Authentication
 
 The go2rtc restream can be secured with RTSP based username / password authentication. Ex:

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -24,6 +24,12 @@ birdseye:
   restream: True
 ```
 
+**Tip:** To improve connection speed when using Birdseye via RTSP or WebRTC,
+ you can enable a small idle heartbeat by setting `birdseye.idle_heartbeat_fps`
+ to a low value (e.g. `1–2`).  
+ This makes Frigate periodically push the last frame even when no motion
+ is detected, reducing initial connection latency.
+
 ### Securing Restream With Authentication
 
 The go2rtc restream can be secured with RTSP based username / password authentication. Ex:

--- a/frigate/config/camera/birdseye.py
+++ b/frigate/config/camera/birdseye.py
@@ -55,7 +55,11 @@ class BirdseyeConfig(FrigateBaseModel):
     layout: BirdseyeLayoutConfig = Field(
         default_factory=BirdseyeLayoutConfig, title="Birdseye Layout Config"
     )
-
+    idle_heartbeat_fps: float = Field(
+        default=0.0,
+        ge=0.0,
+        title="Idle heartbeat FPS (0 disables)",
+    )
 
 # uses BaseModel because some global attributes are not available at the camera level
 class BirdseyeCameraConfig(BaseModel):

--- a/frigate/config/camera/birdseye.py
+++ b/frigate/config/camera/birdseye.py
@@ -58,7 +58,8 @@ class BirdseyeConfig(FrigateBaseModel):
     idle_heartbeat_fps: float = Field(
         default=0.0,
         ge=0.0,
-        title="Idle heartbeat FPS (0 disables)",
+        le=10.0,
+        title="Idle heartbeat FPS (0 disables, max 10)",
     )
 
 # uses BaseModel because some global attributes are not available at the camera level

--- a/frigate/config/camera/birdseye.py
+++ b/frigate/config/camera/birdseye.py
@@ -62,6 +62,7 @@ class BirdseyeConfig(FrigateBaseModel):
         title="Idle heartbeat FPS (0 disables, max 10)",
     )
 
+
 # uses BaseModel because some global attributes are not available at the camera level
 class BirdseyeCameraConfig(BaseModel):
     enabled: bool = Field(default=True, title="Enable birdseye view for camera.")

--- a/frigate/output/birdseye.py
+++ b/frigate/output/birdseye.py
@@ -9,9 +9,9 @@ import os
 import queue
 import subprocess as sp
 import threading
+import time
 import traceback
 from typing import Any, Optional
-import time
 
 import cv2
 import numpy as np
@@ -793,7 +793,9 @@ class Birdseye:
         self.stop_event = stop_event
         self.requestor = InterProcessRequestor()
         self.idle_fps: float = self.config.birdseye.idle_heartbeat_fps
-        self._idle_interval: Optional[float] = (1.0 / self.idle_fps) if self.idle_fps > 0 else None
+        self._idle_interval: Optional[float] = (
+            (1.0 / self.idle_fps) if self.idle_fps > 0 else None
+        )
 
         if config.birdseye.restream:
             self.birdseye_buffer = self.frame_manager.create(
@@ -853,8 +855,12 @@ class Birdseye:
                 self.requestor.send_data(UPDATE_BIRDSEYE_LAYOUT, coordinates)
         if self._idle_interval:
             now = time.monotonic()
-            is_idle = (len(self.birdseye_manager.camera_layout) == 0)
-            if is_idle and (now - self.birdseye_manager.last_output_time) >= self._idle_interval:
+            is_idle = len(self.birdseye_manager.camera_layout) == 0
+            if (
+                is_idle
+                and (now - self.birdseye_manager.last_output_time)
+                >= self._idle_interval
+            ):
                 self.__send_new_frame()
 
     def stop(self) -> None:

--- a/frigate/output/birdseye.py
+++ b/frigate/output/birdseye.py
@@ -792,16 +792,9 @@ class Birdseye:
         self.frame_manager = SharedMemoryFrameManager()
         self.stop_event = stop_event
         self.requestor = InterProcessRequestor()
-        self._heartbeat_thread = None
-
-        # --- Optional idle heartbeat (disabled by default) ---
-        # If FRIGATE_BIRDSEYE_IDLE_FPS > 0, periodically re-send the last frame
-        # when no frames have been output recently. This improves client attach times
-        # without altering default behavior.
-        self.idle_fps = float(self.config.birdseye.idle_heartbeat_fps or 0.0)
-        self.idle_fps = max(0.0, self.idle_fps)
+        self.idle_fps: float = self.config.birdseye.idle_heartbeat_fps
         self._idle_interval: Optional[float] = (1.0 / self.idle_fps) if self.idle_fps > 0 else None
- 
+
         if config.birdseye.restream:
             self.birdseye_buffer = self.frame_manager.create(
                 "birdseye",
@@ -810,16 +803,6 @@ class Birdseye:
 
         self.converter.start()
         self.broadcaster.start()
-
-
-        # Start heartbeat loop only if enabled
-        if self._idle_interval:
-            self._heartbeat_thread = threading.Thread(
-                target=self._idle_heartbeat_loop,
-                name="birdseye_idle_heartbeat",
-                daemon=True,
-            )
-            self._heartbeat_thread.start()
 
     def __send_new_frame(self) -> None:
         frame_bytes = self.birdseye_manager.frame.tobytes()
@@ -868,28 +851,12 @@ class Birdseye:
             if frame_layout_changed:
                 coordinates = self.birdseye_manager.get_camera_coordinates()
                 self.requestor.send_data(UPDATE_BIRDSEYE_LAYOUT, coordinates)
-
-    def _idle_heartbeat_loop(self) -> None:
-        """
-        Periodically re-send the last composed frame when idle.
-        Active only if FRIGATE_BIRDSEYE_IDLE_FPS > 0.
-        """
-        # Small sleep granularity to check often without busy-spinning.
-        min_sleep = 0.2
-        while not self.stop_event.is_set():
-            try:
-                if self._idle_interval:
-                    now = datetime.datetime.now().timestamp()
-                    if (now - self.birdseye_manager.last_output_time) >= self._idle_interval:
-                        self.__send_new_frame()
-            finally:
-                # Sleep at the smaller of idle interval or a safe minimum
-                sleep_for = self._idle_interval if self._idle_interval and self._idle_interval < min_sleep else min_sleep
-                time.sleep(sleep_for)
+        if self._idle_interval:
+            now = time.monotonic()
+            is_idle = (len(self.birdseye_manager.camera_layout) == 0)
+            if is_idle and (now - self.birdseye_manager.last_output_time) >= self._idle_interval:
+                self.__send_new_frame()
 
     def stop(self) -> None:
         self.converter.join()
         self.broadcaster.join()
-        if self._heartbeat_thread and self._heartbeat_thread.is_alive():
-            # the thread is daemon=True; join a moment just for cleanliness
-            self._heartbeat_thread.join(timeout=0.2)


### PR DESCRIPTION
## Actual need
I have several cameras connected to my frigate instance and I want them to visible in birdseye only when motion occurs (eg. Home alarm trigger and I want to display in my echo shows only the relevant video).
The problem is that when I restream the birdeye video to other system (eg. scrypted, or simply ffplay), the stream is extremely slow to attach (talking about 30/40 seconds). Not a problem for ffplay but for other more sensible devices like Alexa this ends up in an error.
Digging through the code seems that frigate is not pushing frames when in idle, thus resulting in a missing keyframe to start an RTSP feed.

## Proposed change

birdseye: add idle_heartbeat_fps config option to periodically resend last frame

This adds an optional idle heartbeat mechanism to Birdseye. When enabled by setting the idle_heartbeat_fps config variable to a value > 0, Birdseye periodically re-sends the last composed frame when idle (no motion or no active frame updates). This helps downstream consumers such as go2rtc or smart display integrations to attach faster and maintain a low-latency stream during idle periods.

Documentation: added section  in docs/configuration/restream.md.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
