### PR TITLE
No recordings indicator on History timeline

### DIFF
--- a/web/src/components/timeline/MotionReviewTimeline.tsx
+++ b/web/src/components/timeline/MotionReviewTimeline.tsx
@@ -203,6 +203,7 @@ export function MotionReviewTimeline({
       scrollToSegment={scrollToSegment}
       isZooming={isZooming}
       zoomDirection={zoomDirection}
+      getRecordingAvailability={getRecordingAvailability}
     >
       <VirtualizedMotionSegments
         ref={virtualizedSegmentsRef}

--- a/web/src/components/timeline/MotionReviewTimeline.tsx
+++ b/web/src/components/timeline/MotionReviewTimeline.tsx
@@ -46,6 +46,7 @@ export type MotionReviewTimelineProps = {
   dense?: boolean;
   isZooming: boolean;
   zoomDirection: TimelineZoomDirection;
+  alwaysShowMotionLine?: boolean;
 };
 
 export function MotionReviewTimeline({
@@ -75,6 +76,7 @@ export function MotionReviewTimeline({
   dense = false,
   isZooming,
   zoomDirection,
+  alwaysShowMotionLine = false,
 }: MotionReviewTimelineProps) {
   const internalTimelineRef = useRef<HTMLDivElement>(null);
   const selectedTimelineRef = timelineRef || internalTimelineRef;
@@ -222,6 +224,7 @@ export function MotionReviewTimeline({
         motionOnly={motionOnly}
         getMotionSegmentValue={getMotionSegmentValue}
         getRecordingAvailability={getRecordingAvailability}
+        alwaysShowMotionLine={alwaysShowMotionLine}
       />
     </ReviewTimeline>
   );

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -16,6 +16,8 @@ type MotionSegmentProps = {
   firstHalfMotionValue: number;
   secondHalfMotionValue: number;
   hasRecording?: boolean;
+  prevIsNoRecording?: boolean;
+  nextIsNoRecording?: boolean;
   motionOnly: boolean;
   showMinimap: boolean;
   minimapStartTime?: number;
@@ -33,6 +35,8 @@ export function MotionSegment({
   firstHalfMotionValue,
   secondHalfMotionValue,
   hasRecording,
+  prevIsNoRecording,
+  nextIsNoRecording,
   motionOnly,
   showMinimap,
   minimapStartTime,
@@ -116,6 +120,16 @@ export function MotionSegment({
     return showMinimap && segmentTime === alignedMinimapEndTime;
   }, [showMinimap, segmentTime, alignedMinimapEndTime]);
 
+  // Top border: current segment has no recording, but previous segment has recordings
+  const isFirstSegmentWithoutRecording = useMemo(() => {
+    return hasRecording === false && prevIsNoRecording === false;
+  }, [hasRecording, prevIsNoRecording]);
+
+  // Bottom border: current segment has no recording, but next segment has recordings
+  const isLastSegmentWithoutRecording = useMemo(() => {
+    return hasRecording === false && nextIsNoRecording === false;
+  }, [hasRecording, nextIsNoRecording]);
+
   const firstMinimapSegmentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -178,16 +192,17 @@ export function MotionSegment({
             segmentClasses,
             severity[0] && "bg-gradient-to-r",
             severity[0] && severityColorsBg[severity[0]],
-            // TODO: will update this for 0.17
-            false &&
-              hasRecording == false &&
-              firstHalfMotionValue == 0 &&
-              secondHalfMotionValue == 0 &&
-              "bg-slashes",
+            hasRecording == false && "bg-background",
           )}
           onClick={segmentClick}
           onTouchEnd={(event) => handleTouchStart(event, segmentClick)}
         >
+          {isFirstSegmentWithoutRecording && (
+            <div className="absolute -top-[1px] left-0 right-0 h-[1px] bg-primary-variant/50" />
+          )}
+          {isLastSegmentWithoutRecording && (
+            <div className="absolute bottom-[0px] left-0 right-0 h-[1px] bg-primary-variant/50" />
+          )}
           {!motionOnly && (
             <>
               {showMinimap && (
@@ -218,45 +233,47 @@ export function MotionSegment({
             </>
           )}
 
-          <div className="absolute left-1/2 z-10 h-[8px] w-[20px] -translate-x-1/2 transform cursor-pointer md:w-[40px]">
-            <div className="mb-[1px] flex w-[20px] flex-row justify-center pt-[1px] md:w-[40px]">
-              <div className="mb-[1px] flex justify-center">
-                <div
-                  key={`${segmentKey}_motion_data_1`}
-                  data-motion-value={secondHalfSegmentWidth}
-                  className={cn(
-                    "h-[2px]",
-                    "rounded-full",
-                    secondHalfSegmentWidth
-                      ? "bg-motion_review"
-                      : "bg-muted-foreground",
-                  )}
-                  style={{
-                    width: secondHalfSegmentWidth || 1,
-                  }}
-                ></div>
+          {hasRecording && (
+            <div className="absolute left-1/2 z-10 h-[8px] w-[20px] -translate-x-1/2 transform cursor-pointer md:w-[40px]">
+              <div className="mb-[1px] flex w-[20px] flex-row justify-center pt-[1px] md:w-[40px]">
+                <div className="mb-[1px] flex justify-center">
+                  <div
+                    key={`${segmentKey}_motion_data_1`}
+                    data-motion-value={secondHalfSegmentWidth}
+                    className={cn(
+                      "h-[2px]",
+                      "rounded-full",
+                      secondHalfSegmentWidth
+                        ? "bg-motion_review"
+                        : "bg-muted-foreground",
+                    )}
+                    style={{
+                      width: secondHalfSegmentWidth || 1,
+                    }}
+                  ></div>
+                </div>
               </div>
-            </div>
 
-            <div className="flex w-[20px] flex-row justify-center pb-[1px] md:w-[40px]">
-              <div className="flex justify-center">
-                <div
-                  key={`${segmentKey}_motion_data_2`}
-                  data-motion-value={firstHalfSegmentWidth}
-                  className={cn(
-                    "h-[2px]",
-                    "rounded-full",
-                    firstHalfSegmentWidth
-                      ? "bg-motion_review"
-                      : "bg-muted-foreground",
-                  )}
-                  style={{
-                    width: firstHalfSegmentWidth || 1,
-                  }}
-                ></div>
+              <div className="flex w-[20px] flex-row justify-center pb-[1px] md:w-[40px]">
+                <div className="flex justify-center">
+                  <div
+                    key={`${segmentKey}_motion_data_2`}
+                    data-motion-value={firstHalfSegmentWidth}
+                    className={cn(
+                      "h-[2px]",
+                      "rounded-full",
+                      firstHalfSegmentWidth
+                        ? "bg-motion_review"
+                        : "bg-muted-foreground",
+                    )}
+                    style={{
+                      width: firstHalfSegmentWidth || 1,
+                    }}
+                  ></div>
+                </div>
               </div>
             </div>
-          </div>
+          )}
         </div>
       )}
     </>

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -198,7 +198,7 @@ export function MotionSegment({
           onTouchEnd={(event) => handleTouchStart(event, segmentClick)}
         >
           {isFirstSegmentWithoutRecording && (
-            <div className="absolute bottom-[0px] left-0 right-0 h-[1px] bg-primary-variant/50" />
+            <div className="absolute bottom-[0px] left-0 right-0 h-[1px] bg-primary-variant/40" />
           )}
           {isLastSegmentWithoutRecording && (
             <div className="absolute -top-[1px] left-0 right-0 h-[1px] bg-primary-variant/50" />

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -25,6 +25,7 @@ type MotionSegmentProps = {
   setHandlebarTime?: React.Dispatch<React.SetStateAction<number>>;
   scrollToSegment: (segmentTime: number, ifNeeded?: boolean) => void;
   dense: boolean;
+  alwaysShowMotionLine?: boolean;
 };
 
 export function MotionSegment({
@@ -44,6 +45,7 @@ export function MotionSegment({
   setHandlebarTime,
   scrollToSegment,
   dense,
+  alwaysShowMotionLine = false,
 }: MotionSegmentProps) {
   const severityType = "all";
   const { getSeverity, getReviewed, displaySeverityType } =
@@ -235,7 +237,8 @@ export function MotionSegment({
 
           {(hasRecording ||
             firstHalfSegmentWidth > 0 ||
-            secondHalfSegmentWidth > 0) && (
+            secondHalfSegmentWidth > 0 ||
+            alwaysShowMotionLine) && (
             <div className="absolute left-1/2 z-10 h-[8px] w-[20px] -translate-x-1/2 transform cursor-pointer md:w-[40px]">
               <div className="mb-[1px] flex w-[20px] flex-row justify-center pt-[1px] md:w-[40px]">
                 <div className="mb-[1px] flex justify-center">

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -120,15 +120,15 @@ export function MotionSegment({
     return showMinimap && segmentTime === alignedMinimapEndTime;
   }, [showMinimap, segmentTime, alignedMinimapEndTime]);
 
-  // Top border: current segment has no recording, but previous segment has recordings
+  // Bottom border: current segment HAS recording, but next segment (below/earlier) has NO recording
   const isFirstSegmentWithoutRecording = useMemo(() => {
-    return hasRecording === false && prevIsNoRecording === false;
-  }, [hasRecording, prevIsNoRecording]);
-
-  // Bottom border: current segment has no recording, but next segment has recordings
-  const isLastSegmentWithoutRecording = useMemo(() => {
-    return hasRecording === false && nextIsNoRecording === false;
+    return hasRecording === true && nextIsNoRecording === true;
   }, [hasRecording, nextIsNoRecording]);
+
+  // Top border: current segment HAS recording, but prev segment (above/later) has NO recording
+  const isLastSegmentWithoutRecording = useMemo(() => {
+    return hasRecording === true && prevIsNoRecording === true;
+  }, [hasRecording, prevIsNoRecording]);
 
   const firstMinimapSegmentRef = useRef<HTMLDivElement>(null);
 
@@ -198,10 +198,10 @@ export function MotionSegment({
           onTouchEnd={(event) => handleTouchStart(event, segmentClick)}
         >
           {isFirstSegmentWithoutRecording && (
-            <div className="absolute -top-[1px] left-0 right-0 h-[1px] bg-primary-variant/50" />
+            <div className="absolute bottom-[0px] left-0 right-0 h-[1px] bg-primary-variant/50" />
           )}
           {isLastSegmentWithoutRecording && (
-            <div className="absolute bottom-[0px] left-0 right-0 h-[1px] bg-primary-variant/50" />
+            <div className="absolute -top-[1px] left-0 right-0 h-[1px] bg-primary-variant/50" />
           )}
           {!motionOnly && (
             <>

--- a/web/src/components/timeline/MotionSegment.tsx
+++ b/web/src/components/timeline/MotionSegment.tsx
@@ -233,7 +233,9 @@ export function MotionSegment({
             </>
           )}
 
-          {hasRecording && (
+          {(hasRecording ||
+            firstHalfSegmentWidth > 0 ||
+            secondHalfSegmentWidth > 0) && (
             <div className="absolute left-1/2 z-10 h-[8px] w-[20px] -translate-x-1/2 transform cursor-pointer md:w-[40px]">
               <div className="mb-[1px] flex w-[20px] flex-row justify-center pt-[1px] md:w-[40px]">
                 <div className="mb-[1px] flex justify-center">

--- a/web/src/components/timeline/ReviewTimeline.tsx
+++ b/web/src/components/timeline/ReviewTimeline.tsx
@@ -402,7 +402,7 @@ export function ReviewTimeline({
                 </div>
               </div>
               {/* TODO: determine if we should keep this tooltip */}
-              {isHandlebarInNoRecordingPeriod && (
+              {false && isHandlebarInNoRecordingPeriod && (
                 <div className="absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 rounded-md bg-destructive/80 px-4 py-1 text-center text-xs text-white shadow-lg">
                   No recordings
                 </div>

--- a/web/src/components/timeline/VirtualizedMotionSegments.tsx
+++ b/web/src/components/timeline/VirtualizedMotionSegments.tsx
@@ -25,6 +25,7 @@ type VirtualizedMotionSegmentsProps = {
   motionOnly: boolean;
   getMotionSegmentValue: (timestamp: number) => number;
   getRecordingAvailability: (timestamp: number) => boolean | undefined;
+  alwaysShowMotionLine: boolean;
 };
 
 export interface VirtualizedMotionSegmentsRef {
@@ -57,6 +58,7 @@ export const VirtualizedMotionSegments = forwardRef<
       motionOnly,
       getMotionSegmentValue,
       getRecordingAvailability,
+      alwaysShowMotionLine,
     },
     ref,
   ) => {
@@ -203,6 +205,7 @@ export const VirtualizedMotionSegments = forwardRef<
               setHandlebarTime={setHandlebarTime}
               scrollToSegment={scrollToSegment}
               dense={dense}
+              alwaysShowMotionLine={alwaysShowMotionLine}
             />
           </div>
         );
@@ -221,6 +224,7 @@ export const VirtualizedMotionSegments = forwardRef<
         dense,
         timestampSpread,
         visibleRange.start,
+        alwaysShowMotionLine,
       ],
     );
 

--- a/web/src/components/timeline/VirtualizedMotionSegments.tsx
+++ b/web/src/components/timeline/VirtualizedMotionSegments.tsx
@@ -158,12 +158,17 @@ export const VirtualizedMotionSegments = forwardRef<
 
         const hasRecording = getRecordingAvailability(segmentTime);
 
+        // Check if previous and next segments have recordings
+        // This is important because in motionOnly mode, the segments array is filtered
         const prevSegmentTime = segmentTime + segmentDuration;
         const nextSegmentTime = segmentTime - segmentDuration;
 
         const prevHasRecording = getRecordingAvailability(prevSegmentTime);
         const nextHasRecording = getRecordingAvailability(nextSegmentTime);
 
+        // Check if prev/next segments have no recording available
+        // Note: We only check hasRecording, not motion values, because segments can have
+        // recordings available but no motion (eg, start of a recording before motion begins)
         const prevIsNoRecording = prevHasRecording === false;
         const nextIsNoRecording = nextHasRecording === false;
 

--- a/web/src/components/timeline/VirtualizedMotionSegments.tsx
+++ b/web/src/components/timeline/VirtualizedMotionSegments.tsx
@@ -158,6 +158,15 @@ export const VirtualizedMotionSegments = forwardRef<
 
         const hasRecording = getRecordingAvailability(segmentTime);
 
+        const prevSegmentTime = segmentTime + segmentDuration;
+        const nextSegmentTime = segmentTime - segmentDuration;
+
+        const prevHasRecording = getRecordingAvailability(prevSegmentTime);
+        const nextHasRecording = getRecordingAvailability(nextSegmentTime);
+
+        const prevIsNoRecording = prevHasRecording === false;
+        const nextIsNoRecording = nextHasRecording === false;
+
         if ((!segmentMotion || overlappingReviewItems) && motionOnly) {
           return null; // Skip rendering this segment in motion only mode
         }
@@ -177,6 +186,8 @@ export const VirtualizedMotionSegments = forwardRef<
               firstHalfMotionValue={firstHalfMotionValue}
               secondHalfMotionValue={secondHalfMotionValue}
               hasRecording={hasRecording}
+              prevIsNoRecording={prevIsNoRecording}
+              nextIsNoRecording={nextIsNoRecording}
               segmentDuration={segmentDuration}
               segmentTime={segmentTime}
               timestampSpread={timestampSpread}

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -895,11 +895,20 @@ function MotionReview({
 
   // motion data
 
+  const { alignStartDateToTimeline, alignEndDateToTimeline } = useTimelineUtils(
+    {
+      segmentDuration,
+    },
+  );
+
+  const alignedAfter = alignStartDateToTimeline(timeRange.after);
+  const alignedBefore = alignEndDateToTimeline(timeRange.before);
+
   const { data: motionData } = useSWR<MotionData[]>([
     "review/activity/motion",
     {
-      before: timeRange.before,
-      after: timeRange.after,
+      before: alignedBefore,
+      after: alignedAfter,
       scale: segmentDuration / 2,
       cameras: filter?.cameras?.join(",") ?? null,
     },
@@ -1005,10 +1014,6 @@ function MotionReview({
       };
     }
   }, [playing, playbackRate, nextTimestamp, setPlaying, timeRange]);
-
-  const { alignStartDateToTimeline } = useTimelineUtils({
-    segmentDuration,
-  });
 
   const getDetectionType = useCallback(
     (cameraName: string) => {
@@ -1159,6 +1164,7 @@ function MotionReview({
             dense={isMobileOnly}
             isZooming={false}
             zoomDirection={null}
+            alwaysShowMotionLine={true}
           />
         ) : (
           <Skeleton className="size-full" />

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -924,7 +924,7 @@ function Timeline({
     {
       before: timeRange.before,
       after: timeRange.after,
-      scale: Math.round(zoomSettings.segmentDuration / 2),
+      scale: Math.round(zoomSettings.segmentDuration),
       cameras: mainCamera,
     },
   ]);

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -56,6 +56,7 @@ import { useFullscreen } from "@/hooks/use-fullscreen";
 import { useTimezone } from "@/hooks/use-date-utils";
 import { useTimelineZoom } from "@/hooks/use-timeline-zoom";
 import { useTranslation } from "react-i18next";
+import { useTimelineUtils } from "@/hooks/use-timeline-utils";
 import {
   Tooltip,
   TooltipContent,
@@ -908,12 +909,20 @@ function Timeline({
   });
 
   // motion data
+  const { alignStartDateToTimeline, alignEndDateToTimeline } = useTimelineUtils(
+    {
+      segmentDuration: zoomSettings.segmentDuration,
+    },
+  );
+
+  const alignedAfter = alignStartDateToTimeline(timeRange.after);
+  const alignedBefore = alignEndDateToTimeline(timeRange.before);
 
   const { data: motionData, isLoading } = useSWR<MotionData[]>([
     "review/activity/motion",
     {
-      before: timeRange.before,
-      after: timeRange.after,
+      before: alignedBefore,
+      after: alignedAfter,
       scale: Math.round(zoomSettings.segmentDuration / 2),
       cameras: mainCamera,
     },
@@ -922,8 +931,8 @@ function Timeline({
   const { data: noRecordings } = useSWR<RecordingSegment[]>([
     "recordings/unavailable",
     {
-      before: timeRange.before,
-      after: timeRange.after,
+      before: alignedBefore,
+      after: alignedAfter,
       scale: Math.round(zoomSettings.segmentDuration),
       cameras: mainCamera,
     },

--- a/web/tailwind.config.cjs
+++ b/web/tailwind.config.cjs
@@ -44,7 +44,7 @@ module.exports = {
       },
       backgroundImage: {
         slashes:
-          "repeating-linear-gradient(45deg, hsl(var(--primary-variant) / 0.2), hsl(var(--primary-variant) / 0.2) 2px, transparent 2px, transparent 8px)",
+          "repeating-linear-gradient(135deg, hsl(var(--primary-variant) / 0.3), hsl(var(--primary-variant) / 0.3) 2px, transparent 2px, transparent 8px), linear-gradient(to right, hsl(var(--background)), hsl(var(--background)))",
       },
       colors: {
         border: "hsl(var(--border))",


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR adds a blank area (no motion bars, no motion line) on the timeline in History when no recordings are available.
- Match Figma
- Optional tooltip when dragging handlebar (currently disabled)
- Fix to ensure params being sent to the API are segment-aligned in both Motion Review and History


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
