### PR TITLE
Add ability to download on demand snapshots

### DIFF
--- a/web/public/locales/en/views/live.json
+++ b/web/public/locales/en/views/live.json
@@ -73,6 +73,12 @@
     "enable": "Enable Snapshots",
     "disable": "Disable Snapshots"
   },
+  "snapshot": {
+    "takeSnapshot": "Download instant snapshot",
+    "noVideoSource": "No video source available for snapshot.",
+    "captureFailed": "Failed to capture snapshot.",
+    "downloadStarted": "Snapshot download started."
+  },
   "audioDetect": {
     "enable": "Enable Audio Detect",
     "disable": "Disable Audio Detect"
@@ -90,8 +96,8 @@
     "disable": "Hide Stream Stats"
   },
   "manualRecording": {
-    "title": "On-Demand Recording",
-    "tips": "Start a manual event based on this camera's recording retention settings.",
+    "title": "On-Demand",
+    "tips": "Download an instant snapshot or start a manual event based on this camera's recording retention settings.",
     "playInBackground": {
       "label": "Play in background",
       "desc": "Enable this option to continue streaming when the player is hidden."

--- a/web/src/components/dynamic/CameraFeatureToggle.tsx
+++ b/web/src/components/dynamic/CameraFeatureToggle.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/ui/tooltip";
 import { isDesktop } from "react-device-detect";
 import { cn } from "@/lib/utils";
+import ActivityIndicator from "../indicators/activity-indicator";
 
 const variants = {
   primary: {
@@ -30,7 +31,8 @@ type CameraFeatureToggleProps = {
   Icon: IconType;
   title: string;
   onClick?: () => void;
-  disabled?: boolean; // New prop for disabling
+  disabled?: boolean;
+  loading?: boolean;
 };
 
 export default function CameraFeatureToggle({
@@ -40,7 +42,8 @@ export default function CameraFeatureToggle({
   Icon,
   title,
   onClick,
-  disabled = false, // Default to false
+  disabled = false,
+  loading = false,
 }: CameraFeatureToggleProps) {
   const content = (
     <div
@@ -53,16 +56,20 @@ export default function CameraFeatureToggle({
         className,
       )}
     >
-      <Icon
-        className={cn(
-          "size-5 md:m-[6px]",
-          disabled
-            ? "text-gray-400"
-            : isActive
-              ? "text-white"
-              : "text-secondary-foreground",
-        )}
-      />
+      {loading ? (
+        <ActivityIndicator className="size-5 md:m-[6px]" />
+      ) : (
+        <Icon
+          className={cn(
+            "size-5 md:m-[6px]",
+            disabled
+              ? "text-gray-400"
+              : isActive
+                ? "text-white"
+                : "text-secondary-foreground",
+          )}
+        />
+      )}
     </div>
   );
 

--- a/web/src/utils/snapshotUtil.ts
+++ b/web/src/utils/snapshotUtil.ts
@@ -1,0 +1,163 @@
+import { baseUrl } from "@/api/baseUrl";
+
+type SnapshotResponse = {
+  dataUrl: string;
+  blob: Blob;
+  contentType: string;
+};
+
+export type SnapshotResult =
+  | {
+      success: true;
+      data: SnapshotResponse;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+export async function fetchCameraSnapshot(
+  name: string,
+): Promise<SnapshotResult> {
+  try {
+    const url = `${baseUrl}api/${encodeURIComponent(name)}/latest.jpg`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `Snapshot request failed with status ${response.status}`,
+      };
+    }
+
+    const blob = await response.blob();
+
+    if (!blob || blob.size === 0) {
+      return {
+        success: false,
+        error: "Snapshot response was empty",
+      };
+    }
+
+    const dataUrl = await blobToDataUrl(blob);
+    const contentType = response.headers.get("content-type") ?? `image/jpeg`;
+
+    return {
+      success: true,
+      data: {
+        dataUrl,
+        blob,
+        contentType,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error occurred",
+    };
+  }
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onloadend = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Failed to convert blob to data URL"));
+      }
+    };
+
+    reader.onerror = () => {
+      reject(reader.error ?? new Error("Failed to read snapshot blob"));
+    };
+
+    reader.readAsDataURL(blob);
+  });
+}
+
+export function downloadSnapshot(dataUrl: string, filename: string): void {
+  try {
+    const link = document.createElement("a");
+    link.href = dataUrl;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`Failed to download snapshot for ${filename}:`, error);
+  }
+}
+
+export function generateSnapshotFilename(cameraName: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, -5);
+  return `${cameraName}_snapshot_${timestamp}.jpg`;
+}
+
+export async function grabVideoSnapshot(): Promise<SnapshotResult> {
+  try {
+    // Find the video element in the player
+    const videoElement = document.querySelector(
+      "#player-container video",
+    ) as HTMLVideoElement;
+
+    if (!videoElement) {
+      return {
+        success: false,
+        error: "Video element not found",
+      };
+    }
+
+    const width = videoElement.videoWidth;
+    const height = videoElement.videoHeight;
+
+    if (width === 0 || height === 0) {
+      return {
+        success: false,
+        error: "Video element has no dimensions",
+      };
+    }
+
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+
+    const context = canvas.getContext("2d");
+
+    if (!context) {
+      return {
+        success: false,
+        error: "Failed to get canvas context",
+      };
+    }
+
+    context.drawImage(videoElement, 0, 0, width, height);
+    const dataUrl = canvas.toDataURL("image/jpeg", 0.9);
+
+    // Convert data URL to blob
+    const response = await fetch(dataUrl);
+    const blob = await response.blob();
+
+    return {
+      success: true,
+      data: {
+        dataUrl,
+        blob,
+        contentType: "image/jpeg",
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error occurred",
+    };
+  }
+}


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR adds the a button to single camera Live view to capture and download a jpeg snapshot of the currently viewed stream. It uses DOM capture for MSE/WebRTC players and an API call to `latest.jpg` for jsmpeg players.

This covers the basic use case of https://github.com/blakeblackshear/frigate/issues/20334

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
