### PR TITLE
add comment about unifi g5 and newer cams

### DIFF
--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -227,6 +227,12 @@ cameras:
 
 ### Unifi Protect Cameras
 
+:::note 
+
+Unifi G5s cameras and newer need a Unifi Protect server to enable rtsps stream, it's not posible to enable it in standalone mode.
+
+:::
+
 Unifi protect cameras require the rtspx stream to be used with go2rtc.
 To utilize a Unifi protect camera, modify the rtsps link to begin with rtspx.
 Additionally, remove the "?enableSrtp" from the end of the Unifi link.


### PR DESCRIPTION
## Proposed change
Unfi have changed the amount of config you can set in standalone mode with G5 and newer cams. Now you have to have a Unfi Protect Server to enable rtps stream to use with e.g. Frigate.
Added a note about in the camera specific module in the docs, to give users a heads up if they consider using Unifi Protect cams with Frigate

Let me know if this is wanted or if the wording need to change

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)

