### PR TITLE
Support remote embeddings providers

### DIFF
--- a/docs/docs/configuration/semantic_search.md
+++ b/docs/docs/configuration/semantic_search.md
@@ -82,13 +82,15 @@ Switching between V1 and V2 requires reindexing your embeddings. The embeddings 
 
 ### Remote Providers
 
-Frigate can be configured to use remote services for generating embeddings. This is done by setting the `provider` field to `openai` or `ollama`.
+Frigate can be configured to use remote services for generating embeddings. This is done by setting the `provider` field to `openai`, `ollama`, or `clip_as_service`.
 
-For vision embeddings, remote providers use a two-step process:
+#### OpenAI and Ollama
+
+For OpenAI and Ollama, vision embeddings use a two-step process:
 1. A text description of the image is generated using the configured GenAI provider.
 2. An embedding is created from that description using the configured remote embedding provider.
 
-This means that you must have a GenAI provider configured to use vision embeddings with a remote provider.
+This means that you must have a GenAI provider configured to use vision embeddings with these providers.
 
 ```yaml
 semantic_search:
@@ -97,6 +99,21 @@ semantic_search:
   remote:
     model: "text-embedding-3-small"
     vision_model_prompt: "A detailed description of the image for semantic search."
+```
+
+#### Jina CLIP-as-Service
+
+Frigate supports [Jina CLIP-as-Service](https://clip-as-service.jina.ai/) which provides a multi-modal embedding service that can be hosted locally or remotely. This provider supports both text and image embeddings directly, without requiring a separate GenAI provider for image descriptions.
+
+You can run CLIP-as-Service using their [getting started guide](https://clip-as-service.jina.ai/user-guides/server/).
+
+```yaml
+semantic_search:
+  enabled: True
+  provider: clip_as_service
+  remote:
+    url: "http://localhost:51000"
+    # model is typically handled by the service configuration
 ```
 
 ### GPU Acceleration

--- a/docs/docs/configuration/semantic_search.md
+++ b/docs/docs/configuration/semantic_search.md
@@ -50,8 +50,8 @@ Differently weighted versions of the Jina models are available and can be select
 ```yaml
 semantic_search:
   enabled: True
-  local_model: "jinav1"
-  local_model_size: small
+  model: "jinav1"
+  model_size: small
 ```
 
 - Configuring the `large` model employs the full Jina model and will automatically run on the GPU if applicable.
@@ -68,8 +68,8 @@ To use the V2 model, update the `model` parameter in your config:
 ```yaml
 semantic_search:
   enabled: True
-  local_model: "jinav2"
-  local_model_size: large
+  model: "jinav2"
+  model_size: large
 ```
 
 For most users, especially native English speakers, the V1 model remains the recommended choice.
@@ -123,7 +123,7 @@ The CLIP models are downloaded in ONNX format, and the `large` model can be acce
 ```yaml
 semantic_search:
   enabled: True
-  local_model_size: large
+  model_size: large
   # Optional, if using the 'large' model in a multi-GPU installation
   device: 0
 ```

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -114,6 +114,30 @@ class CustomClassificationConfig(FrigateBaseModel):
     state_config: CustomClassificationStateConfig | None = Field(default=None)
 
 
+class SemanticSearchProviderEnum(str, Enum):
+    local = "local"
+    openai = "openai"
+    ollama = "ollama"
+
+
+class RemoteSemanticSearchConfig(FrigateBaseModel):
+    """Config for remote semantic search providers."""
+
+    api_key: Optional[str] = Field(
+        default=None, title="API key for the remote embedding provider."
+    )
+    model: Optional[str] = Field(
+        default=None, title="The embedding model to use for semantic search."
+    )
+    url: Optional[str] = Field(
+        default=None, title="URL for the remote embedding provider."
+    )
+    vision_model_prompt: Optional[str] = Field(
+        default="A detailed description of the image for semantic search.",
+        title="Prompt for the vision model to describe the image for embedding. This uses the configured GenAI provider.",
+    )
+
+
 class ClassificationConfig(FrigateBaseModel):
     bird: BirdClassificationConfig = Field(
         default_factory=BirdClassificationConfig, title="Bird classification config."
@@ -124,21 +148,31 @@ class ClassificationConfig(FrigateBaseModel):
 
 
 class SemanticSearchConfig(FrigateBaseModel):
+    """Config for semantic search."""
+
     enabled: bool = Field(default=False, title="Enable semantic search.")
     reindex: Optional[bool] = Field(
         default=False, title="Reindex all tracked objects on startup."
     )
-    model: Optional[SemanticSearchModelEnum] = Field(
-        default=SemanticSearchModelEnum.jinav1,
-        title="The CLIP model to use for semantic search.",
+    provider: SemanticSearchProviderEnum = Field(
+        default=SemanticSearchProviderEnum.local,
+        title="The semantic search provider to use.",
     )
-    model_size: str = Field(
-        default="small", title="The size of the embeddings model used."
+    local_model: Optional[SemanticSearchModelEnum] = Field(
+        default=SemanticSearchModelEnum.jinav1,
+        title="The local CLIP model to use for semantic search.",
+    )
+    local_model_size: str = Field(
+        default="small", title="The size of the local embeddings model used."
     )
     device: Optional[str] = Field(
         default=None,
         title="The device key to use for semantic search.",
         description="This is an override, to target a specific device. See https://onnxruntime.ai/docs/execution-providers/ for more information",
+    )
+    remote: RemoteSemanticSearchConfig = Field(
+        default_factory=RemoteSemanticSearchConfig,
+        title="Remote semantic search provider config.",
     )
 
 

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -159,11 +159,11 @@ class SemanticSearchConfig(FrigateBaseModel):
         default=SemanticSearchProviderEnum.local,
         title="The semantic search provider to use.",
     )
-    local_model: Optional[SemanticSearchModelEnum] = Field(
+    model: Optional[SemanticSearchModelEnum] = Field(
         default=SemanticSearchModelEnum.jinav1,
         title="The local CLIP model to use for semantic search.",
     )
-    local_model_size: str = Field(
+    model_size: str = Field(
         default="small", title="The size of the local embeddings model used."
     )
     device: Optional[str] = Field(

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -118,6 +118,7 @@ class SemanticSearchProviderEnum(str, Enum):
     local = "local"
     openai = "openai"
     ollama = "ollama"
+    clip_as_service = "clip_as_service"
 
 
 class RemoteSemanticSearchConfig(FrigateBaseModel):

--- a/frigate/embeddings/embeddings.py
+++ b/frigate/embeddings/embeddings.py
@@ -108,13 +108,13 @@ class Embeddings:
                     },
                 )
 
-            if self.config.semantic_search.local_model == SemanticSearchModelEnum.jinav2:
+            if self.config.semantic_search.model == SemanticSearchModelEnum.jinav2:
                 # Single JinaV2Embedding instance for both text and vision
                 self.embedding = JinaV2Embedding(
-                    model_size=self.config.semantic_search.local_model_size,
+                    model_size=self.config.semantic_search.model_size,
                     requestor=self.requestor,
                     device=config.semantic_search.device
-                    or ("GPU" if config.semantic_search.local_model_size == "large" else "CPU"),
+                    or ("GPU" if config.semantic_search.model_size == "large" else "CPU"),
                 )
                 self.text_embedding = lambda input_data: self.embedding(
                     input_data, embedding_type="text"
@@ -124,15 +124,15 @@ class Embeddings:
                 )
             else:  # Default to jinav1
                 self.text_embedding = JinaV1TextEmbedding(
-                    model_size=config.semantic_search.local_model_size,
+                    model_size=config.semantic_search.model_size,
                     requestor=self.requestor,
                     device="CPU",
                 )
                 self.vision_embedding = JinaV1ImageEmbedding(
-                    model_size=config.semantic_search.local_model_size,
+                    model_size=config.semantic_search.model_size,
                     requestor=self.requestor,
                     device=config.semantic_search.device
-                    or ("GPU" if config.semantic_search.local_model_size == "large" else "CPU"),
+                    or ("GPU" if config.semantic_search.model_size == "large" else "CPU"),
                 )
         else:
             self.remote_embedding_client = get_embedding_client(self.config)

--- a/frigate/embeddings/remote/__init__.py
+++ b/frigate/embeddings/remote/__init__.py
@@ -1,0 +1,67 @@
+"""Remote embedding clients for Frigate."""
+
+import importlib
+import logging
+import os
+from typing import Any, Optional
+
+from frigate.config import FrigateConfig, SemanticSearchConfig, SemanticSearchProviderEnum
+from frigate.genai import get_genai_client
+
+logger = logging.getLogger(__name__)
+
+PROVIDERS = {}
+
+
+def register_embedding_provider(key: SemanticSearchProviderEnum):
+    """Register a remote embedding provider."""
+
+    def decorator(cls):
+        PROVIDERS[key] = cls
+        return cls
+
+    return decorator
+
+
+class RemoteEmbeddingClient:
+    """Remote embedding client for Frigate."""
+
+    def __init__(self, config: FrigateConfig, timeout: int = 120) -> None:
+        self.config = config
+        self.timeout = timeout
+        self.provider = self._init_provider()
+        self.genai_client = get_genai_client(self.config)
+
+    def _init_provider(self):
+        """Initialize the client."""
+        return None
+
+    def embed_texts(self, texts: list[str]) -> Optional[list[list[float]]]:
+        """Get embeddings for a list of texts."""
+        return None
+
+    def embed_images(self, images: list[bytes]) -> Optional[list[list[float]]]:
+        """Get embeddings for a list of images."""
+        return None
+
+
+
+def get_embedding_client(config: FrigateConfig) -> Optional[RemoteEmbeddingClient]:
+    """Get the embedding client."""
+    if not config.semantic_search.provider or config.semantic_search.provider == SemanticSearchProviderEnum.local:
+        return None
+
+    load_providers()
+    provider = PROVIDERS.get(config.semantic_search.provider)
+    if provider:
+        return provider(config)
+
+    return None
+
+
+def load_providers():
+    package_dir = os.path.dirname(__file__)
+    for filename in os.listdir(package_dir):
+        if filename.endswith(".py") and filename != "__init__.py":
+            module_name = f"frigate.embeddings.remote.{filename[:-3]}"
+            importlib.import_module(module_name)

--- a/frigate/embeddings/remote/clip_as_service.py
+++ b/frigate/embeddings/remote/clip_as_service.py
@@ -1,0 +1,81 @@
+"""Clip-as-service embedding client for Frigate."""
+
+import base64
+import logging
+from typing import Optional
+
+import requests
+
+from frigate.config import SemanticSearchProviderEnum
+from frigate.embeddings.remote import (
+    RemoteEmbeddingClient,
+    register_embedding_provider,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@register_embedding_provider(SemanticSearchProviderEnum.clip_as_service)
+class ClipAsServiceEmbeddingClient(RemoteEmbeddingClient):
+    """Remote embedding client for Frigate using clip-as-service."""
+
+    def _init_provider(self):
+        """Initialize the client."""
+        return True
+
+    def embed_texts(self, texts: list[str]) -> Optional[list[list[float]]]:
+        """Get embeddings for a list of texts."""
+        if not self.config.semantic_search.remote.url:
+            logger.error("Clip-as-service URL is not configured.")
+            return None
+
+        payload = {
+            "data": [{"text": t} for t in texts],
+            "exec_endpoint": "/"
+        }
+
+        try:
+            response = requests.post(
+                f"{self.config.semantic_search.remote.url}/post",
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+            if "data" in data:
+                return [item["embedding"] for item in data["data"]]
+            return None
+        except Exception as e:
+            logger.warning("Clip-as-service error: %s", str(e))
+            return None
+
+    def embed_images(self, images: list[bytes]) -> Optional[list[list[float]]]:
+        """Get embeddings for a list of images."""
+        if not self.config.semantic_search.remote.url:
+            logger.error("Clip-as-service URL is not configured.")
+            return None
+
+        payload_data = []
+        for img_bytes in images:
+            b64_str = base64.b64encode(img_bytes).decode("utf-8")
+            payload_data.append({"blob": b64_str})
+
+        payload = {
+            "data": payload_data,
+            "exec_endpoint": "/"
+        }
+
+        try:
+            response = requests.post(
+                f"{self.config.semantic_search.remote.url}/post",
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+            if "data" in data:
+                return [item["embedding"] for item in data["data"]]
+            return None
+        except Exception as e:
+            logger.warning("Clip-as-service error: %s", str(e))
+            return None

--- a/frigate/embeddings/remote/ollama.py
+++ b/frigate/embeddings/remote/ollama.py
@@ -1,0 +1,91 @@
+"""Ollama embedding client for Frigate."""
+
+import logging
+from typing import Optional
+
+from httpx import TimeoutException
+from ollama import Client as ApiClient
+from ollama import ResponseError
+
+from frigate.config import SemanticSearchProviderEnum
+from frigate.embeddings.remote import (
+    RemoteEmbeddingClient,
+    register_embedding_provider,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@register_embedding_provider(SemanticSearchProviderEnum.ollama)
+class OllamaEmbeddingClient(RemoteEmbeddingClient):
+    """Remote embedding client for Frigate using Ollama."""
+
+    provider: ApiClient
+
+    def _init_provider(self):
+        """Initialize the client."""
+        try:
+            client = ApiClient(
+                host=self.config.semantic_search.remote.url, timeout=self.timeout
+            )
+            # ensure the model is available locally
+            response = client.show(self.config.semantic_search.remote.model)
+            if response.get("error"):
+                logger.error(
+                    "Ollama error: %s",
+                    response["error"],
+                )
+                return None
+            return client
+        except Exception as e:
+            logger.warning("Error initializing Ollama: %s", str(e))
+            return None
+
+    def embed_texts(self, texts: list[str]) -> Optional[list[list[float]]]:
+        """Get embeddings for a list of texts."""
+        if self.provider is None:
+            logger.warning(
+                "Ollama provider has not been initialized, embeddings will not be generated. Check your Ollama configuration."
+            )
+            return None
+        try:
+            embeddings = []
+            for text in texts:
+                result = self.provider.embeddings(
+                    model=self.config.semantic_search.remote.model,
+                    prompt=text,
+                )
+                embeddings.append(result["embedding"])
+            return embeddings
+        except (TimeoutException, ResponseError, ConnectionError) as e:
+            logger.warning("Ollama returned an error: %s", str(e))
+            return None
+
+    def embed_images(self, images: list[bytes]) -> Optional[list[list[float]]]:
+        """Get embeddings for a list of images.
+
+        This uses a two-step process:
+        1. Generate a text description of the image using the configured GenAI provider.
+        2. Create an embedding from the description using the text embedding model.
+        """
+        if not self.genai_client:
+            logger.warning(
+                "A GenAI provider is not configured. Cannot generate image descriptions."
+            )
+            return None
+
+        descriptions = []
+        for image in images:
+            description = self.genai_client.generate_image_description(
+                prompt=self.config.semantic_search.remote.vision_model_prompt,
+                images=[image],
+            )
+            if description:
+                descriptions.append(description)
+            else:
+                descriptions.append("")
+
+        if not descriptions:
+            return None
+
+        return self.embed_texts(descriptions)

--- a/frigate/embeddings/remote/openai.py
+++ b/frigate/embeddings/remote/openai.py
@@ -1,0 +1,78 @@
+"""OpenAI embedding client for Frigate."""
+
+import base64
+import logging
+from typing import Optional
+
+from httpx import TimeoutException
+from openai import OpenAI
+
+from frigate.config import SemanticSearchProviderEnum
+from frigate.embeddings.remote import (
+    RemoteEmbeddingClient,
+    register_embedding_provider,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@register_embedding_provider(SemanticSearchProviderEnum.openai)
+class OpenAIEmbeddingClient(RemoteEmbeddingClient):
+    """Remote embedding client for Frigate using OpenAI."""
+
+    provider: OpenAI
+
+    def _init_provider(self):
+        """Initialize the client."""
+        return OpenAI(
+            api_key=self.config.semantic_search.remote.api_key,
+            base_url=self.config.semantic_search.remote.url,
+        )
+
+    def embed_texts(self, texts: list[str]) -> Optional[list[list[float]]]:
+        """Get embeddings for a list of texts."""
+        try:
+            result = self.provider.embeddings.create(
+                model=self.config.semantic_search.remote.model,
+                input=texts,
+                timeout=self.timeout,
+            )
+            if (
+                result is not None
+                and hasattr(result, "data")
+                and len(result.data) > 0
+            ):
+                return [embedding.embedding for embedding in result.data]
+            return None
+        except (TimeoutException, Exception) as e:
+            logger.warning("OpenAI returned an error: %s", str(e))
+            return None
+
+    def embed_images(self, images: list[bytes]) -> Optional[list[list[float]]]:
+        """Get embeddings for a list of images.
+
+        This uses a two-step process:
+        1. Generate a text description of the image using the configured GenAI provider.
+        2. Create an embedding from the description using the text embedding model.
+        """
+        if not self.genai_client:
+            logger.warning(
+                "A GenAI provider is not configured. Cannot generate image descriptions."
+            )
+            return None
+
+        descriptions = []
+        for image in images:
+            description = self.genai_client.generate_image_description(
+                prompt=self.config.semantic_search.remote.vision_model_prompt,
+                images=[image],
+            )
+            if description:
+                descriptions.append(description)
+            else:
+                descriptions.append("")
+
+        if not descriptions:
+            return None
+
+        return self.embed_texts(descriptions)

--- a/frigate/genai/__init__.py
+++ b/frigate/genai/__init__.py
@@ -291,6 +291,15 @@ Rules for the report:
         logger.debug(f"Sending images to genai provider with prompt: {prompt}")
         return self._send(prompt, thumbnails)
 
+    def generate_image_description(
+        self,
+        prompt: str,
+        images: list[bytes],
+    ) -> Optional[str]:
+        """Generate a description for an image."""
+        logger.debug(f"Sending images to genai provider with prompt: {prompt}")
+        return self._send(prompt, images)
+
     def _init_provider(self):
         """Initialize the client."""
         return None


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This change is meant to support remote/external embeddings providers. In my environment, I have a dedicated system with a large GPU to run LLMs and related models. The existing genai config supports this, however the embeddings config for semantic search does not, and assumes it must run locally. I've added remote embedding model support, which currently adds openai, ollama, and clip as service as providers. For openai and ollama, there does not yet seem to be support in the API to use multi-modal embeddings directly, however I assume that support will be added eventually. For now, those providers are implemented by reusing the genai provider to create a text description prior to doing a text embedding. The clip as service provider appears to be the supported mechanism to run the jina models as a service, so that would be the closest to what is already implemented.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
