### PR TITLE
Improve i18n for lists of text/labels

### DIFF
--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -98,6 +98,10 @@
     "show": "Show {{item}}",
     "ID": "ID"
   },
+  "list": {
+    "two": "{{0}} and {{1}}",
+    "many": "{{items}}, and {{last}}"
+  },
   "field": {
     "optional": "Optional",
     "internalID": "The Internal ID Frigate uses in the configuration and database"

--- a/web/src/utils/lifecycleUtil.ts
+++ b/web/src/utils/lifecycleUtil.ts
@@ -3,6 +3,23 @@ import { t } from "i18next";
 import { getTranslatedLabel } from "./i18n";
 import { capitalizeFirstLetter } from "./stringUtil";
 
+function formatZonesList(zones: string[]): string {
+  if (zones.length === 0) return "";
+  if (zones.length === 1) return zones[0];
+  if (zones.length === 2) {
+    return t("list.two", {
+      0: zones[0],
+      1: zones[1],
+    });
+  }
+
+  const allButLast = zones.slice(0, -1).join(", ");
+  return t("list.many", {
+    items: allButLast,
+    last: zones[zones.length - 1],
+  });
+}
+
 export function getLifecycleItemDescription(
   lifecycleItem: TrackingDetailsSequence,
 ) {
@@ -24,7 +41,7 @@ export function getLifecycleItemDescription(
       return t("trackingDetails.lifecycleItemDesc.entered_zone", {
         ns: "views/explore",
         label,
-        zones: lifecycleItem.data.zones.join(" and ").replaceAll("_", " "),
+        zones: formatZonesList(lifecycleItem.data.zones),
       });
     case "active":
       return t("trackingDetails.lifecycleItemDesc.active", {


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR adds i18n keys and a helper function example to easily format lists with commas and the word "and" in multiple languages.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
