### PR TITLE
Fix script to download yolov9

### DIFF
--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -1534,7 +1534,7 @@ ARG MODEL_SIZE
 ARG IMG_SIZE
 ADD https://github.com/WongKinYiu/yolov9/releases/download/v0.1/yolov9-${MODEL_SIZE}-converted.pt yolov9-${MODEL_SIZE}.pt
 RUN sed -i "s/ckpt = torch.load(attempt_download(w), map_location='cpu')/ckpt = torch.load(attempt_download(w), map_location='cpu', weights_only=False)/g" models/experimental.py
-RUN python3 export.py --weights ./yolov9-${MODEL_SIZE}.pt --imgsz ${IMG_SIZE} --simplify --include onnx
+RUN python3 export.py --weights ./yolov9-${MODEL_SIZE}.pt --imgsz ${IMG_SIZE} --simplify --include onnx --opset 18
 FROM scratch
 ARG MODEL_SIZE
 ARG IMG_SIZE

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -1524,12 +1524,12 @@ YOLOv9 model can be exported as ONNX using the command below. You can copy and p
 ```sh
 docker build . --build-arg MODEL_SIZE=t --build-arg IMG_SIZE=320 --output . -f- <<'EOF'
 FROM python:3.11 AS build
-RUN apt-get update && apt-get install --no-install-recommends -y libgl1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y libgl1 cmake && rm -rf /var/lib/apt/lists/*
 COPY --from=ghcr.io/astral-sh/uv:0.8.0 /uv /bin/
 WORKDIR /yolov9
 ADD https://github.com/WongKinYiu/yolov9.git .
 RUN uv pip install --system -r requirements.txt
-RUN uv pip install --system onnx==1.18.0 onnxruntime onnx-simplifier>=0.4.1 onnxscript
+RUN uv pip install --system onnx==1.18.0 onnxruntime onnxsim>=0.4.1 onnxscript
 ARG MODEL_SIZE
 ARG IMG_SIZE
 ADD https://github.com/WongKinYiu/yolov9/releases/download/v0.1/yolov9-${MODEL_SIZE}-converted.pt yolov9-${MODEL_SIZE}.pt


### PR DESCRIPTION
 ## Proposed change
 cmake missing and unknown package onnx-simplifier, replaced with onnxsim and seems to work.
 
 
 Also changed opset to 18 after getting corrupt models due to
 ```/github/workspace/onnx/version_converter/BaseConverter.h:65: adapter_lookup: Assertion `false` failed: No Adapter To Version $17 for Resize```
 
 Errors I got:
 ```
  > [build  7/10] RUN uv pip install --system onnx==1.18.0 onnxruntime onnx-simplifier>=0.4.1 onnxscript:
0.307 Using Python 3.11.14 environment at: /usr/local
2.652 Resolved 19 packages in 2.34s
2.689 Downloading onnxruntime (14.5MiB)
2.689 Downloading ml-dtypes (4.7MiB)
2.892 Downloading onnx (16.6MiB)
3.388  Downloading ml-dtypes
7.296  Downloading onnxruntime
10.13    Building onnx-simplifier==0.4.36
10.67  Downloading onnx
11.19   × Failed to build `onnx-simplifier==0.4.36`
11.19   ├─▶ The build backend returned an error
11.19   ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit
11.19       status: 1)
11.19
11.19       [stderr]
11.19       <string>:28: DeprecationWarning: Use shutil.which instead of
11.19       find_executable
11.19       fatal: invalid gitfile format: /root/.cache/uv/sdists-v9/.git
11.19       fatal: invalid gitfile format: /root/.cache/uv/sdists-v9/.git
11.19       Traceback (most recent call last):
11.19         File "<string>", line 14, in <module>
11.19         File
11.19       "/root/.cache/uv/builds-v0/.tmpQut3aX/lib/python3.11/site-packages/setuptools/build_meta.py",
11.19       line 331, in get_requires_for_build_wheel
11.19           return self._get_build_requires(config_settings, requirements=[])
11.19                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
11.19         File
11.19       "/root/.cache/uv/builds-v0/.tmpQut3aX/lib/python3.11/site-packages/setuptools/build_meta.py",
11.19       line 301, in _get_build_requires
11.19           self.run_setup()
11.19         File
11.19       "/root/.cache/uv/builds-v0/.tmpQut3aX/lib/python3.11/site-packages/setuptools/build_meta.py",
11.19       line 512, in run_setup
11.19           super().run_setup(setup_script=setup_script)
11.19         File
11.19       "/root/.cache/uv/builds-v0/.tmpQut3aX/lib/python3.11/site-packages/setuptools/build_meta.py",
11.19       line 317, in run_setup
11.19           exec(code, locals())
11.19         File "<string>", line 67, in <module>
11.19       AssertionError: Could not find "cmake" executable!
11.19
11.19       hint: This usually indicates a problem with the package or the build
11.19       environment.
------
```

then

```
 > [build  7/10] RUN uv pip install --system onnx==1.18.0 onnxruntime onnx-simplifier>=0.4.1 onnxscript:
0.251 Using Python 3.11.14 environment at: /usr/local
2.522 Resolved 19 packages in 2.26s
2.559 Downloading onnxruntime (14.5MiB)
2.559 Downloading ml-dtypes (4.7MiB)
2.559 Downloading onnx (16.6MiB)
3.284  Downloading ml-dtypes
9.890  Downloading onnxruntime
10.72  Downloading onnx
11.17    Building onnx-simplifier==0.4.36
117.7   × Failed to download and build `onnx-simplifier==0.4.36`
117.7   ╰─▶ Package metadata name `onnxsim` does not match given name
117.7       `onnx-simplifier`
```



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
