### PR TITLE
Enforce at least one letter in zone names in the UI editor

### DIFF
--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -385,7 +385,8 @@
           "mustNotBeSameWithCamera": "Zone name must not be the same as camera name.",
           "alreadyExists": "A zone with this name already exists for this camera.",
           "mustNotContainPeriod": "Zone name must not contain periods.",
-          "hasIllegalCharacter": "Zone name contains illegal characters."
+          "hasIllegalCharacter": "Zone name contains illegal characters.",
+          "mustHaveAtLeastOneLetter": "Zone name must have at least one letter."
         }
       },
       "distance": {
@@ -443,7 +444,7 @@
       "name": {
         "title": "Name",
         "inputPlaceHolder": "Enter a name…",
-        "tips": "Name must be at least 2 characters and must not be the name of a camera or another zone."
+        "tips": "Name must be at least 2 characters, must have at least one letter, and must not be the name of a camera or another zone."
       },
       "inertia": {
         "title": "Inertia",

--- a/web/src/components/settings/ZoneEditPane.tsx
+++ b/web/src/components/settings/ZoneEditPane.tsx
@@ -149,6 +149,11 @@ export default function ZoneEditPane({
         )
         .refine((value: string) => /^[a-zA-Z0-9_-]+$/.test(value), {
           message: t("masksAndZones.form.zoneName.error.hasIllegalCharacter"),
+        })
+        .refine((value: string) => /[a-zA-Z]/.test(value), {
+          message: t(
+            "masksAndZones.form.zoneName.error.mustHaveAtLeastOneLetter",
+          ),
         }),
       inertia: z.coerce
         .number()


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
The Pydantic model for zones is defined as `dict[str, ZoneConfig]`, so a pure number for a zone name would be invalid. This PR requires zone names entered via the UI to have at least one letter. 


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/20556
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
