### PR TITLE
Support for camera-specific hardware acceleration settings for timelapse exports.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default_target: local
 
 COMMIT_HASH := $(shell git log -1 --pretty=format:"%h"|tail -1)
-VERSION = 0.16.2
+VERSION = 0.16.3
 IMAGE_REPO ?= ghcr.io/blakeblackshear/frigate
 GITHUB_REF_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
 BOARDS= #Initialized empty

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 A complete and local NVR designed for [Home Assistant](https://www.home-assistant.io) with AI object detection. Uses OpenCV and Tensorflow to perform realtime object detection locally for IP cameras.
 
-Use of a GPU or AI accelerator such as a [Google Coral](https://coral.ai/products/) or [Hailo](https://hailo.ai/) is highly recommended. AI accelerators will outperform even the best CPUs with very little overhead.
+Use of a GPU, Integrated GPU, or AI accelerator such as a [Hailo](https://hailo.ai/) is highly recommended. Dedicated hardware will outperform even the best CPUs with very little overhead.
 
 - Tight integration with Home Assistant via a [custom component](https://github.com/blakeblackshear/frigate-hass-integration)
 - Designed to minimize resource use and maximize performance by only looking for objects when and where it is necessary

--- a/docker/main/build_pysqlite3.sh
+++ b/docker/main/build_pysqlite3.sh
@@ -5,21 +5,27 @@ set -euxo pipefail
 SQLITE3_VERSION="3.46.1"
 PYSQLITE3_VERSION="0.5.3"
 
+# Install libsqlite3-dev if not present (needed for some base images like NVIDIA TensorRT)
+if ! dpkg -l | grep -q libsqlite3-dev; then
+  echo "Installing libsqlite3-dev for compilation..."
+  apt-get update && apt-get install -y libsqlite3-dev && rm -rf /var/lib/apt/lists/*
+fi
+
 # Fetch the pre-built sqlite amalgamation instead of building from source
 if [[ ! -d "sqlite" ]]; then
   mkdir sqlite
   cd sqlite
-  
+
   # Download the pre-built amalgamation from sqlite.org
   # For SQLite 3.46.1, the amalgamation version is 3460100
   SQLITE_AMALGAMATION_VERSION="3460100"
-  
+
   wget https://www.sqlite.org/2024/sqlite-amalgamation-${SQLITE_AMALGAMATION_VERSION}.zip -O sqlite-amalgamation.zip
   unzip sqlite-amalgamation.zip
   mv sqlite-amalgamation-${SQLITE_AMALGAMATION_VERSION}/* .
   rmdir sqlite-amalgamation-${SQLITE_AMALGAMATION_VERSION}
   rm sqlite-amalgamation.zip
-  
+
   cd ../
 fi
 

--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -8,6 +8,7 @@ fastapi == 0.115.*
 uvicorn == 0.30.*
 slowapi == 0.1.*
 joserfc == 1.0.*
+cryptography == 44.0.*
 pathvalidate == 3.2.*
 markupsafe == 3.0.*
 python-multipart == 0.0.12

--- a/docker/main/requirements.txt
+++ b/docker/main/requirements.txt
@@ -1,2 +1,1 @@
 scikit-build == 0.18.*
-nvidia-pyindex

--- a/docker/tensorrt/Dockerfile.arm64
+++ b/docker/tensorrt/Dockerfile.arm64
@@ -112,7 +112,7 @@ RUN apt-get update \
     && apt-get install -y protobuf-compiler libprotobuf-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN --mount=type=bind,source=docker/tensorrt/requirements-models-arm64.txt,target=/requirements-tensorrt-models.txt \
-    pip3 wheel --wheel-dir=/trt-model-wheels -r /requirements-tensorrt-models.txt
+    pip3 wheel --wheel-dir=/trt-model-wheels --no-deps -r /requirements-tensorrt-models.txt
 
 FROM wget AS jetson-ffmpeg
 ARG DEBIAN_FRONTEND
@@ -145,7 +145,8 @@ COPY --from=trt-wheels /etc/TENSORRT_VER /etc/TENSORRT_VER
 RUN --mount=type=bind,from=trt-wheels,source=/trt-wheels,target=/deps/trt-wheels \
     --mount=type=bind,from=trt-model-wheels,source=/trt-model-wheels,target=/deps/trt-model-wheels \
     pip3 uninstall -y onnxruntime \
-    && pip3 install -U /deps/trt-wheels/*.whl /deps/trt-model-wheels/*.whl \
+    && pip3 install -U /deps/trt-wheels/*.whl \
+    && pip3 install -U /deps/trt-model-wheels/*.whl \
     && ldconfig
 
 WORKDIR /opt/frigate/

--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -258,6 +258,10 @@ ffmpeg:
 
 TP-Link VIGI cameras need some adjustments to the main stream settings on the camera itself to avoid issues. The stream needs to be configured as `H264` with `Smart Coding` set to `off`. Without these settings you may have problems when trying to watch recorded footage. For example Firefox will stop playback after a few seconds and show the following error message: `The media playback was aborted due to a corruption problem or because the media used features your browser did not support.`.
 
+### Wyze Wireless Cameras
+
+Some community members have found better performance on Wyze cameras by using an alternative firmware known as [Thingino](https://thingino.com/).
+
 ## USB Cameras (aka Webcams)
 
 To use a USB camera (webcam) with Frigate, the recommendation is to use go2rtc's [FFmpeg Device](https://github.com/AlexxIT/go2rtc?tab=readme-ov-file#source-ffmpeg-device) support:
@@ -290,5 +294,3 @@ cameras:
       width: 1024
       height: 576
 ```
-
-

--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -188,10 +188,10 @@ go2rtc:
     # example for connectin to a Reolink camera that supports two way talk
     your_reolink_camera_twt:
       - "ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_main.bcs&user=username&password=password#video=copy#audio=copy#audio=opus"
-      - "rtsp://username:password@reolink_ip/Preview_01_sub
+      - "rtsp://username:password@reolink_ip/Preview_01_sub"
     your_reolink_camera_twt_sub:
       - "ffmpeg:http://reolink_ip/flv?port=1935&app=bcs&stream=channel0_ext.bcs&user=username&password=password"
-      - "rtsp://username:password@reolink_ip/Preview_01_sub
+      - "rtsp://username:password@reolink_ip/Preview_01_sub"
     # example for connecting to a Reolink NVR
     your_reolink_camera_via_nvr:
       - "ffmpeg:http://reolink_nvr_ip/flv?port=1935&app=bcs&stream=channel3_main.bcs&user=username&password=password" # channel numbers are 0-15

--- a/docs/docs/configuration/camera_specific.md
+++ b/docs/docs/configuration/camera_specific.md
@@ -227,6 +227,12 @@ cameras:
 
 ### Unifi Protect Cameras
 
+:::note 
+
+Unifi G5s cameras and newer need a Unifi Protect server to enable rtsps stream, it's not posible to enable it in standalone mode.
+
+:::
+
 Unifi protect cameras require the rtspx stream to be used with go2rtc.
 To utilize a Unifi protect camera, modify the rtsps link to begin with rtspx.
 Additionally, remove the "?enableSrtp" from the end of the Unifi link.

--- a/docs/docs/configuration/cameras.md
+++ b/docs/docs/configuration/cameras.md
@@ -98,6 +98,7 @@ This list of working and non-working PTZ cameras is based on user feedback.
 | Amcrest IP4M-S2112EW-AI      |      ✅      |      ❌      | FOV relative movement not supported.                                                                                                            |
 | Amcrest IP5M-1190EW          |      ✅      |      ❌      | ONVIF Port: 80. FOV relative movement not supported.                                                                                            |
 | Annke CZ504                  |      ✅      |      ✅      | Annke support provide specific firmware ([V5.7.1 build 250227](https://github.com/pierrepinon/annke_cz504/raw/refs/heads/main/digicap_V5-7-1_build_250227.dav)) to fix issue with ONVIF "TranslationSpaceFov" |
+| Axis Q-6155E                 |      ✅      |      ❌      | ONVIF service port: 80; Camera does not support MoveStatus.
 | Ctronics PTZ                 |      ✅      |      ❌      |                                                                                                                                                 |
 | Dahua                        |      ✅      |      ✅      | Some low-end Dahuas (lite series, among others) have been reported to not support autotracking                                                  |
 | Dahua DH-SD2A500HB           |      ✅      |      ❌      |                                                                                                                                                 |

--- a/docs/docs/configuration/live.md
+++ b/docs/docs/configuration/live.md
@@ -15,7 +15,7 @@ The jsmpeg live view will use more browser and client GPU resources. Using go2rt
 | ------ | ------------------------------------- | ---------- | ---------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | jsmpeg | same as `detect -> fps`, capped at 10 | 720p       | no                           | no              | Resolution is configurable, but go2rtc is recommended if you want higher resolutions and better frame rates. jsmpeg is Frigate's default without go2rtc configured. |
 | mse    | native                                | native     | yes (depends on audio codec) | yes             | iPhone requires iOS 17.1+, Firefox is h.264 only. This is Frigate's default when go2rtc is configured.                                                              |
-| webrtc | native                                | native     | yes (depends on audio codec) | yes             | Requires extra configuration, doesn't support h.265. Frigate attempts to use WebRTC when MSE fails or when using a camera's two-way talk feature.                   |
+| webrtc | native                                | native     | yes (depends on audio codec) | yes             | Requires extra configuration. Frigate attempts to use WebRTC when MSE fails or when using a camera's two-way talk feature.                   |
 
 ### Camera Settings Recommendations
 
@@ -127,7 +127,8 @@ WebRTC works by creating a TCP or UDP connection on port `8555`. However, it req
   ```
 
 - For access through Tailscale, the Frigate system's Tailscale IP must be added as a WebRTC candidate. Tailscale IPs all start with `100.`, and are reserved within the `100.64.0.0/10` CIDR block.
-- Note that WebRTC does not support H.265.
+
+- Note that some browsers may not support H.265 (HEVC). You can check your browser's current version for H.265 compatibility [here](https://github.com/AlexxIT/go2rtc?tab=readme-ov-file#codecs-madness). 
 
 :::tip
 

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -1007,12 +1007,12 @@ EOF
 RF-DETR can be exported as ONNX by running the command below. You can copy and paste the whole thing to your terminal and execute, altering `MODEL_SIZE=Nano` in the first line to `Nano`, `Small`, or `Medium` size.
 
 ```sh
-docker build . --build-arg MODEL_SIZE=Nano --output . -f- <<'EOF'
+docker build . --build-arg MODEL_SIZE=Nano --rm --output . -f- <<'EOF'
 FROM python:3.11 AS build
 RUN apt-get update && apt-get install --no-install-recommends -y libgl1 && rm -rf /var/lib/apt/lists/*
 COPY --from=ghcr.io/astral-sh/uv:0.8.0 /uv /bin/
 WORKDIR /rfdetr
-RUN uv pip install --system rfdetr[onnxexport] torch==2.8.0 onnxscript
+RUN uv pip install --system rfdetr[onnxexport] torch==2.8.0 onnx==1.19.1 onnxscript
 ARG MODEL_SIZE
 RUN python3 -c "from rfdetr import RFDETR${MODEL_SIZE}; x = RFDETR${MODEL_SIZE}(resolution=320); x.export(simplify=True)"
 FROM scratch

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -395,7 +395,7 @@ After placing the downloaded onnx model in your config/model_cache folder, you c
 detectors:
   ov:
     type: openvino
-    device: GPU
+    device: CPU
 
 model:
   model_type: dfine
@@ -431,10 +431,10 @@ When using Docker Compose:
 ```yaml
 services:
   frigate:
----
-devices:
-  - /dev/dri
-  - /dev/kfd
+    ...
+    devices:
+      - /dev/dri
+      - /dev/kfd
 ```
 
 For reference on recommended settings see [running ROCm/pytorch in Docker](https://rocm.docs.amd.com/projects/install-on-linux/en/develop/how-to/3rd-party/pytorch-install.html#using-docker-with-pytorch-pre-installed).
@@ -462,9 +462,9 @@ When using Docker Compose:
 ```yaml
 services:
   frigate:
-
-environment:
-  HSA_OVERRIDE_GFX_VERSION: "10.0.0"
+    ...
+    environment:
+      HSA_OVERRIDE_GFX_VERSION: "10.0.0"
 ```
 
 Figuring out what version you need can be complicated as you can't tell the chipset name and driver from the AMD brand name.

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -1002,7 +1002,7 @@ COPY --from=build /dfine/output/dfine_${MODEL_SIZE}_obj2coco.onnx /dfine-${MODEL
 EOF
 ```
 
-### Download RF-DETR Model
+### Downloading RF-DETR Model
 
 RF-DETR can be exported as ONNX by running the command below. You can copy and paste the whole thing to your terminal and execute, altering `MODEL_SIZE=Nano` in the first line to `Nano`, `Small`, or `Medium` size.
 

--- a/docs/docs/configuration/pwa.md
+++ b/docs/docs/configuration/pwa.md
@@ -11,7 +11,7 @@ This adds features including the ability to deep link directly into the app.
 
 In order to install Frigate as a PWA, the following requirements must be met:
 
-- Frigate must be accessed via a secure context (localhost, secure https, etc.)
+- Frigate must be accessed via a secure context (localhost, secure https, VPN, etc.)
 - On Android, Firefox, Chrome, Edge, Opera, and Samsung Internet Browser all support installing PWAs.
 - On iOS 16.4 and later, PWAs can be installed from the Share menu in Safari, Chrome, Edge, Firefox, and Orion.
 
@@ -22,3 +22,7 @@ Installation varies slightly based on the device that is being used:
 - Desktop: Use the install button typically found in right edge of the address bar
 - Android: Use the `Install as App` button in the more options menu for Chrome, and the `Add app to Home screen` button for Firefox
 - iOS: Use the `Add to Homescreen` button in the share menu
+
+## Usage
+
+Once setup, the Frigate app can be used wherever it has access to Frigate. This means it can be setup as local-only, VPN-only, or fully accessible depending on your needs.

--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -169,7 +169,9 @@ record:
 
 :::tip
 
-When using `hwaccel_args`, hardware encoding is used for time lapse generation, using the relevant camera's hwaccel configuration. The encoder determines its own behavior so the resulting file size may be undesirably large.
+When using `hwaccel_args`, hardware encoding is used for timelapse generation. By default, each camera inherits its export hwaccel settings from its own `ffmpeg.hwaccel_args`, which in turn inherits from the global setting. To override for a specific camera (e.g., when camera resolution exceeds hardware encoder limits), set `record.export.hwaccel_args` at the camera level. Using an unrecognized value or empty string will fall back to software encoding (libx264).
+
+The encoder determines its own behavior so the resulting file size may be undesirably large.
 To reduce the output file size the ffmpeg parameter `-qp n` can be utilized (where `n` stands for the value of the quantisation parameter). The value can be adjusted to get an acceptable tradeoff between quality and file size for the given scenario.
 
 :::

--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -169,7 +169,7 @@ record:
 
 :::tip
 
-When using `hwaccel_args` globally hardware encoding is used for time lapse generation. The encoder determines its own behavior so the resulting file size may be undesirably large.
+When using `hwaccel_args`, hardware encoding is used for time lapse generation, using the relevant camera's hwaccel configuration. The encoder determines its own behavior so the resulting file size may be undesirably large.
 To reduce the output file size the ffmpeg parameter `-qp n` can be utilized (where `n` stands for the value of the quantisation parameter). The value can be adjusted to get an acceptable tradeoff between quality and file size for the given scenario.
 
 :::

--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -171,6 +171,8 @@ record:
 
 When using `hwaccel_args`, hardware encoding is used for timelapse generation. By default, each camera inherits its export hwaccel settings from its own `ffmpeg.hwaccel_args`, which in turn inherits from the global setting. To override for a specific camera (e.g., when camera resolution exceeds hardware encoder limits), set `record.export.hwaccel_args` at the camera level. Using an unrecognized value or empty string will fall back to software encoding (libx264).
 
+:::tip
+
 The encoder determines its own behavior so the resulting file size may be undesirably large.
 To reduce the output file size the ffmpeg parameter `-qp n` can be utilized (where `n` stands for the value of the quantisation parameter). The value can be adjusted to get an acceptable tradeoff between quality and file size for the given scenario.
 

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -462,6 +462,8 @@ record:
     # The -r (framerate) dictates how smooth the output video is.
     # So the args would be -vf setpts=0.02*PTS -r 30 in that case.
     timelapse_args: "-vf setpts=0.04*PTS -r 30"
+    # Optional: Global override for hwaccel_args in an export context (default: camera-specific args)
+    hwaccel_args: auto
   # Optional: Recording Preview Settings
   preview:
     # Optional: Quality of recording preview (default: shown below).

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -462,7 +462,11 @@ record:
     # The -r (framerate) dictates how smooth the output video is.
     # So the args would be -vf setpts=0.02*PTS -r 30 in that case.
     timelapse_args: "-vf setpts=0.04*PTS -r 30"
-    # Optional: Global override for hwaccel_args in an export context (default: camera-specific args)
+    # Optional: Hardware acceleration for timelapse exports.
+    # When set to "auto" (default), inherits from camera ffmpeg hwaccel_args, which
+    # in turn inherits from global ffmpeg hwaccel_args. Set to a specific preset
+    # to override, or use an unrecognized value (e.g., empty string) to fall back
+    # to software encoding (libx264).
     hwaccel_args: auto
   # Optional: Recording Preview Settings
   preview:

--- a/docs/docs/frigate/hardware.md
+++ b/docs/docs/frigate/hardware.md
@@ -18,7 +18,7 @@ Here are some of the cameras I recommend:
 - <a href="https://amzn.to/4fwoNWA" target="_blank" rel="nofollow noopener sponsored">Loryta(Dahua) IPC-T549M-ALED-S3</a> (affiliate link)
 - <a href="https://amzn.to/3YXpcMw" target="_blank" rel="nofollow noopener sponsored">Loryta(Dahua) IPC-T54IR-AS</a> (affiliate link)
 - <a href="https://amzn.to/3AvBHoY" target="_blank" rel="nofollow noopener sponsored">Amcrest IP5M-T1179EW-AI-V3</a> (affiliate link)
-- <a href="https://amzn.to/4ltOpaC" target="_blank" rel="nofollow noopener sponsored">HIKVISION DS-2CD2387G2P-LSU/SL ColorVu 8MP Panoramic Turret IP Camera</a> (affiliate link)
+- <a href="https://www.bhphotovideo.com/c/product/1705511-REG/hikvision_colorvu_ds_2cd2387g2p_lsu_sl_8mp_network.html" target="_blank" rel="nofollow noopener">HIKVISION DS-2CD2387G2P-LSU/SL ColorVu 8MP Panoramic Turret IP Camera</a> (affiliate link)
 
 I may earn a small commission for my endorsement, recommendation, testimonial, or link to any products or services from this website.
 

--- a/docs/docs/frigate/hardware.md
+++ b/docs/docs/frigate/hardware.md
@@ -104,10 +104,16 @@ In real-world deployments, even with multiple cameras running concurrently, Frig
 
 ### Google Coral TPU
 
+:::warning
+
+The Coral is no longer recommended for new Frigate installations, except in deployments with particularly low power requirements or hardware incapable of utilizing alternative AI accelerators for object detection. Instead, we suggest using one of the numerous other supported object detectors. Frigate will continue to provide support for the Coral TPU for as long as practicably possible given its still one of the most power-efficient devices for executing object detection models.
+
+:::
+
 Frigate supports both the USB and M.2 versions of the Google Coral.
 
 - The USB version is compatible with the widest variety of hardware and does not require a driver on the host machine. However, it does lack the automatic throttling features of the other versions.
-- The PCIe and M.2 versions require installation of a driver on the host. Follow the instructions for your version from https://coral.ai
+- The PCIe and M.2 versions require installation of a driver on the host. https://github.com/jnicolson/gasket-builder should be used.
 
 A single Coral can handle many cameras using the default model and will be sufficient for the majority of users. You can calculate the maximum performance of your Coral based on the inference speed reported by Frigate. With an inference speed of 10, your Coral will top out at `1000/10=100`, or 100 frames per second. If your detection fps is regularly getting close to that, you should first consider tuning motion masks. If those are already properly configured, a second Coral may be needed.
 

--- a/docs/docs/frigate/hardware.md
+++ b/docs/docs/frigate/hardware.md
@@ -36,9 +36,11 @@ If the EQ13 is out of stock, the link below may take you to a suggested alternat
 
 :::
 
-| Name                                                                                                          | Coral Inference Speed | Coral Compatibility | Notes                                                                                     |
-| ------------------------------------------------------------------------------------------------------------- | --------------------- | ------------------- | ----------------------------------------------------------------------------------------- |
-| Beelink EQ13 (<a href="https://amzn.to/4jn2qVr" target="_blank" rel="nofollow noopener sponsored">Amazon</a>) | 5-10ms                | USB                 | Dual gigabit NICs for easy isolated camera network. Easily handles several 1080p cameras. |
+| Name                                                                                                          | Capabilities                                                               | Notes                                               |
+| ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | --------------------------------------------------- |
+| Beelink EQ13 (<a href="https://amzn.to/4jn2qVr" target="_blank" rel="nofollow noopener sponsored">Amazon</a>) | Can run object detection on several 1080p cameras with low-medium activity | Dual gigabit NICs for easy isolated camera network. |
+| Intel 1120p ([Amazon](https://www.amazon.com/Beelink-i3-1220P-Computer-Display-Gigabit/dp/B0DDCKT9YP)         | Can handle a large number of 1080p cameras with high activity              |                                                     |
+| Intel 125H  ([Amazon](https://www.amazon.com/MINISFORUM-Pro-125H-Barebone-Computer-HDMI2-1/dp/B0FH21FSZM)     | Can handle a significant number of 1080p cameras with high activity        | Includes NPU for more efficient detection in 0.17+  |
 
 ## Detectors
 

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -200,7 +200,7 @@ services:
     shm_size: "512mb" # update for your cameras based on calculation above
     devices:
       - /dev/bus/usb:/dev/bus/usb # Passes the USB Coral, needs to be modified for other versions
-      - /dev/apex_0:/dev/apex_0 # Passes a PCIe Coral, follow driver instructions here https://coral.ai/docs/m2/get-started/#2a-on-linux
+      - /dev/apex_0:/dev/apex_0 # Passes a PCIe Coral, follow driver instructions here https://github.com/jnicolson/gasket-builder
       - /dev/video11:/dev/video11 # For Raspberry Pi 4B
       - /dev/dri/renderD128:/dev/dri/renderD128 # For intel hwaccel, needs to be updated for your hardware
     volumes:

--- a/docs/docs/frigate/updating.md
+++ b/docs/docs/frigate/updating.md
@@ -5,7 +5,7 @@ title: Updating
 
 # Updating Frigate
 
-The current stable version of Frigate is **0.16.2**. The release notes and any breaking changes for this version can be found on the [Frigate GitHub releases page](https://github.com/blakeblackshear/frigate/releases/tag/v0.16.2).
+The current stable version of Frigate is **0.16.3**. The release notes and any breaking changes for this version can be found on the [Frigate GitHub releases page](https://github.com/blakeblackshear/frigate/releases/tag/v0.16.3).
 
 Keeping Frigate up to date ensures you benefit from the latest features, performance improvements, and bug fixes. The update process varies slightly depending on your installation method (Docker, Home Assistant Addon, etc.). Below are instructions for the most common setups.
 
@@ -33,21 +33,21 @@ If you’re running Frigate via Docker (recommended method), follow these steps:
 2. **Update and Pull the Latest Image**:
 
    - If using Docker Compose:
-     - Edit your `docker-compose.yml` file to specify the desired version tag (e.g., `0.16.2` instead of `0.15.2`). For example:
+     - Edit your `docker-compose.yml` file to specify the desired version tag (e.g., `0.16.3` instead of `0.15.2`). For example:
        ```yaml
        services:
          frigate:
-           image: ghcr.io/blakeblackshear/frigate:0.16.2
+           image: ghcr.io/blakeblackshear/frigate:0.16.3
        ```
      - Then pull the image:
        ```bash
-       docker pull ghcr.io/blakeblackshear/frigate:0.16.2
+       docker pull ghcr.io/blakeblackshear/frigate:0.16.3
        ```
      - **Note for `stable` Tag Users**: If your `docker-compose.yml` uses the `stable` tag (e.g., `ghcr.io/blakeblackshear/frigate:stable`), you don’t need to update the tag manually. The `stable` tag always points to the latest stable release after pulling.
    - If using `docker run`:
-     - Pull the image with the appropriate tag (e.g., `0.16.2`, `0.16.2-tensorrt`, or `stable`):
+     - Pull the image with the appropriate tag (e.g., `0.16.3`, `0.16.3-tensorrt`, or `stable`):
        ```bash
-       docker pull ghcr.io/blakeblackshear/frigate:0.16.2
+       docker pull ghcr.io/blakeblackshear/frigate:0.16.3
        ```
 
 3. **Start the Container**:

--- a/docs/docs/guides/getting_started.md
+++ b/docs/docs/guides/getting_started.md
@@ -202,7 +202,7 @@ services:
     ...
     devices:
       - /dev/bus/usb:/dev/bus/usb # passes the USB Coral, needs to be modified for other versions
-      - /dev/apex_0:/dev/apex_0 # passes a PCIe Coral, follow driver instructions here https://coral.ai/docs/m2/get-started/#2a-on-linux
+      - /dev/apex_0:/dev/apex_0 # passes a PCIe Coral, follow driver instructions here https://github.com/jnicolson/gasket-builder
     ...
 ```
 

--- a/docs/docs/troubleshooting/edgetpu.md
+++ b/docs/docs/troubleshooting/edgetpu.md
@@ -68,8 +68,7 @@ The USB Coral can become stuck and need to be restarted, this can happen for a n
 
 The most common reason for the PCIe Coral not being detected is that the driver has not been installed. This process varies based on what OS and kernel that is being run.
 
-- In most cases [the Coral docs](https://coral.ai/docs/m2/get-started/#2-install-the-pcie-driver-and-edge-tpu-runtime) show how to install the driver for the PCIe based Coral.
-- For some newer Linux distros (for example, Ubuntu 22.04+), https://github.com/jnicolson/gasket-builder can be used to build and install the latest version of the driver.
+- In most cases https://github.com/jnicolson/gasket-builder can be used to build and install the latest version of the driver.
 
 ## Attempting to load TPU as pci & Fatal Python error: Illegal instruction
 

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -447,8 +447,14 @@ def create_user(
     return JSONResponse(content={"username": body.username})
 
 
-@router.delete("/users/{username}")
-def delete_user(username: str):
+@router.delete("/users/{username}", dependencies=[Depends(require_role(["admin"]))])
+def delete_user(request: Request, username: str):
+    # Prevent deletion of the built-in admin user
+    if username == "admin":
+        return JSONResponse(
+            content={"message": "Cannot delete admin user"}, status_code=403
+        )
+
     User.delete_by_id(username)
     return JSONResponse(content={"success": True})
 

--- a/frigate/config/camera/record.py
+++ b/frigate/config/camera/record.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import Field
 

--- a/frigate/config/camera/record.py
+++ b/frigate/config/camera/record.py
@@ -66,6 +66,9 @@ class RecordExportConfig(FrigateBaseModel):
     timelapse_args: str = Field(
         default=DEFAULT_TIME_LAPSE_FFMPEG_ARGS, title="Timelapse Args"
     )
+    hwaccel_args: Union[str, list[str]] = Field(
+        default="auto", title="Export-specific FFmpeg hardware acceleration arguments."
+    )
 
 
 class RecordConfig(FrigateBaseModel):

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -545,6 +545,9 @@ class FrigateConfig(FrigateBaseModel):
             if camera_config.ffmpeg.hwaccel_args == "auto":
                 camera_config.ffmpeg.hwaccel_args = self.ffmpeg.hwaccel_args
 
+            # Resolve export hwaccel_args: camera export -> camera ffmpeg -> global ffmpeg
+            # This allows per-camera override for exports (e.g., when camera resolution
+            # exceeds hardware encoder limits)
             if camera_config.record.export.hwaccel_args == "auto":
                 camera_config.record.export.hwaccel_args = camera_config.ffmpeg.hwaccel_args
 

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -549,7 +549,9 @@ class FrigateConfig(FrigateBaseModel):
             # This allows per-camera override for exports (e.g., when camera resolution
             # exceeds hardware encoder limits)
             if camera_config.record.export.hwaccel_args == "auto":
-                camera_config.record.export.hwaccel_args = camera_config.ffmpeg.hwaccel_args
+                camera_config.record.export.hwaccel_args = (
+                    camera_config.ffmpeg.hwaccel_args
+                )
 
             for input in camera_config.ffmpeg.inputs:
                 need_detect_dimensions = "detect" in input.roles and (

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -545,6 +545,9 @@ class FrigateConfig(FrigateBaseModel):
             if camera_config.ffmpeg.hwaccel_args == "auto":
                 camera_config.ffmpeg.hwaccel_args = self.ffmpeg.hwaccel_args
 
+            if camera_config.record.export.hwaccel_args == "auto":
+                camera_config.record.export.hwaccel_args = camera_config.ffmpeg.hwaccel_args
+
             for input in camera_config.ffmpeg.inputs:
                 need_detect_dimensions = "detect" in input.roles and (
                     camera_config.detect.height is None

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -225,7 +225,7 @@ class RecordingExporter(threading.Thread):
             ffmpeg_cmd = (
                 parse_preset_hardware_acceleration_encode(
                     self.config.ffmpeg.ffmpeg_path,
-                    self.config.cameras[self.camera].record.export.timelapse_args,
+                    self.config.cameras[self.camera].record.export.hwaccel_args,
                     f"-an {ffmpeg_input}",
                     f"{self.config.cameras[self.camera].record.export.timelapse_args} -movflags +faststart",
                     EncodeTypeEnum.timelapse,

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -225,7 +225,7 @@ class RecordingExporter(threading.Thread):
             ffmpeg_cmd = (
                 parse_preset_hardware_acceleration_encode(
                     self.config.ffmpeg.ffmpeg_path,
-                    self.config.ffmpeg.hwaccel_args,
+                    self.config.cameras[self.camera].record.export.timelapse_args,
                     f"-an {ffmpeg_input}",
                     f"{self.config.cameras[self.camera].record.export.timelapse_args} -movflags +faststart",
                     EncodeTypeEnum.timelapse,
@@ -316,7 +316,7 @@ class RecordingExporter(threading.Thread):
             ffmpeg_cmd = (
                 parse_preset_hardware_acceleration_encode(
                     self.config.ffmpeg.ffmpeg_path,
-                    self.config.ffmpeg.hwaccel_args,
+                    self.config.cameras[self.camera].record.export.hwaccel_args,
                     f"{TIMELAPSE_DATA_INPUT_ARGS} {ffmpeg_input}",
                     f"{self.config.cameras[self.camera].record.export.timelapse_args} -movflags +faststart {video_path}",
                     EncodeTypeEnum.timelapse,

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from "react";
 import Hls from "hls.js";
-import { isAndroid, isDesktop, isMobile } from "react-device-detect";
+import { isDesktop, isMobile } from "react-device-detect";
 import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
 import VideoControls from "./VideoControls";
 import { VideoResolutionType } from "@/types/live";
@@ -21,7 +21,7 @@ import { ASPECT_VERTICAL_LAYOUT, RecordingPlayerError } from "@/types/record";
 import { useTranslation } from "react-i18next";
 
 // Android native hls does not seek correctly
-const USE_NATIVE_HLS = !isAndroid;
+const USE_NATIVE_HLS = false;
 const HLS_MIME_TYPE = "application/vnd.apple.mpegurl" as const;
 const unsupportedErrorCodes = [
   MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED,

--- a/web/src/components/player/dynamic/DynamicVideoController.ts
+++ b/web/src/components/player/dynamic/DynamicVideoController.ts
@@ -2,7 +2,10 @@ import { Recording } from "@/types/record";
 import { DynamicPlayback } from "@/types/playback";
 import { PreviewController } from "../PreviewPlayer";
 import { TimeRange, ObjectLifecycleSequence } from "@/types/timeline";
-import { calculateInpointOffset } from "@/utils/videoUtil";
+import {
+  calculateInpointOffset,
+  calculateSeekPosition,
+} from "@/utils/videoUtil";
 
 type PlayerMode = "playback" | "scrubbing";
 
@@ -68,38 +71,20 @@ export class DynamicVideoController {
       return;
     }
 
-    if (
-      this.recordings.length == 0 ||
-      time < this.recordings[0].start_time ||
-      time > this.recordings[this.recordings.length - 1].end_time
-    ) {
-      this.setNoRecording(true);
-      return;
-    }
-
     if (this.playerMode != "playback") {
       this.playerMode = "playback";
     }
 
-    let seekSeconds = 0;
-    (this.recordings || []).every((segment) => {
-      // if the next segment is past the desired time, stop calculating
-      if (segment.start_time > time) {
-        return false;
-      }
+    const seekSeconds = calculateSeekPosition(
+      time,
+      this.recordings,
+      this.inpointOffset,
+    );
 
-      if (segment.end_time < time) {
-        seekSeconds += segment.end_time - segment.start_time;
-        return true;
-      }
-
-      seekSeconds +=
-        segment.end_time - segment.start_time - (segment.end_time - time);
-      return true;
-    });
-
-    // adjust for HLS inpoint offset
-    seekSeconds -= this.inpointOffset;
+    if (seekSeconds === undefined) {
+      this.setNoRecording(true);
+      return;
+    }
 
     if (seekSeconds != 0) {
       this.playerController.currentTime = seekSeconds;

--- a/web/src/utils/videoUtil.ts
+++ b/web/src/utils/videoUtil.ts
@@ -24,3 +24,57 @@ export function calculateInpointOffset(
 
   return 0;
 }
+
+/**
+ * Calculates the video player time (in seconds) for a given timestamp
+ * by iterating through recording segments and summing their durations.
+ * This accounts for the fact that the video is a concatenation of segments,
+ * not a single continuous stream.
+ *
+ * @param timestamp - The target timestamp to seek to
+ * @param recordings - Array of recording segments
+ * @param inpointOffset - HLS inpoint offset to subtract from the result
+ * @returns The calculated seek position in seconds, or undefined if timestamp is out of range
+ */
+export function calculateSeekPosition(
+  timestamp: number,
+  recordings: Recording[],
+  inpointOffset: number = 0,
+): number | undefined {
+  if (!recordings || recordings.length === 0) {
+    return undefined;
+  }
+
+  // Check if timestamp is within the recordings range
+  if (
+    timestamp < recordings[0].start_time ||
+    timestamp > recordings[recordings.length - 1].end_time
+  ) {
+    return undefined;
+  }
+
+  let seekSeconds = 0;
+
+  (recordings || []).every((segment) => {
+    // if the next segment is past the desired time, stop calculating
+    if (segment.start_time > timestamp) {
+      return false;
+    }
+
+    if (segment.end_time < timestamp) {
+      // Add the full duration of this segment
+      seekSeconds += segment.end_time - segment.start_time;
+      return true;
+    }
+
+    // We're in this segment - calculate position within it
+    seekSeconds +=
+      segment.end_time - segment.start_time - (segment.end_time - timestamp);
+    return true;
+  });
+
+  // Adjust for HLS inpoint offset
+  seekSeconds -= inpointOffset;
+
+  return seekSeconds >= 0 ? seekSeconds : undefined;
+}


### PR DESCRIPTION
## Proposed change

  This PR adds support for camera-specific hardware acceleration settings for timelapse exports.

  Currently, timelapse export hardware acceleration is driven by the global ffmpeg.hwaccel_args config. This is problematic when a specific camera's resolution exceeds the hardware encoder's limits (e.g., vaapi on Intel iGPU with high-resolution cameras, or even just unconventional dimensions), causing exports to fail for that camera while working fine for others.

  This PR adds an optional record.export.hwaccel_args config at the camera level, allowing per-camera override of hardware acceleration settings for exports. The setting uses a cascade resolution:

  1. camera.record.export.hwaccel_args (if set)
  2. camera.ffmpeg.hwaccel_args (if above is "auto")
  3. global.ffmpeg.hwaccel_args (if above is "auto")

  The hardware acceleration can also be disabled, now. Example usage to disable hwaccel for a specific high-resolution camera:

```yaml
  cameras:
    camera_to_disable:
      record:
        export:
          hwaccel_args: ""  # Falls back to software encoding (libx264)

```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information
  - This PR fixes or closes issue: fixes #12758


## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)

