### PR TITLE
Improve recording retention logic

### DIFF
--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -25,9 +25,11 @@ record:
   alerts:
     retain:
       days: 30
+      mode: all
   detections:
     retain:
       days: 30
+      mode: all
 ```
 
 ### Reduced storage: Only saving video when motion is detected
@@ -42,9 +44,11 @@ record:
   alerts:
     retain:
       days: 30
+      mode: motion
   detections:
     retain:
       days: 30
+      mode: motion
 ```
 
 ### Minimum: Alerts only
@@ -59,6 +63,7 @@ record:
   alerts:
     retain:
       days: 30
+      mode: motion
 ```
 
 ## Will Frigate delete old recordings if my storage runs out?

--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -25,16 +25,14 @@ record:
   alerts:
     retain:
       days: 30
-      mode: motion
   detections:
     retain:
       days: 30
-      mode: motion
 ```
 
 ### Reduced storage: Only saving video when motion is detected
 
-In order to reduce storage requirements, you can adjust your config to only retain video where motion was detected.
+In order to reduce storage requirements, you can adjust your config to only retain video where motion / activity was detected.
 
 ```yaml
 record:
@@ -44,16 +42,14 @@ record:
   alerts:
     retain:
       days: 30
-      mode: motion
   detections:
     retain:
       days: 30
-      mode: motion
 ```
 
 ### Minimum: Alerts only
 
-If you only want to retain video that occurs during a tracked object, this config will discard video unless an alert is ongoing.
+If you only want to retain video that occurs during activity caused by tracked object(s), this config will discard video unless an alert is ongoing.
 
 ```yaml
 record:
@@ -63,7 +59,6 @@ record:
   alerts:
     retain:
       days: 30
-      mode: motion
 ```
 
 ## Will Frigate delete old recordings if my storage runs out?

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -537,7 +537,7 @@ record:
     # Optional: Retention settings for recordings of alerts
     retain:
       # Required: Retention days (default: shown below)
-      days: 14
+      days: 10
       # Optional: Mode for retention. (default: shown below)
       #   all - save all recording segments for alerts regardless of activity
       #   motion - save all recordings segments for alerts with any detected motion
@@ -547,7 +547,7 @@ record:
       #       here, the segments will already be gone by the time this mode is applied.
       #       For example, if the camera retain mode is "motion", the segments without motion are
       #       never stored, so setting the mode to "all" here won't bring them back.
-      mode: motion
+      mode: all
   # Optional: detection recording settings
   detections:
     # Optional: Number of seconds before the detection to include (default: shown below)
@@ -557,7 +557,7 @@ record:
     # Optional: Retention settings for recordings of detections
     retain:
       # Required: Retention days (default: shown below)
-      days: 14
+      days: 10
       # Optional: Mode for retention. (default: shown below)
       #   all - save all recording segments for detections regardless of activity
       #   motion - save all recordings segments for detections with any detected motion
@@ -567,7 +567,7 @@ record:
       #       here, the segments will already be gone by the time this mode is applied.
       #       For example, if the camera retain mode is "motion", the segments without motion are
       #       never stored, so setting the mode to "all" here won't bring them back.
-      mode: motion
+      mode: all
 
 # Optional: Configuration for the jpg snapshots written to the clips directory for each tracked object
 # NOTE: Can be overridden at the camera level

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -547,7 +547,7 @@ record:
       #       here, the segments will already be gone by the time this mode is applied.
       #       For example, if the camera retain mode is "motion", the segments without motion are
       #       never stored, so setting the mode to "all" here won't bring them back.
-      mode: all
+      mode: motion
   # Optional: detection recording settings
   detections:
     # Optional: Number of seconds before the detection to include (default: shown below)
@@ -567,7 +567,7 @@ record:
       #       here, the segments will already be gone by the time this mode is applied.
       #       For example, if the camera retain mode is "motion", the segments without motion are
       #       never stored, so setting the mode to "all" here won't bring them back.
-      mode: all
+      mode: motion
 
 # Optional: Configuration for the jpg snapshots written to the clips directory for each tracked object
 # NOTE: Can be overridden at the camera level

