### PR TITLE
Fix History layout for mobile portrait cameras

### DIFF
--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -710,13 +710,12 @@ export function RecordingView({
                       ? "h-full"
                       : "w-full"
                     : cn(
-                        "flex-shrink-0 pt-2",
+                        "flex-shrink-0 portrait:w-full landscape:h-full",
                         mainCameraAspect == "wide"
                           ? "aspect-wide"
                           : mainCameraAspect == "tall"
-                            ? "aspect-tall"
+                            ? "aspect-tall portrait:h-full"
                             : "aspect-video",
-                        "portrait:w-full landscape:h-full",
                       ),
                 )}
                 style={{


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
As a follow-up to the use of flexbox for History view in https://github.com/blakeblackshear/frigate/pull/20662, this PR fixes the layout for portrait cameras on mobile devices. As with desktop, a height-based fit should be what mobile portrait cameras use.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
