### PR TITLE
[MemryX] Clean shutdown of detector process

### DIFF
--- a/frigate/detectors/plugins/memryx.py
+++ b/frigate/detectors/plugins/memryx.py
@@ -54,7 +54,7 @@ class MemryXDetector(DetectionApi):
                 "MemryX SDK is not installed. Install it and set up MIX environment."
             )
             return
-        
+
         # Get stop_event from detector_config
         self.stop_event = getattr(detector_config, "_stop_event", stop_event)
 
@@ -372,10 +372,7 @@ class MemryXDetector(DetectionApi):
                 return None
             try:
                 # Wait for a frame from the queue with timeout to check stop_event periodically
-                frame = self.capture_queue.get(
-                    block=True, 
-                    timeout=0.5
-                )  
+                frame = self.capture_queue.get(block=True, timeout=0.5)
 
                 return frame
 
@@ -388,18 +385,15 @@ class MemryXDetector(DetectionApi):
 
     def receive_output(self):
         """Retrieve processed results from MemryX output queue + a copy of the original frame"""
-        try: 
+        try:
             # Get connection ID with timeout
-            connection_id = (
-                self.capture_id_queue.get(
-                    block=True, 
-                    timeout=1.0
-                )
+            connection_id = self.capture_id_queue.get(
+                block=True, timeout=1.0
             )  # Get the corresponding connection ID
             detections = self.output_queue.get()  # Get detections from MemryX
 
             return connection_id, detections
-        
+
         except Exception as e:
             # On timeout or stop event, return None
             if self.stop_event.is_set():
@@ -409,7 +403,6 @@ class MemryXDetector(DetectionApi):
                 logger.warning(f"[receive_output] Error receiving output: {e}")
 
             return None, None
-    
 
     def post_process_yolonas(self, output):
         predictions = output[0]
@@ -857,7 +850,7 @@ class MemryXDetector(DetectionApi):
             raise Exception(
                 f"{self.memx_model_type} is currently not supported for memryx. See the docs for more info on supported models."
             )
-        
+
     def shutdown(self):
         """Gracefully shutdown the MemryX accelerator"""
         try:

--- a/frigate/detectors/plugins/memryx.py
+++ b/frigate/detectors/plugins/memryx.py
@@ -44,7 +44,7 @@ class MemryXDetector(DetectionApi):
         ModelTypeEnum.yolox,
     ]
 
-    def __init__(self, detector_config):
+    def __init__(self, detector_config, stop_event=None):
         """Initialize MemryX detector with the provided configuration."""
         try:
             # Import MemryX SDK
@@ -54,6 +54,9 @@ class MemryXDetector(DetectionApi):
                 "MemryX SDK is not installed. Install it and set up MIX environment."
             )
             return
+        
+        # Get stop_event from detector_config
+        self.stop_event = getattr(detector_config, "_stop_event", stop_event)
 
         model_cfg = getattr(detector_config, "model", None)
 
@@ -363,26 +366,50 @@ class MemryXDetector(DetectionApi):
     def process_input(self):
         """Input callback function: wait for frames in the input queue, preprocess, and send to MX3 (return)"""
         while True:
+            # Check if shutdown is requested
+            if self.stop_event.is_set():
+                logger.debug("[process_input] Stop event detected, returning None")
+                return None
             try:
-                # Wait for a frame from the queue (blocking call)
+                # Wait for a frame from the queue with timeout to check stop_event periodically
                 frame = self.capture_queue.get(
-                    block=True
-                )  # Blocks until data is available
+                    block=True, 
+                    timeout=0.5
+                )  
 
                 return frame
 
             except Exception as e:
-                logger.info(f"[process_input] Error processing input: {e}")
-                time.sleep(0.1)  # Prevent busy waiting in case of error
+                # Silently handle queue.Empty timeouts (expected during normal operation)
+                # Log any other unexpected exceptions
+                if "Empty" not in str(type(e).__name__):
+                    logger.warning(f"[process_input] Unexpected error: {e}")
+                # Loop continues and will check stop_event at the top
 
     def receive_output(self):
         """Retrieve processed results from MemryX output queue + a copy of the original frame"""
-        connection_id = (
-            self.capture_id_queue.get()
-        )  # Get the corresponding connection ID
-        detections = self.output_queue.get()  # Get detections from MemryX
+        try: 
+            # Get connection ID with timeout
+            connection_id = (
+                self.capture_id_queue.get(
+                    block=True, 
+                    timeout=1.0
+                )
+            )  # Get the corresponding connection ID
+            detections = self.output_queue.get()  # Get detections from MemryX
 
