### PR TITLE
Unify list of objects under dedicated section

### DIFF
--- a/frigate/data_processing/post/review_descriptions.py
+++ b/frigate/data_processing/post/review_descriptions.py
@@ -402,25 +402,25 @@ def run_analysis(
         "duration": round(final_data["end_time"] - final_data["start_time"]),
     }
 
-    objects = []
-    named_objects = []
+    unified_objects = []
 
     objects_list = final_data["data"]["objects"]
     sub_labels_list = final_data["data"]["sub_labels"]
 
+    for i, verified_label in enumerate(final_data["data"]["verified_objects"]):
+        object_type = verified_label.replace("-verified", "").replace("_", " ")
+        name = sub_labels_list[i].replace("_", " ").title()
+        unified_objects.append(f"{name} ({object_type})")
+
+    # Add non-verified objects as "Unknown (type)"
     for label in objects_list:
         if "-verified" in label:
             continue
         elif label in labelmap_objects:
-            objects.append(label.replace("_", " ").title())
+            object_type = label.replace("_", " ")
+            unified_objects.append(f"Unknown ({object_type})")
 
-    for i, verified_label in enumerate(final_data["data"]["verified_objects"]):
-        named_objects.append(
-            f"{sub_labels_list[i].replace('_', ' ').title()} ({verified_label.replace('-verified', '')})"
-        )
-
-    analytics_data["objects"] = objects
-    analytics_data["recognized_objects"] = named_objects
+    analytics_data["unified_objects"] = unified_objects
 
     metadata = genai_client.generate_review_description(
         analytics_data,

--- a/frigate/genai/__init__.py
+++ b/frigate/genai/__init__.py
@@ -63,6 +63,12 @@ class GenAIClient:
             else:
                 return ""
 
+        def get_objects_list() -> str:
+            if review_data["unified_objects"]:
+                return "\n- " + "\n- ".join(review_data["unified_objects"])
+            else:
+                return "\n- (No objects detected)"
+
         context_prompt = f"""
 Your task is to analyze the sequence of images ({len(thumbnails)} total) taken in chronological order from the perspective of the {review_data["camera"].replace("_", " ")} security camera.
 
@@ -115,7 +121,7 @@ Your response MUST be a flat JSON object with:
 ## Objects in Scene
 
 Each line represents one object in the scene. Named objects are verified identities; "Unknown" indicates unverified objects of that type:
-{"".join(f"\n- {obj}" for obj in review_data["unified_objects"])}
+{get_objects_list()}
 
 ## Important Notes
 - Values must be plain strings, floats, or integers — no nested objects, no extra commentary.


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Currently we display a list of detected objects and then separately a list of verified objects in the review item. However, this becomes confusing for the LLM to analyze and summarize as they are separate and not clearly linked, so it has no context how many people total. This leads to reluctance to use the sub labels as instructed. Unifying these objects and marking unknown objects as unknown more clearly delineates the overall scene and is more clear contextually.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
