### PR TITLE
Tracked Object Details pane tweaks

### DIFF
--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -96,7 +96,9 @@
     "back": "Go back",
     "hide": "Hide {{item}}",
     "show": "Show {{item}}",
-    "ID": "ID"
+    "ID": "ID",
+    "none": "None",
+    "all": "All"
   },
   "list": {
     "two": "{{0}} and {{1}}",

--- a/web/src/components/overlay/CreateTriggerDialog.tsx
+++ b/web/src/components/overlay/CreateTriggerDialog.tsx
@@ -159,7 +159,7 @@ export default function CreateTriggerDialog({
   });
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
-    if (trigger) {
+    if (trigger && existingTriggerNames.includes(trigger.name)) {
       onEdit({ ...values });
     } else {
       onCreate(

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -1490,7 +1490,7 @@ function ObjectDetailsTab({
             </div>
           ) : (
             <div className="overflow-auto text-sm text-primary">
-              {desc || "None"}
+              {desc || t("label.none", { ns: "common" })}
             </div>
           )
         ) : (

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -367,16 +367,11 @@ function DialogContentComponent({
 
   if (isDesktop) {
     return (
-      <div className="flex h-full gap-4 overflow-hidden">
-        <div
-          className={cn(
-            "scrollbar-container flex-[3] overflow-y-hidden",
-            !search.has_snapshot && "flex-[2]",
-          )}
-        >
+      <div className="grid h-full w-full grid-cols-[60%_40%] gap-4">
+        <div className="scrollbar-container min-w-0 overflow-y-auto overflow-x-hidden">
           {snapshotElement}
         </div>
-        <div className="flex flex-col gap-4 overflow-hidden md:basis-2/5">
+        <div className="flex min-w-0 flex-col gap-4 pr-2">
           <TabsWithActions
             search={search}
             searchTabs={searchTabs}
@@ -389,7 +384,7 @@ function DialogContentComponent({
             setIsPopoverOpen={setIsPopoverOpen}
             dialogContainer={dialogContainer}
           />
-          <div className="scrollbar-container flex-1 overflow-y-auto">
+          <div className="scrollbar-container min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-4">
             <ObjectDetailsTab
               search={search}
               config={config}

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -37,7 +37,6 @@ import {
   FaChevronLeft,
   FaChevronRight,
   FaMicrophone,
-  FaRedo,
   FaCheck,
   FaTimes,
 } from "react-icons/fa";
@@ -92,6 +91,7 @@ import { CameraNameLabel } from "@/components/camera/FriendlyNameLabel";
 import { DialogPortal } from "@radix-ui/react-dialog";
 import { useDetailStream } from "@/context/detail-stream-context";
 import { PiSlidersHorizontalBold } from "react-icons/pi";
+import { HiSparkles } from "react-icons/hi";
 
 const SEARCH_TABS = ["snapshot", "tracking_details"] as const;
 export type SearchTab = (typeof SEARCH_TABS)[number];
@@ -1122,7 +1122,7 @@ function ObjectDetailsTab({
   const canRegenerate = !!(
     config?.cameras[search.camera].objects.genai.enabled && search.end_time
   );
-  const showAiPlaceholder = !!(
+  const showGenAIPlaceholder = !!(
     config?.cameras[search.camera].objects.genai.enabled &&
     !search.end_time &&
     (config.cameras[search.camera].objects.genai.required_zones.length === 0 ||
@@ -1396,16 +1396,16 @@ function ObjectDetailsTab({
           </div>
         )}
       <div className="flex flex-col gap-1.5">
-        <div className="flex items-start justify-start gap-2">
+        <div className="flex items-center justify-start gap-3">
           <div className="text-sm text-primary/40">
             {t("details.description.label")}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
                   aria-label={t("button.edit", { ns: "common" })}
-                  className="text-primary/40 hover:text-primary"
+                  className="text-primary/40 hover:text-primary/80"
                   onClick={() => {
                     originalDescRef.current = desc ?? "";
                     setIsEditingDesc(true);
@@ -1426,7 +1426,7 @@ function ObjectDetailsTab({
                   <TooltipTrigger asChild>
                     <button
                       aria-label={t("itemMenu.audioTranscription.label")}
-                      className="text-primary/40 hover:text-primary"
+                      className="text-primary/40 hover:text-primary/80"
                       onClick={onTranscribe}
                     >
                       <FaMicrophone className="size-4" />
@@ -1441,21 +1441,21 @@ function ObjectDetailsTab({
             {canRegenerate && (
               <div className="relative">
                 <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
                         <button
                           aria-label={t("details.button.regenerate.label")}
-                          className="text-primary/40 hover:text-primary"
+                          className="text-primary/40 hover:text-primary/80"
                         >
-                          <FaRedo className="size-4" />
+                          <HiSparkles className="size-4" />
                         </button>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        {t("details.button.regenerate.title")}
-                      </TooltipContent>
-                    </Tooltip>
-                  </DropdownMenuTrigger>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {t("details.button.regenerate.title")}
+                    </TooltipContent>
+                  </Tooltip>
                   <DropdownMenuContent>
                     {search.has_snapshot && (
                       <DropdownMenuItem
@@ -1481,7 +1481,7 @@ function ObjectDetailsTab({
         </div>
 
         {!isEditingDesc ? (
-          showAiPlaceholder ? (
+          showGenAIPlaceholder ? (
             <div className="flex h-32 flex-col items-center justify-center gap-3 border p-4 text-sm text-primary/40">
               <div className="flex">
                 <ActivityIndicator />
@@ -1504,27 +1504,42 @@ function ObjectDetailsTab({
               onBlur={handleDescriptionBlur}
               autoFocus
             />
-            <div className="flex flex-row justify-end gap-2">
-              <button
-                aria-label={t("button.save", { ns: "common" })}
-                className="text-primary/40 hover:text-primary"
-                onClick={() => {
-                  setIsEditingDesc(false);
-                  updateDescription();
-                }}
-              >
-                <FaCheck className="size-4" />
-              </button>
-              <button
-                aria-label={t("button.cancel", { ns: "common" })}
-                className="text-primary/40 hover:text-primary"
-                onClick={() => {
-                  setIsEditingDesc(false);
-                  setDesc(originalDescRef.current ?? "");
-                }}
-              >
-                <FaTimes className="size-4" />
-              </button>
+            <div className="flex flex-row justify-end gap-4">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    aria-label={t("button.save", { ns: "common" })}
+                    className="text-primary/40 hover:text-primary/80"
+                    onClick={() => {
+                      setIsEditingDesc(false);
+                      updateDescription();
+                    }}
+                  >
+                    <FaCheck className="size-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {t("button.save", { ns: "common" })}
+                </TooltipContent>
+              </Tooltip>
+
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    aria-label={t("button.cancel", { ns: "common" })}
+                    className="text-primary/40 hover:text-primary"
+                    onClick={() => {
+                      setIsEditingDesc(false);
+                      setDesc(originalDescRef.current ?? "");
+                    }}
+                  >
+                    <FaTimes className="size-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {t("button.cancel", { ns: "common" })}
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
         )}

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -351,7 +351,12 @@ function DialogContentComponent({
       }
     />
   ) : (
-    <div className={cn(!isDesktop ? "mb-4 w-full md:max-w-lg" : "size-full")}>
+    <div
+      className={cn(
+        "max-w-lg",
+        !isDesktop ? "mb-4 w-full" : "mx-auto size-full",
+      )}
+    >
       <img
         className="w-full select-none rounded-lg object-contain transition-opacity"
         style={


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR makes tweaks to the Tracked Object Details pane in Explore:
- Use css grid for the pane instead of flexbox to ensure consistent width between tracked objects
- Make the description text box look like a normal field
- Remove the regenerate, transcribe, and save buttons and add them next to the field label
- Set max width on thumbnails

Also, this PR fixes Trigger creation when navigating from Explore.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
