### PR TITLE
consider anonymous user authenticated

### DIFF
--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -143,17 +143,6 @@ def require_admin_by_default():
     return admin_checker
 
 
-def _is_authenticated(request: Request) -> bool:
-    """
-    Helper to determine if a request is from an authenticated user.
-
-    Returns True if the request has a valid authenticated user (not anonymous).
-    Port 5000 internal requests are considered anonymous despite having admin role.
-    """
-    username = request.headers.get("remote-user")
-    return username is not None
-
-
 def allow_public():
     """
     Override dependency to allow unauthenticated access to an endpoint.
@@ -173,27 +162,24 @@ def allow_public():
 
 def allow_any_authenticated():
     """
-    Override dependency to allow any authenticated user (bypass admin requirement).
+    Override dependency to allow any request that passed through the /auth endpoint.
 
     Allows:
-    - Port 5000 internal requests (have admin role despite anonymous user)
-    - Any authenticated user with a real username (not "anonymous")
+    - Port 5000 internal requests (remote-user: "anonymous", remote-role: "admin")
+    - Authenticated users with JWT tokens (remote-user: username)
+    - Unauthenticated requests when auth is disabled (remote-user: "anonymous")
 
     Rejects:
-    - Port 8971 requests with anonymous user (auth disabled, no proxy auth)
+    - Requests with no remote-user header (did not pass through /auth endpoint)
 
     Example:
         @router.get("/authenticated-endpoint", dependencies=[Depends(allow_any_authenticated())])
     """
 
     async def auth_checker(request: Request):
-        # Port 5000 requests have admin role and should be allowed
-        role = request.headers.get("remote-role")
-        if role == "admin":
-            return
-
-        # Otherwise require a real authenticated user (not anonymous)
-        if not _is_authenticated(request):
+        # Ensure a remote-user has been set by the /auth endpoint
+        username = request.headers.get("remote-user")
+        if username is None:
             raise HTTPException(status_code=401, detail="Authentication required")
         return
 

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -151,7 +151,7 @@ def _is_authenticated(request: Request) -> bool:
     Port 5000 internal requests are considered anonymous despite having admin role.
     """
     username = request.headers.get("remote-user")
-    return username is not None and username != "anonymous"
+    return username is not None
 
 
 def allow_public():


### PR DESCRIPTION
## Proposed change
This pull request makes a minor adjustment to the authentication logic in `frigate/api/auth.py`. The change allows requests with the username "anonymous" to be considered authenticated, rather than excluding them.

* Modified the `_is_authenticated` function to treat requests with the username "anonymous" as authenticated, by removing the check that excluded "anonymous" usernames.
* Since the `/auth` endpoint has exclusive access to set the `remote-user` header, we should consider it to be authenticated even for anonymous users.
* This also makes proxy auth work properly in cases where the upstream proxy is only passing a role and not a user

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
