### PR TITLE
Fix intermittent hangs in Tracking Details videos

### DIFF
--- a/web/src/components/overlay/detail/TrackingDetails.tsx
+++ b/web/src/components/overlay/detail/TrackingDetails.tsx
@@ -446,7 +446,7 @@ export function TrackingDetails({
       (event.end_time ?? Date.now() / 1000) + annotationOffset / 1000;
     const startTime = eventStartRecord - REVIEW_PADDING;
     const endTime = eventEndRecord + REVIEW_PADDING;
-    const playlist = `${baseUrl}vod/${event.camera}/start/${startTime}/end/${endTime}/index.m3u8`;
+    const playlist = `${baseUrl}vod/clip/${event.camera}/start/${startTime}/end/${endTime}/index.m3u8`;
 
     return {
       playlist,
@@ -559,7 +559,6 @@ export function TrackingDetails({
                 isDetailMode={true}
                 camera={event.camera}
                 currentTimeOverride={currentTime}
-                enableGapControllerRecovery={true}
               />
               {isVideoLoading && (
                 <ActivityIndicator className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2" />

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -57,7 +57,6 @@ type HlsVideoPlayerProps = {
   isDetailMode?: boolean;
   camera?: string;
   currentTimeOverride?: number;
-  enableGapControllerRecovery?: boolean;
 };
 
 export default function HlsVideoPlayer({
@@ -82,7 +81,6 @@ export default function HlsVideoPlayer({
   isDetailMode = false,
   camera,
   currentTimeOverride,
-  enableGapControllerRecovery = false,
 }: HlsVideoPlayerProps) {
   const { t } = useTranslation("components/player");
   const { data: config } = useSWR<FrigateConfig>("config");
@@ -173,20 +171,11 @@ export default function HlsVideoPlayer({
     }
 
     // Base HLS configuration
-    const baseConfig: Partial<HlsConfig> = {
+    const hlsConfig: Partial<HlsConfig> = {
       maxBufferLength: 10,
       maxBufferSize: 20 * 1000 * 1000,
       startPosition: currentSource.startPosition,
     };
-
-    const hlsConfig = { ...baseConfig };
-
-    if (enableGapControllerRecovery) {
-      hlsConfig.highBufferWatchdogPeriod = 1; // Check for stalls every 1 second (default: 3)
-      hlsConfig.nudgeOffset = 0.2; // Nudge playhead forward 0.2s when stalled (default: 0.1)
-      hlsConfig.nudgeMaxRetry = 5; // Try up to 5 nudges before giving up (default: 3)
-      hlsConfig.maxBufferHole = 0.5; // Tolerate up to 0.5s gaps between fragments (default: 0.1)
-    }
 
     hlsRef.current = new Hls(hlsConfig);
     hlsRef.current.attachMedia(videoRef.current);
@@ -201,13 +190,7 @@ export default function HlsVideoPlayer({
         hlsRef.current.destroy();
       }
     };
-  }, [
-    videoRef,
-    hlsRef,
-    useHlsCompat,
-    currentSource,
-    enableGapControllerRecovery,
-  ]);
+  }, [videoRef, hlsRef, useHlsCompat, currentSource]);
 
   // state handling
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR fixes intermittent HLS playback stalls in Tracking Details by adding a dedicated tracking VOD mapping endpoint that forces discontinuities for short, trimmed clips. It preserves existing behavior for hourly recordings and exports by keeping discontinuity disabled by default. The change prevents fMP4 buffer stalls caused by timestamp discontinuities (likely introduced by clip trimming) without altering other VOD flows.

The additional gap controller params added to try to fix the issue were removed as `discontinuity: True` seems to resolve the problem.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
