### PR TITLE
Add on the fly transcoding

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -69,6 +69,7 @@ http {
         vod_mode mapped;
         vod_max_mapping_response_size 1m;
         vod_upstream_location /api;
+        vod_remote_upstream_location '/transcode';
         vod_align_segments_to_key_frames on;
         vod_manifest_segment_durations_mode accurate;
         vod_ignore_edit_list on;
@@ -101,6 +102,12 @@ http {
 
         include auth_location.conf;
         include base_path.conf;
+
+        location ~ /transcode/(.*) {
+            include auth_request.conf;
+            internal;
+            proxy_pass 'http://frigate_api/vod/transcode?file=$1';
+        }
 
         location /vod/ {
             include auth_request.conf;

--- a/frigate/api/fastapi_app.py
+++ b/frigate/api/fastapi_app.py
@@ -34,6 +34,7 @@ from frigate.embeddings import EmbeddingsContext
 from frigate.ptz.onvif import OnvifController
 from frigate.stats.emitter import StatsEmitter
 from frigate.storage import StorageMaintainer
+from frigate.transcode.temp_file_cache import TempFileCache
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,7 @@ class RemoteUserPlugin(Plugin):
 def create_fastapi_app(
     frigate_config: FrigateConfig,
     database: SqliteQueueDatabase,
+    temp_file_cache: TempFileCache,
     embeddings: Optional[EmbeddingsContext],
     detected_frames_processor,
     storage_maintainer: StorageMaintainer,
@@ -134,6 +136,7 @@ def create_fastapi_app(
     app.stats_emitter = stats_emitter
     app.event_metadata_updater = event_metadata_updater
     app.config_publisher = config_publisher
+    app.temp_file_cache = temp_file_cache
 
     if frigate_config.auth.enabled:
         secret = get_jwt_secret()

--- a/frigate/transcode/temp_file_cache.py
+++ b/frigate/transcode/temp_file_cache.py
@@ -1,0 +1,81 @@
+import os
+import tempfile
+import threading
+import time
+
+
+class TempFileCache:
+    def __init__(self, ttl_seconds=300, cleanup_interval=1):
+        self.ttl = ttl_seconds
+        self.cleanup_interval = cleanup_interval
+
+        self.cache = {}  # key -> (path, timestamp)
+        self.pending = set()  # keys being generated
+        self.lock = threading.Condition()
+        self._stop = False
+
+        # Start background cleanup thread
+        self.thread = threading.Thread(target=self._cleanup_loop, daemon=True)
+        self.thread.start()
+
+    def _remove_file(self, path):
+        if path and os.path.exists(path):
+            try:
+                os.remove(path)
+            except Exception:
+                pass
+
+    def _cleanup_expired(self):
+        now = time.time()
+        expired_keys = [k for k, (_, ts) in self.cache.items() if now - ts > self.ttl]
+
+        for key in expired_keys:
+            path, _ = self.cache.pop(key, (None, None))
+            self._remove_file(path)
+
+    def _cleanup_loop(self):
+        while not self._stop:
+            with self.lock:
+                self._cleanup_expired()
+            time.sleep(self.cleanup_interval)
+
+    def stop(self):
+        """Stop the cleanup thread."""
+        self._stop = True
+        self.thread.join(timeout=2)
+
+    def get(self, key, generator_fn):
+        with self.lock:
+            # Return cached file if fresh
+            if key in self.cache:
+                path, ts = self.cache[key]
+                # refresh timestamp
+                self.cache[key] = (path, time.time())
+                return path
+
+            # If another thread is generating this file, wait
+            while key in self.pending:
+                self.lock.wait()
+
+            # Mark this key as pending generation
+            self.pending.add(key)
+
+        # Outside lock: generate the file
+        path = tempfile.mktemp()
+
+        try:
+            generator_fn(path)
+        except Exception:
+            self._remove_file(path)
+            with self.lock:
+                self.pending.remove(key)
+                self.lock.notify_all()
+            raise
+
+        # Store file and notify waiters
+        with self.lock:
+            self.cache[key] = (path, time.time())
+            self.pending.remove(key)
+            self.lock.notify_all()
+
+        return path


### PR DESCRIPTION
## Proposed change

This branch/PR currently shows a proof of concept of how the review files could be transcoded on the fly when being played. It's currently not in a mergable state, but I'd be interested in getting some opinions on whether something like this could be merged.

Reviewing previous discussions:
- https://github.com/blakeblackshear/frigate/discussions/18750
- https://github.com/blakeblackshear/frigate/issues/5335
- https://github.com/blakeblackshear/frigate/issues/18497
- Personally I see this feature being useful for scenarios where clips are reviewed infrequently and remotely on low-end devices (high res videos tend to cause slowdowns on these devices) and slow (or metered) connections.

The answer to date seems to be to use the previews capability. This is reasonable, but they are _very_ low res. This proposal is to produce a high-ish quality preview on the fly. The change works by:
- Changing the clips provided to `nginx-vod-module` to `http` (from `file`)
- Adds a new location in the nginx config to handle the paths provided to the vod module
- Adds a new API endpoint to the app which transcodes, caches, and serves the clips

My initial approach was to transcode the files and stream them back. However, I was unable to get `nginx-vod-module` to play ball. By the looks of it, it performs (and requires) range requests. Ideally NGINX would handle the caching, but this [seems to be unsupported](https://github.com/kaltura/nginx-vod-module/issues/997#issuecomment-496284132). Regardless, this is just a proof of concept -- I'm open to suggestions on a better way to accomplish this. 

Obvious areas for improvement:
- Improve the cache mechanism (use a library/in memory/other)
- Tie this into the configuration (hwaccell args, filter pipeline, scaling parameters, etc...)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

N/A

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
