### PR TITLE
Add yolov9 inference speeds for UHD 730 GPU.

### DIFF
--- a/docs/docs/frigate/hardware.md
+++ b/docs/docs/frigate/hardware.md
@@ -159,7 +159,7 @@ Inference speeds vary greatly depending on the CPU or GPU used, some known examp
 | Intel HD 530   | 15 - 35 ms                 |                                                   |                           |                        | Can only run one detector instance |
 | Intel HD 620   | 15 - 25 ms                 |                                                   | 320: ~ 35 ms              |                        |                                    |
 | Intel HD 630   | ~ 15 ms                    |                                                   | 320: ~ 30 ms              |                        |                                    |
-| Intel UHD 730  | ~ 10 ms                    |                                                   | 320: ~ 19 ms 640: ~ 54 ms |                        |                                    |
+| Intel UHD 730  | ~ 10 ms                    | t-320: 14ms s-320: 24ms t-640: 34ms s-640: 65ms   | 320: ~ 19 ms 640: ~ 54 ms |                        |                                    |
 | Intel UHD 770  | ~ 15 ms                    | t-320: ~ 16 ms s-320: ~ 20 ms s-640: ~ 40 ms      | 320: ~ 20 ms 640: ~ 46 ms |                        |                                    |
 | Intel N100     | ~ 15 ms                    | s-320: 30 ms                                      | 320: ~ 25 ms              |                        | Can only run one detector instance |
 | Intel N150     | ~ 15 ms                    | t-320: 16 ms s-320: 24 ms                         |                           |                        |                                    |


### PR DESCRIPTION
## Proposed change
This adds the inference speeds measured on an i5-11400T with a UHD 730 GPU running at nominal temperatures.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

N/A

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
