### PR TITLE
Adds support for YOLO v9 models running on Google Coral

### DIFF
--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -161,12 +161,6 @@ A Tensorflow Lite is provided in the container at `/openvino-model/ssdlite_mobil
 
 [YOLOv9](https://github.com/dbro/frigate-detector-edgetpu-yolo9/releases/download/v1.0/yolov9-s-relu6-best_320_int8_edgetpu.tflite) models that are compiled for Tensorflow Lite and properly quantized are supported, but not included by default. To provide your own model, bind mount the file into the container and provide the path with `model.path`. Note that the model may require a custom label file (eg. [use this 17 label file](https://raw.githubusercontent.com/dbro/frigate-detector-edgetpu-yolo9/refs/heads/main/labels-coco17.txt) for the model linked above.)
 
-:::tip
-
-The YOLO detector has been designed to support YOLOv9 models, and may support other YOLO model architectures as well.
-
-:::
-
 <details>
   <summary>YOLOv9 Setup & Config</summary>
 

--- a/frigate/detectors/plugins/edgetpu_tfl.py
+++ b/frigate/detectors/plugins/edgetpu_tfl.py
@@ -272,9 +272,7 @@ class EdgeTpuTfl(DetectionApi):
                 )  # initialize zero results
                 scores_output_quantized = self.interpreter.get_tensor(
                     self.scores_tensor_index
-                )[
-                    0
-                ]  # (2100, NC)
+                )[0]  # (2100, NC)
                 max_scores_quantized = np.max(
                     scores_output_quantized, axis=1
                 )  # (2100,)
@@ -293,9 +291,7 @@ class EdgeTpuTfl(DetectionApi):
                 # remove candidates with probabilities < threshold
                 boxes_output_quantized_filtered = (
                     self.interpreter.get_tensor(self.boxes_tensor_index)[0]
-                )[
-                    mask
-                ]  # (N, 64)
+                )[mask]  # (N, 64)
                 boxes_output_filtered = (
                     boxes_output_quantized_filtered.astype(np.float32)
                     - self.boxes_zero_point

--- a/frigate/detectors/plugins/edgetpu_tfl.py
+++ b/frigate/detectors/plugins/edgetpu_tfl.py
@@ -24,7 +24,6 @@ DETECTOR_KEY = "edgetpu"
 class EdgeTpuDetectorConfig(BaseDetectorConfig):
     type: Literal[DETECTOR_KEY]
     device: str = Field(default=None, title="Device Type")
-    # model_type inherited from BaseDetectorConfig, but can override default
 
 
 class EdgeTpuTfl(DetectionApi):

--- a/frigate/detectors/plugins/edgetpu_tfl.py
+++ b/frigate/detectors/plugins/edgetpu_tfl.py
@@ -1,18 +1,20 @@
 import logging
+import math
 import os
 
+import cv2
 import numpy as np
 from pydantic import Field
 from typing_extensions import Literal
 
 from frigate.detectors.detection_api import DetectionApi
-from frigate.detectors.detector_config import BaseDetectorConfig
+from frigate.detectors.detector_config import BaseDetectorConfig, ModelTypeEnum
+from frigate.util.model import post_process_yolo
 
 try:
     from tflite_runtime.interpreter import Interpreter, load_delegate
 except ModuleNotFoundError:
     from tensorflow.lite.python.interpreter import Interpreter, load_delegate
-
 
 logger = logging.getLogger(__name__)
 
@@ -22,12 +24,20 @@ DETECTOR_KEY = "edgetpu"
 class EdgeTpuDetectorConfig(BaseDetectorConfig):
     type: Literal[DETECTOR_KEY]
     device: str = Field(default=None, title="Device Type")
+    # model_type inherited from BaseDetectorConfig, but can override default
 
 
 class EdgeTpuTfl(DetectionApi):
     type_key = DETECTOR_KEY
+    supported_models = [
+        ModelTypeEnum.ssd,
+        ModelTypeEnum.yologeneric,
+    ]
 
     def __init__(self, detector_config: EdgeTpuDetectorConfig):
+        logger.info(
+            f"Initializing {DETECTOR_KEY} detector with support for SSD and YOLOv9 models"
+        )
         device_config = {}
         if detector_config.device is not None:
             device_config = {"device": detector_config.device}
@@ -63,31 +73,329 @@ class EdgeTpuTfl(DetectionApi):
 
         self.tensor_input_details = self.interpreter.get_input_details()
         self.tensor_output_details = self.interpreter.get_output_details()
-        self.model_type = detector_config.model.model_type
+        self.model_width = detector_config.model.width
+        self.model_height = detector_config.model.height
+
+        self.min_score = 0.4
+        try:
+            self.min_score = detector_config.model.min_score
+        except AttributeError:
+            pass
+
+        self.max_detections = 20
+        try:
+            self.max_detections = detector_config.model.max_detections
+        except AttributeError:
+            pass
+
+        model_type = detector_config.model.model_type
+        self.yolo_model = model_type == ModelTypeEnum.yologeneric
+        self.model_requires_int8 = self.tensor_input_details[0]["dtype"] == np.int8
+        if self.model_requires_int8:
+            logger.info("Detection model requires int8 format input")
+
+        if self.yolo_model:
+            logger.info(
+                f"Preparing YOLO postprocessing for {len(self.tensor_output_details)}-tensor output"
+            )
+            if len(self.tensor_output_details) > 1:  # expecting 2 or 3
+                self.reg_max = 16  # = 64 dfl_channels // 4 # YOLO standard
+                self.min_logit_value = np.log(
+                    self.min_score / (1 - self.min_score)
+                )  # for filtering
+                self._generate_anchors_and_strides()  # decode bounding box DFL
+                self.project = np.arange(
+                    self.reg_max, dtype=np.float32
+                )  # for decoding bounding box DFL information
+
+                # Determine YOLO tensor indices and quantization scales for
+                # boxes and class_scores the tensor ordering and names are
+                # not reliable, so use tensor shape to detect which tensor
+                # holds boxes or class scores.
+                # The tensors have shapes (B, N, C)
+                # where N is the number of candidates (=2100 for 320x320)
+                # this may guess wrong if the number of classes is exactly 64
+                output_boxes_index = None
+                output_classes_index = None
+                for i, x in enumerate(self.tensor_output_details):
+                    # the nominal index seems to start at 1 instead of 0
+                    if len(x["shape"]) == 3 and x["shape"][2] == 64:
+                        output_boxes_index = i
+                    elif len(x["shape"]) == 3 and x["shape"][2] > 1:
+                        # require the number of classes to be more than 1
+                        # to differentiate from (not used) max score tensor
+                        output_classes_index = i
+                if output_boxes_index is None or output_classes_index is None:
+                    logger.warning(
+                        "Unrecognized model output, unexpected tensor shapes."
+                    )
+                    output_classes_index = (
+                        0
+                        if (output_boxes_index is None or output_classes_index == 1)
+                        else 1
+                    )  # 0 is default guess
+                    output_boxes_index = 1 if (output_boxes_index == 0) else 0
+                scores_details = self.tensor_output_details[output_classes_index]
+                classes_count = scores_details["shape"][2]
+                self.scores_tensor_index = scores_details["index"]
+                self.scores_scale, self.scores_zero_point = scores_details[
+                    "quantization"
+                ]
+                # calculate the quantized version of the min_score
+                self.min_score_quantized = int(
+                    (self.min_logit_value / self.scores_scale) + self.scores_zero_point
+                )
+                self.logit_shift_to_positive_values = (
+                    max(
+                        0, math.ceil((128 + self.scores_zero_point) * self.scores_scale)
+                    )
+                    + 1
+                )  # round up
+
+                boxes_details = self.tensor_output_details[output_boxes_index]
+                self.boxes_tensor_index = boxes_details["index"]
+                self.boxes_scale, self.boxes_zero_point = boxes_details["quantization"]
+                logger.info(
+                    f"Using tensor index {output_boxes_index} for boxes(DFL), {output_classes_index} for {classes_count} class scores"
+                )
+
+        else:
+            if model_type not in [ModelTypeEnum.ssd, None]:
+                logger.warning(
+                    f"Unsupported model_type '{model_type}' for EdgeTPU detector, falling back to SSD"
+                )
+            logger.info("Using SSD preprocessing/postprocessing")
+
+            # SSD model indices (4 outputs: boxes, class_ids, scores, count)
+            for x in self.tensor_output_details:
+                if len(x["shape"]) == 3:
+                    self.output_boxes_index = x["index"]
+                elif len(x["shape"]) == 1:
+                    self.output_count_index = x["index"]
+
+            self.output_class_ids_index = None
+            self.output_class_scores_index = None
+
+    def _generate_anchors_and_strides(self):
+        # for decoding the bounding box DFL information into xy coordinates
+        all_anchors = []
+        all_strides = []
+        strides = (8, 16, 32)  # YOLO's small, medium, large detection heads
+
+        for stride in strides:
+            feat_h, feat_w = self.model_height // stride, self.model_width // stride
+
+            grid_y, grid_x = np.meshgrid(
+                np.arange(feat_h, dtype=np.float32),
+                np.arange(feat_w, dtype=np.float32),
+                indexing="ij",
+            )
+
+            grid_coords = np.stack((grid_x.flatten(), grid_y.flatten()), axis=1)
+            anchor_points = grid_coords + 0.5
+
+            all_anchors.append(anchor_points)
+            all_strides.append(np.full((feat_h * feat_w, 1), stride, dtype=np.float32))
+
+        self.anchors = np.concatenate(all_anchors, axis=0)
+        self.anchor_strides = np.concatenate(all_strides, axis=0)
+
+    def determine_indexes_for_non_yolo_models(self):
+        """Legacy method for SSD models."""
+        if (
+            self.output_class_ids_index is None
+            or self.output_class_scores_index is None
+        ):
+            for i in range(4):
+                index = self.tensor_output_details[i]["index"]
+                if (
+                    index != self.output_boxes_index
+                    and index != self.output_count_index
+                ):
+                    if (
+                        np.mod(np.float32(self.interpreter.tensor(index)()[0][0]), 1)
+                        == 0.0
+                    ):
+                        self.output_class_ids_index = index
+                    else:
+                        self.output_scores_index = index
 
     def detect_raw(self, tensor_input):
+        if self.model_requires_int8:
+            tensor_input = np.bitwise_xor(tensor_input, 128).view(
+                np.int8
+            )  # shift by -128
         self.interpreter.set_tensor(self.tensor_input_details[0]["index"], tensor_input)
         self.interpreter.invoke()
 
-        boxes = self.interpreter.tensor(self.tensor_output_details[0]["index"])()[0]
-        class_ids = self.interpreter.tensor(self.tensor_output_details[1]["index"])()[0]
-        scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[0]
-        count = int(
-            self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
-        )
+        if self.yolo_model:
+            if len(self.tensor_output_details) == 1:
+                # Single-tensor YOLO model
+                # model output is (1, NC+4, 2100) for 320x320 image size
+                # boxes as xywh (normalized to [0,1])
+                # followed by NC class probabilities (also [0,1])
+                # BEWARE the tensor has only one quantization scale/zero_point,
+                # so it should be assembled carefully to have a range of [0,1]
+                outputs = []
+                for output in self.tensor_output_details:
+                    x = self.interpreter.get_tensor(output["index"])
+                    scale, zero_point = output["quantization"]
+                    x = (x.astype(np.float32) - zero_point) * scale
+                    # Denormalize xywh by image size
+                    x[:, [0, 2]] *= self.model_width
+                    x[:, [1, 3]] *= self.model_height
+                    outputs.append(x)
 
-        detections = np.zeros((20, 6), np.float32)
+                return post_process_yolo(outputs, self.model_width, self.model_height)
 
-        for i in range(count):
-            if scores[i] < 0.4 or i == 20:
-                break
-            detections[i] = [
-                class_ids[i],
-                float(scores[i]),
-                boxes[i][0],
-                boxes[i][1],
-                boxes[i][2],
-                boxes[i][3],
+            else:
+                # Multi-tensor YOLO model with (non-standard B(H*W)C output format).
+                # (the comments indicate the shape of tensors,
+                # using "2100" as the anchor count (for image size of 320x320),
+                # "NC" as number of classes,
+                # "N" as the count that survive after min-score filtering)
+                # TENSOR A) class scores (1, 2100, NC) with logit values
+                # TENSOR B) box coordinates (1, 2100, 64) encoded as dfl scores
+                # Recommend that the model clamp the logit values in tensor (A)
+                # to the range [-4,+4] to preserve precision from [2%,98%]
+                # and because NMS requires the min_score parameter to be >= 0
+
+                # don't dequantize scores data yet, wait until the low-confidence
+                # candidates are filtered out from the overall result set.
+                # This reduces the work and makes post-processing faster.
+                # this method works with raw quantized numbers when possible,
+                # which relies on the value of the scale factor to be >0.
+                # This speeds up max and argmax operations.
+                # Get max confidence for each detection and create the mask
+                detections = np.zeros(
+                    (self.max_detections, 6), np.float32
+                )  # initialize zero results
+                scores_output_quantized = self.interpreter.get_tensor(
+                    self.scores_tensor_index
+                )[
+                    0
+                ]  # (2100, NC)
+                max_scores_quantized = np.max(
+                    scores_output_quantized, axis=1
+                )  # (2100,)
+                mask = max_scores_quantized >= self.min_score_quantized  # (2100,)
+
+                if not np.any(mask):
+                    return detections  # empty results
+
+                max_scores_filtered_shiftedpositive = (
+                    (max_scores_quantized[mask] - self.scores_zero_point)
+                    * self.scores_scale
+                ) + self.logit_shift_to_positive_values  # (N,1) shifted logit values
+                scores_output_quantized_filtered = scores_output_quantized[mask]
+
+                # dequantize boxes. NMS needs them to be in float format
+                # remove candidates with probabilities < threshold
+                boxes_output_quantized_filtered = (
+                    self.interpreter.get_tensor(self.boxes_tensor_index)[0]
+                )[
+                    mask
+                ]  # (N, 64)
+                boxes_output_filtered = (
+                    boxes_output_quantized_filtered.astype(np.float32)
+                    - self.boxes_zero_point
+                ) * self.boxes_scale
+
+                # 2. Decode DFL to distances (ltrb)
+                dfl_distributions = boxes_output_filtered.reshape(
+                    -1, 4, self.reg_max
+                )  # (N, 4, 16)
+
+                # Softmax over the 16 bins
+                dfl_max = np.max(dfl_distributions, axis=2, keepdims=True)
+                dfl_exp = np.exp(dfl_distributions - dfl_max)
+                dfl_probs = dfl_exp / np.sum(
+                    dfl_exp, axis=2, keepdims=True
+                )  # (N, 4, 16)
+
+                # Weighted sum: (N, 4, 16) * (16,) -> (N, 4)
+                distances = np.einsum("pcr,r->pc", dfl_probs, self.project)
+
+                # Calculate box corners in pixel coordinates
+                anchors_filtered = self.anchors[mask]
+                anchor_strides_filtered = self.anchor_strides[mask]
+                x1y1 = (
+                    anchors_filtered - distances[:, [0, 1]]
+                ) * anchor_strides_filtered  # (N, 2)
+                x2y2 = (
+                    anchors_filtered + distances[:, [2, 3]]
+                ) * anchor_strides_filtered  # (N, 2)
+                boxes_filtered_decoded = np.concatenate((x1y1, x2y2), axis=-1)  # (N, 4)
+
+                # 9. Apply NMS. Use logit scores here to defer sigmoid()
+                # until after filtering out redundant boxes
+                # Shift the logit scores to be non-negative (required by cv2)
+                indices = cv2.dnn.NMSBoxes(
+                    bboxes=boxes_filtered_decoded,
+                    scores=max_scores_filtered_shiftedpositive,
+                    score_threshold=(
+                        self.min_logit_value + self.logit_shift_to_positive_values
+                    ),
+                    nms_threshold=0.4,  # should this be a model config setting?
+                )
+                num_detections = len(indices)
+                if num_detections == 0:
+                    return detections  # empty results
+
+                nms_indices = np.array(indices, dtype=np.int32).ravel()  # or .flatten()
+                if num_detections > self.max_detections:
+                    nms_indices = nms_indices[: self.max_detections]
+                    num_detections = self.max_detections
+                kept_logits_quantized = scores_output_quantized_filtered[nms_indices]
+                class_ids_post_nms = np.argmax(kept_logits_quantized, axis=1)
+
+                # Extract the final boxes and scores using fancy indexing
+                final_boxes = boxes_filtered_decoded[nms_indices]
+                final_scores_logits = (
+                    max_scores_filtered_shiftedpositive[nms_indices]
+                    - self.logit_shift_to_positive_values
+                )  # Unshifted logits
+
+                # Detections array format: [class_id, score, ymin, xmin, ymax, xmax]
+                detections[:num_detections, 0] = class_ids_post_nms
+                detections[:num_detections, 1] = 1.0 / (
+                    1.0 + np.exp(-final_scores_logits)
+                )  # sigmoid
+                detections[:num_detections, 2] = final_boxes[:, 1] / self.model_height
+                detections[:num_detections, 3] = final_boxes[:, 0] / self.model_width
+                detections[:num_detections, 4] = final_boxes[:, 3] / self.model_height
+                detections[:num_detections, 5] = final_boxes[:, 2] / self.model_width
+                return detections
+
+        else:
+            # Default SSD model
+            self.determine_indexes_for_non_yolo_models()
+            boxes = self.interpreter.tensor(self.tensor_output_details[0]["index"])()[0]
+            class_ids = self.interpreter.tensor(
+                self.tensor_output_details[1]["index"]
+            )()[0]
+            scores = self.interpreter.tensor(self.tensor_output_details[2]["index"])()[
+                0
             ]
+            count = int(
+                self.interpreter.tensor(self.tensor_output_details[3]["index"])()[0]
+            )
 
-        return detections
+            detections = np.zeros((self.max_detections, 6), np.float32)
+
+            for i in range(count):
+                if scores[i] < self.min_score:
+                    break
+                if i == self.max_detections:
+                    logger.info(f"Too many detections ({count})!")
+                    break
+                detections[i] = [
+                    class_ids[i],
+                    float(scores[i]),
+                    boxes[i][0],
+                    boxes[i][1],
+                    boxes[i][2],
+                    boxes[i][3],
+                ]
+
+            return detections

--- a/frigate/detectors/plugins/edgetpu_tfl.py
+++ b/frigate/detectors/plugins/edgetpu_tfl.py
@@ -73,24 +73,14 @@ class EdgeTpuTfl(DetectionApi):
         self.model_height = detector_config.model.height
 
         self.min_score = 0.4
-        try:
-            self.min_score = detector_config.model.min_score
-        except AttributeError:
-            pass
-
         self.max_detections = 20
-        try:
-            self.max_detections = detector_config.model.max_detections
-        except AttributeError:
-            pass
 
         model_type = detector_config.model.model_type
-        self.yolo_model = model_type == ModelTypeEnum.yologeneric
         self.model_requires_int8 = self.tensor_input_details[0]["dtype"] == np.int8
         if self.model_requires_int8:
             logger.info("Detection model requires int8 format input")
 
-        if self.yolo_model:
+        if model_type == ModelTypeEnum.yologeneric
             logger.info(
                 f"Preparing YOLO postprocessing for {len(self.tensor_output_details)}-tensor output"
             )
@@ -224,7 +214,7 @@ class EdgeTpuTfl(DetectionApi):
         self.interpreter.set_tensor(self.tensor_input_details[0]["index"], tensor_input)
         self.interpreter.invoke()
 
-        if self.yolo_model:
+        if model_type == ModelTypeEnum.yologeneric
             if len(self.tensor_output_details) == 1:
                 # Single-tensor YOLO model
                 # model output is (1, NC+4, 2100) for 320x320 image size

--- a/frigate/detectors/plugins/edgetpu_tfl.py
+++ b/frigate/detectors/plugins/edgetpu_tfl.py
@@ -9,7 +9,6 @@ from typing_extensions import Literal
 
 from frigate.detectors.detection_api import DetectionApi
 from frigate.detectors.detector_config import BaseDetectorConfig, ModelTypeEnum
-from frigate.util.model import post_process_yolo
 
 try:
     from tflite_runtime.interpreter import Interpreter, load_delegate
@@ -123,7 +122,6 @@ class EdgeTpuTfl(DetectionApi):
                 output_boxes_index = 1 if (output_boxes_index == 0) else 0
 
             scores_details = self.tensor_output_details[output_classes_index]
-            classes_count = scores_details["shape"][2]
             self.scores_tensor_index = scores_details["index"]
             self.scores_scale, self.scores_zero_point = scores_details["quantization"]
             # calculate the quantized version of the min_score

--- a/frigate/detectors/plugins/edgetpu_tfl.py
+++ b/frigate/detectors/plugins/edgetpu_tfl.py
@@ -34,9 +34,6 @@ class EdgeTpuTfl(DetectionApi):
     ]
 
     def __init__(self, detector_config: EdgeTpuDetectorConfig):
-        logger.info(
-            f"Initializing {DETECTOR_KEY} detector with support for SSD and YOLOv9 models"
-        )
         device_config = {}
         if detector_config.device is not None:
             device_config = {"device": detector_config.device}


### PR DESCRIPTION
The goal of this change is to improve object detection accuracy by enabling the use of a YOLO v9 model as  an alternate to the default SSD/MobileNet model. This means fewer false positive detection, as well as fewer false negative detections.

## Accuracy improvement

In addition to the positive qualitative assessments from testing, the YOLO v9 model shows superior quantitative accuracy measurements, with mAP@50 of about 40% significantly better than 25% of the default model.

| Device | Model | Size | mAP 50% | Detection Time |
|---|---|---|---|---|
| Coral | [SSD/MobileNet](https://github.com/google-coral/test_data/raw/release-frogfish/ssdlite_mobiledet_coco_qat_postprocess_edgetpu.tflite) (Frigate's default for Coral) | 320x320 | **25.6%** | 8ms |
| Coral | [YOLO v9 s](https://github.com/dbro/frigate-detector-edgetpu-yolo9/releases/download/v1.0/yolov9-s-relu6-best_320_int8_edgetpu.tflite) (**recommended**) | 320x320 | **40.6%** | 10ms |
| Coral | [YOLO v9 s](https://github.com/dbro/frigate-detector-edgetpu-yolo9/releases/download/v1.5/yolov9-s-relu6-tpumax_512_int8_edgetpu.tflite) | 512x512 | 44.3% | 21ms |
| OpenVINO (CPU) | YOLO v9 s ReLU6 ONNX | 320x320 | 48.5% | 133ms |
| OpenVINO (CPU) | YOLO v9 s SiLU ONNX | 320x320 | 52.1% | 155ms |

These measurements are the result of my own testing, using 5000 COCO validation images and using only 17 of the COCO classes. The measurements for OpenVINO are added for context to indicate the degradation in accuracy from using the simpler ReLU6 activation function, and from quantization to 8-bit precision for Google Coral.

Detector inference speed is slightly slower at 10ms vs 8ms, both measured on my machine with a 3rd generation Intel CPU. Note that a bit more than 1ms is spent in post-processing the results (filtering, NMS, dequantizing).

## Proposed change

The detector plugin for Edge TPU gets updated, following the example from the existing OpenVINO plug-in which already supports YOLO v9. Post-processing is done in the plug-in to benefit inference speed by avoiding unnecessary dequantization and calculation.

This PR retains SSD/MobileNet as the default model for Google Coral, and does not require any configuration changes for continued use of the default model. It does not change any code or documentation regarding Frigate+ . I would be happy to assist in getting YOLO v9 models built for Frigate+ . This code is licensed with the MIT license.

For more information including a brief description of the changes made to the [source YOLO v9 model](https://github.com/WongKinYiu/yolov9), see the repo here https://github.com/dbro/frigate-detector-edgetpu-yolo9

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #21119 
- This PR is related to issue: #20260 
- Reddit discussions are here: [recent](https://www.reddit.com/r/frigate_nvr/comments/1ox2qmk/new_10ms_detection_time_running_yolo_v9_on_google/) and [older](https://www.reddit.com/r/frigate_nvr/comments/1ohgzsv/reducing_false_positives_by_running_yolo_v9_on/): 

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)

I did not use Ruff, but I did use black, isort, and flake8 .