### PR TITLE
Add Hailo-8 temperature retrieval

### DIFF
--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -22,6 +22,7 @@ from frigate.util.services import (
     get_bandwidth_stats,
     get_cpu_stats,
     get_fs_type,
+    get_hailo_temps,
     get_intel_gpu_stats,
     get_jetson_stats,
     get_nvidia_gpu_stats,
@@ -90,6 +91,9 @@ def get_temperatures() -> dict[str, float]:
             temp = read_temperature(os.path.join(base, apex, "temp"))
             if temp is not None:
                 temps[apex] = temp
+
+    # Get temperatures for Hailo devices
+    temps.update(get_hailo_temps())
 
     return temps
 

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -18,7 +18,6 @@ import cv2
 import psutil
 import py3nvml.py3nvml as nvml
 import requests
-from hailo_platform import Device
 
 from frigate.const import (
     DRIVER_AMD,
@@ -552,6 +551,11 @@ def get_jetson_stats() -> Optional[dict[int, dict]]:
 
 def get_hailo_temps() -> dict[str, float]:
     """Get temperatures for Hailo devices."""
+    try:
+        from hailo_platform import Device
+    except ModuleNotFoundError:
+        return {}
+
     temps = {}
 
     try:

--- a/web/src/views/system/GeneralMetrics.tsx
+++ b/web/src/views/system/GeneralMetrics.tsx
@@ -144,7 +144,7 @@ export default function GeneralMetrics({
       }
 
       Object.entries(stats.detectors).forEach(([key], cIdx) => {
-        if (!key.includes("coral")) {
+        if (!key.includes("coral") && !key.includes("hailo")) {
           return;
         }
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This change adds temperature retrieval for Hailo-8 devices:

<img width="894" height="267" alt="image" src="https://github.com/user-attachments/assets/c5dbed4b-b12e-4032-afd2-a7f590218805" />

```jsonc
// curl -s localhost:8971/api/stats | jq .service.temperatures
{
  "hailo8": 45.5
}
```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
