### PR TITLE
Use Mesa 25.3.x Teflon delegate with support for Rocket

### DIFF
--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -33,16 +33,10 @@ unset DEBIAN_FRONTEND
 yes | dpkg -i /tmp/libedgetpu1-max.deb && export DEBIAN_FRONTEND=noninteractive
 rm /tmp/libedgetpu1-max.deb
 
-# install mesa-teflon-delegate from bookworm-backports
+# install mesa-teflon-delegate
 # Only available for arm64 at the moment
 if [[ "${TARGETARCH}" == "arm64" ]]; then
-    if [[ "${BASE_IMAGE}" == *"nvcr.io/nvidia/tensorrt"* ]]; then
-        echo "Info: Skipping apt-get commands because BASE_IMAGE includes 'nvcr.io/nvidia/tensorrt' for arm64."
-    else
-        echo "deb http://deb.debian.org/debian bookworm-backports main" | tee /etc/apt/sources.list.d/bookworm-backbacks.list
-        apt-get -qq update
-        apt-get -qq install --no-install-recommends --no-install-suggests -y mesa-teflon-delegate/bookworm-backports
-    fi
+    wget -qO /usr/lib/teflon/libteflon.so https://github.com/jimmyhon/frigate-builds/releases/download/mesa-25.3.1/libteflon.so
 fi
 
 # ffmpeg -> amd64


### PR DESCRIPTION
Support for the Rockchip RK3588 NPU has been added to the mainline 6.18 kernel as the `rocket` module.

The userspace Mesa Teflon Delegate driver with support for the Rocket kernel module has been added in Mesa 25.3.

Bookworm Backports only has an older 25.0 version of Mesa. So manually compile a newer version of Mesa 25.3 for Debian Bookworm. (It's built as a GitHub Action using a Debian Bookworm docker image.)
https://github.com/jimmyhon/frigate-builds/blob/master/Dockerfile

https://docs.mesa3d.org/teflon.html

This follows on PR #18310

Discussion for supporting Mainline Rockchip via Teflon #18311


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
