### PR TITLE
Fix for gamma disable env var

### DIFF
--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -246,7 +246,7 @@ def parse_preset_hardware_acceleration_scale(
         ",hwdownload,format=nv12,eq=gamma=1.4:gamma_weight=0.5" in scale
         and os.environ.get("FFMPEG_DISABLE_GAMMA_EQUALIZER") is not None
     ):
-        scale.replace(
+        scale = scale.replace(
             ",hwdownload,format=nv12,eq=gamma=1.4:gamma_weight=0.5",
             ":format=nv12,hwdownload,format=nv12,format=yuv420p",
         )


### PR DESCRIPTION
### Proposed change
Fix the FFMPEG gamma-equalizer disable path so that setting the environment variable actually removes the CPU-heavy gamma filter from the detect scaling chain.

Details:
- In `parse_preset_hardware_acceleration_scale`, `str.replace(...)` was called without assignment. Since Python strings are immutable, the call had no effect, so `FFMPEG_DISABLE_GAMMA_EQUALIZER` did not work.
- Change assigns the replaced string back to `scale`, ensuring the filter segment `,hwdownload,format=nv12,eq=gamma=1.4:gamma_weight=0.5` is removed when `FFMPEG_DISABLE_GAMMA_EQUALIZER` is set, and replaced with a neutral format chain `:format=nv12,hwdownload,format=nv12,format=yuv420p`.
- Default behavior is unchanged when the env var is not set.
- Practical impact: lower CPU usage in the detect pipeline when users opt-in via the env var.

### Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

### Additional information
- This PR fixes or closes issue: fixes N/A
- This PR is related to issue: N/A
- Affected area: detect pipeline scaling chain across hwaccel presets that include the gamma equalizer.

### Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`).
