### PR TITLE
fix: Correctly apply API filter for "reviewed"

### DIFF
--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -144,6 +144,8 @@ async def review(
             (UserReviewStatus.has_been_reviewed == False)
             | (UserReviewStatus.has_been_reviewed.is_null())
         )
+    elif reviewed == 1:
+        review_query = review_query.where(UserReviewStatus.has_been_reviewed == True)
 
     # Apply ordering and limit
     review_query = (

--- a/frigate/test/http_api/base_http_test.py
+++ b/frigate/test/http_api/base_http_test.py
@@ -171,8 +171,8 @@ class BaseTestHttp(unittest.TestCase):
     def insert_mock_event(
         self,
         id: str,
-        start_time: float = datetime.datetime.now().timestamp(),
-        end_time: float = datetime.datetime.now().timestamp() + 20,
+        start_time: float | None = None,
+        end_time: float | None = None,
         has_clip: bool = True,
         top_score: int = 100,
         score: int = 0,
@@ -180,6 +180,11 @@ class BaseTestHttp(unittest.TestCase):
         camera: str = "front_door",
     ) -> Event:
         """Inserts a basic event model with a given id."""
+        if start_time is None:
+            start_time = datetime.datetime.now().timestamp()
+        if end_time is None:
+            end_time = start_time + 20
+
         return Event.insert(
             id=id,
             label="Mock",
@@ -229,11 +234,16 @@ class BaseTestHttp(unittest.TestCase):
     def insert_mock_recording(
         self,
         id: str,
-        start_time: float = datetime.datetime.now().timestamp(),
-        end_time: float = datetime.datetime.now().timestamp() + 20,
+        start_time: float | None = None,
+        end_time: float | None = None,
         motion: int = 0,
     ) -> Event:
         """Inserts a recording model with a given id."""
+        if start_time is None:
+            start_time = datetime.datetime.now().timestamp()
+        if end_time is None:
+            end_time = start_time + 20
+
         return Recordings.insert(
             id=id,
             path=id,

--- a/frigate/test/http_api/test_http_event.py
+++ b/frigate/test/http_api/test_http_event.py
@@ -96,16 +96,17 @@ class TestHttpApp(BaseTestHttp):
             assert len(events) == 0
 
     def test_get_event_list_limit(self):
+        now = datetime.now().timestamp()
         id = "123456.random"
         id2 = "54321.random"
 
         with AuthTestClient(self.app) as client:
-            super().insert_mock_event(id)
+            super().insert_mock_event(id, start_time=now + 1)
             events = client.get("/events").json()
             assert len(events) == 1
             assert events[0]["id"] == id
 
-            super().insert_mock_event(id2)
+            super().insert_mock_event(id2, start_time=now)
             events = client.get("/events").json()
             assert len(events) == 2
 
@@ -144,7 +145,7 @@ class TestHttpApp(BaseTestHttp):
             assert events[0]["id"] == id2
             assert events[1]["id"] == id
 
-            events = client.get("/events", params={"sort": "score_des"}).json()
+            events = client.get("/events", params={"sort": "score_desc"}).json()
             assert len(events) == 2
             assert events[0]["id"] == id
             assert events[1]["id"] == id2

--- a/frigate/test/http_api/test_http_review.py
+++ b/frigate/test/http_api/test_http_review.py
@@ -196,6 +196,50 @@ class TestHttpReview(BaseTestHttp):
             assert len(response_json) == 1
             assert response_json[0]["id"] == id
 
+    def test_get_review_with_reviewed_filter_unreviewed(self):
+        """Test that reviewed=0 returns only unreviewed items."""
+        now = datetime.now().timestamp()
+
+        with AuthTestClient(self.app) as client:
+            id_unreviewed = "123456.unreviewed"
+            id_reviewed = "123456.reviewed"
+            super().insert_mock_review_segment(id_unreviewed, now, now + 2)
+            super().insert_mock_review_segment(id_reviewed, now, now + 2)
+            self._insert_user_review_status(id_reviewed, reviewed=True)
+
+            params = {
+                "reviewed": 0,
+                "after": now - 1,
+                "before": now + 3,
+            }
+            response = client.get("/review", params=params)
+            assert response.status_code == 200
+            response_json = response.json()
+            assert len(response_json) == 1
+            assert response_json[0]["id"] == id_unreviewed
+
+    def test_get_review_with_reviewed_filter_reviewed(self):
+        """Test that reviewed=1 returns only reviewed items."""
+        now = datetime.now().timestamp()
+
+        with AuthTestClient(self.app) as client:
+            id_unreviewed = "123456.unreviewed"
+            id_reviewed = "123456.reviewed"
+            super().insert_mock_review_segment(id_unreviewed, now, now + 2)
+            super().insert_mock_review_segment(id_reviewed, now, now + 2)
+            self._insert_user_review_status(id_reviewed, reviewed=True)
+
+            params = {
+                "reviewed": 1,
+                "after": now - 1,
+                "before": now + 3,
+            }
+            response = client.get("/review", params=params)
+            assert response.status_code == 200
+            response_json = response.json()
+            assert len(response_json) == 1
+            assert response_json[0]["id"] == id_reviewed
+
     ####################################################################################################################
     ###################################  GET /review/summary Endpoint   #################################################
     ####################################################################################################################


### PR DESCRIPTION
## Proposed change

 - Fix minor API bug where filter is not applied if asked for reviewed (vs unreviewed) reviews
 - Fix minor test typo & race condition issue 

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/dermotduffy/advanced-camera-card/issues/1502

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [n/a] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
