### PR TITLE
fix(recording): handle unexpected filenames in cache maintainer to prevent crash

### DIFF
--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -97,6 +97,7 @@ class RecordingMaintainer(threading.Thread):
         self.object_recordings_info: dict[str, list] = defaultdict(list)
         self.audio_recordings_info: dict[str, list] = defaultdict(list)
         self.end_time_cache: dict[str, Tuple[datetime.datetime, float]] = {}
+        self.unexpected_cache_files_seen: set[str] = set()
 
     async def move_files(self) -> None:
         cache_files = [
@@ -115,7 +116,9 @@ class RecordingMaintainer(threading.Thread):
             try:
                 camera, date = basename.rsplit("@", maxsplit=1)
             except ValueError:
-                logger.warning(f"Skipping unexpected file in cache: {cache}")
+                if cache not in self.unexpected_cache_files_seen:
+                    logger.warning(f"Skipping unexpected file in cache: {cache}")
+                    self.unexpected_cache_files_seen.add(cache)
                 continue
 
             start_time = datetime.datetime.strptime(
@@ -172,7 +175,9 @@ class RecordingMaintainer(threading.Thread):
             try:
                 camera, date = basename.rsplit("@", maxsplit=1)
             except ValueError:
-                logger.warning(f"Skipping unexpected file in cache: {cache}")
+                if cache not in self.unexpected_cache_files_seen:
+                    logger.warning(f"Skipping unexpected file in cache: {cache}")
+                    self.unexpected_cache_files_seen.add(cache)
                 continue
 
             # important that start_time is utc because recordings are stored and compared in utc

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -112,7 +112,12 @@ class RecordingMaintainer(threading.Thread):
         for cache in cache_files:
             cache_path = os.path.join(CACHE_DIR, cache)
             basename = os.path.splitext(cache)[0]
-            camera, date = basename.rsplit("@", maxsplit=1)
+            try:
+                camera, date = basename.rsplit("@", maxsplit=1)
+            except ValueError:
+                logger.warning(f"Skipping unexpected file in cache: {cache}")
+                continue
+
             start_time = datetime.datetime.strptime(
                 date, CACHE_SEGMENT_FORMAT
             ).astimezone(datetime.timezone.utc)
@@ -164,7 +169,11 @@ class RecordingMaintainer(threading.Thread):
 
             cache_path = os.path.join(CACHE_DIR, cache)
             basename = os.path.splitext(cache)[0]
-            camera, date = basename.rsplit("@", maxsplit=1)
+            try:
+                camera, date = basename.rsplit("@", maxsplit=1)
+            except ValueError:
+                logger.warning(f"Skipping unexpected file in cache: {cache}")
+                continue
 
             # important that start_time is utc because recordings are stored and compared in utc
             start_time = datetime.datetime.strptime(

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -97,7 +97,7 @@ class RecordingMaintainer(threading.Thread):
         self.object_recordings_info: dict[str, list] = defaultdict(list)
         self.audio_recordings_info: dict[str, list] = defaultdict(list)
         self.end_time_cache: dict[str, Tuple[datetime.datetime, float]] = {}
-        self.unexpected_cache_files_seen: set[str] = set()
+        self.unexpected_cache_files_logged: bool = False
 
     async def move_files(self) -> None:
         cache_files = [
@@ -116,9 +116,9 @@ class RecordingMaintainer(threading.Thread):
             try:
                 camera, date = basename.rsplit("@", maxsplit=1)
             except ValueError:
-                if cache not in self.unexpected_cache_files_seen:
-                    logger.warning(f"Skipping unexpected file in cache: {cache}")
-                    self.unexpected_cache_files_seen.add(cache)
+                if not self.unexpected_cache_files_logged:
+                    logger.warning("Skipping unexpected files in cache")
+                    self.unexpected_cache_files_logged = True
                 continue
 
             start_time = datetime.datetime.strptime(
@@ -175,9 +175,9 @@ class RecordingMaintainer(threading.Thread):
             try:
                 camera, date = basename.rsplit("@", maxsplit=1)
             except ValueError:
-                if cache not in self.unexpected_cache_files_seen:
-                    logger.warning(f"Skipping unexpected file in cache: {cache}")
-                    self.unexpected_cache_files_seen.add(cache)
+                if not self.unexpected_cache_files_logged:
+                    logger.warning("Skipping unexpected files in cache")
+                    self.unexpected_cache_files_logged = True
                 continue
 
             # important that start_time is utc because recordings are stored and compared in utc

--- a/frigate/test/test_maintainer.py
+++ b/frigate/test/test_maintainer.py
@@ -1,38 +1,40 @@
-
 import unittest
 from unittest.mock import MagicMock, patch
 import sys
 import datetime
 
 # Mock complex imports before importing maintainer
-sys.modules['frigate.comms.inter_process'] = MagicMock()
-sys.modules['frigate.comms.detections_updater'] = MagicMock()
-sys.modules['frigate.comms.recordings_updater'] = MagicMock()
-sys.modules['frigate.config.camera.updater'] = MagicMock()
+sys.modules["frigate.comms.inter_process"] = MagicMock()
+sys.modules["frigate.comms.detections_updater"] = MagicMock()
+sys.modules["frigate.comms.recordings_updater"] = MagicMock()
+sys.modules["frigate.config.camera.updater"] = MagicMock()
 
 # Now import the class under test
 from frigate.record.maintainer import RecordingMaintainer
 from frigate.config import FrigateConfig
+
 
 class TestMaintainer(unittest.IsolatedAsyncioTestCase):
     async def test_move_files_survives_bad_filename(self):
         config = MagicMock(spec=FrigateConfig)
         config.cameras = {}
         stop_event = MagicMock()
-        
+
         maintainer = RecordingMaintainer(config, stop_event)
-        
+
         # We need to mock end_time_cache to avoid key errors if logic proceeds
         maintainer.end_time_cache = {}
 
         # Mock filesystem
         # One bad file, one good file
-        files = ['bad_filename.mp4', 'camera@20210101000000+0000.mp4']
-        
-        with patch('os.listdir', return_value=files):
-            with patch('os.path.isfile', return_value=True):
-                with patch('frigate.record.maintainer.psutil.process_iter', return_value=[]):
-                    with patch('frigate.record.maintainer.logger.warning') as warn:
+        files = ["bad_filename.mp4", "camera@20210101000000+0000.mp4"]
+
+        with patch("os.listdir", return_value=files):
+            with patch("os.path.isfile", return_value=True):
+                with patch(
+                    "frigate.record.maintainer.psutil.process_iter", return_value=[]
+                ):
+                    with patch("frigate.record.maintainer.logger.warning") as warn:
                         # Mock validate_and_move_segment to avoid further logic
                         maintainer.validate_and_move_segment = MagicMock()
 
@@ -61,5 +63,6 @@ class TestMaintainer(unittest.IsolatedAsyncioTestCase):
                             f"Expected a single warning for bad filename, got {len(matching)}",
                         )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/frigate/test/test_maintainer.py
+++ b/frigate/test/test_maintainer.py
@@ -32,18 +32,34 @@ class TestMaintainer(unittest.IsolatedAsyncioTestCase):
         with patch('os.listdir', return_value=files):
             with patch('os.path.isfile', return_value=True):
                 with patch('frigate.record.maintainer.psutil.process_iter', return_value=[]):
-                    # Mock validate_and_move_segment to avoid further logic
-                    maintainer.validate_and_move_segment = MagicMock()
-                    
-                    try:
-                        await maintainer.move_files()
-                    except ValueError as e:
-                        if "not enough values to unpack" in str(e):
-                            self.fail("move_files() crashed on bad filename!")
-                        raise e
-                    except Exception:
-                        # Ignore other errors (like DB connection) as we only care about the unpack crash
-                        pass
+                    with patch('frigate.record.maintainer.logger.warning') as warn:
+                        # Mock validate_and_move_segment to avoid further logic
+                        maintainer.validate_and_move_segment = MagicMock()
+
+                        try:
+                            await maintainer.move_files()
+                        except ValueError as e:
+                            if "not enough values to unpack" in str(e):
+                                self.fail("move_files() crashed on bad filename!")
+                            raise e
+                        except Exception:
+                            # Ignore other errors (like DB connection) as we only care about the unpack crash
+                            pass
+
+                        # The bad filename is encountered in multiple loops, but should only warn once.
+                        matching = [
+                            c
+                            for c in warn.call_args_list
+                            if c.args
+                            and isinstance(c.args[0], str)
+                            and "Skipping unexpected file in cache: bad_filename.mp4"
+                            in c.args[0]
+                        ]
+                        self.assertEqual(
+                            1,
+                            len(matching),
+                            f"Expected a single warning for bad filename, got {len(matching)}",
+                        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/frigate/test/test_maintainer.py
+++ b/frigate/test/test_maintainer.py
@@ -1,0 +1,49 @@
+
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import datetime
+
+# Mock complex imports before importing maintainer
+sys.modules['frigate.comms.inter_process'] = MagicMock()
+sys.modules['frigate.comms.detections_updater'] = MagicMock()
+sys.modules['frigate.comms.recordings_updater'] = MagicMock()
+sys.modules['frigate.config.camera.updater'] = MagicMock()
+
+# Now import the class under test
+from frigate.record.maintainer import RecordingMaintainer
+from frigate.config import FrigateConfig
+
+class TestMaintainer(unittest.IsolatedAsyncioTestCase):
+    async def test_move_files_survives_bad_filename(self):
+        config = MagicMock(spec=FrigateConfig)
+        config.cameras = {}
+        stop_event = MagicMock()
+        
+        maintainer = RecordingMaintainer(config, stop_event)
+        
+        # We need to mock end_time_cache to avoid key errors if logic proceeds
+        maintainer.end_time_cache = {}
+
+        # Mock filesystem
+        # One bad file, one good file
+        files = ['bad_filename.mp4', 'camera@20210101000000+0000.mp4']
+        
+        with patch('os.listdir', return_value=files):
+            with patch('os.path.isfile', return_value=True):
+                with patch('frigate.record.maintainer.psutil.process_iter', return_value=[]):
+                    # Mock validate_and_move_segment to avoid further logic
+                    maintainer.validate_and_move_segment = MagicMock()
+                    
+                    try:
+                        await maintainer.move_files()
+                    except ValueError as e:
+                        if "not enough values to unpack" in str(e):
+                            self.fail("move_files() crashed on bad filename!")
+                        raise e
+                    except Exception:
+                        # Ignore other errors (like DB connection) as we only care about the unpack crash
+                        pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/frigate/test/test_maintainer.py
+++ b/frigate/test/test_maintainer.py
@@ -1,7 +1,6 @@
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
-import sys
-import datetime
 
 # Mock complex imports before importing maintainer
 sys.modules["frigate.comms.inter_process"] = MagicMock()
@@ -10,8 +9,8 @@ sys.modules["frigate.comms.recordings_updater"] = MagicMock()
 sys.modules["frigate.config.camera.updater"] = MagicMock()
 
 # Now import the class under test
-from frigate.record.maintainer import RecordingMaintainer
-from frigate.config import FrigateConfig
+from frigate.config import FrigateConfig  # noqa: E402
+from frigate.record.maintainer import RecordingMaintainer  # noqa: E402
 
 
 class TestMaintainer(unittest.IsolatedAsyncioTestCase):
@@ -54,13 +53,12 @@ class TestMaintainer(unittest.IsolatedAsyncioTestCase):
                             for c in warn.call_args_list
                             if c.args
                             and isinstance(c.args[0], str)
-                            and "Skipping unexpected file in cache: bad_filename.mp4"
-                            in c.args[0]
+                            and "Skipping unexpected files in cache" in c.args[0]
                         ]
                         self.assertEqual(
                             1,
                             len(matching),
-                            f"Expected a single warning for bad filename, got {len(matching)}",
+                            f"Expected a single warning for unexpected files, got {len(matching)}",
                         )
 
 


### PR DESCRIPTION
## Proposed change

The recording maintainer thread scans `/tmp/cache` for `.mp4` files to process into recordings. It assumes all files follow the `camera@timestamp.mp4` naming convention and uses `rsplit("@", maxsplit=1)` to parse them.

If a file exists in the cache without an `@` separator (e.g., artifacts from manual ffmpeg testing like `test.mp4`, or other stray files), the unpack operation fails with `ValueError: not enough values to unpack`. This unhandled exception crashes the entire `recording_maintainer` thread.

Once crashed, the maintainer stops processing **all** recordings. Segments continue to accumulate in cache but are never moved to storage or inserted into the database, effectively breaking recording functionality until the container is restarted or the file is removed.

This PR wraps the filename parsing logic in a `try-except ValueError` block. If an unexpected filename is encountered, it logs a warning and skips the file instead of crashing the thread. This ensures the recording pipeline remains robust against cache pollution.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)