### PR TITLE
Mark delivery objects so LLM knows what is happening

### DIFF
--- a/frigate/data_processing/post/review_descriptions.py
+++ b/frigate/data_processing/post/review_descriptions.py
@@ -186,6 +186,7 @@ class ReviewDescriptionProcessor(PostProcessorApi):
                     thumbs,
                     camera_config.review.genai,
                     list(self.config.model.merged_labelmap.values()),
+                    self.config.model.all_attributes,
                 ),
             ).start()
 
@@ -414,6 +415,7 @@ def run_analysis(
     thumbs: list[bytes],
     genai_config: GenAIReviewConfig,
     labelmap_objects: list[str],
+    attribute_labels: list[str],
 ) -> None:
     start = datetime.datetime.now().timestamp()
     analytics_data = {
@@ -441,7 +443,11 @@ def run_analysis(
             continue
         elif label in labelmap_objects:
             object_type = label.replace("_", " ").title()
-            unified_objects.append(object_type)
+
+            if label in attribute_labels:
+                unified_objects.append(f"{object_type} (delivery/service)")
+            else:
+                unified_objects.append(object_type)
 
     analytics_data["unified_objects"] = unified_objects
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Delivery labels (Amazon, FedEx) are treated as standard labels in the UI and backend because they are not verified, bit it is an additional level of classification. However, just putting `Amazon` in the object list confuses the LLM. We need to add some additional context so it understands when something is likely to be a delivery.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
