### PR TITLE
Change clean snapshots from png to webp format

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -574,7 +574,7 @@ record:
 snapshots:
   # Optional: Enable writing jpg snapshot to /media/frigate/clips (default: shown below)
   enabled: False
-  # Optional: save a clean PNG copy of the snapshot image (default: shown below)
+  # Optional: save a clean copy of the snapshot image (default: shown below)
   clean_copy: True
   # Optional: print a timestamp on the snapshots (default: shown below)
   timestamp: False

--- a/docs/static/frigate-api.yaml
+++ b/docs/static/frigate-api.yaml
@@ -4077,7 +4077,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /events/{event_id}/snapshot-clean.png:
+  /events/{event_id}/snapshot-clean.webp:
     get:
       tags:
         - Media

--- a/frigate/camera/state.py
+++ b/frigate/camera/state.py
@@ -531,7 +531,7 @@ class CameraState:
         # write clean snapshot if enabled
         if self.camera_config.snapshots.clean_copy:
             ret, webp = cv2.imencode(
-                ".webp", img_frame, [int(cv2.IMWRITE_WEBP_QUALITY), 60]
+                ".webp", img_frame, [int(cv2.IMWRITE_WEBP_QUALITY), 80]
             )
 
             if ret:

--- a/frigate/camera/state.py
+++ b/frigate/camera/state.py
@@ -530,17 +530,19 @@ class CameraState:
 
         # write clean snapshot if enabled
         if self.camera_config.snapshots.clean_copy:
-            ret, png = cv2.imencode(".png", img_frame)
+            ret, webp = cv2.imencode(
+                ".webp", img_frame, [int(cv2.IMWRITE_WEBP_QUALITY), 60]
+            )
 
             if ret:
                 with open(
                     os.path.join(
                         CLIPS_DIR,
-                        f"{self.camera_config.name}-{event_id}-clean.png",
+                        f"{self.camera_config.name}-{event_id}-clean.webp",
                     ),
                     "wb",
                 ) as p:
-                    p.write(png.tobytes())
+                    p.write(webp.tobytes())
 
         # write jpg snapshot with optional annotations
         if draw.get("boxes") and isinstance(draw.get("boxes"), list):

--- a/frigate/events/cleanup.py
+++ b/frigate/events/cleanup.py
@@ -230,6 +230,11 @@ class EventCleanup(threading.Thread):
                 media_path.unlink(missing_ok=True)
                 if file_extension == "jpg":
                     media_path = Path(
+                        f"{os.path.join(CLIPS_DIR, media_name)}-clean.webp"
+                    )
+                    media_path.unlink(missing_ok=True)
+                    # Also delete clean.png (legacy) for backward compatibility
+                    media_path = Path(
                         f"{os.path.join(CLIPS_DIR, media_name)}-clean.png"
                     )
                     media_path.unlink(missing_ok=True)

--- a/frigate/track/tracked_object.py
+++ b/frigate/track/tracked_object.py
@@ -432,7 +432,7 @@ class TrackedObject:
             _, img = cv2.imencode(f".{ext}", np.zeros((175, 175, 3), np.uint8))
             return img.tobytes()
 
-    def get_clean_png(self) -> bytes | None:
+    def get_clean_webp(self) -> bytes | None:
         if self.thumbnail_data is None:
             return None
 
@@ -443,13 +443,15 @@ class TrackedObject:
             )
         except KeyError:
             logger.warning(
-                f"Unable to create clean png because frame {self.thumbnail_data['frame_time']} is not in the cache"
+                f"Unable to create clean webp because frame {self.thumbnail_data['frame_time']} is not in the cache"
             )
             return None
 
-        ret, png = cv2.imencode(".png", best_frame)
+        ret, webp = cv2.imencode(
+            ".webp", best_frame, [int(cv2.IMWRITE_WEBP_QUALITY), 60]
+        )
         if ret:
-            return png.tobytes()
+            return webp.tobytes()
         else:
             return None
 
@@ -583,8 +585,8 @@ class TrackedObject:
 
         # write clean snapshot if enabled
         if snapshot_config.clean_copy:
-            png_bytes = self.get_clean_png()
-            if png_bytes is None:
+            webp_bytes = self.get_clean_webp()
+            if webp_bytes is None:
                 logger.warning(
                     f"Unable to save clean snapshot for {self.obj_data['id']}."
                 )
@@ -592,11 +594,11 @@ class TrackedObject:
                 with open(
                     os.path.join(
                         CLIPS_DIR,
-                        f"{self.camera_config.name}-{self.obj_data['id']}-clean.png",
+                        f"{self.camera_config.name}-{self.obj_data['id']}-clean.webp",
                     ),
                     "wb",
                 ) as p:
-                    p.write(png_bytes)
+                    p.write(webp_bytes)
 
     def write_thumbnail_to_disk(self) -> None:
         if not self.camera_config.name:

--- a/frigate/util/path.py
+++ b/frigate/util/path.py
@@ -42,6 +42,9 @@ def delete_event_snapshot(event: Event) -> bool:
 
     try:
         media_path.unlink(missing_ok=True)
+        media_path = Path(f"{os.path.join(CLIPS_DIR, media_name)}-clean.webp")
+        media_path.unlink(missing_ok=True)
+        # also delete clean.png (legacy) for backward compatibility
         media_path = Path(f"{os.path.join(CLIPS_DIR, media_name)}-clean.png")
         media_path.unlink(missing_ok=True)
         return True


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR migrates clean snapshot images from png to webp format for better compression and modern web compatibility. New clean snapshots are now saved as webp files, while existing png files are automatically converted to webp on-demand and cached for future requests. All API endpoints, cleanup functions, and documentation have been updated to handle both formats seamlessly for backward compatibility with existing data.

This should provide significant storage savings for users that save clean snapshots as webp files are significantly smaller than png. Example:

```
$ ls -lh drivewaycamdev-1760308240.461059-k54e96-clean.*
-rw-r--r-- 1 vscode vscode 2.1M Oct 12 17:31 drivewaycamdev-1760308240.461059-k54e96-clean.png
-rw-r--r-- 1 vscode vscode 209K Oct 14 07:44 drivewaycamdev-1760308240.461059-k54e96-clean.webp
```

While it likely won't affect many users, the breaking change is that the API endpoint `/events/{event_id}/snapshot-clean.png` is now deprecated and should be replaced with `/events/{event_id}/snapshot-clean.webp`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
