### PR TITLE
Fallback from tflite-runtime to ai-edge-litert (instead of tensorflow)

### DIFF
--- a/frigate/data_processing/real_time/bird.py
+++ b/frigate/data_processing/real_time/bird.py
@@ -22,7 +22,7 @@ from .api import RealTimeProcessorApi
 try:
     from tflite_runtime.interpreter import Interpreter
 except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter
+    from ai_edge_litert.interpreter import Interpreter
 
 logger = logging.getLogger(__name__)
 

--- a/frigate/data_processing/real_time/custom_classification.py
+++ b/frigate/data_processing/real_time/custom_classification.py
@@ -32,7 +32,7 @@ from .api import RealTimeProcessorApi
 try:
     from tflite_runtime.interpreter import Interpreter
 except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter
+    from ai_edge_litert.interpreter import Interpreter
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +76,7 @@ class CustomStateClassificationProcessor(RealTimeProcessorApi):
         try:
             from tflite_runtime.interpreter import Interpreter
         except ModuleNotFoundError:
-            from tensorflow.lite.python.interpreter import Interpreter
+            from ai_edge_litert.interpreter import Interpreter
 
         model_path = os.path.join(self.model_dir, "model.tflite")
         labelmap_path = os.path.join(self.model_dir, "labelmap.txt")

--- a/frigate/detectors/detector_utils.py
+++ b/frigate/detectors/detector_utils.py
@@ -6,7 +6,7 @@ import numpy as np
 try:
     from tflite_runtime.interpreter import Interpreter, load_delegate
 except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter, load_delegate
+    from ai_edge_litert.interpreter import Interpreter, load_delegate
 
 
 logger = logging.getLogger(__name__)

--- a/frigate/detectors/plugins/cpu_tfl.py
+++ b/frigate/detectors/plugins/cpu_tfl.py
@@ -12,7 +12,7 @@ from ..detector_utils import tflite_detect_raw, tflite_init
 try:
     from tflite_runtime.interpreter import Interpreter
 except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter
+    from ai_edge_litert.interpreter import Interpreter
 
 
 logger = logging.getLogger(__name__)

--- a/frigate/detectors/plugins/edgetpu_tfl.py
+++ b/frigate/detectors/plugins/edgetpu_tfl.py
@@ -13,7 +13,7 @@ from frigate.detectors.detector_config import BaseDetectorConfig, ModelTypeEnum
 try:
     from tflite_runtime.interpreter import Interpreter, load_delegate
 except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter, load_delegate
+    from ai_edge_litert.interpreter import Interpreter, load_delegate
 
 logger = logging.getLogger(__name__)
 

--- a/frigate/embeddings/onnx/face_embedding.py
+++ b/frigate/embeddings/onnx/face_embedding.py
@@ -17,7 +17,7 @@ from .base_embedding import BaseEmbedding
 try:
     from tflite_runtime.interpreter import Interpreter
 except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter
+    from ai_edge_litert.interpreter import Interpreter
 
 logger = logging.getLogger(__name__)
 

--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -43,7 +43,7 @@ from frigate.video import start_or_restart_ffmpeg, stop_ffmpeg
 try:
     from tflite_runtime.interpreter import Interpreter
 except ModuleNotFoundError:
-    from tensorflow.lite.python.interpreter import Interpreter
+    from ai_edge_litert.interpreter import Interpreter
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Proposed change

The fallback to tensorflow was established back in 2023, because we could not provide tflite-runtime downstream in nixpkgs.

By now we have ai-edge-litert available, which is the successor to the tflite-runtime. It still provides the same entrypoints as tflite-runtime and functionality has been verified in multiple deployments for the last two weeks.
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
