### PR TITLE
feat: add train classification download weights file endpoint

### DIFF
--- a/frigate/util/classification.py
+++ b/frigate/util/classification.py
@@ -22,6 +22,7 @@ from frigate.const import (
 from frigate.log import redirect_output_to_logger
 from frigate.models import Event, Recordings, ReviewSegment
 from frigate.types import ModelStatusTypesEnum
+from frigate.util.downloader import ModelDownloader
 from frigate.util.file import get_event_thumbnail_bytes
 from frigate.util.image import get_image_from_recording
 from frigate.util.process import FrigateProcess
@@ -121,6 +122,10 @@ def get_dataset_image_count(model_name: str) -> int:
 
 class ClassificationTrainingProcess(FrigateProcess):
     def __init__(self, model_name: str) -> None:
+        self.BASE_WEIGHT_PATH = os.environ.get(
+            "TF_KERAS_MOBILENET_V2_ENDPOINT",
+            "https://storage.googleapis.com/tensorflow/keras-applications/mobilenet_v2/",
+        )
         super().__init__(
             stop_event=None,
             priority=PROCESS_PRIORITY_LOW,
@@ -179,12 +184,23 @@ class ClassificationTrainingProcess(FrigateProcess):
                 )
                 return False
 
+            alpha = 0.35
+            # Download MobileNetV2 weights if not present
+            weights_filename = (
+                f"mobilenet_v2_weights_tf_dim_ordering_tf_kernels_{alpha}_224_no_top.h5"
+            )
+            weights_path = os.path.join(MODEL_CACHE_DIR, "MobileNet", weights_filename)
+            if not os.path.exists(weights_path):
+                weights_url = self.BASE_WEIGHT_PATH + weights_filename
+                logger.info(f"Downloading MobileNet V2 weights file: {weights_url}")
+                ModelDownloader.download_from_url(weights_url, weights_path)
+
             # Start with imagenet base model with 35% of channels in each layer
             base_model = MobileNetV2(
                 input_shape=(224, 224, 3),
                 include_top=False,
-                weights="imagenet",
-                alpha=0.35,
+                weights=weights_path,
+                alpha=alpha,
             )
             base_model.trainable = False  # Freeze pre-trained layers
 

--- a/frigate/util/classification.py
+++ b/frigate/util/classification.py
@@ -122,9 +122,9 @@ def get_dataset_image_count(model_name: str) -> int:
 
 class ClassificationTrainingProcess(FrigateProcess):
     def __init__(self, model_name: str) -> None:
-        self.BASE_WEIGHT_PATH = os.environ.get(
-            "TF_KERAS_MOBILENET_V2_ENDPOINT",
-            "https://storage.googleapis.com/tensorflow/keras-applications/mobilenet_v2/",
+        self.BASE_WEIGHT_URL = os.environ.get(
+            "TF_KERAS_MOBILENET_V2_WEIGHTS_URL",
+            "",
         )
         super().__init__(
             stop_event=None,
@@ -184,23 +184,24 @@ class ClassificationTrainingProcess(FrigateProcess):
                 )
                 return False
 
-            alpha = 0.35
+            weights_path = "imagenet"
             # Download MobileNetV2 weights if not present
-            weights_filename = (
-                f"mobilenet_v2_weights_tf_dim_ordering_tf_kernels_{alpha}_224_no_top.h5"
-            )
-            weights_path = os.path.join(MODEL_CACHE_DIR, "MobileNet", weights_filename)
-            if not os.path.exists(weights_path):
-                weights_url = self.BASE_WEIGHT_PATH + weights_filename
-                logger.info(f"Downloading MobileNet V2 weights file: {weights_url}")
-                ModelDownloader.download_from_url(weights_url, weights_path)
+            if self.BASE_WEIGHT_URL:
+                weights_path = os.path.join(
+                    MODEL_CACHE_DIR, "MobileNet", "mobilenet_v2_weights.h5"
+                )
+                if not os.path.exists(weights_path):
+                    logger.info("Downloading MobileNet V2 weights file")
+                    ModelDownloader.download_from_url(
+                        self.BASE_WEIGHT_URL, weights_path
+                    )
 
             # Start with imagenet base model with 35% of channels in each layer
             base_model = MobileNetV2(
                 input_shape=(224, 224, 3),
                 include_top=False,
                 weights=weights_path,
-                alpha=alpha,
+                alpha=0.35,
             )
             base_model.trainable = False  # Freeze pre-trained layers
 


### PR DESCRIPTION
…RAS_MOBILENET_V2_ENDPOINT"

## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Keras uses weights files downloaded from `storage.googleapis.com`, but in some regions Google is not accessible, which prevents classification from being trained properly.

Add classification weights file endpoint: `TF_KERAS_MOBILENET_V2_ENDPOINT`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