--- a/frigate/config/camera/record.py
+++ b/frigate/config/camera/record.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from pydantic import Field
-R
+
 from frigate.const import MAX_PRE_CAPTURE
 from frigate.review.types import SeverityEnum
 

--- a/frigate/config/camera/record.py
+++ b/frigate/config/camera/record.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from pydantic import Field
-
+R
 from frigate.const import MAX_PRE_CAPTURE
 from frigate.review.types import SeverityEnum
 
@@ -34,7 +34,7 @@ class RetainModeEnum(str, Enum):
 
 class ReviewRetainConfig(FrigateBaseModel):
     days: float = Field(default=10, ge=0, title="Default retention period.")
-    mode: RetainModeEnum = Field(default=RetainModeEnum.all, title="Retain mode.")
+    mode: RetainModeEnum = Field(default=RetainModeEnum.motion, title="Retain mode.")
 
 
 class EventsConfig(FrigateBaseModel):

--- a/frigate/config/camera/record.py
+++ b/frigate/config/camera/record.py
@@ -34,7 +34,7 @@ class RetainModeEnum(str, Enum):
 
 class ReviewRetainConfig(FrigateBaseModel):
     days: float = Field(default=10, ge=0, title="Default retention period.")
-    mode: RetainModeEnum = Field(default=RetainModeEnum.motion, title="Retain mode.")
+    mode: RetainModeEnum = Field(default=RetainModeEnum.all, title="Retain mode.")
 
 
 class EventsConfig(FrigateBaseModel):

--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -180,7 +180,11 @@ class RecordingCleanup(threading.Thread):
             # Delete recordings outside of the retention window or based on the retention mode
             if (
                 not keep
-                or (mode == RetainModeEnum.motion and recording.motion == 0)
+                or (
+                    mode == RetainModeEnum.motion
+                    and recording.motion == 0
+                    and recording.objects == 0
+                )
                 or (mode == RetainModeEnum.active_objects and recording.objects == 0)
             ):
                 Path(recording.path).unlink(missing_ok=True)

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -348,63 +348,10 @@ class RecordingMaintainer(threading.Thread):
         elif record_config.motion.days > 0:
             highest = "motion"
 
