### PR TITLE
feat: use persisted state for selected camera on settings page

### DIFF
--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -37,6 +37,7 @@ import EnrichmentsSettingsView from "@/views/settings/EnrichmentsSettingsView";
 import UiSettingsView from "@/views/settings/UiSettingsView";
 import FrigatePlusSettingsView from "@/views/settings/FrigatePlusSettingsView";
 import { useSearchEffect } from "@/hooks/use-overlay-state";
+import { usePersistence } from "@/hooks/use-persistence";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useInitialCameraState } from "@/api/ws";
 import { useIsAdmin } from "@/hooks/use-is-admin";
@@ -207,7 +208,21 @@ export default function Settings() {
       .sort((aConf, bConf) => aConf.ui.order - bConf.ui.order);
   }, [config]);
 
-  const [selectedCamera, setSelectedCamera] = useState<string>("");
+  const [persistedCamera, setPersistedCamera] = usePersistence(
+    "selectedCamera",
+    "",
+  );
+  const [selectedCamera, setSelectedCamera] = useState(persistedCamera);
+  useEffect(() => {
+    if (persistedCamera) {
+      setSelectedCamera(persistedCamera);
+    }
+  }, [persistedCamera]);
+  useEffect(() => {
+    if (selectedCamera) {
+      setPersistedCamera(selectedCamera);
+    }
+  }, [selectedCamera, setPersistedCamera]);
 
   const { payload: allCameraStates } = useInitialCameraState(
     cameras.length > 0 ? cameras[0].name : "",


### PR DESCRIPTION
## Proposed change

Leverage the usePersistence() hook to store the selected camera so that navigating away from the settings page and back will remember the selected camera.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [n/a] UI changes including text have used i18n keys and have been added to the `en` locale.
- [prettier] The code has been formatted using Ruff (`ruff format frigate`)
