### PR TITLE
Create i18n key for list separator

### DIFF
--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -100,7 +100,8 @@
   },
   "list": {
     "two": "{{0}} and {{1}}",
-    "many": "{{items}}, and {{last}}"
+    "many": "{{items}}, and {{last}}",
+    "separatorWithSpace": ", "
   },
   "field": {
     "optional": "Optional",

--- a/web/src/utils/lifecycleUtil.ts
+++ b/web/src/utils/lifecycleUtil.ts
@@ -13,7 +13,8 @@ function formatZonesList(zones: string[]): string {
     });
   }
 
-  const allButLast = zones.slice(0, -1).join(", ");
+  const separatorWithSpace = t("list.separatorWithSpace", { ns: "common" });
+  const allButLast = zones.slice(0, -1).join(separatorWithSpace);
   return t("list.many", {
     items: allButLast,
     last: zones[zones.length - 1],


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR adds the ability for Weblate contributors to add a list separator character that best suits their language. Changes should be made to the `many` key as well as the `separatorWithSpace` key.

This change was applied to zones in the details/lifecycle item lists.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