-        return connection_id, detections
+            return connection_id, detections
+        
+        except Exception as e:
+            # On timeout or stop event, return None
+            if self.stop_event.is_set():
+                logger.debug("[receive_output] Stop event detected, exiting")
+            # Silently handle queue.Empty timeouts, they're expected during normal operation
+            elif "Empty" not in str(type(e).__name__):
+                logger.warning(f"[receive_output] Error receiving output: {e}")
+
+            return None, None
+    
 
     def post_process_yolonas(self, output):
         predictions = output[0]
@@ -830,6 +857,15 @@ class MemryXDetector(DetectionApi):
             raise Exception(
                 f"{self.memx_model_type} is currently not supported for memryx. See the docs for more info on supported models."
             )
+        
+    def shutdown(self):
+        """Gracefully shutdown the MemryX accelerator"""
+        try:
+            if hasattr(self, "accl") and self.accl is not None:
+                self.accl.shutdown()
+                logger.info("MemryX accelerator shutdown complete")
+        except Exception as e:
+            logger.error(f"Error during MemryX shutdown: {e}")
 
     def detect_raw(self, tensor_input: np.ndarray):
         """Removed synchronous detect_raw() function so that we only use async"""

--- a/frigate/detectors/plugins/memryx.py
+++ b/frigate/detectors/plugins/memryx.py
@@ -2,7 +2,6 @@ import glob
 import logging
 import os
 import shutil
-import time
 import urllib.request
 import zipfile
 from queue import Queue

--- a/frigate/object_detection/base.py
+++ b/frigate/object_detection/base.py
@@ -336,7 +336,7 @@ class ObjectDetectProcess:
         # if the process has already exited on its own, just return
         if self.detect_process and self.detect_process.exitcode:
             return
-        
+
         logging.info("Waiting for detection process to exit gracefully...")
         self.detect_process.join(timeout=30)
         if self.detect_process.exitcode is None:

--- a/frigate/object_detection/base.py
+++ b/frigate/object_detection/base.py
@@ -61,7 +61,7 @@ class BaseLocalDetector(ObjectDetector):
 
         self.detect_api = create_detector(detector_config)
 
-        # If the detector supports setting stop_event, provide it
+        # If the detector supports stop_event, pass it
         if hasattr(self.detect_api, "set_stop_event") and stop_event:
             self.detect_api.set_stop_event(stop_event)
 
@@ -299,10 +299,8 @@ class AsyncDetectorRunner(FrigateProcess):
             t_detect.join(timeout=5)
             t_result.join(timeout=5)
 
-            # Explicitly shutdown MemryX accelerator
-            if hasattr(self._detector.detect_api, "shutdown"):
-                logger.info("Calling MemryX shutdown method...")
-                self._detector.detect_api.shutdown()
+            # Shutdown the AsyncDetector
+            self._detector.detect_api.shutdown()
 
             self._publisher.stop()
         except Exception as e:

--- a/frigate/object_detection/base.py
+++ b/frigate/object_detection/base.py
@@ -59,11 +59,11 @@ class BaseLocalDetector(ObjectDetector):
             self.input_transform = None
             self.dtype = InputDTypeEnum.int
 
-        # Attach stop_event to detector_config so detectors can access it
-        if detector_config and stop_event:
-            detector_config._stop_event = stop_event
-
         self.detect_api = create_detector(detector_config)
+
+        # If the detector supports setting stop_event, provide it
+        if hasattr(self.detect_api, "set_stop_event") and stop_event:
+            self.detect_api.set_stop_event(stop_event)
 
     def _transform_input(self, tensor_input: np.ndarray) -> np.ndarray:
         if self.input_transform:


### PR DESCRIPTION
## Proposed change
This PR updates the detector shutdown logic to ensure a clean exit of the detection process.
 
Correct me if I’m wrong, but is there any reason why `terminate()` is called before `join()`?
 
When `terminate()` is called first, it sends a `SIGTERM` signal that immediately interrupts the detection process before it can execute its cleanup code.

I’ve added the MemryX shutdown logic to exit gracefully, and I also removed the `terminate()` call before `join() `because it was blocking the cleanup path. 
 
I also tested this with the CPU detector. When terminate() is called first, the cleanup section does not run.
 
```
detector_publisher.stop()
logger.info("Exited detection process...")
```

Is it okay to remove the `terminate()` call? Please let me know if this approach is acceptable.
 
## Type of change
 
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update
 
## Additional information
 
- This PR fixes or closes issue: fixes #
- This PR is related to issue:
 
## Checklist
 
<!--
  Put an `x` in the boxes that apply.
-->
 
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)