### PR TITLE
Ensure that a user must provide an image in an expected location

### DIFF
--- a/frigate/api/export.py
+++ b/frigate/api/export.py
@@ -16,7 +16,7 @@ from frigate.api.auth import require_role
 from frigate.api.defs.request.export_recordings_body import ExportRecordingsBody
 from frigate.api.defs.request.export_rename_body import ExportRenameBody
 from frigate.api.defs.tags import Tags
-from frigate.const import EXPORT_DIR
+from frigate.const import CLIPS_DIR, EXPORT_DIR
 from frigate.models import Export, Previews, Recordings
 from frigate.record.export import (
     PlaybackFactorEnum,
@@ -58,7 +58,7 @@ def export_recording(
     existing_image = sanitize_filepath(body.image_path) if body.image_path else None
 
     # Ensure that existing_image is a valid path
-    if existing_image and not existing_image.startswith("/media/frigate/clips/"):
+    if existing_image and not existing_image.startswith(CLIPS_DIR):
         return JSONResponse(
             content=({"success": False, "message": "Invalid image path"}),
             status_code=400,


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

A user could call the export API but enter an arbitrary path, not required to me an image file, and then read those contents. 

NOTE: This still required authentication / access

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
