### PR TITLE
Improve handling of backchannel audio in camera wizard

### DIFF
--- a/web/src/components/settings/CameraStreamingDialog.tsx
+++ b/web/src/components/settings/CameraStreamingDialog.tsx
@@ -34,6 +34,7 @@ import { LiveStreamMetadata } from "@/types/live";
 import { Trans, useTranslation } from "react-i18next";
 import { useDocDomain } from "@/hooks/use-doc-domain";
 import { useCameraFriendlyName } from "@/hooks/use-camera-friendly-name";
+import { detectCameraAudioFeatures } from "@/utils/cameraUtil";
 
 type CameraStreamingDialogProps = {
   camera: string;
@@ -80,20 +81,11 @@ export function CameraStreamingDialog({
 
   const cameraMetadata = streamName ? streamMetadata?.[streamName] : undefined;
 
-  const supportsAudioOutput = useMemo(() => {
-    if (!cameraMetadata) {
-      return false;
-    }
-
-    return (
-      cameraMetadata.producers.find(
-        (prod) =>
-          prod.medias &&
-          prod.medias.find((media) => media.includes("audio, recvonly")) !=
-            undefined,
-      ) != undefined
-    );
+  const audioFeatures = useMemo(() => {
+    return detectCameraAudioFeatures(cameraMetadata);
   }, [cameraMetadata]);
+
+  const supportsAudioOutput = audioFeatures.audioOutput;
 
   // handlers
 

--- a/web/src/components/settings/CameraStreamingDialog.tsx
+++ b/web/src/components/settings/CameraStreamingDialog.tsx
@@ -81,11 +81,10 @@ export function CameraStreamingDialog({
 
   const cameraMetadata = streamName ? streamMetadata?.[streamName] : undefined;
 
-  const audioFeatures = useMemo(() => {
-    return detectCameraAudioFeatures(cameraMetadata);
-  }, [cameraMetadata]);
-
-  const supportsAudioOutput = audioFeatures.audioOutput;
+  const { audioOutput: supportsAudioOutput } = useMemo(
+    () => detectCameraAudioFeatures(cameraMetadata),
+    [cameraMetadata],
+  );
 
   // handlers
 

--- a/web/src/components/settings/CameraWizardDialog.tsx
+++ b/web/src/components/settings/CameraWizardDialog.tsx
@@ -237,7 +237,18 @@ export default function CameraWizardDialog({
                 const streamUrl = stream.useFfmpeg
                   ? `ffmpeg:${stream.url}`
                   : stream.url;
-                go2rtcStreams[streamName] = [streamUrl];
+
+                if (wizardData.hasBackchannel ?? false) {
+                  // Add two streams: one with #backchannel=0 and one without
+                  // in order to avoid taking control of the microphone during connections
+                  go2rtcStreams[streamName] = [
+                    `${streamUrl}#backchannel=0`,
+                    streamUrl,
+                  ];
+                } else {
+                  // Add single stream as normal
+                  go2rtcStreams[streamName] = [streamUrl];
+                }
               });
 
               if (Object.keys(go2rtcStreams).length > 0) {

--- a/web/src/components/settings/wizard/Step4Validation.tsx
+++ b/web/src/components/settings/wizard/Step4Validation.tsx
@@ -139,7 +139,6 @@ export default function Step4Validation({
       }
 
       try {
-        // Query the specific go2rtc stream we just created
         const response = await axios.get<LiveStreamMetadata>(
           `go2rtc/streams/${go2rtcStreamId}`,
         );

--- a/web/src/hooks/use-camera-live-mode.ts
+++ b/web/src/hooks/use-camera-live-mode.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState, useMemo } from "react";
 import useSWR from "swr";
 import { LivePlayerMode } from "@/types/live";
 import useDeferredStreamMetadata from "./use-deferred-stream-metadata";
+import { detectCameraAudioFeatures } from "@/utils/cameraUtil";
 
 export default function useCameraLiveMode(
   cameras: CameraConfig[],
@@ -83,16 +84,9 @@ export default function useCameraLiveMode(
       if (isRestreamed) {
         Object.values(camera.live.streams).forEach((streamName) => {
           const metadata = streamMetadata[streamName];
+          const audioFeatures = detectCameraAudioFeatures(metadata);
           newSupportsAudioOutputStates[streamName] = {
-            supportsAudio: metadata
-              ? metadata.producers.find(
-                  (prod) =>
-                    prod.medias &&
-                    prod.medias.find((media) =>
-                      media.includes("audio, recvonly"),
-                    ) !== undefined,
-                ) !== undefined
-              : false,
+            supportsAudio: audioFeatures.audioOutput,
             cameraName: camera.name,
           };
         });

--- a/web/src/types/cameraWizard.ts
+++ b/web/src/types/cameraWizard.ts
@@ -118,6 +118,7 @@ export type WizardFormData = {
   probeResult?: OnvifProbeResponse;
   probeCandidates?: string[]; // candidate URLs from probe
   candidateTests?: CandidateTestMap; // test results for candidates
+  hasBackchannel?: boolean; // true if camera supports backchannel audio
 };
 
 // API Response Types

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -110,6 +110,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { useIsAdmin } from "@/hooks/use-is-admin";
 import { useTranslation } from "react-i18next";
 import { useDocDomain } from "@/hooks/use-doc-domain";
+import { detectCameraAudioFeatures } from "@/utils/cameraUtil";
 import PtzControlPanel from "@/components/overlay/PtzControlPanel";
 import ObjectSettingsView from "../settings/ObjectSettingsView";
 import { useSearchEffect } from "@/hooks/use-overlay-state";
@@ -168,34 +169,12 @@ export default function LiveCameraView({
     },
   );
 
-  const supports2WayTalk = useMemo(() => {
-    if (!window.isSecureContext || !cameraMetadata) {
-      return false;
-    }
-
-    return (
-      cameraMetadata.producers.find(
-        (prod) =>
-          prod.medias &&
-          prod.medias.find((media) => media.includes("audio, sendonly")) !=
-            undefined,
-      ) != undefined
-    );
+  const audioFeatures = useMemo(() => {
+    return detectCameraAudioFeatures(cameraMetadata);
   }, [cameraMetadata]);
-  const supportsAudioOutput = useMemo(() => {
-    if (!cameraMetadata) {
-      return false;
-    }
 
-    return (
-      cameraMetadata.producers.find(
-        (prod) =>
-          prod.medias &&
-          prod.medias.find((media) => media.includes("audio, recvonly")) !=
-            undefined,
-      ) != undefined
-    );
-  }, [cameraMetadata]);
+  const supports2WayTalk = audioFeatures.twoWayAudio;
+  const supportsAudioOutput = audioFeatures.audioOutput;
 
   // camera enabled state
   const { payload: enabledState } = useEnabledState(camera.name);

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -169,12 +169,8 @@ export default function LiveCameraView({
     },
   );
 
-  const audioFeatures = useMemo(() => {
-    return detectCameraAudioFeatures(cameraMetadata);
-  }, [cameraMetadata]);
-
-  const supports2WayTalk = audioFeatures.twoWayAudio;
-  const supportsAudioOutput = audioFeatures.audioOutput;
+  const { twoWayAudio: supports2WayTalk, audioOutput: supportsAudioOutput } =
+    useMemo(() => detectCameraAudioFeatures(cameraMetadata), [cameraMetadata]);
 
   // camera enabled state
   const { payload: enabledState } = useEnabledState(camera.name);


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Cameras that support backchannel audio can often have limitations when go2rtc is used for restreaming without backchannel disabled, as it takes over the connection, disallowing the cameras default app or other software from connecting to it.

This PR implements a check on the camera via go2rtc to check for backchannel audio and if the camera supports it then it will disable it in the default stream, adding a second stream so two way talk is preserved.

This PR also refactors the go2rtc stream checking into a utility to reduce duplicated logic.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
