### PR TITLE
Docs: Fix indentation in getting_started.md

### DIFF
--- a/docs/docs/guides/getting_started.md
+++ b/docs/docs/guides/getting_started.md
@@ -282,10 +282,11 @@ cameras:
         - path: rtsp://10.0.10.10:554/high_res_stream # <----- Add stream you want to record from
           roles:
             - record
-    detect: ...
-    record: # <----- Enable recording
-      enabled: True
-    motion: ...
+
+detect: ...
+record: # <----- Enable recording
+   enabled: True
+motion: ...
 ```
 
 If you don't have separate streams for detect and record, you would just add the record role to the list on the first input.


### PR DESCRIPTION
For *Step 6: Enable recordings* the `detect`, `motion` and `record` keys were nested within `cameras` whereas they should be on the same level (at least according to docs/configuration.reference.md).

## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- ~This PR fixes or closes issue: fixes #~
- ~This PR is related to issue:~

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] ~UI changes including text have used i18n keys and have been added to the `en` locale.~
- [ ] ~The code has been formatted using Ruff (`ruff format frigate`)~
