### PR TITLE
Fix incorrect counting in sync_recordings

### DIFF
--- a/frigate/util/media.py
+++ b/frigate/util/media.py
@@ -98,7 +98,6 @@ def sync_recordings(
                         {"id": recording.id, "path": recording.path}
                     )
 
-        result.files_checked += recordings_count
         result.orphans_found += len(recordings_to_delete)
         result.orphan_paths.extend(
             [
@@ -173,7 +172,7 @@ def sync_recordings(
                 for file in files
             }
 
-        result.files_checked += len(files_on_disk)
+        result.files_checked = len(files_on_disk)
 
         files_to_delete: list[str] = []
         for file in files_on_disk:


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Fix the logic where the `files_checked` result returns the number of recordings on disk excluding entries in the database. The number could be incorrectly inflated with the old logic.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
