### PR TITLE
fix: 'reviewed' filter in API should be tristate

### DIFF
--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -138,14 +138,15 @@ async def review(
         .where(reduce(operator.and_, clauses))
     )
 
-    # Filter unreviewed items without subquery
-    if reviewed == 0:
-        review_query = review_query.where(
-            (UserReviewStatus.has_been_reviewed == False)
-            | (UserReviewStatus.has_been_reviewed.is_null())
-        )
-    elif reviewed == 1:
-        review_query = review_query.where(UserReviewStatus.has_been_reviewed == True)
+    # Filter by reviewed status (None = all, 0 = unreviewed only, 1 = reviewed only)
+    if reviewed is not None:
+        if reviewed == 0:
+            review_query = review_query.where(
+                (UserReviewStatus.has_been_reviewed == False)
+                | (UserReviewStatus.has_been_reviewed.is_null())
+            )
+        elif reviewed == 1:
+            review_query = review_query.where(UserReviewStatus.has_been_reviewed == True)
 
     # Apply ordering and limit
     review_query = (

--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -146,7 +146,9 @@ async def review(
                 | (UserReviewStatus.has_been_reviewed.is_null())
             )
         elif reviewed == 1:
-            review_query = review_query.where(UserReviewStatus.has_been_reviewed == True)
+            review_query = review_query.where(
+                UserReviewStatus.has_been_reviewed == True
+            )
 
     # Apply ordering and limit
     review_query = (

--- a/frigate/test/http_api/test_http_review.py
+++ b/frigate/test/http_api/test_http_review.py
@@ -240,6 +240,28 @@ class TestHttpReview(BaseTestHttp):
             assert len(response_json) == 1
             assert response_json[0]["id"] == id_reviewed
 
+    def test_get_review_with_no_reviewed_filter(self):
+        """Test that omitting 'reviewed' parameter returns both reviewed and unreviewed items."""
+        now = datetime.now().timestamp()
+
+        with AuthTestClient(self.app) as client:
+            id_unreviewed = "123456.unreviewed"
+            id_reviewed = "123456.reviewed"
+            super().insert_mock_review_segment(id_unreviewed, now, now + 2)
+            super().insert_mock_review_segment(id_reviewed, now, now + 2)
+            self._insert_user_review_status(id_reviewed, reviewed=True)
+
+            params = {
+                "after": now - 1,
+                "before": now + 3,
+            }
+            response = client.get("/review", params=params)
+            assert response.status_code == 200
+            response_json = response.json()
+            assert len(response_json) == 2
+            returned_ids = {item["id"] for item in response_json}
+            assert returned_ids == {id_unreviewed, id_reviewed}
+
     ####################################################################################################################
     ###################################  GET /review/summary Endpoint   #################################################
     ####################################################################################################################


### PR DESCRIPTION
## Proposed change

I think my [fix](https://github.com/blakeblackshear/frigate/pull/21600) was incomplete. Even with the change @NickM-27 subsequently made [here](https://github.com/blakeblackshear/frigate/pull/21607/changes#diff-aebb925b5554abc1bbc5083da316357f7a2f84a7ad9f292a99b81f38146e1e72) the API will still not provide correct responses for queries that do not include a `reviewed` parameter, i.e. it's not possible to currently query for 'either'.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [N/A] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
