### PR TITLE
Chore/update yq to 4.48.2

### DIFF
--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -145,6 +145,6 @@ rm -rf /var/lib/apt/lists/*
 
 # Install yq, for frigate-prepare and go2rtc echo source
 curl -fsSL \
-    "https://github.com/mikefarah/yq/releases/download/v4.33.3/yq_linux_$(dpkg --print-architecture)" \
+    "https://github.com/mikefarah/yq/releases/download/v4.48.2/yq_linux_$(dpkg --print-architecture)" \
     --output /usr/local/bin/yq
 chmod +x /usr/local/bin/yq

--- a/docs/docs/configuration/advanced.md
+++ b/docs/docs/configuration/advanced.md
@@ -247,7 +247,7 @@ curl -X POST http://frigate_host:5000/api/config/save -d @config.json
 if you'd like you can use your yaml config directly by using [`yq`](https://github.com/mikefarah/yq) to convert it to json:
 
 ```bash
-yq r -j config.yml | curl -X POST http://frigate_host:5000/api/config/save -d @-
+yq -o=json '.' config.yaml | curl -X POST 'http://frigate_host:5000/api/config/save?save_option=saveonly' --data-binary @-
 ```
 
 ### Via Command Line


### PR DESCRIPTION
## Proposed change

This pull request updates the bundled `yq` binary to **v4.48.2** and adjusts the Frigate configuration upload command to use the correct **yq v4 syntax**.

The previous version (v4.33.3) was built with an outdated Go runtime containing multiple HIGH and CRITICAL security vulnerabilities. Upgrading to v4.48.2 resolves these issues and aligns with current upstream releases.

**Trivy scan results for v4.33.3:** Total: 48 (UNKNOWN: 0, LOW: 0, MEDIUM: 33, HIGH: 13, CRITICAL: 2)

Additionally, the existing command used deprecated `yq r -j` syntax from yq v3. This has been replaced with the modern, v4-compatible syntax:

No breaking changes are introduced.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update


## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)  