### PR TITLE
Tracked Object Details pane tweaks

### DIFF
--- a/web/public/locales/en/views/explore.json
+++ b/web/public/locales/en/views/explore.json
@@ -215,6 +215,8 @@
   "trackedObjectsCount_other": "{{count}} tracked objects ",
   "searchResult": {
     "tooltip": "Matched {{type}} at {{confidence}}%",
+    "previousTrackedObject": "Previous tracked object",
+    "nextTrackedObject": "Next tracked object",
     "deleteTrackedObject": {
       "toast": {
         "success": "Tracked object deleted successfully.",

--- a/web/public/locales/en/views/explore.json
+++ b/web/public/locales/en/views/explore.json
@@ -74,7 +74,7 @@
         "label": "Annotation Offset",
         "desc": "This data comes from your camera's detect feed but is overlayed on images from the the record feed. It is unlikely that the two streams are perfectly in sync. As a result, the bounding box and the footage will not line up perfectly. You can use this setting to offset the annotations forward or backward in time to better align them with the recorded footage.",
         "millisecondsToOffset": "Milliseconds to offset detect annotations by. <em>Default: 0</em>",
-        "tips": "TIP: Imagine there is an event clip with a person walking from left to right. If the event timeline bounding box is consistently to the left of the person then the value should be decreased. Similarly, if a person is walking from left to right and the bounding box is consistently ahead of the person then the value should be increased.",
+        "tips": "Lower the value if the video playback is ahead of the boxes and path points, and increase the value if the video playback is behind them. This value can be negative.",
         "toast": {
           "success": "Annotation offset for {{camera}} has been saved to the config file. Restart Frigate to apply your changes."
         }

--- a/web/src/components/overlay/detail/AnnotationOffsetSlider.tsx
+++ b/web/src/components/overlay/detail/AnnotationOffsetSlider.tsx
@@ -121,13 +121,13 @@ export default function AnnotationOffsetSlider({ className }: Props) {
           <PopoverTrigger asChild>
             <button
               className="focus:outline-none"
-              aria-label={t("trackingDetails.annotationSettings.offset.desc")}
+              aria-label={t("trackingDetails.annotationSettings.offset.tips")}
             >
               <LuInfo className="size-4" />
             </button>
           </PopoverTrigger>
           <PopoverContent className="w-80 text-sm">
-            {t("trackingDetails.annotationSettings.offset.desc")}
+            {t("trackingDetails.annotationSettings.offset.tips")}
           </PopoverContent>
         </Popover>
       </div>

--- a/web/src/components/overlay/detail/AnnotationSettingsPane.tsx
+++ b/web/src/components/overlay/detail/AnnotationSettingsPane.tsx
@@ -1,6 +1,4 @@
 import Heading from "@/components/ui/heading";
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import { Event } from "@/types/event";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -8,7 +6,6 @@ import axios from "axios";
 import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
 import { LuExternalLink } from "react-icons/lu";
-import { PiWarningCircle } from "react-icons/pi";
 import { Link } from "react-router-dom";
 import { toast } from "sonner";
 import useSWR from "swr";
@@ -31,15 +28,11 @@ import { useDocDomain } from "@/hooks/use-doc-domain";
 
 type AnnotationSettingsPaneProps = {
   event: Event;
-  showZones: boolean;
-  setShowZones: React.Dispatch<React.SetStateAction<boolean>>;
   annotationOffset: number;
   setAnnotationOffset: React.Dispatch<React.SetStateAction<number>>;
 };
 export function AnnotationSettingsPane({
   event,
-  showZones,
-  setShowZones,
   annotationOffset,
   setAnnotationOffset,
 }: AnnotationSettingsPaneProps) {
@@ -144,21 +137,7 @@ export function AnnotationSettingsPane({
       <Heading as="h4" className="my-2">
         {t("trackingDetails.annotationSettings.title")}
       </Heading>
-      <div className="flex flex-col">
-        <div className="flex flex-row items-center justify-start gap-2 p-3">
-          <Switch
-            id="show-zones"
-            checked={showZones}
-            onCheckedChange={setShowZones}
-          />
-          <Label className="cursor-pointer" htmlFor="show-zones">
-            {t("trackingDetails.annotationSettings.showAllZones.title")}
-          </Label>
-        </div>
-        <div className="text-sm text-muted-foreground">
-          {t("trackingDetails.annotationSettings.showAllZones.desc")}
-        </div>
-      </div>
+
       <Separator className="my-2 flex bg-secondary" />
       <Form {...form}>
         <form
@@ -169,17 +148,17 @@ export function AnnotationSettingsPane({
             control={form.control}
             name="annotationOffset"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  {t("trackingDetails.annotationSettings.offset.label")}
-                </FormLabel>
-                <div className="flex flex-col gap-3 md:flex-row-reverse md:gap-8">
-                  <div className="flex flex-row items-center gap-3 rounded-lg bg-destructive/50 p-3 text-sm text-primary-variant md:my-5">
-                    <PiWarningCircle className="size-24" />
-                    <div>
-                      <Trans ns="views/explore">
-                        trackingDetails.annotationSettings.offset.desc
-                      </Trans>
+              <FormItem className="flex flex-row items-start justify-between space-x-2">
+                <div className="flex flex-col gap-1">
+                  <FormLabel>
+                    {t("trackingDetails.annotationSettings.offset.label")}
+                  </FormLabel>
+                  <FormDescription>
+                    <Trans ns="views/explore">
+                      trackingDetails.annotationSettings.offset.millisecondsToOffset
+                    </Trans>
+                    <div className="mt-2">
+                      {t("trackingDetails.annotationSettings.offset.tips")}
                       <div className="mt-2 flex items-center text-primary">
                         <Link
                           to={getLocaleDocUrl("configuration/reference")}
@@ -192,23 +171,26 @@ export function AnnotationSettingsPane({
                         </Link>
                       </div>
                     </div>
-                  </div>
-                  <div className="flex flex-col">
+                  </FormDescription>
+                </div>
+                <div className="flex flex-col gap-3">
+                  {/* <div className="flex flex-row items-center gap-3 rounded-lg bg-destructive/50 p-3 text-sm text-primary-variant md:my-5">
+                    <PiWarningCircle className="size-24" />
+                    <div>
+                      <Trans ns="views/explore">
+                        trackingDetails.annotationSettings.offset.desc
+                      </Trans>
+
+                    </div>
+                  </div> */}
+                  <div className="min-w-24">
                     <FormControl>
                       <Input
-                        className="text-md w-full border border-input bg-background p-2 hover:bg-accent hover:text-accent-foreground dark:[color-scheme:dark]"
+                        className="text-md w-full border border-input bg-background p-2 text-center hover:bg-accent hover:text-accent-foreground dark:[color-scheme:dark]"
                         placeholder="0"
                         {...field}
                       />
                     </FormControl>
-                    <FormDescription>
-                      <Trans ns="views/explore">
-                        trackingDetails.annotationSettings.offset.millisecondsToOffset
-                      </Trans>
-                      <div className="mt-2">
-                        {t("trackingDetails.annotationSettings.offset.tips")}
-                      </div>
-                    </FormDescription>
                   </div>
                 </div>
                 <FormMessage />

--- a/web/src/components/overlay/detail/AnnotationSettingsPane.tsx
+++ b/web/src/components/overlay/detail/AnnotationSettingsPane.tsx
@@ -140,7 +140,7 @@ export function AnnotationSettingsPane({
   }
 
   return (
-    <div className="mb-3 space-y-3 rounded-lg border border-secondary-foreground bg-background_alt p-2">
+    <div className="space-y-3 p-4">
       <Heading as="h4" className="my-2">
         {t("trackingDetails.annotationSettings.title")}
       </Heading>

--- a/web/src/components/overlay/detail/AnnotationSettingsPane.tsx
+++ b/web/src/components/overlay/detail/AnnotationSettingsPane.tsx
@@ -156,6 +156,7 @@ export function AnnotationSettingsPane({
                     <Trans ns="views/explore">
                       trackingDetails.annotationSettings.offset.millisecondsToOffset
                     </Trans>
+                    <FormMessage />
                     <div className="mt-2">
                       {t("trackingDetails.annotationSettings.offset.tips")}
                       <div className="mt-2 flex items-center text-primary">
@@ -183,7 +184,6 @@ export function AnnotationSettingsPane({
                     </FormControl>
                   </div>
                 </div>
-                <FormMessage />
               </FormItem>
             )}
           />
@@ -192,6 +192,7 @@ export function AnnotationSettingsPane({
             <div className="flex flex-row gap-2 pt-5">
               <Button
                 className="flex flex-1"
+                variant="default"
                 aria-label={t("button.apply", { ns: "common" })}
                 onClick={form.handleSubmit(onApply)}
               >

--- a/web/src/components/overlay/detail/AnnotationSettingsPane.tsx
+++ b/web/src/components/overlay/detail/AnnotationSettingsPane.tsx
@@ -194,6 +194,7 @@ export function AnnotationSettingsPane({
                 className="flex flex-1"
                 variant="default"
                 aria-label={t("button.apply", { ns: "common" })}
+                type="button"
                 onClick={form.handleSubmit(onApply)}
               >
                 {t("button.apply", { ns: "common" })}

--- a/web/src/components/overlay/detail/AnnotationSettingsPane.tsx
+++ b/web/src/components/overlay/detail/AnnotationSettingsPane.tsx
@@ -1,4 +1,3 @@
-import Heading from "@/components/ui/heading";
 import { Event } from "@/types/event";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -133,12 +132,12 @@ export function AnnotationSettingsPane({
   }
 
   return (
-    <div className="space-y-3 p-4">
-      <Heading as="h4" className="my-2">
+    <div className="p-4">
+      <div className="text-md mb-2">
         {t("trackingDetails.annotationSettings.title")}
-      </Heading>
+      </div>
 
-      <Separator className="my-2 flex bg-secondary" />
+      <Separator className="mb-4 flex bg-secondary" />
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}

--- a/web/src/components/overlay/detail/AnnotationSettingsPane.tsx
+++ b/web/src/components/overlay/detail/AnnotationSettingsPane.tsx
@@ -174,15 +174,6 @@ export function AnnotationSettingsPane({
                   </FormDescription>
                 </div>
                 <div className="flex flex-col gap-3">
-                  {/* <div className="flex flex-row items-center gap-3 rounded-lg bg-destructive/50 p-3 text-sm text-primary-variant md:my-5">
-                    <PiWarningCircle className="size-24" />
-                    <div>
-                      <Trans ns="views/explore">
-                        trackingDetails.annotationSettings.offset.desc
-                      </Trans>
-
-                    </div>
-                  </div> */}
                   <div className="min-w-24">
                     <FormControl>
                       <Input

--- a/web/src/components/overlay/detail/DetailActionsMenu.tsx
+++ b/web/src/components/overlay/detail/DetailActionsMenu.tsx
@@ -1,0 +1,135 @@
+import { useMemo, useState } from "react";
+import { Event } from "@/types/event";
+import { baseUrl } from "@/api/baseUrl";
+import { ReviewSegment, REVIEW_PADDING } from "@/types/review";
+import useSWR from "swr";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  DropdownMenuPortal,
+} from "@/components/ui/dropdown-menu";
+import { HiDotsHorizontal } from "react-icons/hi";
+import FaceSelectionDialog from "../FaceSelectionDialog";
+import { SearchResult } from "@/types/search";
+import { FrigateConfig } from "@/types/frigateConfig";
+
+type Props = {
+  search: SearchResult | Event;
+  config?: FrigateConfig;
+  setSearch?: (s: SearchResult | undefined) => void;
+  setSimilarity?: () => void;
+  faceNames?: string[];
+  onTrainFace?: (name: string) => void;
+  hasFace?: boolean;
+};
+
+export default function DetailActionsMenu({
+  search,
+  config,
+  setSearch,
+  setSimilarity,
+  faceNames = [],
+  onTrainFace,
+  hasFace = false,
+}: Props) {
+  const { t } = useTranslation(["views/explore", "views/faceLibrary"]);
+  const navigate = useNavigate();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const clipTimeRange = useMemo(() => {
+    const startTime = (search.start_time ?? 0) - REVIEW_PADDING;
+    const endTime = (search.end_time ?? Date.now() / 1000) + REVIEW_PADDING;
+    return `start/${startTime}/end/${endTime}`;
+  }, [search]);
+
+  const { data: reviewItem } = useSWR<ReviewSegment>([
+    `review/event/${search.id}`,
+  ]);
+
+  return (
+    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+      <DropdownMenuTrigger>
+        <div className="rounded p-1 pr-2" role="button">
+          <HiDotsHorizontal className="size-4 text-muted-foreground" />
+        </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuPortal>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem>
+            <a
+              className="w-full"
+              href={`${baseUrl}api/events/${search.id}/snapshot.jpg?bbox=1`}
+              download={`${search.camera}_${search.label}.jpg`}
+            >
+              <div className="flex cursor-pointer items-center gap-2">
+                <span>{t("itemMenu.downloadSnapshot.label")}</span>
+              </div>
+            </a>
+          </DropdownMenuItem>
+
+          <DropdownMenuItem>
+            <a
+              className="w-full"
+              href={`${baseUrl}api/${search.camera}/${clipTimeRange}/clip.mp4`}
+              download
+            >
+              <div className="flex cursor-pointer items-center gap-2">
+                <span>{t("itemMenu.downloadVideo.label")}</span>
+              </div>
+            </a>
+          </DropdownMenuItem>
+
+          {config?.semantic_search.enabled &&
+            setSimilarity != undefined &&
+            search.data?.type == "object" && (
+              <DropdownMenuItem
+                onClick={() => {
+                  setIsOpen(false);
+                  setTimeout(() => {
+                    setSearch?.(undefined);
+                    setSimilarity?.();
+                  }, 0);
+                }}
+              >
+                <div className="flex cursor-pointer items-center gap-2">
+                  <span>{t("itemMenu.findSimilar.label")}</span>
+                </div>
+              </DropdownMenuItem>
+            )}
+
+          {reviewItem && reviewItem.id && (
+            <DropdownMenuItem
+              onClick={() => {
+                setIsOpen(false);
+                setTimeout(() => {
+                  navigate(`/review?id=${reviewItem.id}`);
+                }, 0);
+              }}
+            >
+              <div className="flex cursor-pointer items-center gap-2">
+                <span>{t("itemMenu.viewInHistory.label")}</span>
+              </div>
+            </DropdownMenuItem>
+          )}
+
+          {hasFace && onTrainFace && (
+            <DropdownMenuItem asChild>
+              <FaceSelectionDialog
+                faceNames={faceNames}
+                onTrainAttempt={onTrainFace}
+              >
+                <div className="flex cursor-pointer items-center gap-2">
+                  <span>{t("trainFace", { ns: "views/faceLibrary" })}</span>
+                </div>
+              </FaceSelectionDialog>
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenuPortal>
+    </DropdownMenu>
+  );
+}

--- a/web/src/components/overlay/detail/DetailActionsMenu.tsx
+++ b/web/src/components/overlay/detail/DetailActionsMenu.tsx
@@ -13,7 +13,6 @@ import {
   DropdownMenuPortal,
 } from "@/components/ui/dropdown-menu";
 import { HiDotsHorizontal } from "react-icons/hi";
-import FaceSelectionDialog from "../FaceSelectionDialog";
 import { SearchResult } from "@/types/search";
 import { FrigateConfig } from "@/types/frigateConfig";
 
@@ -32,9 +31,6 @@ export default function DetailActionsMenu({
   config,
   setSearch,
   setSimilarity,
-  faceNames = [],
-  onTrainFace,
-  hasFace = false,
 }: Props) {
   const { t } = useTranslation(["views/explore", "views/faceLibrary"]);
   const navigate = useNavigate();
@@ -113,19 +109,6 @@ export default function DetailActionsMenu({
               <div className="flex cursor-pointer items-center gap-2">
                 <span>{t("itemMenu.viewInHistory.label")}</span>
               </div>
-            </DropdownMenuItem>
-          )}
-
-          {hasFace && onTrainFace && (
-            <DropdownMenuItem asChild>
-              <FaceSelectionDialog
-                faceNames={faceNames}
-                onTrainAttempt={onTrainFace}
-              >
-                <div className="flex cursor-pointer items-center gap-2">
-                  <span>{t("trainFace", { ns: "views/faceLibrary" })}</span>
-                </div>
-              </FaceSelectionDialog>
             </DropdownMenuItem>
           )}
         </DropdownMenuContent>

--- a/web/src/components/overlay/detail/DetailActionsMenu.tsx
+++ b/web/src/components/overlay/detail/DetailActionsMenu.tsx
@@ -49,7 +49,7 @@ export default function DetailActionsMenu({
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger>
-        <div className="rounded p-1 pr-2" role="button">
+        <div className="rounded" role="button">
           <HiDotsHorizontal className="size-4 text-muted-foreground" />
         </div>
       </DropdownMenuTrigger>

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -235,18 +235,12 @@ function AnnotationSettings({
               : "mx-1 max-h-[75dvh] overflow-hidden rounded-t-2xl px-4 pb-4"
           }
           {...(isDesktop ? { align: "end" } : {})}
+          data-annotation-popover
         >
           <AnnotationSettingsPane
             event={search as unknown as Event}
             annotationOffset={annotationOffset}
-            setAnnotationOffset={(value) => {
-              if (typeof value === "function") {
-                const newValue = value(annotationOffset);
-                setAnnotationOffset(newValue);
-              } else {
-                setAnnotationOffset(value);
-              }
-            }}
+            setAnnotationOffset={setAnnotationOffset}
           />
         </Content>
       </Overlay>

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -340,19 +340,21 @@ export default function SearchDetailDialog({
                     />
                   )}
                   {page === "snapshot" && !search.has_snapshot && (
-                    <img
-                      className="size-full select-none rounded-lg object-contain transition-opacity"
-                      style={
-                        isIOS
-                          ? {
-                              WebkitUserSelect: "none",
-                              WebkitTouchCallout: "none",
-                            }
-                          : undefined
-                      }
-                      draggable={false}
-                      src={`${apiHost}api/events/${search.id}/thumbnail.webp`}
-                    />
+                    <div className="size-full">
+                      <img
+                        className="w-full select-none rounded-lg object-contain transition-opacity"
+                        style={
+                          isIOS
+                            ? {
+                                WebkitUserSelect: "none",
+                                WebkitTouchCallout: "none",
+                              }
+                            : undefined
+                        }
+                        draggable={false}
+                        src={`${apiHost}api/events/${search.id}/thumbnail.webp`}
+                      />
+                    </div>
                   )}
                 </div>
                 <div className="flex flex-[2] flex-col gap-4 overflow-hidden">
@@ -1298,7 +1300,7 @@ export function ObjectSnapshotTab({
   );
 
   return (
-    <div className="relative size-full">
+    <div className="relative w-full">
       <ImageLoadingIndicator
         className="absolute inset-0 aspect-video min-h-[60dvh] w-full"
         imgLoaded={imgLoaded}
@@ -1321,7 +1323,7 @@ export function ObjectSnapshotTab({
                 <div className="relative mx-auto">
                   <img
                     ref={imgRef}
-                    className={`mx-auto max-h-[60dvh] bg-black object-contain`}
+                    className="mx-auto max-h-[60dvh] rounded-lg bg-background object-contain"
                     src={`${baseUrl}api/events/${search?.id}/snapshot.jpg`}
                     alt={`${search?.label}`}
                     loading={isSafari ? "eager" : "lazy"}
@@ -1360,7 +1362,7 @@ export function ObjectSnapshotTab({
               search.end_time &&
               search.label != "on_demand" && (
                 <Card className="p-1 text-sm md:p-2">
-                  <CardContent className="flex flex-col items-center justify-between gap-3 p-2 md:flex-row">
+                  <CardContent className="flex flex-col items-start justify-between gap-3 p-2 md:flex-row md:items-center">
                     <div className={cn("flex max-w-sm flex-col space-y-3")}>
                       <div className={"text-lg leading-none"}>
                         {t("explore.plus.submitToPlus.label")}
@@ -1475,10 +1477,7 @@ export function VideoTab({ search }: VideoTabProps) {
       <span tabIndex={0} className="sr-only" />
       <GenericVideoPlayer source={source}>
         <div
-          className={cn(
-            "absolute top-2 z-10 flex items-center gap-2",
-            isIOS ? "right-8" : "right-2",
-          )}
+          className={cn("absolute right-2 top-2 z-10 flex items-center gap-2")}
         >
           {reviewItem && (
             <Tooltip>

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -252,10 +252,11 @@ function AnnotationSettings({
         <Content
           className={
             isDesktop
-              ? "w-[90vw] max-w-md p-0"
+              ? "w-[90vw] max-w-md bg-background_alt p-0"
               : "mx-1 max-h-[75dvh] overflow-hidden rounded-t-2xl px-4 pb-4"
           }
           {...contentProps}
+          {...(isDesktop ? { disablePortal: true } : {})}
           data-annotation-popover
         >
           <AnnotationSettingsPane

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -368,7 +368,7 @@ function DialogContentComponent({
         >
           {snapshotElement}
         </div>
-        <div className="flex flex-[2] flex-col gap-4 overflow-hidden">
+        <div className="flex flex-col gap-4 overflow-hidden md:basis-2/5">
           <TabsWithActions
             search={search}
             searchTabs={searchTabs}
@@ -1491,14 +1491,19 @@ export function ObjectSnapshotTab({
   const [imgRef, imgLoaded, onImgLoad] = useImageLoaded();
 
   return (
-    <div className={cn("relative w-full", className)}>
+    <div className={cn("relative", isDesktop && "size-full", className)}>
       <ImageLoadingIndicator
         className="absolute inset-0 aspect-video min-h-[60dvh] w-full"
         imgLoaded={imgLoaded}
       />
-      <div className={`${imgLoaded ? "visible" : "invisible"}`}>
+      <div
+        className={cn(
+          "flex size-full items-center",
+          imgLoaded ? "visible" : "invisible",
+        )}
+      >
         <TransformWrapper minScale={1.0} wheel={{ smoothStep: 0.005 }}>
-          <div className="flex flex-col space-y-3">
+          <div className="flex w-full flex-col space-y-3 overflow-hidden">
             <TransformComponent
               wrapperStyle={{
                 width: "100%",
@@ -1511,7 +1516,7 @@ export function ObjectSnapshotTab({
               }}
             >
               {search?.id && (
-                <div className="relative mx-auto">
+                <div className="relative mx-auto flex h-full">
                   <img
                     ref={imgRef}
                     className="mx-auto max-h-[60dvh] rounded-lg bg-background object-contain"

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -32,7 +32,6 @@ import {
   FaChevronRight,
   FaDownload,
   FaHistory,
-  FaImage,
 } from "react-icons/fa";
 import { TrackingDetails } from "./TrackingDetails";
 import { DetailStreamProvider } from "@/context/detail-stream-context";
@@ -80,7 +79,6 @@ import FaceSelectionDialog from "../FaceSelectionDialog";
 import { getTranslatedLabel } from "@/utils/i18n";
 import { CgTranscript } from "react-icons/cg";
 import { CameraNameLabel } from "@/components/camera/CameraNameLabel";
-import { PiPath } from "react-icons/pi";
 import Heading from "@/components/ui/heading";
 import { DialogPortal } from "@radix-ui/react-dialog";
 
@@ -193,8 +191,6 @@ export default function SearchDetailDialog({
               data-nav-item={item}
               aria-label={`Select ${item}`}
             >
-              {item == "snapshot" && <FaImage className="size-4" />}
-              {item == "tracking_details" && <PiPath className="size-4" />}
               <div className="smart-capitalize">
                 {item === "snapshot"
                   ? search?.has_snapshot
@@ -395,10 +391,6 @@ export default function SearchDetailDialog({
                         data-nav-item={item}
                         aria-label={`Select ${item}`}
                       >
-                        {item == "snapshot" && <FaImage className="size-4" />}
-                        {item == "tracking_details" && (
-                          <PiPath className="size-4" />
-                        )}
                         <div className="smart-capitalize">
                           {t(`type.${item}`)}
                         </div>

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -28,6 +28,8 @@ import {
   FaArrowRight,
   FaCheckCircle,
   FaChevronDown,
+  FaChevronLeft,
+  FaChevronRight,
   FaDownload,
   FaHistory,
   FaImage,
@@ -80,6 +82,7 @@ import { CgTranscript } from "react-icons/cg";
 import { CameraNameLabel } from "@/components/camera/CameraNameLabel";
 import { PiPath } from "react-icons/pi";
 import Heading from "@/components/ui/heading";
+import { DialogPortal } from "@radix-ui/react-dialog";
 
 const SEARCH_TABS = ["snapshot", "tracking_details"] as const;
 export type SearchTab = (typeof SEARCH_TABS)[number];
@@ -91,6 +94,8 @@ type SearchDetailDialogProps = {
   setSearchPage: (page: SearchTab) => void;
   setSimilarity?: () => void;
   setInputFocused: React.Dispatch<React.SetStateAction<boolean>>;
+  onPrevious?: () => void;
+  onNext?: () => void;
 };
 export default function SearchDetailDialog({
   search,
@@ -99,6 +104,8 @@ export default function SearchDetailDialog({
   setSearchPage,
   setSimilarity,
   setInputFocused,
+  onPrevious,
+  onNext,
 }: SearchDetailDialogProps) {
   const { t } = useTranslation(["views/explore", "views/faceLibrary"]);
   const { data: config } = useSWR<FrigateConfig>("config", {
@@ -227,6 +234,57 @@ export default function SearchDetailDialog({
         onOpenChange={handleOpenChange}
         enableHistoryBack={true}
       >
+        {isDesktop && onPrevious && onNext && (
+          <DialogPortal>
+            <div className="pointer-events-none fixed inset-0 z-[200] flex items-center justify-center">
+              <div
+                className={cn(
+                  "relative flex items-center justify-between",
+                  "w-full",
+                  // match dialog's max-width classes
+                  "sm:max-w-xl md:max-w-4xl lg:max-w-4xl xl:max-w-7xl",
+                  page == "tracking_details" && "lg:max-w-[75%] xl:max-w-[80%]",
+                )}
+              >
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onPrevious?.();
+                      }}
+                      className="nav-button pointer-events-auto absolute -left-16 rounded-lg border bg-secondary/60 p-2 text-primary-variant shadow-lg backdrop-blur-sm hover:bg-secondary/80 hover:text-primary"
+                      aria-label={t("searchResult.previousTrackedObject")}
+                    >
+                      <FaChevronLeft className="size-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {t("searchResult.previousTrackedObject")}
+                  </TooltipContent>
+                </Tooltip>
+
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onNext?.();
+                      }}
+                      className="nav-button pointer-events-auto absolute -right-16 rounded-lg border bg-secondary/60 p-2 text-primary-variant shadow-lg backdrop-blur-sm hover:bg-secondary/80 hover:text-primary"
+                      aria-label={t("searchResult.nextTrackedObject")}
+                    >
+                      <FaChevronRight className="size-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {t("searchResult.nextTrackedObject")}
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            </div>
+          </DialogPortal>
+        )}
         <Content
           className={cn(
             "scrollbar-container overflow-y-auto",
@@ -237,11 +295,18 @@ export default function SearchDetailDialog({
               "lg:max-w-[75%] xl:max-w-[80%]",
             isMobile && "px-4",
           )}
+          onInteractOutside={(e) => {
+            const target = e.target as HTMLElement;
+            if (target.closest(".nav-button")) {
+              e.preventDefault();
+            }
+          }}
         >
           <Header>
             <Title>{t("trackedObjectDetails")}</Title>
             <Description className="sr-only">
               {t("trackedObjectDetails")}
+              <span className="sr-only" tabIndex={0} />
             </Description>
           </Header>
           {isDesktop ? (

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -242,8 +242,7 @@ export default function SearchDetailDialog({
                   "relative flex items-center justify-between",
                   "w-full",
                   // match dialog's max-width classes
-                  "sm:max-w-xl md:max-w-4xl lg:max-w-4xl xl:max-w-7xl",
-                  page == "tracking_details" && "lg:max-w-[75%] xl:max-w-[80%]",
+                  "sm:max-w-xl md:max-w-4xl lg:max-w-[75%] xl:max-w-[80%]",
                 )}
               >
                 <Tooltip>
@@ -289,10 +288,7 @@ export default function SearchDetailDialog({
           className={cn(
             "scrollbar-container overflow-y-auto",
             isDesktop &&
-              "max-h-[95dvh] sm:max-w-xl md:max-w-4xl lg:max-w-4xl xl:max-w-7xl",
-            isDesktop &&
-              page == "tracking_details" &&
-              "lg:max-w-[75%] xl:max-w-[80%]",
+              "max-h-[95dvh] sm:max-w-xl md:max-w-4xl lg:max-w-[75%] xl:max-w-[80%]",
             isMobile && "px-4",
           )}
           onInteractOutside={(e) => {

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -141,7 +141,7 @@ function TabsWithActions({
             {Object.values(searchTabs).map((item) => (
               <ToggleGroupItem
                 key={item}
-                className={`flex scroll-mx-10 items-center justify-between gap-2 ${pageToggle == item ? "" : "*:text-muted-foreground"}`}
+                className="flex scroll-mx-10 items-center justify-between gap-2 text-muted-foreground"
                 value={item}
                 data-nav-item={item}
                 aria-label={`Select ${item}`}

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -46,7 +46,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { REVIEW_PADDING } from "@/types/review";
-// Chip removed from VideoTab - kept import commented out previously
 import { capitalizeAll } from "@/utils/stringUtil";
 import useGlobalMutation from "@/hooks/use-global-mutate";
 import DetailActionsMenu from "./DetailActionsMenu";
@@ -71,7 +70,6 @@ import { FaPencilAlt } from "react-icons/fa";
 import TextEntryDialog from "@/components/overlay/dialog/TextEntryDialog";
 import { Trans, useTranslation } from "react-i18next";
 import { useIsAdmin } from "@/hooks/use-is-admin";
-// FaceSelectionDialog moved into DetailActionsMenu
 import { getTranslatedLabel } from "@/utils/i18n";
 import { CameraNameLabel } from "@/components/camera/CameraNameLabel";
 import Heading from "@/components/ui/heading";
@@ -589,8 +587,6 @@ function ObjectDetailsTab({
     }
   }, [search]);
 
-  // clipTimeRange is calculated inside the shared DetailActionsMenu
-
   const updateDescription = useCallback(() => {
     if (!search) {
       return;
@@ -843,57 +839,6 @@ function ObjectDetailsTab({
     [search, apiHost, mutate, setSearch, t],
   );
 
-  // face training
-
-  const hasFace = useMemo(() => {
-    if (!config?.face_recognition.enabled || !search) {
-      return false;
-    }
-
-    return search.data.attributes?.find((attr) => attr.label == "face");
-  }, [config, search]);
-
-  const { data: faceData } = useSWR(hasFace ? "faces" : null);
-
-  const faceNames = useMemo<string[]>(
-    () =>
-      faceData ? Object.keys(faceData).filter((face) => face != "train") : [],
-    [faceData],
-  );
-
-  const onTrainFace = useCallback(
-    (trainName: string) => {
-      axios
-        .post(`/faces/train/${trainName}/classify`, { event_id: search.id })
-        .then((resp) => {
-          if (resp.status == 200) {
-            toast.success(
-              t("toast.success.trainedFace", { ns: "views/faceLibrary" }),
-              {
-                position: "top-center",
-              },
-            );
-          }
-        })
-        .catch((error) => {
-          const errorMessage =
-            error.response?.data?.message ||
-            error.response?.data?.detail ||
-            "Unknown error";
-          toast.error(
-            t("toast.error.trainFailed", {
-              ns: "views/faceLibrary",
-              errorMessage,
-            }),
-            {
-              position: "top-center",
-            },
-          );
-        });
-    },
-    [search, t],
-  );
-
   // speech transcription
 
   const onTranscribe = useCallback(() => {
@@ -967,9 +912,6 @@ function ObjectDetailsTab({
               config={config}
               setSearch={setSearch}
               setSimilarity={setSimilarity}
-              faceNames={faceNames}
-              onTrainFace={onTrainFace}
-              hasFace={!!hasFace}
             />
           </div>
         </div>

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -536,7 +536,7 @@ export default function SearchDetailDialog({
                   "relative flex items-center justify-between",
                   "w-full",
                   // match dialog's max-width classes
-                  "sm:max-w-xl md:max-w-4xl lg:max-w-[75%] xl:max-w-[80%]",
+                  "sm:max-w-xl md:max-w-4xl lg:max-w-[70%]",
                 )}
               >
                 <Tooltip>
@@ -583,7 +583,7 @@ export default function SearchDetailDialog({
           className={cn(
             "scrollbar-container overflow-y-auto",
             isDesktop &&
-              "max-h-[95dvh] sm:max-w-xl md:max-w-4xl lg:max-w-[75%] xl:max-w-[80%]",
+              "max-h-[95dvh] sm:max-w-xl md:max-w-4xl lg:max-w-[70%]",
             isMobile && "px-4",
           )}
           onInteractOutside={(e) => {

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -65,6 +65,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { Drawer, DrawerContent, DrawerTrigger } from "@/components/ui/drawer";
 import { LuInfo } from "react-icons/lu";
 import { TooltipPortal } from "@radix-ui/react-tooltip";
 import { FaPencilAlt } from "react-icons/fa";
@@ -150,7 +151,7 @@ function TabsWithActions({
         setSimilarity={setSimilarity}
       />
       {pageToggle === "tracking_details" && (
-        <AnnotationSettingsPopover
+        <AnnotationSettings
           search={search}
           open={isPopoverOpen}
           setIsOpen={setIsPopoverOpen}
@@ -160,17 +161,17 @@ function TabsWithActions({
   );
 }
 
-type AnnotationSettingsPopoverProps = {
+type AnnotationSettingsProps = {
   search: SearchResult;
   open: boolean;
   setIsOpen: (open: boolean) => void;
 };
 
-function AnnotationSettingsPopover({
+function AnnotationSettings({
   search,
   open,
   setIsOpen,
-}: AnnotationSettingsPopoverProps) {
+}: AnnotationSettingsProps) {
   const { t } = useTranslation(["views/explore"]);
   const { annotationOffset, setAnnotationOffset } = useDetailStream();
 
@@ -202,29 +203,39 @@ function AnnotationSettingsPopover({
     }
   }, [open]);
 
+  const Overlay = isDesktop ? Popover : Drawer;
+  const Trigger = isDesktop ? PopoverTrigger : DrawerTrigger;
+  const Content = isDesktop ? PopoverContent : DrawerContent;
+
   return (
     <div className="ml-2">
-      <Popover modal={true} open={open} onOpenChange={handleOpenChange}>
-        <PopoverTrigger
-          asChild
-          onPointerDown={registerTriggerCloseIntent}
-          onKeyDown={(event) => {
-            if (open && (event.key === "Enter" || event.key === " ")) {
-              registerTriggerCloseIntent();
-            }
-          }}
-        >
+      <Overlay modal={isDesktop} open={open} onOpenChange={handleOpenChange}>
+        <Trigger asChild>
           <Button
             type="button"
             className="size-7 p-1.5"
             variant={open ? "select" : "ghost"}
             aria-label={t("trackingDetails.adjustAnnotationSettings")}
             aria-expanded={open}
+            onPointerDown={registerTriggerCloseIntent}
+            onKeyDown={(event) => {
+              if (open && (event.key === "Enter" || event.key === " ")) {
+                registerTriggerCloseIntent();
+              }
+            }}
           >
             <PiSlidersHorizontalBold className="size-5" />
           </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-[90vw] max-w-md p-0" align="end">
+        </Trigger>
+
+        <Content
+          className={
+            isDesktop
+              ? "w-[90vw] max-w-md p-0"
+              : "mx-1 max-h-[75dvh] overflow-hidden rounded-t-2xl px-4 pb-4"
+          }
+          {...(isDesktop ? { align: "end" } : {})}
+        >
           <AnnotationSettingsPane
             event={search as unknown as Event}
             annotationOffset={annotationOffset}
@@ -237,8 +248,8 @@ function AnnotationSettingsPopover({
               }
             }}
           />
-        </PopoverContent>
-      </Popover>
+        </Content>
+      </Overlay>
     </div>
   );
 }

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -72,7 +72,6 @@ import { Trans, useTranslation } from "react-i18next";
 import { useIsAdmin } from "@/hooks/use-is-admin";
 import { getTranslatedLabel } from "@/utils/i18n";
 import { CameraNameLabel } from "@/components/camera/CameraNameLabel";
-import Heading from "@/components/ui/heading";
 import { DialogPortal } from "@radix-ui/react-dialog";
 
 const SEARCH_TABS = ["snapshot", "tracking_details"] as const;
@@ -356,7 +355,6 @@ export default function SearchDetailDialog({
                         setSearch={setSearch}
                         setSimilarity={setSimilarity}
                         setInputFocused={setInputFocused}
-                        showThumbnail={false}
                         tabs={tabsComponent}
                       />
                     )}
@@ -427,16 +425,12 @@ export default function SearchDetailDialog({
                       src={`${apiHost}api/events/${search.id}/thumbnail.webp`}
                     />
                   )}
-                  <Heading as="h3" className="mt-2 smart-capitalize">
-                    {t("type.details")}
-                  </Heading>
                   <ObjectDetailsTab
                     search={search}
                     config={config}
                     setSearch={setSearch}
                     setSimilarity={setSimilarity}
                     setInputFocused={setInputFocused}
-                    showThumbnail={false}
                   />
                 </>
               )}
@@ -457,7 +451,6 @@ type ObjectDetailsTabProps = {
   setSearch: (search: SearchResult | undefined) => void;
   setSimilarity?: () => void;
   setInputFocused: React.Dispatch<React.SetStateAction<boolean>>;
-  showThumbnail?: boolean;
   tabs?: React.ReactNode;
 };
 function ObjectDetailsTab({
@@ -466,7 +459,6 @@ function ObjectDetailsTab({
   setSearch,
   setSimilarity,
   setInputFocused,
-  showThumbnail = true,
   tabs,
 }: ObjectDetailsTabProps) {
   const { t, i18n } = useTranslation([
@@ -1169,24 +1161,6 @@ function ObjectDetailsTab({
             </div>
           )}
         </div>
-
-        {showThumbnail && (
-          <div className="flex w-full flex-col gap-2 pl-6">
-            <img
-              className="aspect-video select-none rounded-lg object-contain transition-opacity"
-              style={
-                isIOS
-                  ? {
-                      WebkitUserSelect: "none",
-                      WebkitTouchCallout: "none",
-                    }
-                  : undefined
-              }
-              draggable={false}
-              src={`${apiHost}api/events/${search.id}/thumbnail.webp`}
-            />
-          </div>
-        )}
       </div>
       <div className="flex flex-col gap-1.5">
         {config?.cameras[search.camera].objects.genai.enabled &&

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -1128,7 +1128,12 @@ function ObjectDetailsTab({
         </div>
       </div>
 
-      <div className="my-2 flex flex-col gap-1.5">
+      <div
+        className={cn(
+          "my-2 flex w-full flex-col justify-between gap-1.5",
+          state == "submitted" && "flex-row",
+        )}
+      >
         <div className="text-sm text-primary/40">
           <div className="flex flex-row items-center gap-1">
             {t("explore.plus.submitToPlus.label", {
@@ -1153,7 +1158,7 @@ function ObjectDetailsTab({
           </div>
         </div>
 
-        <div className="flex w-full flex-1 flex-row items-center justify-between gap-2 text-sm md:flex-1">
+        <div className="flex flex-row items-center justify-between gap-2 text-sm">
           {state == "reviewing" && (
             <>
               <div>

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -33,7 +33,6 @@ import {
 } from "react-icons/fa";
 import { TrackingDetails } from "./TrackingDetails";
 import { AnnotationSettingsPane } from "./AnnotationSettingsPane";
-import { LuSettings } from "react-icons/lu";
 import { DetailStreamProvider } from "@/context/detail-stream-context";
 import {
   MobilePage,
@@ -76,6 +75,7 @@ import { getTranslatedLabel } from "@/utils/i18n";
 import { CameraNameLabel } from "@/components/camera/CameraNameLabel";
 import { DialogPortal } from "@radix-ui/react-dialog";
 import { useDetailStream } from "@/context/detail-stream-context";
+import { PiSlidersHorizontalBold } from "react-icons/pi";
 
 const SEARCH_TABS = ["snapshot", "tracking_details"] as const;
 export type SearchTab = (typeof SEARCH_TABS)[number];
@@ -108,7 +108,7 @@ function TabsWithActions({
   if (!search) return null;
 
   return (
-    <div className="flex items-center justify-between gap-2">
+    <div className="flex items-center justify-between gap-1">
       <ScrollArea className="flex-1 whitespace-nowrap">
         <div className="mb-2 flex flex-row md:mb-0">
           <ToggleGroup
@@ -173,7 +173,6 @@ function AnnotationSettingsPopover({
 }: AnnotationSettingsPopoverProps) {
   const { t } = useTranslation(["views/explore"]);
   const { annotationOffset, setAnnotationOffset } = useDetailStream();
-  const [showZones, setShowZones] = useState(true);
 
   const ignoreNextOpenRef = useRef(false);
 
@@ -218,18 +217,16 @@ function AnnotationSettingsPopover({
           <Button
             type="button"
             className="size-7 p-1.5"
-            variant={open ? "select" : "default"}
+            variant={open ? "select" : "ghost"}
             aria-label={t("trackingDetails.adjustAnnotationSettings")}
             aria-expanded={open}
           >
-            <LuSettings className="size-5" />
+            <PiSlidersHorizontalBold className="size-5" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-[90vw] max-w-2xl p-0" align="end">
+        <PopoverContent className="w-[90vw] max-w-md p-0" align="end">
           <AnnotationSettingsPane
             event={search as unknown as Event}
-            showZones={showZones}
-            setShowZones={setShowZones}
             annotationOffset={annotationOffset}
             setAnnotationOffset={(value) => {
               if (typeof value === "function") {

--- a/web/src/components/overlay/detail/TrackingDetails.tsx
+++ b/web/src/components/overlay/detail/TrackingDetails.tsx
@@ -599,7 +599,7 @@ export function TrackingDetails({
                   </div>
                   <div className="flex items-center gap-2">
                     <span className="capitalize">{label}</span>
-                    <span className="text-secondary-foreground">
+                    <span className="md:text-md text-sm text-secondary-foreground">
                       {formattedStart ?? ""} - {formattedEnd ?? ""}
                     </span>
                     {event.data?.recognized_license_plate && (

--- a/web/src/components/overlay/detail/TrackingDetails.tsx
+++ b/web/src/components/overlay/detail/TrackingDetails.tsx
@@ -8,8 +8,6 @@ import { formatUnixTimestampToDateTime } from "@/utils/dateUtil";
 import { getIconForLabel } from "@/utils/iconUtil";
 import { LuCircle, LuFolderX } from "react-icons/lu";
 import { cn } from "@/lib/utils";
-import { AnnotationSettingsPane } from "./AnnotationSettingsPane";
-
 import HlsVideoPlayer from "@/components/player/HlsVideoPlayer";
 import { baseUrl } from "@/api/baseUrl";
 import { REVIEW_PADDING } from "@/types/review";
@@ -40,15 +38,12 @@ type TrackingDetailsProps = {
   event: Event;
   fullscreen?: boolean;
   tabs?: React.ReactNode;
-  showControls?: boolean;
-  setShowControls?: (v: boolean) => void;
 };
 
 export function TrackingDetails({
   className,
   event,
   tabs,
-  showControls = false,
 }: TrackingDetailsProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const { t } = useTranslation(["views/explore"]);
@@ -58,8 +53,7 @@ export function TrackingDetails({
   const [displaySource, _setDisplaySource] = useState<"video" | "image">(
     "video",
   );
-  const { setSelectedObjectIds, annotationOffset, setAnnotationOffset } =
-    useDetailStream();
+  const { setSelectedObjectIds, annotationOffset } = useDetailStream();
 
   // manualOverride holds a record-stream timestamp explicitly chosen by the
   // user (eg, clicking a lifecycle row). When null we display `currentTime`.
@@ -90,7 +84,6 @@ export function TrackingDetails({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [_selectedZone, setSelectedZone] = useState("");
   const [_lifecycleZones, setLifecycleZones] = useState<string[]>([]);
-  const [showZones, setShowZones] = useState(true);
   const [seekToTimestamp, setSeekToTimestamp] = useState<number | null>(null);
 
   const aspectRatio = useMemo(() => {
@@ -463,22 +456,6 @@ export function TrackingDetails({
             <div className="-mt-2 mb-2 text-sm text-danger">
               {t("trackingDetails.autoTrackingTips")}
             </div>
-          )}
-          {showControls && (
-            <AnnotationSettingsPane
-              event={event}
-              showZones={showZones}
-              setShowZones={setShowZones}
-              annotationOffset={annotationOffset}
-              setAnnotationOffset={(value) => {
-                if (typeof value === "function") {
-                  const newValue = value(annotationOffset);
-                  setAnnotationOffset(newValue);
-                } else {
-                  setAnnotationOffset(value);
-                }
-              }}
-            />
           )}
 
           <div className="mt-4">

--- a/web/src/components/overlay/detail/TrackingDetails.tsx
+++ b/web/src/components/overlay/detail/TrackingDetails.tsx
@@ -2,20 +2,14 @@ import useSWR from "swr";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Event } from "@/types/event";
 import ActivityIndicator from "@/components/indicators/activity-indicator";
-import { Button } from "@/components/ui/button";
 import { TrackingDetailsSequence } from "@/types/timeline";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { formatUnixTimestampToDateTime } from "@/utils/dateUtil";
 import { getIconForLabel } from "@/utils/iconUtil";
-import { LuCircle, LuFolderX, LuSettings } from "react-icons/lu";
+import { LuCircle, LuFolderX } from "react-icons/lu";
 import { cn } from "@/lib/utils";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { AnnotationSettingsPane } from "./AnnotationSettingsPane";
-import { TooltipPortal } from "@radix-ui/react-tooltip";
+
 import HlsVideoPlayer from "@/components/player/HlsVideoPlayer";
 import { baseUrl } from "@/api/baseUrl";
 import { REVIEW_PADDING } from "@/types/review";
@@ -46,14 +40,15 @@ type TrackingDetailsProps = {
   event: Event;
   fullscreen?: boolean;
   tabs?: React.ReactNode;
-  actions?: React.ReactNode;
+  showControls?: boolean;
+  setShowControls?: (v: boolean) => void;
 };
 
 export function TrackingDetails({
   className,
   event,
   tabs,
-  actions,
+  showControls = false,
 }: TrackingDetailsProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const { t } = useTranslation(["views/explore"]);
@@ -95,7 +90,6 @@ export function TrackingDetails({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [_selectedZone, setSelectedZone] = useState("");
   const [_lifecycleZones, setLifecycleZones] = useState<string[]>([]);
-  const [showControls, setShowControls] = useState(false);
   const [showZones, setShowZones] = useState(true);
   const [seekToTimestamp, setSeekToTimestamp] = useState<number | null>(null);
 
@@ -454,10 +448,9 @@ export function TrackingDetails({
       </div>
 
       <div className={cn(isDesktop && "flex-[2] overflow-hidden")}>
-        {isDesktop && (tabs || actions) && (
+        {isDesktop && tabs && (
           <div className="mb-4 flex items-center justify-between">
             <div className="flex-1">{tabs}</div>
-            <div className="ml-2">{actions}</div>
           </div>
         )}
         <div
@@ -465,30 +458,6 @@ export function TrackingDetails({
             isDesktop && "scrollbar-container h-full overflow-y-auto",
           )}
         >
-          <div className="flex flex-row items-center justify-between">
-            <div className="flex flex-row gap-2">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant={showControls ? "select" : "default"}
-                    className="size-7 p-1.5"
-                    aria-label={t("trackingDetails.adjustAnnotationSettings")}
-                  >
-                    <LuSettings
-                      className="size-5"
-                      onClick={() => setShowControls(!showControls)}
-                    />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipPortal>
-                  <TooltipContent>
-                    {t("trackingDetails.adjustAnnotationSettings")}
-                  </TooltipContent>
-                </TooltipPortal>
-              </Tooltip>
-            </div>
-          </div>
-
           {config?.cameras[event.camera]?.onvif.autotracking
             .enabled_in_config && (
             <div className="-mt-2 mb-2 text-sm text-danger">

--- a/web/src/components/overlay/detail/TrackingDetails.tsx
+++ b/web/src/components/overlay/detail/TrackingDetails.tsx
@@ -440,7 +440,7 @@ export function TrackingDetails({
         </div>
       </div>
 
-      <div className={cn(isDesktop && "flex-[2] overflow-hidden")}>
+      <div className={cn(isDesktop && "overflow-hidden md:basis-2/5")}>
         {isDesktop && tabs && (
           <div className="mb-4 flex items-center justify-between">
             <div className="flex-1">{tabs}</div>
@@ -453,7 +453,7 @@ export function TrackingDetails({
         >
           {config?.cameras[event.camera]?.onvif.autotracking
             .enabled_in_config && (
-            <div className="-mt-2 mb-2 text-sm text-danger">
+            <div className="mb-2 text-sm text-danger">
               {t("trackingDetails.autoTrackingTips")}
             </div>
           )}

--- a/web/src/components/overlay/detail/TrackingDetails.tsx
+++ b/web/src/components/overlay/detail/TrackingDetails.tsx
@@ -344,7 +344,7 @@ export function TrackingDetails({
     <div
       className={cn(
         isDesktop
-          ? "flex size-full gap-4 overflow-hidden"
+          ? "flex size-full justify-evenly gap-4 overflow-hidden"
           : "flex size-full flex-col gap-2",
         className,
       )}
@@ -440,7 +440,11 @@ export function TrackingDetails({
         </div>
       </div>
 
-      <div className={cn(isDesktop && "overflow-hidden md:basis-2/5")}>
+      <div
+        className={cn(
+          isDesktop && "justify-between overflow-hidden md:basis-2/5",
+        )}
+      >
         {isDesktop && tabs && (
           <div className="mb-4 flex items-center justify-between">
             <div className="flex-1">{tabs}</div>

--- a/web/src/components/overlay/detail/TrackingDetails.tsx
+++ b/web/src/components/overlay/detail/TrackingDetails.tsx
@@ -4,7 +4,6 @@ import { Event } from "@/types/event";
 import ActivityIndicator from "@/components/indicators/activity-indicator";
 import { Button } from "@/components/ui/button";
 import { TrackingDetailsSequence } from "@/types/timeline";
-import Heading from "@/components/ui/heading";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { formatUnixTimestampToDateTime } from "@/utils/dateUtil";
 import { getIconForLabel } from "@/utils/iconUtil";
@@ -511,8 +510,6 @@ export function TrackingDetails({
           )}
         >
           <div className="flex flex-row items-center justify-between">
-            <Heading as="h4">{t("trackingDetails.title")}</Heading>
-
             <div className="flex flex-row gap-2">
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -535,17 +532,7 @@ export function TrackingDetails({
               </Tooltip>
             </div>
           </div>
-          <div className="flex flex-row items-center justify-between">
-            <div className="mb-2 text-sm text-muted-foreground">
-              {t("trackingDetails.scrollViewTips")}
-            </div>
-            <div className="min-w-20 text-right text-sm text-muted-foreground">
-              {t("trackingDetails.count", {
-                first: eventSequence?.length ?? 0,
-                second: eventSequence?.length ?? 0,
-              })}
-            </div>
-          </div>
+
           {config?.cameras[event.camera]?.onvif.autotracking
             .enabled_in_config && (
             <div className="-mt-2 mb-2 text-sm text-danger">

--- a/web/src/components/overlay/detail/TrackingDetails.tsx
+++ b/web/src/components/overlay/detail/TrackingDetails.tsx
@@ -37,8 +37,6 @@ import axios from "axios";
 import { toast } from "sonner";
 import { useDetailStream } from "@/context/detail-stream-context";
 import { isDesktop, isIOS, isMobileOnly, isSafari } from "react-device-detect";
-import Chip from "@/components/indicators/Chip";
-import { FaDownload, FaHistory } from "react-icons/fa";
 import { useApiHost } from "@/api";
 import ImageLoadingIndicator from "@/components/indicators/ImageLoadingIndicator";
 import ObjectTrackOverlay from "../ObjectTrackOverlay";
@@ -48,16 +46,17 @@ type TrackingDetailsProps = {
   event: Event;
   fullscreen?: boolean;
   tabs?: React.ReactNode;
+  actions?: React.ReactNode;
 };
 
 export function TrackingDetails({
   className,
   event,
   tabs,
+  actions,
 }: TrackingDetailsProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const { t } = useTranslation(["views/explore"]);
-  const navigate = useNavigate();
   const apiHost = useApiHost();
   const imgRef = useRef<HTMLImageElement | null>(null);
   const [imgLoaded, setImgLoaded] = useState(false);
@@ -451,59 +450,16 @@ export function TrackingDetails({
               </div>
             </>
           )}
-          <div
-            className={cn(
-              "absolute top-2 z-[5] flex items-center gap-2",
-              isIOS ? "right-8" : "right-2",
-            )}
-          >
-            {event && (
-              <Tooltip>
-                <TooltipTrigger>
-                  <Chip
-                    className="cursor-pointer rounded-md bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500"
-                    onClick={() => {
-                      if (event?.id) {
-                        const params = new URLSearchParams({
-                          id: event.id,
-                        }).toString();
-                        navigate(`/review?${params}`);
-                      }
-                    }}
-                  >
-                    <FaHistory className="size-4 text-white" />
-                  </Chip>
-                </TooltipTrigger>
-                <TooltipPortal>
-                  <TooltipContent>
-                    {t("itemMenu.viewInHistory.label")}
-                  </TooltipContent>
-                </TooltipPortal>
-              </Tooltip>
-            )}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <a
-                  download
-                  href={`${baseUrl}api/${event.camera}/start/${event.start_time - REVIEW_PADDING}/end/${(event.end_time ?? Date.now() / 1000) + REVIEW_PADDING}/clip.mp4`}
-                >
-                  <Chip className="cursor-pointer rounded-md bg-gray-500 bg-gradient-to-br from-gray-400 to-gray-500">
-                    <FaDownload className="size-4 text-white" />
-                  </Chip>
-                </a>
-              </TooltipTrigger>
-              <TooltipPortal>
-                <TooltipContent>
-                  {t("button.download", { ns: "common" })}
-                </TooltipContent>
-              </TooltipPortal>
-            </Tooltip>
-          </div>
         </div>
       </div>
 
       <div className={cn(isDesktop && "flex-[2] overflow-hidden")}>
-        {isDesktop && tabs && <div className="mb-4">{tabs}</div>}
+        {isDesktop && (tabs || actions) && (
+          <div className="mb-4 flex items-center justify-between">
+            <div className="flex-1">{tabs}</div>
+            <div className="ml-2">{actions}</div>
+          </div>
+        )}
         <div
           className={cn(
             isDesktop && "scrollbar-container h-full overflow-y-auto",

--- a/web/src/components/overlay/detail/TrackingDetails.tsx
+++ b/web/src/components/overlay/detail/TrackingDetails.tsx
@@ -558,9 +558,7 @@ export function TrackingDetails({
 
           <div className="mt-4">
             <div
-              className={cn(
-                "rounded-md bg-secondary p-3 outline outline-[3px] -outline-offset-[2.8px] outline-transparent duration-500",
-              )}
+              className={cn("rounded-md bg-background_alt px-0 py-3 md:px-2")}
             >
               <div className="flex w-full items-center justify-between">
                 <div
@@ -586,7 +584,7 @@ export function TrackingDetails({
                   </div>
                   <div className="flex items-center gap-2">
                     <span className="capitalize">{label}</span>
-                    <span className="md:text-md text-sm text-secondary-foreground">
+                    <span className="md:text-md text-xs text-secondary-foreground">
                       {formattedStart ?? ""} - {formattedEnd ?? ""}
                     </span>
                     {event.data?.recognized_license_plate && (

--- a/web/src/components/timeline/DetailStream.tsx
+++ b/web/src/components/timeline/DetailStream.tsx
@@ -27,6 +27,7 @@ import { Switch } from "@/components/ui/switch";
 import { usePersistence } from "@/hooks/use-persistence";
 import { isDesktop } from "react-device-detect";
 import { PiSlidersHorizontalBold } from "react-icons/pi";
+import { MdAutoAwesome } from "react-icons/md";
 
 type DetailStreamProps = {
   reviewItems?: ReviewSegment[];

--- a/web/src/components/timeline/DetailStream.tsx
+++ b/web/src/components/timeline/DetailStream.tsx
@@ -16,13 +16,7 @@ import ActivityIndicator from "../indicators/activity-indicator";
 import { Event } from "@/types/event";
 import { getIconForLabel } from "@/utils/iconUtil";
 import { ReviewSegment } from "@/types/review";
-import {
-  LuChevronDown,
-  LuCircle,
-  LuChevronRight,
-  LuSettings,
-} from "react-icons/lu";
-import { MdAutoAwesome } from "react-icons/md";
+import { LuChevronDown, LuCircle, LuChevronRight } from "react-icons/lu";
 import { getTranslatedLabel } from "@/utils/i18n";
 import EventMenu from "@/components/timeline/EventMenu";
 import { FrigatePlusDialog } from "@/components/overlay/dialog/FrigatePlusDialog";
@@ -32,6 +26,7 @@ import { Link } from "react-router-dom";
 import { Switch } from "@/components/ui/switch";
 import { usePersistence } from "@/hooks/use-persistence";
 import { isDesktop } from "react-device-detect";
+import { PiSlidersHorizontalBold } from "react-icons/pi";
 
 type DetailStreamProps = {
   reviewItems?: ReviewSegment[];
@@ -237,7 +232,7 @@ export default function DetailStream({
             className="flex w-full items-center justify-between p-3"
           >
             <div className="flex items-center gap-2 text-sm font-medium">
-              <LuSettings className="size-4" />
+              <PiSlidersHorizontalBold className="size-4" />
               <span>{t("detail.settings")}</span>
             </div>
             {controlsExpanded ? (

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -11,13 +11,21 @@ const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
     container?: HTMLElement | null;
+    disablePortal?: boolean;
   }
 >(
   (
-    { className, container, align = "center", sideOffset = 4, ...props },
+    {
+      className,
+      container,
+      disablePortal = false,
+      align = "center",
+      sideOffset = 4,
+      ...props
+    },
     ref,
-  ) => (
-    <PopoverPrimitive.Portal container={container}>
+  ) => {
+    const content = (
       <PopoverPrimitive.Content
         ref={ref}
         align={align}
@@ -28,8 +36,18 @@ const PopoverContent = React.forwardRef<
         )}
         {...props}
       />
-    </PopoverPrimitive.Portal>
-  ),
+    );
+
+    if (disablePortal) {
+      return content;
+    }
+
+    return (
+      <PopoverPrimitive.Portal container={container}>
+        {content}
+      </PopoverPrimitive.Portal>
+    );
+  },
 );
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 

--- a/web/src/context/detail-stream-context.tsx
+++ b/web/src/context/detail-stream-context.tsx
@@ -8,7 +8,7 @@ export interface DetailStreamContextType {
   camera: string;
   annotationOffset: number; // milliseconds
   setSelectedObjectIds: React.Dispatch<React.SetStateAction<string[]>>;
-  setAnnotationOffset: (ms: number) => void;
+  setAnnotationOffset: React.Dispatch<React.SetStateAction<number>>;
   toggleObjectSelection: (id: string | undefined) => void;
   isDetailMode: boolean;
 }

--- a/web/src/pages/FaceLibrary.tsx
+++ b/web/src/pages/FaceLibrary.tsx
@@ -524,7 +524,7 @@ function LibrarySelector({
         regexErrorMessage={t("description.invalidName")}
       />
 
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <Button className="flex justify-between smart-capitalize">
             {pageToggle == "train" ? t("train.title") : pageToggle}


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR makes the following changes to the Tracked Object Details pane in Explore:
- Add navigation icons outside the dialog to navigate to next/previous tracked object (arrow keys can still be used) in both summary and grid view
- Update the layout to match elements in the Figma design
- Consolidate buttons and add an action menu 
- Use two columns for details
- Refactor annotation settings as a popover on desktop and drawer on mobile
- Move Frigate+ submission to details area

Other changes:
- Add an optional prop to the popover component to disable portaling
- Change language of annotation settings per Blake's suggestion
- Set modal as false on the face library dropdown to prevent loss of pointer events on canceling the delete dialog


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
