### PR TITLE
remove audio snapshot menu

### DIFF
--- a/web/src/components/menu/SearchResultActions.tsx
+++ b/web/src/components/menu/SearchResultActions.tsx
@@ -99,7 +99,7 @@ export default function SearchResultActions({
           </a>
         </MenuItem>
       )}
-      {searchResult.has_snapshot && (
+      {searchResult.has_snapshot && searchResult?.data?.type === "object" && (
         <MenuItem aria-label={t("itemMenu.downloadSnapshot.aria")}>
           <a
             className="flex items-center"
@@ -111,6 +111,7 @@ export default function SearchResultActions({
         </MenuItem>
       )}
       {searchResult.has_snapshot &&
+        searchResult?.data?.type === "object" &&
         config?.cameras[searchResult.camera].snapshots.clean_copy && (
           <MenuItem aria-label={t("itemMenu.downloadCleanSnapshot.aria")}>
             <a

--- a/web/src/components/overlay/detail/DetailActionsMenu.tsx
+++ b/web/src/components/overlay/detail/DetailActionsMenu.tsx
@@ -81,7 +81,7 @@ export default function DetailActionsMenu({
       </DropdownMenuTrigger>
       <DropdownMenuPortal>
         <DropdownMenuContent align="end">
-          {search.has_snapshot && (
+          {search.has_snapshot && search?.data?.type === "object" && (
             <DropdownMenuItem>
               <a
                 className="w-full"
@@ -95,7 +95,8 @@ export default function DetailActionsMenu({
             </DropdownMenuItem>
           )}
           {search.has_snapshot &&
-            config?.cameras[search.camera].snapshots.clean_copy && (
+            config?.cameras[search.camera].snapshots.clean_copy &&
+            search?.data?.type === "object" && (
               <DropdownMenuItem>
                 <a
                   className="w-full"

--- a/web/src/views/explore/ExploreView.tsx
+++ b/web/src/views/explore/ExploreView.tsx
@@ -23,6 +23,7 @@ import { FrigateConfig } from "@/types/frigateConfig";
 import { useTranslation } from "react-i18next";
 import { getTranslatedLabel } from "@/utils/i18n";
 import { LuSearchX } from "react-icons/lu";
+import { getIconForLabel } from "@/utils/iconUtil";
 
 type ExploreViewProps = {
   setSearchDetail: (search: SearchResult | undefined) => void;
@@ -149,6 +150,9 @@ function ThumbnailRow({
   return (
     <div className="rounded-lg bg-background_alt p-2 md:px-4">
       <div className="flex flex-row items-center text-lg smart-capitalize">
+        {labelType === "audio"
+          ? getIconForLabel("", labelType, "size-4 mr-1")
+          : null}
         {getTranslatedLabel(label, labelType)}
         {searchResults && (
           <span className="ml-3 text-sm text-secondary-foreground">


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Objects of the Audio type do not have specific bounding boxes, and sound triggers are not absolutely associated with visual frames. This PR will remove the "Download Snapshot" button for audio-type objects.

Additionally, to better distinguish between detected objects and audio in Explore, an additional icon will be added for audio types.

<img width="859" height="490" alt="image" src="https://github.com/user-attachments/assets/436fe677-fe7f-45c1-ae88-2ae869badba3" />



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
