### PR TITLE
Update peewee-migrate to 0.14.x

### DIFF
--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -21,7 +21,7 @@ onvif-zeep-async == 4.0.*
 paho-mqtt == 2.1.*
 pandas == 2.2.*
 peewee == 3.17.*
-peewee_migrate == 1.13.*
+peewee_migrate == 1.14.*
 psutil == 7.1.*
 pydantic == 2.10.*
 git+https://github.com/fbcotter/py3nvml#egg=py3nvml

--- a/migrations/001_create_events_table.py
+++ b/migrations/001_create_events_table.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/002_add_clip_snapshot.py
+++ b/migrations/002_add_clip_snapshot.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/003_create_recordings_table.py
+++ b/migrations/003_create_recordings_table.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/004_add_bbox_region_area.py
+++ b/migrations/004_add_bbox_region_area.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/005_make_end_time_nullable.py
+++ b/migrations/005_make_end_time_nullable.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/006_add_motion_active_objects.py
+++ b/migrations/006_add_motion_active_objects.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/007_add_retain_indefinitely.py
+++ b/migrations/007_add_retain_indefinitely.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/008_add_sub_label.py
+++ b/migrations/008_add_sub_label.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/009_add_object_filter_ratio.py
+++ b/migrations/009_add_object_filter_ratio.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/010_add_plus_image_id.py
+++ b/migrations/010_add_plus_image_id.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/011_update_indexes.py
+++ b/migrations/011_update_indexes.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/012_add_segment_size.py
+++ b/migrations/012_add_segment_size.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/013_create_timeline_table.py
+++ b/migrations/013_create_timeline_table.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/014_event_updates_for_fp.py
+++ b/migrations/014_event_updates_for_fp.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/015_event_refactor.py
+++ b/migrations/015_event_refactor.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/016_sublabel_increase.py
+++ b/migrations/016_sublabel_increase.py
@@ -4,8 +4,8 @@ from frigate.models import Event
 
 
 def migrate(migrator, database, fake=False, **kwargs):
-    migrator.change_columns(Event, sub_label=pw.CharField(max_length=100, null=True))
+    migrator.change_fields(Event, sub_label=pw.CharField(max_length=100, null=True))
 
 
 def rollback(migrator, database, fake=False, **kwargs):
-    migrator.change_columns(Event, sub_label=pw.CharField(max_length=20, null=True))
+    migrator.change_fields(Event, sub_label=pw.CharField(max_length=20, null=True))

--- a/migrations/017_update_indexes.py
+++ b/migrations/017_update_indexes.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/018_add_dbfs.py
+++ b/migrations/018_add_dbfs.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/019_create_regions_table.py
+++ b/migrations/019_create_regions_table.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/020_update_index_recordings.py
+++ b/migrations/020_update_index_recordings.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/021_create_previews_table.py
+++ b/migrations/021_create_previews_table.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/022_create_review_segment_table.py
+++ b/migrations/022_create_review_segment_table.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/023_add_regions.py
+++ b/migrations/023_add_regions.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/024_create_export_table.py
+++ b/migrations/024_create_export_table.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/025_create_user_table.py
+++ b/migrations/025_create_user_table.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/026_add_notification_tokens.py
+++ b/migrations/026_add_notification_tokens.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/027_create_explore_index.py
+++ b/migrations/027_create_explore_index.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/028_optional_event_thumbnail.py
+++ b/migrations/028_optional_event_thumbnail.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/029_add_user_role.py
+++ b/migrations/029_add_user_role.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/030_create_user_review_status.py
+++ b/migrations/030_create_user_review_status.py
@@ -8,7 +8,7 @@ Some examples (model - class or model_name)::
 
     > Model = migrator.orm['model_name']            # Return model in current state by name
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model
@@ -76,7 +76,7 @@ def migrate(migrator, database, fake=False, **kwargs):
                 )
 
     if not fake:  # Only run data migration if not faking
-        migrator.python(migrate_data)
+        migrator.run(migrate_data)
 
     migrator.sql('ALTER TABLE "reviewsegment" DROP COLUMN "has_been_reviewed"')
 

--- a/migrations/031_create_trigger_table.py
+++ b/migrations/031_create_trigger_table.py
@@ -6,7 +6,7 @@ Some examples (model - class or model_name)::
 
     > Model = migrator.orm['model_name']            # Return model in current state by name
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model

--- a/migrations/032_add_password_changed_at.py
+++ b/migrations/032_add_password_changed_at.py
@@ -5,7 +5,7 @@ Some examples (model - class or model name)::
     > Model = migrator.orm['model_name']            # Return model in current state by name
 
     > migrator.sql(sql)                             # Run custom SQL
-    > migrator.python(func, *args, **kwargs)        # Run python code
+    > migrator.run(func, *args, **kwargs)           # Run python code
     > migrator.create_model(Model)                  # Create a model (could be used as decorator)
     > migrator.remove_model(model, cascade=True)    # Remove a model
     > migrator.add_fields(model, **fields)          # Add fields to a model


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Updates peewee-migrate to 0.14.x and fixes deprecations in the migrations.

Replaces two functions calls, that were deprecated and aliases for the new function name:

- `Migrator.python` -> `Migration.run` (https://github.com/klen/peewee_migrate/blob/1.13.0/peewee_migrate/migrator.py#L123)
- `Migrator.change_column` -> `Migrator.change_field` (https://github.com/klen/peewee_migrate/blob/1.13.0/peewee_migrate/migrator.py#L240)


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
