### PR TITLE
Camera-specific hwaccel settings for timelapse exports (correct base)

### DIFF
--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -139,7 +139,7 @@ record:
 
 :::tip
 
-When using `hwaccel_args`, hardware encoding is used for timelapse generation. By default, each camera inherits its export hwaccel settings from its own `ffmpeg.hwaccel_args`, which in turn inherits from the global setting. To override for a specific camera (e.g., when camera resolution exceeds hardware encoder limits), set `record.export.hwaccel_args` at the camera level. Using an unrecognized value or empty string will fall back to software encoding (libx264).
+When using `hwaccel_args`, hardware encoding is used for timelapse generation. This setting can be overridden for a specific camera (e.g., when camera resolution exceeds hardware encoder limits); set `cameras.<camera>.record.export.hwaccel_args` with the appropriate settings. Using an unrecognized value or empty string will fall back to software encoding (libx264).
 
 :::tip
 

--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -139,7 +139,9 @@ record:
 
 :::tip
 
-When using `hwaccel_args`, hardware encoding is used for time lapse generation, using the relevant camera's hwaccel configuration. The encoder determines its own behavior so the resulting file size may be undesirably large.
+When using `hwaccel_args`, hardware encoding is used for timelapse generation. By default, each camera inherits its export hwaccel settings from its own `ffmpeg.hwaccel_args`, which in turn inherits from the global setting. To override for a specific camera (e.g., when camera resolution exceeds hardware encoder limits), set `record.export.hwaccel_args` at the camera level. Using an unrecognized value or empty string will fall back to software encoding (libx264).
+
+The encoder determines its own behavior so the resulting file size may be undesirably large.
 To reduce the output file size the ffmpeg parameter `-qp n` can be utilized (where `n` stands for the value of the quantisation parameter). The value can be adjusted to get an acceptable tradeoff between quality and file size for the given scenario.
 
 :::

--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -139,7 +139,7 @@ record:
 
 :::tip
 
-When using `hwaccel_args` globally hardware encoding is used for time lapse generation. The encoder determines its own behavior so the resulting file size may be undesirably large.
+When using `hwaccel_args`, hardware encoding is used for time lapse generation, using the relevant camera's hwaccel configuration. The encoder determines its own behavior so the resulting file size may be undesirably large.
 To reduce the output file size the ffmpeg parameter `-qp n` can be utilized (where `n` stands for the value of the quantisation parameter). The value can be adjusted to get an acceptable tradeoff between quality and file size for the given scenario.
 
 :::

--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -141,6 +141,8 @@ record:
 
 When using `hwaccel_args`, hardware encoding is used for timelapse generation. By default, each camera inherits its export hwaccel settings from its own `ffmpeg.hwaccel_args`, which in turn inherits from the global setting. To override for a specific camera (e.g., when camera resolution exceeds hardware encoder limits), set `record.export.hwaccel_args` at the camera level. Using an unrecognized value or empty string will fall back to software encoding (libx264).
 
+:::tip
+
 The encoder determines its own behavior so the resulting file size may be undesirably large.
 To reduce the output file size the ffmpeg parameter `-qp n` can be utilized (where `n` stands for the value of the quantisation parameter). The value can be adjusted to get an acceptable tradeoff between quality and file size for the given scenario.
 

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -534,7 +534,11 @@ record:
     # The -r (framerate) dictates how smooth the output video is.
     # So the args would be -vf setpts=0.02*PTS -r 30 in that case.
     timelapse_args: "-vf setpts=0.04*PTS -r 30"
-    # Optional: Global override for hwaccel_args in an export context (default: camera-specific args)
+    # Optional: Hardware acceleration for timelapse exports.
+    # When set to "auto" (default), inherits from camera ffmpeg hwaccel_args, which
+    # in turn inherits from global ffmpeg hwaccel_args. Set to a specific preset
+    # to override, or use an unrecognized value (e.g., empty string) to fall back
+    # to software encoding (libx264).
     hwaccel_args: auto
   # Optional: Recording Preview Settings
   preview:

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -534,11 +534,7 @@ record:
     # The -r (framerate) dictates how smooth the output video is.
     # So the args would be -vf setpts=0.02*PTS -r 30 in that case.
     timelapse_args: "-vf setpts=0.04*PTS -r 30"
-    # Optional: Hardware acceleration for timelapse exports.
-    # When set to "auto" (default), inherits from camera ffmpeg hwaccel_args, which
-    # in turn inherits from global ffmpeg hwaccel_args. Set to a specific preset
-    # to override, or use an unrecognized value (e.g., empty string) to fall back
-    # to software encoding (libx264).
+    # Optional: Global hardware acceleration settings for timelapse exports. (default: inherit)
     hwaccel_args: auto
   # Optional: Recording Preview Settings
   preview:
@@ -840,6 +836,11 @@ cameras:
       # input_args:
       # Optional: camera specific output args (default: inherit)
       # output_args:
+
+    # Optional: camera specific hwaccel args for timelapse export (default: inherit)
+    # record:
+    #   export:
+    #     hwaccel_args:
 
     # Optional: timeout for highest scoring image before allowing it
     # to be replaced by a newer image. (default: shown below)

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -534,6 +534,8 @@ record:
     # The -r (framerate) dictates how smooth the output video is.
     # So the args would be -vf setpts=0.02*PTS -r 30 in that case.
     timelapse_args: "-vf setpts=0.04*PTS -r 30"
