### PR TITLE
Fix HLS jumping to end of timeChunk

### DIFF
--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -135,6 +135,23 @@ export default function HlsVideoPlayer({
     if (!useHlsCompat) {
       videoRef.current.src = currentSource.playlist;
       videoRef.current.load();
+      // For native HLS, we need to seek after metadata loads since startPosition isn't supported
+      if (currentSource.startPosition !== undefined) {
+        videoRef.current.addEventListener(
+          "loadedmetadata",
+          () => {
+            if (videoRef.current && currentSource.startPosition !== undefined) {
+              // Clamp startPosition to video duration to prevent seeking beyond the end
+              const clampedPosition = Math.min(
+                currentSource.startPosition,
+                videoRef.current.duration || Infinity,
+              );
+              videoRef.current.currentTime = clampedPosition;
+            }
+          },
+          { once: true },
+        );
+      }
       return;
     }
 

--- a/web/src/components/player/dynamic/DynamicVideoController.ts
+++ b/web/src/components/player/dynamic/DynamicVideoController.ts
@@ -113,6 +113,8 @@ export class DynamicVideoController {
       } else {
         this.playerController.pause();
       }
+    } else {
+      // no op
     }
   }
 

--- a/web/src/components/player/dynamic/DynamicVideoController.ts
+++ b/web/src/components/player/dynamic/DynamicVideoController.ts
@@ -113,8 +113,6 @@ export class DynamicVideoController {
       } else {
         this.playerController.pause();
       }
-    } else {
-      // no op
     }
   }
 

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -111,7 +111,6 @@ export default function DynamicVideoPlayer({
   const [loadingTimeout, setLoadingTimeout] = useState<NodeJS.Timeout>();
   const [source, setSource] = useState<HlsSource>({
     playlist: `${apiHost}vod/${camera}/start/${timeRange.after}/end/${timeRange.before}/master.m3u8`,
-    startPosition: startTimestamp ? timeRange.after - startTimestamp : 0,
   });
 
   // start at correct time
@@ -196,26 +195,8 @@ export default function DynamicVideoPlayer({
       playerRef.current.autoplay = !isScrubbing;
     }
 
-    let startPosition = undefined;
-
-    if (startTimestamp) {
-      const inpointOffset = calculateInpointOffset(
-        recordingParams.after,
-        (recordings || [])[0],
-      );
-      const idealStartPosition = Math.max(
-        0,
-        startTimestamp - timeRange.after - inpointOffset,
-      );
-
-      if (idealStartPosition >= recordings[0].start_time - timeRange.after) {
-        startPosition = idealStartPosition;
-      }
-    }
-
     setSource({
       playlist: `${apiHost}vod/${camera}/start/${recordingParams.after}/end/${recordingParams.before}/master.m3u8`,
-      startPosition,
     });
 
     setLoadingTimeout(setTimeout(() => setIsLoading(true), 1000));


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

There are some differences between HLS.js and native browser HLS support. Native browser HLS does not support `startPosition`. This leads to cases where the browser tries to jump to the end of the current HLS playlist and then tries to jump back. 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
