### PR TITLE
Improve directory cleanup performance

### DIFF
--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from playhouse.sqlite_ext import SqliteExtDatabase
 
 from frigate.config import CameraConfig, FrigateConfig, RetainModeEnum
-from frigate.const import CACHE_DIR, CLIPS_DIR, MAX_WAL_SIZE, RECORD_DIR
+from frigate.const import CACHE_DIR, CLIPS_DIR, MAX_WAL_SIZE
 from frigate.models import Previews, Recordings, ReviewSegment, UserReviewStatus
 from frigate.util.builtin import clear_and_unlink
 from frigate.util.media import remove_empty_directories
@@ -60,7 +60,7 @@ class RecordingCleanup(threading.Thread):
             db.execute_sql("PRAGMA wal_checkpoint(TRUNCATE);")
             db.close()
 
-    def expire_review_segments(self, config: CameraConfig, now: datetime) -> None:
+    def expire_review_segments(self, config: CameraConfig, now: datetime) -> set[Path]:
         """Delete review segments that are expired"""
         alert_expire_date = (
             now - datetime.timedelta(days=config.record.alerts.retain.days)
@@ -84,9 +84,12 @@ class RecordingCleanup(threading.Thread):
             .namedtuples()
         )
 
+        maybe_empty_dirs = set()
         thumbs_to_delete = list(map(lambda x: x[1], expired_reviews))
         for thumb_path in thumbs_to_delete:
-            Path(thumb_path).unlink(missing_ok=True)
+            thumb_path = Path(thumb_path)
+            thumb_path.unlink(missing_ok=True)
+            maybe_empty_dirs.add(thumb_path.parent)
 
         max_deletes = 100000
         deleted_reviews_list = list(map(lambda x: x[0], expired_reviews))
@@ -99,13 +102,15 @@ class RecordingCleanup(threading.Thread):
                 << deleted_reviews_list[i : i + max_deletes]
             ).execute()
 
+        return maybe_empty_dirs
+
     def expire_existing_camera_recordings(
         self,
         continuous_expire_date: float,
         motion_expire_date: float,
         config: CameraConfig,
         reviews: ReviewSegment,
-    ) -> None:
+    ) -> set[Path]:
         """Delete recordings for existing camera based on retention config."""
         # Get the timestamp for cutoff of retained days
 
@@ -133,6 +138,8 @@ class RecordingCleanup(threading.Thread):
             .namedtuples()
             .iterator()
         )
+
+        maybe_empty_dirs = set()
 
         # loop over recordings and see if they overlap with any non-expired reviews
         # TODO: expire segments based on segment stats according to config
@@ -187,8 +194,10 @@ class RecordingCleanup(threading.Thread):
                 )
                 or (mode == RetainModeEnum.active_objects and recording.objects == 0)
             ):
-                Path(recording.path).unlink(missing_ok=True)
+                recording_path = Path(recording.path)
+                recording_path.unlink(missing_ok=True)
                 deleted_recordings.add(recording.id)
+                maybe_empty_dirs.add(recording_path.parent)
             else:
                 kept_recordings.append((recording.start_time, recording.end_time))
 
@@ -249,8 +258,10 @@ class RecordingCleanup(threading.Thread):
 
             # Delete previews without any relevant recordings
             if not keep:
-                Path(preview.path).unlink(missing_ok=True)
+                preview_path = Path(preview.path)
+                preview_path.unlink(missing_ok=True)
                 deleted_previews.add(preview.id)
+                maybe_empty_dirs.add(preview_path.parent)
 
         # expire previews
         logger.debug(f"Expiring {len(deleted_previews)} previews")
@@ -262,7 +273,9 @@ class RecordingCleanup(threading.Thread):
                 Previews.id << deleted_previews_list[i : i + max_deletes]
             ).execute()
 
-    def expire_recordings(self) -> None:
+        return maybe_empty_dirs
+
+    def expire_recordings(self) -> set[Path]:
         """Delete recordings based on retention config."""
         logger.debug("Start expire recordings.")
         logger.debug("Start deleted cameras.")
@@ -287,10 +300,14 @@ class RecordingCleanup(threading.Thread):
             .iterator()
         )
 
+        maybe_empty_dirs = set()
+
         deleted_recordings = set()
         for recording in no_camera_recordings:
-            Path(recording.path).unlink(missing_ok=True)
+            recording_path = Path(recording.path)
+            recording_path.unlink(missing_ok=True)
             deleted_recordings.add(recording.id)
+            maybe_empty_dirs.add(recording_path.parent)
 
         logger.debug(f"Expiring {len(deleted_recordings)} recordings")
         # delete up to 100,000 at a time
@@ -307,7 +324,7 @@ class RecordingCleanup(threading.Thread):
             logger.debug(f"Start camera: {camera}.")
             now = datetime.datetime.now()
 
-            self.expire_review_segments(config, now)
+            maybe_empty_dirs |= self.expire_review_segments(config, now)
             continuous_expire_date = (
                 now - datetime.timedelta(days=config.record.continuous.days)
             ).timestamp()
@@ -337,13 +354,15 @@ class RecordingCleanup(threading.Thread):
                 .namedtuples()
             )
 
-            self.expire_existing_camera_recordings(
+            maybe_empty_dirs |= self.expire_existing_camera_recordings(
                 continuous_expire_date, motion_expire_date, config, reviews
             )
             logger.debug(f"End camera: {camera}.")
 
         logger.debug("End all cameras.")
         logger.debug("End expire recordings.")
+
+        return maybe_empty_dirs
 
     def run(self) -> None:
         # Expire tmp clips every minute, recordings and clean directories every hour.
@@ -356,6 +375,6 @@ class RecordingCleanup(threading.Thread):
 
             if counter == 0:
                 self.clean_tmp_clips()
-                self.expire_recordings()
-                remove_empty_directories(RECORD_DIR)
+                maybe_empty_dirs = self.expire_recordings()
+                remove_empty_directories(maybe_empty_dirs)
                 self.truncate_wal()


### PR DESCRIPTION
## Proposed change

Improve performance of recording directory cleanup by only attempting to remove directories that might be empty due to a recent file removal instead of doing a full recursive directory walk.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

The existing implementation does a full recursive directory scan to find empty dirs which is extremely expensive in certain cases. In my situation, I have the recordings directory on an remote NAS with BTRFS filesystem. The NAS is mounted via SMB to the frigate server. This single directory scan consumes 25MB/s of sustained I/O read traffic on my NAS and takes 2+ hours to complete for 30 days of recordings for 6 cameras. And this happens on repeat basically continuously, essentially overloading the the NAS.

This approach avoids the directory scan altogether by being smart about which directories could be empty and using the minimal number of system calls to remove the dir. With this change, the new cleanup step is basically instant.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
