### PR TITLE
fix: temp directory is only created when there are review_items.

### DIFF
--- a/frigate/util/classification.py
+++ b/frigate/util/classification.py
@@ -355,8 +355,6 @@ def collect_state_classification_examples(
         cameras: Dict mapping camera names to normalized crop coordinates [x1, y1, x2, y2] (0-1)
     """
     dataset_dir = os.path.join(CLIPS_DIR, model_name, "dataset")
-    temp_dir = os.path.join(dataset_dir, "temp")
-    os.makedirs(temp_dir, exist_ok=True)
 
     # Step 1: Get review items for the cameras
     camera_names = list(cameras.keys())
@@ -370,6 +368,10 @@ def collect_state_classification_examples(
     if not review_items:
         logger.warning(f"No review items found for cameras: {camera_names}")
         return
+
+    # The temp directory is only created when there are review_items.
+    temp_dir = os.path.join(dataset_dir, "temp")
+    os.makedirs(temp_dir, exist_ok=True)
 
     # Step 2: Create balanced timestamp selection (100 samples)
     timestamps = _select_balanced_timestamps(review_items, target_count=100)


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
When creating a classification model, if there are no review items, it may result in an empty temp directory being generated and not cleaned up, which will then be displayed in the type.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/blakeblackshear/frigate/discussions/21274#discussioncomment-15277935

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
