### PR TITLE
Add login page docs hint

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -274,6 +274,18 @@ http {
                 include proxy.conf;
             }
 
+            # Allow unauthenticated access to the first_time_login endpoint
+            # so the login page can load help text before authentication.
+            location /api/auth/first_time_login {
+                auth_request off;
+                limit_except GET {
+                    deny all;
+                }
+                rewrite ^/api(/.*)$ $1 break;
+                proxy_pass http://frigate_api;
+                include proxy.conf;
+            }
+
             location /api/stats {
                 include auth_request.conf;
                 access_log off;

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -534,14 +534,9 @@ def login(request: Request, body: AppPostLoginBody):
         )
         # Clear admin_first_time_login flag after successful admin login so the
         # UI stops showing the first-time login documentation link.
-        try:
-            if role == "admin":
-                if getattr(
-                    request.app.frigate_config.auth, "admin_first_time_login", False
-                ):
-                    request.app.frigate_config.auth.admin_first_time_login = False
-        except Exception:
-            logger.exception("Failed to clear admin_first_time_login flag on config")
+        if role == "admin":
+            request.app.frigate_config.auth.admin_first_time_login = False
+
         return response
     return JSONResponse(content={"message": "Login failed"}, status_code=401)
 

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -488,6 +488,8 @@ class FrigateApp:
                     }
                 ).execute()
 
+                self.config.auth.admin_first_time_login = True
+
                 logger.info("********************************************************")
                 logger.info("********************************************************")
                 logger.info("***    Auth is enabled, but no users exist.          ***")

--- a/frigate/config/auth.py
+++ b/frigate/config/auth.py
@@ -38,6 +38,13 @@ class AuthConfig(FrigateBaseModel):
         default_factory=dict,
         title="Role to camera mappings. Empty list grants access to all cameras.",
     )
+    admin_first_time_login: Optional[bool] = Field(
+        default=False,
+        title="Internal field to expose first-time admin login flag to the UI",
+        description=(
+            "When true the UI may show a help link on the login page informing users how to sign in after an admin password reset. "
+        ),
+    )
 
     @field_validator("roles")
     @classmethod

--- a/web/public/locales/en/components/auth.json
+++ b/web/public/locales/en/components/auth.json
@@ -3,6 +3,7 @@
     "user": "Username",
     "password": "Password",
     "login": "Login",
+    "firstTimeLogin": "Trying to log in for the first time? Credentials are printed in the Frigate logs.",
     "errors": {
       "usernameRequired": "Username is required",
       "passwordRequired": "Password is required",


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR implements a card on the login page with a link to the auth docs when users are onboarding for the first time or have `reset_admin_password` enabled in their config. This should help reduce confusion on how to initially log in.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
