### PR TITLE
Fix layout shift on settings page

### DIFF
--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -438,7 +438,7 @@ export default function Settings() {
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between border-b border-secondary p-3">
-        <Heading as="h3" className="mb-0">
+        <Heading as="h3" className="mb-0 min-h-9">
           {t("menu.settings", { ns: "common" })}
         </Heading>
         {CAMERA_SELECT_BUTTON_PAGES.includes(page) && (


### PR DESCRIPTION
## Proposed change

This PR fixes some minor layout shift with the settings page that occurs when switching between a tab with the camera select button in the header and a tab that doesn't have the camera select button in the header.

This happened on the old style settings page as well. I fixed it by setting the minimum height of the header bar to the height of the button, where previously it would grow when the button appeared.

I looked in issues/PRs and couldn't see any others referencing this bug, so hopefully this isn't a duplicate.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

Before:

https://github.com/user-attachments/assets/9d58e59e-51e9-4292-ba24-01419a02b104

After:

https://github.com/user-attachments/assets/2d48f162-ce5d-4a6b-a014-beac9ef8a49b

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
