### PR TITLE
Refresh recordings when data is stale

### DIFF
--- a/web/src/components/player/dynamic/DynamicVideoController.ts
+++ b/web/src/components/player/dynamic/DynamicVideoController.ts
@@ -62,6 +62,10 @@ export class DynamicVideoController {
     this.playerController.pause();
   }
 
+  isPlaying(): boolean {
+    return !this.playerController.paused && !this.playerController.ended;
+  }
+
   seekToTimestamp(time: number, play: boolean = false) {
     if (time < this.timeRange.after || time > this.timeRange.before) {
       this.timeToStart = time;

--- a/web/src/pages/Events.tsx
+++ b/web/src/pages/Events.tsx
@@ -484,6 +484,7 @@ export default function Events() {
           timeRange={selectedTimeRange}
           filter={reviewFilter}
           updateFilter={onUpdateFilter}
+          refreshData={reloadData}
         />
       );
     }

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -68,7 +68,7 @@ import { CameraNameLabel } from "@/components/camera/CameraNameLabel";
 import { useAllowedCameras } from "@/hooks/use-allowed-cameras";
 import { GenAISummaryDialog } from "@/components/overlay/chip/GenAISummaryChip";
 
-const DATA_REFRESH_TIME = 60000; // 1 minute
+const DATA_REFRESH_TIME = 600000; // 10 minutes
 
 type RecordingViewProps = {
   startCamera: string;

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -220,7 +220,7 @@ export function RecordingView({
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [onRefreshNeeded]);
+  }, [refreshData]);
 
   // scrubbing and timeline state
 

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -68,6 +68,8 @@ import { CameraNameLabel } from "@/components/camera/CameraNameLabel";
 import { useAllowedCameras } from "@/hooks/use-allowed-cameras";
 import { GenAISummaryDialog } from "@/components/overlay/chip/GenAISummaryChip";
 
+const DATA_REFRESH_TIME = 60000; // 1 minute
+
 type RecordingViewProps = {
   startCamera: string;
   startTime: number;
@@ -203,9 +205,15 @@ export function RecordingView({
       if (document.visibilityState === "visible") {
         const now = Date.now();
         const timeSinceLastVisible = now - lastVisibilityTime.current;
-        const tenMinutesInMs = 10 * 60 * 1000;
 
-        if (timeSinceLastVisible >= tenMinutesInMs && refreshData) {
+        // Only refresh if user was away for a while
+        // and the video is not currently playing
+        if (
+          timeSinceLastVisible >= DATA_REFRESH_TIME &&
+          refreshData &&
+          mainControllerRef.current &&
+          !mainControllerRef.current.isPlaying()
+        ) {
           refreshData();
         }
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

when a user unfocuses the browser window while on the RecordingsView for a considerable amount of time, when they come back the data will be stale requiring a refresh. If the window is not interacted with for 10 minute then and a refocus happens then the data will be refreshed to be up to date.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: closes #20049 
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