+    # Optional: Global override for hwaccel_args in an export context (default: camera-specific args)
+    hwaccel_args: auto
   # Optional: Recording Preview Settings
   preview:
     # Optional: Quality of recording preview (default: shown below).

--- a/frigate/config/camera/record.py
+++ b/frigate/config/camera/record.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import Field
 

--- a/frigate/config/camera/record.py
+++ b/frigate/config/camera/record.py
@@ -70,6 +70,9 @@ class RecordExportConfig(FrigateBaseModel):
     timelapse_args: str = Field(
         default=DEFAULT_TIME_LAPSE_FFMPEG_ARGS, title="Timelapse Args"
     )
+    hwaccel_args: Union[str, list[str]] = Field(
+        default="auto", title="Export-specific FFmpeg hardware acceleration arguments."
+    )
 
 
 class RecordConfig(FrigateBaseModel):

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -523,6 +523,9 @@ class FrigateConfig(FrigateBaseModel):
             if camera_config.ffmpeg.hwaccel_args == "auto":
                 camera_config.ffmpeg.hwaccel_args = self.ffmpeg.hwaccel_args
 
+            if camera_config.record.export.hwaccel_args == "auto":
+                camera_config.record.export.hwaccel_args = camera_config.ffmpeg.hwaccel_args
+
             for input in camera_config.ffmpeg.inputs:
                 need_detect_dimensions = "detect" in input.roles and (
                     camera_config.detect.height is None

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -523,6 +523,9 @@ class FrigateConfig(FrigateBaseModel):
             if camera_config.ffmpeg.hwaccel_args == "auto":
                 camera_config.ffmpeg.hwaccel_args = self.ffmpeg.hwaccel_args
 
+            # Resolve export hwaccel_args: camera export -> camera ffmpeg -> global ffmpeg
+            # This allows per-camera override for exports (e.g., when camera resolution
+            # exceeds hardware encoder limits)
             if camera_config.record.export.hwaccel_args == "auto":
                 camera_config.record.export.hwaccel_args = camera_config.ffmpeg.hwaccel_args
 

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -527,7 +527,9 @@ class FrigateConfig(FrigateBaseModel):
             # This allows per-camera override for exports (e.g., when camera resolution
             # exceeds hardware encoder limits)
             if camera_config.record.export.hwaccel_args == "auto":
-                camera_config.record.export.hwaccel_args = camera_config.ffmpeg.hwaccel_args
+                camera_config.record.export.hwaccel_args = (
+                    camera_config.ffmpeg.hwaccel_args
+                )
 
             for input in camera_config.ffmpeg.inputs:
                 need_detect_dimensions = "detect" in input.roles and (

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -228,7 +228,7 @@ class RecordingExporter(threading.Thread):
             ffmpeg_cmd = (
                 parse_preset_hardware_acceleration_encode(
                     self.config.ffmpeg.ffmpeg_path,
-                    self.config.ffmpeg.hwaccel_args,
+                    self.config.cameras[self.camera].record.export.timelapse_args,
                     f"-an {ffmpeg_input}",
                     f"{self.config.cameras[self.camera].record.export.timelapse_args} -movflags +faststart",
                     EncodeTypeEnum.timelapse,
@@ -319,7 +319,7 @@ class RecordingExporter(threading.Thread):
             ffmpeg_cmd = (
                 parse_preset_hardware_acceleration_encode(
                     self.config.ffmpeg.ffmpeg_path,
-                    self.config.ffmpeg.hwaccel_args,
+                    self.config.cameras[self.camera].record.export.hwaccel_args,
                     f"{TIMELAPSE_DATA_INPUT_ARGS} {ffmpeg_input}",
                     f"{self.config.cameras[self.camera].record.export.timelapse_args} -movflags +faststart {video_path}",
                     EncodeTypeEnum.timelapse,

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -228,7 +228,7 @@ class RecordingExporter(threading.Thread):
             ffmpeg_cmd = (
                 parse_preset_hardware_acceleration_encode(
                     self.config.ffmpeg.ffmpeg_path,
-                    self.config.cameras[self.camera].record.export.timelapse_args,
+                    self.config.cameras[self.camera].record.export.hwaccel_args,
                     f"-an {ffmpeg_input}",
                     f"{self.config.cameras[self.camera].record.export.timelapse_args} -movflags +faststart",
                     EncodeTypeEnum.timelapse,


### PR DESCRIPTION
## Proposed change

  This PR adds support for camera-specific hardware acceleration settings for timelapse exports.

  Currently, timelapse export hardware acceleration is driven by the global ffmpeg.hwaccel_args config. This is problematic when a specific camera's resolution exceeds the hardware encoder's limits (e.g., vaapi on Intel iGPU with high-resolution cameras, or even just unconventional dimensions), causing exports to fail for that camera while working fine for others.

  This PR adds an optional record.export.hwaccel_args config at the camera level, allowing per-camera override of hardware acceleration settings for exports. The setting uses a cascade resolution:

  1. camera.record.export.hwaccel_args (if set)
  2. camera.ffmpeg.hwaccel_args (if above is "auto")
  3. global.ffmpeg.hwaccel_args (if above is "auto")

  The hardware acceleration can also be disabled, now. Example usage to disable hwaccel for a specific high-resolution camera:

```yaml
  cameras:
    camera_to_disable:
      record:
        export:
          hwaccel_args: ""  # Falls back to software encoding (libx264)

```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information
  - This PR fixes or closes issue: fixes #12758


## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)

