### PR TITLE
Settings page layout shift - follow up

### DIFF
--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -437,8 +437,8 @@ export default function Settings() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b border-secondary p-3">
-        <Heading as="h3" className="mb-0 min-h-9">
+      <div className="flex min-h-16 items-center justify-between border-b border-secondary p-3">
+        <Heading as="h3" className="mb-0">
           {t("menu.settings", { ns: "common" })}
         </Heading>
         {CAMERA_SELECT_BUTTON_PAGES.includes(page) && (

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -438,7 +438,7 @@ export default function Settings() {
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between border-b border-secondary p-3">
-        <Heading as="h3" className="mb-0">
+        <Heading as="h3" className="mb-0 min-h-9">
           {t("menu.settings", { ns: "common" })}
         </Heading>
         {CAMERA_SELECT_BUTTON_PAGES.includes(page) && (


### PR DESCRIPTION
## Proposed change

Follow up to https://github.com/blakeblackshear/frigate/pull/21298 moving the fixed minimum height from the heading element to the parent element, following a PR comment https://github.com/blakeblackshear/frigate/pull/21298#discussion_r2620396626

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

Layout shift still fixed.

https://github.com/user-attachments/assets/7382566a-3e9b-4714-ab12-40e7efbfd149

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
