### PR TITLE
Refactor vainfo endpoint to search for first GPU

### DIFF
--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -32,6 +32,7 @@ from frigate.config.camera.updater import (
     CameraConfigUpdateEnum,
     CameraConfigUpdateTopic,
 )
+from frigate.ffmpeg_presets import FFMPEG_HWACCEL_VAAPI, _gpu_selector
 from frigate.models import Event, Timeline
 from frigate.stats.prometheus import get_metrics, update_metrics
 from frigate.util.builtin import (
@@ -458,7 +459,15 @@ def config_set(request: Request, body: AppConfigSetBody):
 
 @router.get("/vainfo", dependencies=[Depends(allow_any_authenticated())])
 def vainfo():
-    vainfo = vainfo_hwaccel()
+    # Use LibvaGpuSelector to pick an appropriate libva device (if available)
+    selected_gpu = ""
+    try:
+        selected_gpu = _gpu_selector.get_gpu_arg(FFMPEG_HWACCEL_VAAPI, 0) or ""
+    except Exception:
+        selected_gpu = ""
+
+    # If selected_gpu is empty, pass None to vainfo_hwaccel to run plain `vainfo`.
+    vainfo = vainfo_hwaccel(device_name=selected_gpu or None)
     return JSONResponse(
         content={
             "return_code": vainfo.returncode,

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -584,12 +584,17 @@ def ffprobe_stream(ffmpeg, path: str, detailed: bool = False) -> sp.CompletedPro
 
 def vainfo_hwaccel(device_name: Optional[str] = None) -> sp.CompletedProcess:
     """Run vainfo."""
-    ffprobe_cmd = (
-        ["vainfo"]
-        if not device_name
-        else ["vainfo", "--display", "drm", "--device", f"/dev/dri/{device_name}"]
-    )
-    return sp.run(ffprobe_cmd, capture_output=True)
+    if not device_name:
+        cmd = ["vainfo"]
+    else:
+        if os.path.isabs(device_name) and device_name.startswith("/dev/dri/"):
+            device_path = device_name
+        else:
+            device_path = f"/dev/dri/{device_name}"
+
+        cmd = ["vainfo", "--display", "drm", "--device", device_path]
+
+    return sp.run(cmd, capture_output=True)
 
 
 def get_nvidia_driver_info() -> dict[str, Any]:


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Currently, the `vainfo` API endpoint just runs `vainfo` without any device name and searches for `renderD128` by default, which may not be correct if a user maps in `renderD129`, but not `renderD128`, for example. This PR uses the existing `LibvaGpuSelector` to find the correct GPU and passes that as the arg to `vainfo` so the endpoint works correctly.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
