### PR TITLE
Always use fmp4 for HLS

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -73,6 +73,8 @@ http {
         vod_manifest_segment_durations_mode accurate;
         vod_ignore_edit_list on;
         vod_segment_duration 10000;
+
+        # MPEG-TS settings (not used when fMP4 is enabled, kept for reference)
         vod_hls_mpegts_align_frames off;
         vod_hls_mpegts_interleave_frames on;
 
@@ -104,6 +106,10 @@ http {
             include auth_request.conf;
             aio threads;
             vod hls;
+
+            # Use fMP4 (fragmented MP4) instead of MPEG-TS for better performance
+            # Smaller segments, faster generation, better browser compatibility
+            vod_hls_segment_container fmp4;
 
             secure_token $args;
             secure_token_types application/vnd.apple.mpegurl;


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Currently, fmp4 is used for H.265 HLS and mpeg-ts is used for H.264. This is inefficient because Frigate already saves the recordings as mp4. Converting to mpeg-ts requires additional CPU for every segment to be demuxed and remuxed. The browser implementation for mpeg-ts is also less efficient leading to higher memory usage and less seeking accuracy.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