-        # continuous / motion recording is not enabled
-        if highest is None:
-            # if the cached segment overlaps with the review items:
-            overlaps = False
-            for review in reviews:
-                severity = SeverityEnum[review.severity]
-
-                # if the review item starts in the future, stop checking review items
-                # and remove this segment
-                if (
-                    review.start_time - record_config.get_review_pre_capture(severity)
-                ) > end_time.timestamp():
-                    overlaps = False
-                    break
-
-                # if the review item is in progress or ends after the recording starts, keep it
-                # and stop looking at review items
-                if (
-                    review.end_time is None
-                    or (
-                        review.end_time
-                        + record_config.get_review_post_capture(severity)
-                    )
-                    >= start_time.timestamp()
-                ):
-                    overlaps = True
-                    break
-
-            if overlaps:
-                record_mode = (
-                    record_config.alerts.retain.mode
-                    if review.severity == "alert"
-                    else record_config.detections.retain.mode
-                )
-                # move from cache to recordings immediately
-                return await self.move_segment(
-                    camera,
-                    start_time,
-                    end_time,
-                    duration,
-                    cache_path,
-                    record_mode,
-                )
-            # if it doesn't overlap with an review item, go ahead and drop the segment
-            # if it ends more than the configured pre_capture for the camera
-            else:
-                camera_info = self.object_recordings_info[camera]
-                most_recently_processed_frame_time = (
-                    camera_info[-1][0] if len(camera_info) > 0 else 0
-                )
-                retain_cutoff = datetime.datetime.fromtimestamp(
-                    most_recently_processed_frame_time - record_config.event_pre_capture
-                ).astimezone(datetime.timezone.utc)
-                if end_time < retain_cutoff:
-                    self.drop_segment(cache_path)
-        # continuous / motion is enabled
-        else:
+        # if we have continuous or motion recording enabled
+        # we should first just check if this segment matches that
+        # and avoid any DB calls
+        if highest is not None:
             # assume that empty means the relevant recording info has not been received yet
             camera_info = self.object_recordings_info[camera]
             most_recently_processed_frame_time = (
@@ -426,6 +373,61 @@ class RecordingMaintainer(threading.Thread):
                 return await self.move_segment(
                     camera, start_time, end_time, duration, cache_path, record_mode
                 )
+
+        # we fell through the continuous / motion check, so we need to check the review items
+        # if the cached segment overlaps with the review items:
+        overlaps = False
+        for review in reviews:
+            severity = SeverityEnum[review.severity]
+
+            # if the review item starts in the future, stop checking review items
+            # and remove this segment
+            if (
+                review.start_time - record_config.get_review_pre_capture(severity)
+            ) > end_time.timestamp():
+                overlaps = False
+                break
+
+            # if the review item is in progress or ends after the recording starts, keep it
+            # and stop looking at review items
+            if (
+                review.end_time is None
+                or (
+                    review.end_time
+                    + record_config.get_review_post_capture(severity)
+                )
+                >= start_time.timestamp()
+            ):
+                overlaps = True
+                break
+
+        if overlaps:
+            record_mode = (
+                record_config.alerts.retain.mode
+                if review.severity == "alert"
+                else record_config.detections.retain.mode
+            )
+            # move from cache to recordings immediately
+            return await self.move_segment(
+                camera,
+                start_time,
+                end_time,
+                duration,
+                cache_path,
+                record_mode,
+            )
+        # if it doesn't overlap with an review item, go ahead and drop the segment
+        # if it ends more than the configured pre_capture for the camera
+        else:
+            camera_info = self.object_recordings_info[camera]
+            most_recently_processed_frame_time = (
+                camera_info[-1][0] if len(camera_info) > 0 else 0
+            )
+            retain_cutoff = datetime.datetime.fromtimestamp(
+                most_recently_processed_frame_time - record_config.event_pre_capture
+            ).astimezone(datetime.timezone.utc)
+            if end_time < retain_cutoff:
+                self.drop_segment(cache_path)
 
     def segment_stats(
         self, camera: str, start_time: datetime.datetime, end_time: datetime.datetime

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -57,14 +57,25 @@ class SegmentInfo:
         self.average_dBFS = average_dBFS
 
     def should_discard_segment(self, retain_mode: RetainModeEnum) -> bool:
-        return (
-            retain_mode == RetainModeEnum.motion
-            and self.motion_count == 0
-            and self.average_dBFS == 0
-        ) or (
-            retain_mode == RetainModeEnum.active_objects
-            and self.active_object_count == 0
-        )
+        keep = False
+
+        # all mode should never discard
+        if retain_mode == RetainModeEnum.all:
+            keep = True
+
+        # motion mode should keep if motion or audio is detected
+        if (
+            not keep
+            and retain_mode == RetainModeEnum.motion
+            and (self.motion_count > 0 or self.average_dBFS > 0)
+        ):
+            keep = True
+
+        # active objects mode should keep if any active objects are detected
+        if not keep and self.active_object_count > 0:
+            keep = True
+
+        return not keep
 
 
 class RecordingMaintainer(threading.Thread):

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -392,10 +392,7 @@ class RecordingMaintainer(threading.Thread):
             # and stop looking at review items
             if (
                 review.end_time is None
-                or (
-                    review.end_time
-                    + record_config.get_review_post_capture(severity)
-                )
+                or (review.end_time + record_config.get_review_post_capture(severity))
                 >= start_time.timestamp()
             ):
                 overlaps = True
@@ -418,7 +415,8 @@ class RecordingMaintainer(threading.Thread):
             )
         # if it doesn't overlap with an review item, go ahead and drop the segment
         # if it ends more than the configured pre_capture for the camera
-        else:
+        # BUT only if continuous/motion is NOT enabled (otherwise wait for processing)
+        elif highest is None:
             camera_info = self.object_recordings_info[camera]
             most_recently_processed_frame_time = (
                 camera_info[-1][0] if len(camera_info) > 0 else 0

--- a/frigate/test/test_record_retention.py
+++ b/frigate/test/test_record_retention.py
@@ -12,11 +12,11 @@ class TestRecordRetention(unittest.TestCase):
         assert not segment_info.should_discard_segment(RetainModeEnum.motion)
         assert segment_info.should_discard_segment(RetainModeEnum.active_objects)
 
-    def test_object_should_keep_object_not_motion(self):
+    def test_object_should_keep_object_when_motion(self):
         segment_info = SegmentInfo(
             motion_count=0, active_object_count=1, region_count=0, average_dBFS=0
         )
-        assert segment_info.should_discard_segment(RetainModeEnum.motion)
+        assert not segment_info.should_discard_segment(RetainModeEnum.motion)
         assert not segment_info.should_discard_segment(RetainModeEnum.active_objects)
 
     def test_all_should_keep_all(self):

--- a/web/public/locales/en/views/live.json
+++ b/web/public/locales/en/views/live.json
@@ -165,8 +165,7 @@
       "all": "All",
       "motion": "Motion",
       "active_objects": "Active Objects"
-    },
-    "notAllTips": "Your {{source}} recording retention configuration is set to <code>mode: {{effectiveRetainMode}}</code>, so this on-demand recording will only keep segments with {{effectiveRetainModeName}}."
+    }
   },
   "editLayout": {
     "label": "Edit Layout",

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -712,42 +712,6 @@ export default function LiveCameraView({
   );
 }
 
-function OnDemandRetentionMessage({ camera }: { camera: CameraConfig }) {
-  const { t } = useTranslation(["views/live", "views/events"]);
-  const rankMap = { all: 0, motion: 1, active_objects: 2 };
-  const getValidMode = (retain?: { mode?: string }): keyof typeof rankMap => {
-    const mode = retain?.mode;
-    return mode && mode in rankMap ? (mode as keyof typeof rankMap) : "all";
-  };
-
-  const recordRetainMode = getValidMode(camera.record.retain);
-  const alertsRetainMode = getValidMode(camera.review.alerts.retain);
-
-  const effectiveRetainMode =
-    rankMap[alertsRetainMode] < rankMap[recordRetainMode]
-      ? recordRetainMode
-      : alertsRetainMode;
-
-  const source = effectiveRetainMode === recordRetainMode ? "camera" : "alerts";
-
-  return effectiveRetainMode !== "all" ? (
-    <div>
-      <Trans
-        ns="views/live"
-        values={{
-          source,
-          effectiveRetainMode,
-          effectiveRetainModeName: t(
-            "effectiveRetainMode.modes." + effectiveRetainMode,
-          ),
-        }}
-      >
-        effectiveRetainMode.notAllTips
-      </Trans>
-    </div>
-  ) : null;
-}
-
 type FrigateCameraFeaturesProps = {
   camera: CameraConfig;
   recordingEnabled: boolean;
@@ -841,11 +805,10 @@ function FrigateCameraFeatures({
         const toastId = toast.success(
           <div className="flex flex-col space-y-3">
             <div className="font-semibold">{t("manualRecording.started")}</div>
-            {!camera.record.enabled || camera.record.alerts.retain.days == 0 ? (
-              <div>{t("manualRecording.recordDisabledTips")}</div>
-            ) : (
-              <OnDemandRetentionMessage camera={camera} />
-            )}
+            {!camera.record.enabled ||
+              (camera.record.alerts.retain.days == 0 && (
+                <div>{t("manualRecording.recordDisabledTips")}</div>
+              ))}
           </div>,
           {
             position: "top-center",

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -108,7 +108,7 @@ import axios from "axios";
 import { toast } from "sonner";
 import { Toaster } from "@/components/ui/sonner";
 import { useIsAdmin } from "@/hooks/use-is-admin";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { useDocDomain } from "@/hooks/use-doc-domain";
 import PtzControlPanel from "@/components/overlay/PtzControlPanel";
 import ObjectSettingsView from "../settings/ObjectSettingsView";


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Currently, recording maintenance is handled as an either / or approach. Either the segment qualifies for continuous / motion or it qualifies for review. This does not match optimal behavior where we check all valid reasons to keep a recording segment regardless of the specific config. This implementation still maintains optimal approach of avoiding DB calls when not necessary.

This also makes the `mode` a hierarchy, meaning that `motion` will include active objects too. Making sure that on_demand review items are retained for recordings.

Also fixes some documentation items that were inaccurate

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
