### PR TITLE
Change camera_activity effect to run only when config updates

### DIFF
--- a/web/src/api/ws.tsx
+++ b/web/src/api/ws.tsx
@@ -33,14 +33,9 @@ function useValue(): useValueReturn {
 
   // main state
 
-  const [hasCameraState, setHasCameraState] = useState(false);
   const [wsState, setWsState] = useState<WsState>({});
 
   useEffect(() => {
-    if (hasCameraState) {
-      return;
-    }
-
     const activityValue: string = wsState["camera_activity"] as string;
 
     if (!activityValue) {
@@ -105,12 +100,9 @@ function useValue(): useValueReturn {
       ...cameraStates,
     }));
 
-    if (Object.keys(cameraStates).length > 0) {
-      setHasCameraState(true);
-    }
     // we only want this to run initially when the config is loaded
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wsState]);
+  }, [wsState["camera_activity"]]);
 
   // ws handler
   const { sendJsonMessage, readyState } = useWebSocket(wsUrl, {
@@ -131,9 +123,7 @@ function useValue(): useValueReturn {
         retain: false,
       });
     },
-    onClose: () => {
-      setHasCameraState(false);
-    },
+    onClose: () => {},
     shouldReconnect: () => true,
     retryOnError: true,
   });


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
When adding a new camera via the wizard, the initial states of that camera in the UI showed that it was disabled. This PR changes the `camera_activity` init effect to depend directly on `wsState["camera_activity"]` instead of using a `hasCameraState` flag. This ensures the camera states are populated once when the initial config is loaded, and automatically refreshed when sending an updated `camera_activity` payload (without re-running on every websocket message).


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
