### PR TITLE
Remove parents in remove_empty_directories

### DIFF
--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from playhouse.sqlite_ext import SqliteExtDatabase
 
 from frigate.config import CameraConfig, FrigateConfig, RetainModeEnum
-from frigate.const import CACHE_DIR, CLIPS_DIR, MAX_WAL_SIZE
+from frigate.const import CACHE_DIR, CLIPS_DIR, MAX_WAL_SIZE, RECORD_DIR
 from frigate.models import Previews, Recordings, ReviewSegment, UserReviewStatus
 from frigate.util.builtin import clear_and_unlink
 from frigate.util.media import remove_empty_directories
@@ -376,5 +376,5 @@ class RecordingCleanup(threading.Thread):
             if counter == 0:
                 self.clean_tmp_clips()
                 maybe_empty_dirs = self.expire_recordings()
-                remove_empty_directories(maybe_empty_dirs)
+                remove_empty_directories(Path(RECORD_DIR), maybe_empty_dirs)
                 self.truncate_wal()


### PR DESCRIPTION
## Proposed change

Follow up to #21695. I failed to account for the tree traversal aspect which cleans up parent directories. My original change was only cleaning up the leaves, but the original removed parents as well. This PR fixes the issue. It modifies the code to do a simple level order traversal from the leaves up. I added a stop condition to ensure the top-level recordings directory doesn't get removed if it happens to become empty.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
