### PR TITLE
MemryX: Update installation code to hold SDK 2.1 version

### DIFF
--- a/docker/main/install_memryx.sh
+++ b/docker/main/install_memryx.sh
@@ -2,9 +2,9 @@
 set -e
 
 # Download the MxAccl for Frigate github release
-wget https://github.com/memryx/mx_accl_frigate/archive/refs/heads/main.zip -O /tmp/mxaccl.zip
+wget https://github.com/memryx/mx_accl_frigate/archive/refs/tags/v2.1.0.zip -O /tmp/mxaccl.zip
 unzip /tmp/mxaccl.zip -d /tmp
-mv /tmp/mx_accl_frigate-main /opt/mx_accl_frigate
+mv /tmp/mx_accl_frigate-2.1.0 /opt/mx_accl_frigate
 rm /tmp/mxaccl.zip
 
 # Install Python dependencies

--- a/docker/memryx/user_installation.sh
+++ b/docker/memryx/user_installation.sh
@@ -24,10 +24,13 @@ echo "Adding MemryX GPG key and repository..."
 wget -qO- https://developer.memryx.com/deb/memryx.asc | sudo tee /etc/apt/trusted.gpg.d/memryx.asc >/dev/null
 echo 'deb https://developer.memryx.com/deb stable main' | sudo tee /etc/apt/sources.list.d/memryx.list >/dev/null
 
-# Update and install memx-drivers
-echo "Installing memx-drivers..."
+# Update and install specific SDK 2.1 packages
+echo "Installing MemryX SDK 2.1 packages..."
 sudo apt update
-sudo apt install -y memx-drivers
+sudo apt install -y memx-drivers=2.1.* memx-accl=2.1.* mxa-manager=2.1.*
+
+# Hold packages to prevent automatic upgrades
+sudo apt-mark hold memx-drivers memx-accl mxa-manager
 
 # ARM-specific board setup
 if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
@@ -37,11 +40,5 @@ fi
 
 echo -e "\n\n\033[1;31mYOU MUST RESTART YOUR COMPUTER NOW\033[0m\n\n"
 
-# Install other runtime packages
-packages=("memx-accl" "mxa-manager")
-for pkg in "${packages[@]}"; do
-    echo "Installing $pkg..."
-    sudo apt install -y "$pkg"
-done
+echo "MemryX SDK 2.1 installation complete!"
 
-echo "MemryX installation complete!"


### PR DESCRIPTION
## Proposed change

This PR updates the MemryX installation scripts to **lock the installed packages to SDK version 2.1**.
Previously, the installer always pulled the latest MemryX packages from the repository, which could introduce compatibility issues when newer SDK versions were released.

By pinning the installation to SDK 2.1, the build remains stable and reproducible across environments.


## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- No functional changes to Frigate core logic.
- The update ensures the MemryX runtime environment consistently uses SDK 2.1.
- This helps maintain compatibility between host and container installations.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
