### PR TITLE
Enforce default admin role requirement for API endpoints

### DIFF
--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -90,7 +90,7 @@ def stats_history(request: Request, keys: str = None):
     return JSONResponse(content=request.app.stats_emitter.get_stats_history(keys))
 
 
-@router.get("/metrics", dependencies=[Depends(allow_public())])
+@router.get("/metrics", dependencies=[Depends(allow_any_authenticated())])
 def metrics(request: Request):
     """Expose Prometheus metrics endpoint and update metrics with latest stats"""
     # Retrieve the latest statistics and update the Prometheus metrics

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -677,7 +677,9 @@ def delete_user(request: Request, username: str):
     return JSONResponse(content={"success": True})
 
 
-@router.put("/users/{username}/password")
+@router.put(
+    "/users/{username}/password", dependencies=[Depends(allow_any_authenticated())]
+)
 async def update_password(
     request: Request,
     username: str,

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -86,7 +86,8 @@ def require_admin_by_default():
     # Path prefixes that should be exempt (for paths with parameters)
     EXEMPT_PREFIXES = (
         "/logs/",  # /logs/{service}
-        "/review",  # /review, /review/{id}, /review_ids, etc.
+        "/review",  # /review, /review/{id}, /review_ids, /review/summary, etc.
+        "/reviews/",  # /reviews/viewed, /reviews/delete
         "/events/",  # /events/{id}/thumbnail, etc. (camera-scoped)
         "/go2rtc/streams/",  # /go2rtc/streams/{camera}
         "/users/",  # /users/{username}/password (has own auth)
@@ -166,7 +167,7 @@ def allow_any_authenticated():
         role = request.headers.get("remote-role")
         if role == "admin":
             return
-        
+
         # Otherwise require a real authenticated user (not anonymous)
         if not _is_authenticated(request):
             raise HTTPException(status_code=401, detail="Authentication required")

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -22,6 +22,7 @@ from peewee import JOIN, DoesNotExist, fn, operator
 from playhouse.shortcuts import model_to_dict
 
 from frigate.api.auth import (
+    allow_any_authenticated,
     get_allowed_cameras_for_filter,
     require_camera_access,
     require_role,
@@ -808,7 +809,7 @@ def events_search(
     return JSONResponse(content=processed_events)
 
 
-@router.get("/events/summary")
+@router.get("/events/summary", dependencies=[Depends(allow_any_authenticated())])
 def events_summary(
     params: EventsSummaryQueryParams = Depends(),
     allowed_cameras: List[str] = Depends(get_allowed_cameras_for_filter),

--- a/frigate/api/fastapi_app.py
+++ b/frigate/api/fastapi_app.py
@@ -2,7 +2,7 @@ import logging
 import re
 from typing import Optional
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse
 from joserfc.jwk import OctKey
 from playhouse.sqliteq import SqliteQueueDatabase
@@ -24,7 +24,7 @@ from frigate.api import (
     preview,
     review,
 )
-from frigate.api.auth import get_jwt_secret, limiter
+from frigate.api.auth import get_jwt_secret, limiter, require_admin_by_default
 from frigate.comms.event_metadata_updater import (
     EventMetadataPublisher,
 )
@@ -67,6 +67,7 @@ def create_fastapi_app(
     app = FastAPI(
         debug=False,
         swagger_ui_parameters={"apisSorter": "alpha", "operationsSorter": "alpha"},
+        dependencies=[Depends(require_admin_by_default())],
     )
 
     # update the request_address with the x-forwarded-for header from nginx

--- a/frigate/api/fastapi_app.py
+++ b/frigate/api/fastapi_app.py
@@ -62,12 +62,15 @@ def create_fastapi_app(
     stats_emitter: StatsEmitter,
     event_metadata_updater: EventMetadataPublisher,
     config_publisher: CameraConfigUpdatePublisher,
+    enforce_default_admin: bool = True,
 ):
     logger.info("Starting FastAPI app")
     app = FastAPI(
         debug=False,
         swagger_ui_parameters={"apisSorter": "alpha", "operationsSorter": "alpha"},
-        dependencies=[Depends(require_admin_by_default())],
+        dependencies=[Depends(require_admin_by_default())]
+        if enforce_default_admin
+        else [],
     )
 
     # update the request_address with the x-forwarded-for header from nginx

--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -14,6 +14,7 @@ from peewee import Case, DoesNotExist, IntegrityError, fn, operator
 from playhouse.shortcuts import model_to_dict
 
 from frigate.api.auth import (
+    allow_any_authenticated,
     get_allowed_cameras_for_filter,
     get_current_user,
     require_camera_access,
@@ -43,7 +44,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=[Tags.review])
 
 
-@router.get("/review", response_model=list[ReviewSegmentResponse])
+@router.get(
+    "/review",
+    response_model=list[ReviewSegmentResponse],
+    dependencies=[Depends(allow_any_authenticated())],
+)
 async def review(
     params: ReviewQueryParams = Depends(),
     current_user: dict = Depends(get_current_user),
@@ -152,7 +157,11 @@ async def review(
     return JSONResponse(content=[r for r in review_query])
 
 
-@router.get("/review_ids", response_model=list[ReviewSegmentResponse])
+@router.get(
+    "/review_ids",
+    response_model=list[ReviewSegmentResponse],
+    dependencies=[Depends(allow_any_authenticated())],
+)
 async def review_ids(request: Request, ids: str):
     ids = ids.split(",")
 
@@ -186,7 +195,11 @@ async def review_ids(request: Request, ids: str):
         )
 
 
-@router.get("/review/summary", response_model=ReviewSummaryResponse)
+@router.get(
+    "/review/summary",
+    response_model=ReviewSummaryResponse,
+    dependencies=[Depends(allow_any_authenticated())],
+)
 async def review_summary(
     params: ReviewSummaryQueryParams = Depends(),
     current_user: dict = Depends(get_current_user),
@@ -461,7 +474,11 @@ async def review_summary(
     return JSONResponse(content=data)
 
 
-@router.post("/reviews/viewed", response_model=GenericResponse)
+@router.post(
+    "/reviews/viewed",
+    response_model=GenericResponse,
+    dependencies=[Depends(allow_any_authenticated())],
+)
 async def set_multiple_reviewed(
     request: Request,
     body: ReviewModifyMultipleBody,
@@ -644,7 +661,11 @@ def motion_activity(
     return JSONResponse(content=normalized)
 
 
-@router.get("/review/event/{event_id}", response_model=ReviewSegmentResponse)
+@router.get(
+    "/review/event/{event_id}",
+    response_model=ReviewSegmentResponse,
+    dependencies=[Depends(allow_any_authenticated())],
+)
 async def get_review_from_event(request: Request, event_id: str):
     try:
         review = ReviewSegment.get(
@@ -659,7 +680,11 @@ async def get_review_from_event(request: Request, event_id: str):
         )
 
 
-@router.get("/review/{review_id}", response_model=ReviewSegmentResponse)
+@router.get(
+    "/review/{review_id}",
+    response_model=ReviewSegmentResponse,
+    dependencies=[Depends(allow_any_authenticated())],
+)
 async def get_review(request: Request, review_id: str):
     try:
         review = ReviewSegment.get(ReviewSegment.id == review_id)
@@ -672,7 +697,11 @@ async def get_review(request: Request, review_id: str):
         )
 
 
-@router.delete("/review/{review_id}/viewed", response_model=GenericResponse)
+@router.delete(
+    "/review/{review_id}/viewed",
+    response_model=GenericResponse,
+    dependencies=[Depends(allow_any_authenticated())],
+)
 async def set_not_reviewed(
     review_id: str,
     current_user: dict = Depends(get_current_user),

--- a/frigate/test/http_api/test_http_app.py
+++ b/frigate/test/http_api/test_http_app.py
@@ -1,10 +1,8 @@
 from unittest.mock import Mock
 
-from fastapi.testclient import TestClient
-
 from frigate.models import Event, Recordings, ReviewSegment
 from frigate.stats.emitter import StatsEmitter
-from frigate.test.http_api.base_http_test import BaseTestHttp
+from frigate.test.http_api.base_http_test import AuthTestClient, BaseTestHttp
 
 
 class TestHttpApp(BaseTestHttp):
@@ -20,7 +18,7 @@ class TestHttpApp(BaseTestHttp):
         stats.get_latest_stats.return_value = self.test_stats
         app = super().create_app(stats)
 
-        with TestClient(app) as client:
+        with AuthTestClient(app) as client:
             response = client.get("/stats")
             response_json = response.json()
             assert response_json == self.test_stats

--- a/frigate/test/http_api/test_http_camera_access.py
+++ b/frigate/test/http_api/test_http_camera_access.py
@@ -1,14 +1,13 @@
 from unittest.mock import patch
 
 from fastapi import HTTPException, Request
-from fastapi.testclient import TestClient
 
 from frigate.api.auth import (
     get_allowed_cameras_for_filter,
     get_current_user,
 )
 from frigate.models import Event, Recordings, ReviewSegment
-from frigate.test.http_api.base_http_test import BaseTestHttp
+from frigate.test.http_api.base_http_test import AuthTestClient, BaseTestHttp
 
 
 class TestCameraAccessEventReview(BaseTestHttp):
@@ -16,9 +15,17 @@ class TestCameraAccessEventReview(BaseTestHttp):
         super().setUp([Event, ReviewSegment, Recordings])
         self.app = super().create_app()
 
-        # Mock get_current_user to return valid user for all tests
-        async def mock_get_current_user():
-            return {"username": "test_user", "role": "user"}
+        # Mock get_current_user for all tests
+        async def mock_get_current_user(request: Request):
+            username = request.headers.get("remote-user")
+            role = request.headers.get("remote-role")
+            if not username or not role:
+                from fastapi.responses import JSONResponse
+
+                return JSONResponse(
+                    content={"message": "No authorization headers."}, status_code=401
+                )
+            return {"username": username, "role": role}
 
         self.app.dependency_overrides[get_current_user] = mock_get_current_user
 
@@ -30,21 +37,25 @@ class TestCameraAccessEventReview(BaseTestHttp):
         super().insert_mock_event("event1", camera="front_door")
         super().insert_mock_event("event2", camera="back_door")
 
-        self.app.dependency_overrides[get_allowed_cameras_for_filter] = lambda: [
-            "front_door"
-        ]
-        with TestClient(self.app) as client:
+        async def mock_cameras(request: Request):
+            return ["front_door"]
+
+        self.app.dependency_overrides[get_allowed_cameras_for_filter] = mock_cameras
+        with AuthTestClient(self.app) as client:
             resp = client.get("/events")
             assert resp.status_code == 200
             ids = [e["id"] for e in resp.json()]
             assert "event1" in ids
             assert "event2" not in ids
 
-        self.app.dependency_overrides[get_allowed_cameras_for_filter] = lambda: [
-            "front_door",
-            "back_door",
-        ]
-        with TestClient(self.app) as client:
+        async def mock_cameras(request: Request):
+            return [
+                "front_door",
+                "back_door",
+            ]
+
+        self.app.dependency_overrides[get_allowed_cameras_for_filter] = mock_cameras
+        with AuthTestClient(self.app) as client:
             resp = client.get("/events")
             assert resp.status_code == 200
             ids = [e["id"] for e in resp.json()]
@@ -54,21 +65,25 @@ class TestCameraAccessEventReview(BaseTestHttp):
         super().insert_mock_review_segment("rev1", camera="front_door")
         super().insert_mock_review_segment("rev2", camera="back_door")
 
-        self.app.dependency_overrides[get_allowed_cameras_for_filter] = lambda: [
-            "front_door"
-        ]
-        with TestClient(self.app) as client:
+        async def mock_cameras(request: Request):
+            return ["front_door"]
+
+        self.app.dependency_overrides[get_allowed_cameras_for_filter] = mock_cameras
+        with AuthTestClient(self.app) as client:
             resp = client.get("/review")
             assert resp.status_code == 200
             ids = [r["id"] for r in resp.json()]
             assert "rev1" in ids
             assert "rev2" not in ids
 
-        self.app.dependency_overrides[get_allowed_cameras_for_filter] = lambda: [
-            "front_door",
-            "back_door",
-        ]
-        with TestClient(self.app) as client:
+        async def mock_cameras(request: Request):
+            return [
+                "front_door",
+                "back_door",
+            ]
+
+        self.app.dependency_overrides[get_allowed_cameras_for_filter] = mock_cameras
+        with AuthTestClient(self.app) as client:
             resp = client.get("/review")
             assert resp.status_code == 200
             ids = [r["id"] for r in resp.json()]
@@ -84,7 +99,7 @@ class TestCameraAccessEventReview(BaseTestHttp):
             raise HTTPException(status_code=403, detail="Access denied")
 
         with patch("frigate.api.event.require_camera_access", mock_require_allowed):
-            with TestClient(self.app) as client:
+            with AuthTestClient(self.app) as client:
                 resp = client.get("/events/event1")
                 assert resp.status_code == 200
                 assert resp.json()["id"] == "event1"
@@ -94,7 +109,7 @@ class TestCameraAccessEventReview(BaseTestHttp):
             raise HTTPException(status_code=403, detail="Access denied")
 
         with patch("frigate.api.event.require_camera_access", mock_require_disallowed):
-            with TestClient(self.app) as client:
+            with AuthTestClient(self.app) as client:
                 resp = client.get("/events/event1")
                 assert resp.status_code == 403
 
@@ -108,7 +123,7 @@ class TestCameraAccessEventReview(BaseTestHttp):
             raise HTTPException(status_code=403, detail="Access denied")
 
         with patch("frigate.api.review.require_camera_access", mock_require_allowed):
-            with TestClient(self.app) as client:
+            with AuthTestClient(self.app) as client:
                 resp = client.get("/review/rev1")
                 assert resp.status_code == 200
                 assert resp.json()["id"] == "rev1"
@@ -118,7 +133,7 @@ class TestCameraAccessEventReview(BaseTestHttp):
             raise HTTPException(status_code=403, detail="Access denied")
 
         with patch("frigate.api.review.require_camera_access", mock_require_disallowed):
-            with TestClient(self.app) as client:
+            with AuthTestClient(self.app) as client:
                 resp = client.get("/review/rev1")
                 assert resp.status_code == 403
 
@@ -126,21 +141,25 @@ class TestCameraAccessEventReview(BaseTestHttp):
         super().insert_mock_event("event1", camera="front_door")
         super().insert_mock_event("event2", camera="back_door")
 
-        self.app.dependency_overrides[get_allowed_cameras_for_filter] = lambda: [
-            "front_door"
-        ]
-        with TestClient(self.app) as client:
+        async def mock_cameras(request: Request):
+            return ["front_door"]
+
+        self.app.dependency_overrides[get_allowed_cameras_for_filter] = mock_cameras
+        with AuthTestClient(self.app) as client:
             resp = client.get("/events", params={"cameras": "all"})
             assert resp.status_code == 200
             ids = [e["id"] for e in resp.json()]
             assert "event1" in ids
             assert "event2" not in ids
 
-        self.app.dependency_overrides[get_allowed_cameras_for_filter] = lambda: [
-            "front_door",
-            "back_door",
-        ]
-        with TestClient(self.app) as client:
+        async def mock_cameras(request: Request):
+            return [
+                "front_door",
+                "back_door",
+            ]
+
+        self.app.dependency_overrides[get_allowed_cameras_for_filter] = mock_cameras
+        with AuthTestClient(self.app) as client:
             resp = client.get("/events", params={"cameras": "all"})
             assert resp.status_code == 200
             ids = [e["id"] for e in resp.json()]
@@ -150,20 +169,24 @@ class TestCameraAccessEventReview(BaseTestHttp):
         super().insert_mock_event("event1", camera="front_door")
         super().insert_mock_event("event2", camera="back_door")
 
-        self.app.dependency_overrides[get_allowed_cameras_for_filter] = lambda: [
-            "front_door"
-        ]
-        with TestClient(self.app) as client:
+        async def mock_cameras(request: Request):
+            return ["front_door"]
+
+        self.app.dependency_overrides[get_allowed_cameras_for_filter] = mock_cameras
+        with AuthTestClient(self.app) as client:
             resp = client.get("/events/summary")
             assert resp.status_code == 200
             summary_list = resp.json()
             assert len(summary_list) == 1
 
-        self.app.dependency_overrides[get_allowed_cameras_for_filter] = lambda: [
-            "front_door",
-            "back_door",
-        ]
-        with TestClient(self.app) as client:
+        async def mock_cameras(request: Request):
+            return [
+                "front_door",
+                "back_door",
+            ]
+
+        self.app.dependency_overrides[get_allowed_cameras_for_filter] = mock_cameras
+        with AuthTestClient(self.app) as client:
             resp = client.get("/events/summary")
             summary_list = resp.json()
             assert len(summary_list) == 2


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR implements a default `admin` role requirement for all API endpoints to prevent security vulnerabilities for endpoints missing explicit authentication dependencies. New endpoints are admin-only unless a developer explicitly chooses a lower-privilege access policy.

- All endpoints now require admin role by default via `require_admin_by_default()` dependency
- Add comprehensive lists of paths exempt from the global check and allow route-level dependencies to handle their own authorization
- When adding a new API endpoint, a dependency must be specified and its route added to the exception lists

Changes to tests: 

- Tests use `enforce_default_admin=False` flag to disable the global check for running tests
- Fix tests to use new `AuthTestClient` and `remote-role` headers
- All dependency override mocks use proper `async def func(request: Request):` signatures required by FastAPI


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
