### PR TITLE
Add Previous/Next event navigation buttons to recording player

### DIFF
--- a/web/public/locales/en/components/player.json
+++ b/web/public/locales/en/components/player.json
@@ -6,6 +6,10 @@
     "title": "Submit this frame to Frigate+?",
     "submit": "Submit"
   },
+  "eventNavigation": {
+    "previous": "Previous Event",
+    "next": "Next Event"
+  },
   "livePlayerRequiredIOSVersion": "iOS 17.1 or greater is required for this live stream type.",
   "streamOffline": {
     "title": "Stream Offline",

--- a/web/public/locales/en/components/player.json
+++ b/web/public/locales/en/components/player.json
@@ -6,10 +6,6 @@
     "title": "Submit this frame to Frigate+?",
     "submit": "Submit"
   },
-  "eventNavigation": {
-    "previous": "Previous Event",
-    "next": "Next Event"
-  },
   "livePlayerRequiredIOSVersion": "iOS 17.1 or greater is required for this live stream type.",
   "streamOffline": {
     "title": "Stream Offline",

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -49,6 +49,7 @@ type HlsVideoPlayerProps = {
   onTimeUpdate?: (time: number) => void;
   onPlaying?: () => void;
   onSeekToTime?: (timestamp: number, play?: boolean) => void;
+  onJumpToEvent?: (direction: "next" | "previous") => void;
   setFullResolution?: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
   onUploadFrame?: (playTime: number) => Promise<AxiosResponse> | undefined;
   toggleFullscreen?: () => void;
@@ -73,6 +74,7 @@ export default function HlsVideoPlayer({
   onTimeUpdate,
   onPlaying,
   onSeekToTime,
+  onJumpToEvent,
   setFullResolution,
   onUploadFrame,
   toggleFullscreen,
@@ -257,6 +259,7 @@ export default function HlsVideoPlayer({
             playbackRate: true,
             plusUpload: config?.plus?.enabled == true,
             fullscreen: supportsFullscreen,
+            eventNavigation: onJumpToEvent != undefined,
           }}
           setControlsOpen={setControlsOpen}
           setMuted={(muted) => setMuted(muted)}
@@ -296,6 +299,7 @@ export default function HlsVideoPlayer({
               }
             }
           }}
+          onJumpToEvent={onJumpToEvent}
           fullscreen={fullscreen}
           toggleFullscreen={toggleFullscreen}
           containerRef={containerRef}

--- a/web/src/components/player/VideoControls.tsx
+++ b/web/src/components/player/VideoControls.tsx
@@ -100,6 +100,8 @@ export default function VideoControls({
   toggleFullscreen,
   containerRef,
 }: VideoControlsProps) {
+  const { t } = useTranslation(["components/player"]);
+
   // layout
 
   const controlsContainerRef = useRef<HTMLDivElement | null>(null);
@@ -300,7 +302,7 @@ export default function VideoControls({
         <>
           <IoMdSkipBackward
             className="size-5 cursor-pointer"
-            title="Previous Event"
+            title={t("eventNavigation.previous")}
             onClick={(e) => {
               e.stopPropagation();
               onJumpToEvent("previous");
@@ -308,7 +310,7 @@ export default function VideoControls({
           />
           <IoMdSkipForward
             className="size-5 cursor-pointer"
-            title="Next Event"
+            title={t("eventNavigation.next")}
             onClick={(e) => {
               e.stopPropagation();
               onJumpToEvent("next");

--- a/web/src/components/player/VideoControls.tsx
+++ b/web/src/components/player/VideoControls.tsx
@@ -16,6 +16,7 @@ import {
   MdVolumeOff,
   MdVolumeUp,
 } from "react-icons/md";
+import { IoMdSkipBackward, IoMdSkipForward } from "react-icons/io";
 import useKeyboardListener, {
   KeyModifiers,
 } from "@/hooks/use-keyboard-listener";
@@ -41,6 +42,7 @@ type VideoControls = {
   playbackRate?: boolean;
   plusUpload?: boolean;
   fullscreen?: boolean;
+  eventNavigation?: boolean;
 };
 
 const CONTROLS_DEFAULT: VideoControls = {
@@ -49,6 +51,7 @@ const CONTROLS_DEFAULT: VideoControls = {
   playbackRate: true,
   plusUpload: false,
   fullscreen: false,
+  eventNavigation: false,
 };
 const PLAYBACK_RATE_DEFAULT = isSafari ? [0.5, 1, 2] : [0.5, 1, 2, 4, 8, 16];
 const MIN_ITEMS_WRAP = 6;
@@ -71,6 +74,7 @@ type VideoControlsProps = {
   onSeek: (diff: number) => void;
   onSetPlaybackRate: (rate: number) => void;
   onUploadFrame?: () => void;
+  onJumpToEvent?: (direction: "next" | "previous") => void;
   toggleFullscreen?: () => void;
   containerRef?: React.MutableRefObject<HTMLDivElement | null>;
 };
@@ -92,6 +96,7 @@ export default function VideoControls({
   onSeek,
   onSetPlaybackRate,
   onUploadFrame,
+  onJumpToEvent,
   toggleFullscreen,
   containerRef,
 }: VideoControlsProps) {
@@ -290,6 +295,26 @@ export default function VideoControls({
           onUploadFrame={onUploadFrame}
           containerRef={containerRef}
         />
+      )}
+      {features.eventNavigation && onJumpToEvent && (
+        <>
+          <IoMdSkipBackward
+            className="size-5 cursor-pointer"
+            title="Previous Event"
+            onClick={(e) => {
+              e.stopPropagation();
+              onJumpToEvent("previous");
+            }}
+          />
+          <IoMdSkipForward
+            className="size-5 cursor-pointer"
+            title="Next Event"
+            onClick={(e) => {
+              e.stopPropagation();
+              onJumpToEvent("next");
+            }}
+          />
+        </>
       )}
       {features.fullscreen && toggleFullscreen && (
         <div className="cursor-pointer" onClick={toggleFullscreen}>

--- a/web/src/components/player/VideoControls.tsx
+++ b/web/src/components/player/VideoControls.tsx
@@ -302,7 +302,6 @@ export default function VideoControls({
         <>
           <IoMdSkipBackward
             className="size-5 cursor-pointer"
-            title={t("eventNavigation.previous")}
             onClick={(e) => {
               e.stopPropagation();
               onJumpToEvent("previous");
@@ -310,7 +309,6 @@ export default function VideoControls({
           />
           <IoMdSkipForward
             className="size-5 cursor-pointer"
-            title={t("eventNavigation.next")}
             onClick={(e) => {
               e.stopPropagation();
               onJumpToEvent("next");

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -34,6 +34,7 @@ type DynamicVideoPlayerProps = {
   onTimestampUpdate?: (timestamp: number) => void;
   onClipEnded?: () => void;
   onSeekToTime?: (timestamp: number, play?: boolean) => void;
+  onJumpToEvent?: (direction: "next" | "previous") => void;
   setFullResolution: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
   toggleFullscreen: () => void;
   containerRef?: React.MutableRefObject<HTMLDivElement | null>;
@@ -52,6 +53,7 @@ export default function DynamicVideoPlayer({
   onTimestampUpdate,
   onClipEnded,
   onSeekToTime,
+  onJumpToEvent,
   setFullResolution,
   toggleFullscreen,
   containerRef,
@@ -280,6 +282,7 @@ export default function DynamicVideoPlayer({
             onSeekToTime(timestamp, play);
           }
         }}
+        onJumpToEvent={onJumpToEvent}
         onPlaying={() => {
           if (isScrubbing) {
             playerRef.current?.pause();

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -308,7 +308,9 @@ export function RecordingView({
       }
 
       // Sort all events by start time to ensure correct order
-      const sortedEvents = [...mainCameraReviewItems].sort((a, b) => a.start_time - b.start_time);
+      const sortedEvents = [...mainCameraReviewItems].sort(
+        (a, b) => a.start_time - b.start_time,
+      );
 
       // Find which event we're currently viewing
       // Check if current time is between (event start - REVIEW_PADDING) and (event end or start + 60s)
@@ -319,7 +321,7 @@ export function RecordingView({
       });
 
       let targetEvent;
-      
+
       if (currentEventIndex >= 0) {
         // We identified the current event - use index-based navigation
         if (direction === "next") {


### PR DESCRIPTION
## Proposed change

Adds Previous Event and Next Event navigation buttons to the recording player controls, allowing users to quickly jump between review events.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

Adds Previous Event and Next Event navigation buttons to the recording player controls, allowing users to quickly jump between review events.

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
