### PR TITLE
Refactor temperature reporting for detectors and implement Hailo temp reading

### DIFF
--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -22,6 +22,7 @@ from frigate.util.services import (
     get_bandwidth_stats,
     get_cpu_stats,
     get_fs_type,
+    get_hailo_temps,
     get_intel_gpu_stats,
     get_jetson_stats,
     get_nvidia_gpu_stats,
@@ -90,6 +91,9 @@ def get_temperatures() -> dict[str, float]:
             temp = read_temperature(os.path.join(base, apex, "temp"))
             if temp is not None:
                 temps[apex] = temp
+
+    # Get temperatures for Hailo devices
+    temps.update(get_hailo_temps())
 
     return temps
 

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -98,6 +98,70 @@ def get_temperatures() -> dict[str, float]:
     return temps
 
 
+def get_detector_temperature(
+    detector_type: str,
+    detector_index_by_type: dict[str, int],
+) -> Optional[float]:
+    """Get temperature for a specific detector based on its type."""
+    if detector_type == "edgetpu":
+        # Get temperatures for all attached Corals
+        base = "/sys/class/apex/"
+        if os.path.isdir(base):
+            apex_devices = sorted(os.listdir(base))
+            index = detector_index_by_type.get("edgetpu", 0)
+            if index < len(apex_devices):
+                apex_name = apex_devices[index]
+                temp = read_temperature(os.path.join(base, apex_name, "temp"))
+                if temp is not None:
+                    return temp
+    elif detector_type == "hailo8l":
+        # Get temperatures for Hailo devices
+        hailo_temps = get_hailo_temps()
+        if hailo_temps:
+            hailo_device_names = sorted(hailo_temps.keys())
+            index = detector_index_by_type.get("hailo8l", 0)
+            if index < len(hailo_device_names):
+                device_name = hailo_device_names[index]
+                return hailo_temps[device_name]
+
+    return None
+
+
+def get_detector_stats(
+    stats_tracking: StatsTrackingTypes,
+) -> dict[str, dict[str, Any]]:
+    """Get stats for all detectors, including temperatures based on detector type."""
+    detector_stats: dict[str, dict[str, Any]] = {}
+    detector_type_indices: dict[str, int] = {}
+
+    for name, detector in stats_tracking["detectors"].items():
+        pid = detector.detect_process.pid if detector.detect_process else None
+        detector_type = detector.detector_config.type
+
+        # Keep track of the index for each detector type to match temperatures correctly
+        current_index = detector_type_indices.get(detector_type, 0)
+        detector_type_indices[detector_type] = current_index + 1
+
+        detector_stat = {
+            "inference_speed": round(detector.avg_inference_speed.value * 1000, 2),  # type: ignore[attr-defined]
+            # issue https://github.com/python/typeshed/issues/8799
+            # from mypy 0.981 onwards
+            "detection_start": detector.detection_start.value,  # type: ignore[attr-defined]
+            # issue https://github.com/python/typeshed/issues/8799
+            # from mypy 0.981 onwards
+            "pid": pid,
+        }
+
+        temp = get_detector_temperature(detector_type, {detector_type: current_index})
+
+        if temp is not None:
+            detector_stat["temperature"] = round(temp, 1)
+
+        detector_stats[name] = detector_stat
+
+    return detector_stats
+
+
 def get_processing_stats(
     config: FrigateConfig, stats: dict[str, str], hwaccel_errors: list[str]
 ) -> None:
@@ -296,18 +360,7 @@ def stats_snapshot(
             "audio_dBFS": round(camera_stats.audio_dBFS.value, 4),
         }
 
-    stats["detectors"] = {}
-    for name, detector in stats_tracking["detectors"].items():
-        pid = detector.detect_process.pid if detector.detect_process else None
-        stats["detectors"][name] = {
-            "inference_speed": round(detector.avg_inference_speed.value * 1000, 2),  # type: ignore[attr-defined]
-            # issue https://github.com/python/typeshed/issues/8799
-            # from mypy 0.981 onwards
-            "detection_start": detector.detection_start.value,  # type: ignore[attr-defined]
-            # issue https://github.com/python/typeshed/issues/8799
-            # from mypy 0.981 onwards
-            "pid": pid,
-        }
+    stats["detectors"] = get_detector_stats(stats_tracking)
     stats["camera_fps"] = round(total_camera_fps, 2)
     stats["process_fps"] = round(total_process_fps, 2)
     stats["skipped_fps"] = round(total_skipped_fps, 2)
@@ -393,7 +446,6 @@ def stats_snapshot(
         "version": VERSION,
         "latest_version": stats_tracking["latest_frigate_version"],
         "storage": {},
-        "temperatures": get_temperatures(),
         "last_updated": int(time.time()),
     }
 

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -18,7 +18,6 @@ import cv2
 import psutil
 import py3nvml.py3nvml as nvml
 import requests
-from hailo_platform import Device
 
 from frigate.const import (
     DRIVER_AMD,
@@ -552,6 +551,11 @@ def get_jetson_stats() -> Optional[dict[int, dict]]:
 
 def get_hailo_temps() -> dict[str, float]:
     """Get temperatures for Hailo devices."""
+    try:
+        from hailo_platform import Device
+    except ModuleNotFoundError:
+        return {}
+
     temps = {}
 
     try:

--- a/web/src/types/stats.ts
+++ b/web/src/types/stats.ts
@@ -37,6 +37,7 @@ export type DetectorStats = {
   detection_start: number;
   inference_speed: number;
   pid: number;
+  temperature?: number;
 };
 
 export type EmbeddingsStats = {
@@ -68,7 +69,6 @@ export type GpuInfo = "vainfo" | "nvinfo";
 export type ServiceStats = {
   last_updated: number;
   storage: { [path: string]: StorageStats };
-  temperatures: { [apex: string]: number };
   uptime: number;
   latest_version: string;
   version: string;

--- a/web/src/views/system/GeneralMetrics.tsx
+++ b/web/src/views/system/GeneralMetrics.tsx
@@ -144,7 +144,7 @@ export default function GeneralMetrics({
       }
 
       Object.entries(stats.detectors).forEach(([key], cIdx) => {
-        if (!key.includes("coral")) {
+        if (!key.includes("coral") && !key.includes("hailo")) {
           return;
         }
 

--- a/web/src/views/system/GeneralMetrics.tsx
+++ b/web/src/views/system/GeneralMetrics.tsx
@@ -127,13 +127,6 @@ export default function GeneralMetrics({
       return undefined;
     }
 
-    if (
-      statsHistory.length > 0 &&
-      Object.keys(statsHistory[0].service.temperatures).length == 0
-    ) {
-      return undefined;
-    }
-
     const series: {
       [key: string]: { name: string; data: { x: number; y: number }[] };
     } = {};
@@ -143,22 +136,22 @@ export default function GeneralMetrics({
         return;
       }
 
-      Object.entries(stats.detectors).forEach(([key], cIdx) => {
-        if (!key.includes("coral") && !key.includes("hailo")) {
+      Object.entries(stats.detectors).forEach(([key, detectorStats]) => {
+        if (detectorStats.temperature === undefined) {
           return;
         }
 
-        if (cIdx <= Object.keys(stats.service.temperatures).length) {
-          if (!(key in series)) {
-            series[key] = {
-              name: key,
-              data: [],
-            };
-          }
-
-          const temp = Object.values(stats.service.temperatures)[cIdx];
-          series[key].data.push({ x: statsIdx + 1, y: Math.round(temp) });
+        if (!(key in series)) {
+          series[key] = {
+            name: key,
+            data: [],
+          };
         }
+
+        series[key].data.push({
+          x: statsIdx + 1,
+          y: Math.round(detectorStats.temperature),
+        });
       });
     });
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This PR supersedes https://github.com/blakeblackshear/frigate/pull/21109 which added hailo temp reporting but made it so we always had to import hailo plugin which causes problems. This PR refactors temperature reporting to be dynamic based on the detector and part of the detector stats reporting itself.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
