### PR TITLE
Update hailo installation instructions and script

### DIFF
--- a/docker/hailo8l/user_installation.sh
+++ b/docker/hailo8l/user_installation.sh
@@ -2,15 +2,19 @@
 
 # Update package list and install dependencies
 sudo apt-get update
-sudo apt-get install -y build-essential cmake git wget
+sudo apt-get install -y build-essential cmake git wget linux-headers-$(uname -r)
 
 hailo_version="4.21.0"
 arch=$(uname -m)
 
-if [[ $arch == "x86_64" ]]; then
-    sudo apt install -y linux-headers-$(uname -r);
-else
-    sudo apt install -y linux-modules-extra-$(uname -r);
+if [[ $arch == "aarch64" ]]; then
+    source /etc/os-release
+    os_codename=$VERSION_CODENAME
+    echo "Detected OS codename: $VERSION_CODENAME"
+fi
+
+if [ "$os_codename" = "trixie" ]; then
+    sudo apt install -y dkms
 fi
 
 # Clone the HailoRT driver repository
@@ -47,3 +51,4 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 
 echo "HailoRT driver installation complete."
 echo "reboot your system to load the firmware!"
+echo "Driver version: $(modinfo -F version hailo_pci)"

--- a/docker/hailo8l/user_installation.sh
+++ b/docker/hailo8l/user_installation.sh
@@ -10,7 +10,7 @@ arch=$(uname -m)
 if [[ $arch == "aarch64" ]]; then
     source /etc/os-release
     os_codename=$VERSION_CODENAME
-    echo "Detected OS codename: $VERSION_CODENAME"
+    echo "Detected OS codename: $os_codename"
 fi
 
 if [ "$os_codename" = "trixie" ]; then

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -153,7 +153,6 @@ On Raspberry Pi OS **Trixie**, the Hailo driver is no longer shipped with the ke
    ```
    /lib/modules/6.6.31+rpt-rpi-2712/kernel/drivers/media/pci/hailo/hailo_pci.ko.xz
    ```
-
    Save the module path to a variable:
    
    ```bash
@@ -246,6 +245,27 @@ On Raspberry Pi OS **Trixie**, the Hailo driver is no longer shipped with the ke
    
    ```bash
    ls -l /lib/firmware/hailo/hailo8_fw.bin
+   ```
+
+  **Optional: Fix PCIe descriptor page size error**
+
+   If you encounter the following error:
+
+   ```
+   [HailoRT] [error] CHECK failed - max_desc_page_size given 16384 is bigger than hw max desc page size 4096
+   ```
+
+   Create a configuration file to force the correct descriptor page size:
+
+   ```bash
+   echo 'options hailo_pci force_desc_page_size=4096' | sudo tee /etc/modprobe.d/hailo_pci.conf
+   ```
+
+   and reboot:
+
+   ```bash
+   sudo reboot
+   ```
 
 #### Setup
 

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -112,42 +112,47 @@ The Hailo-8 and Hailo-8L AI accelerators are available in both M.2 and HAT form 
 
 :::warning
 
-The Raspberry Pi kernel includes an older version of the Hailo driver that is incompatible with Frigate. You **must** follow the installation steps below to install the correct driver version, and you **must** disable the built-in kernel driver as described in step 1.
+On Raspberry Pi OS **Bookworm**, the kernel includes an older version of the Hailo driver that is incompatible with Frigate. You **must** follow the installation steps below to install the correct driver version, and you **must** disable the built-in kernel driver as described in step 1.
+
+On Raspberry Pi OS **Trixie**, the Hailo driver is no longer shipped with the kernel. It is installed via DKMS, and the conflict described below does not apply. You can simply run the installation script.
 
 :::
 
-1. **Disable the built-in Hailo driver (Raspberry Pi only)**:
+1. **Disable the built-in Hailo driver (Raspberry Pi Bookworm OS only)**:
 
    :::note
 
-   If you are **not** using a Raspberry Pi, skip this step and proceed directly to step 2.
+   If you are **not** using a Raspberry Pi with **Bookworm OS**, skip this step and proceed directly to step 2.
+   
+   If you are using Raspberry Pi with **Trixie OS**, also skip this step and proceed directly to step 2.
 
    :::
 
-   If you are using a Raspberry Pi, you need to blacklist the built-in kernel Hailo driver to prevent conflicts. First, check if the driver is currently loaded:
+   First, check if the driver is currently loaded:
 
    ```bash
    lsmod | grep hailo
    ```
-
+   
    If it shows `hailo_pci`, unload it:
 
    ```bash
-   sudo rmmod hailo_pci
+   sudo modprobe -r hailo_pci
    ```
-
-   Now blacklist the driver to prevent it from loading on boot:
-
+   
+   Then rename the built-in driver so it can be restored later if needed:
+    
    ```bash
-   echo "blacklist hailo_pci" | sudo tee /etc/modprobe.d/blacklist-hailo_pci.conf
+   sudo mv /lib/modules/$(uname -r)/kernel/drivers/media/pci/hailo/hailo_pci.ko.xz \
+           /lib/modules/$(uname -r)/kernel/drivers/media/pci/hailo/hailo_pci.ko.xz.bak
    ```
-
-   Update initramfs to ensure the blacklist takes effect:
-
+   
+   Now refresh the kernel module map so the system recognizes the change:
+   
    ```bash
-   sudo update-initramfs -u
+   sudo depmod -a
    ```
-
+   
    Reboot your Raspberry Pi:
 
    ```bash
@@ -160,7 +165,7 @@ The Raspberry Pi kernel includes an older version of the Hailo driver that is in
    lsmod | grep hailo
    ```
 
-   This command should return no results. If it still shows `hailo_pci`, the blacklist did not take effect properly and you may need to check for other Hailo packages installed via apt that are loading the driver.
+   This command should return no results.
 
 2. **Run the installation script**:
 
@@ -211,6 +216,17 @@ The Raspberry Pi kernel includes an older version of the Hailo driver that is in
    ```bash
    lsmod | grep hailo_pci
    ```
+
+   Verify the driver version:
+   
+   ```bash
+   modinfo hailo_pci | grep version
+   ```
+   
+   Verify that the firmware was installed correctly:
+   
+   ```bash
+   ls -l /lib/firmware/hailo/hailo8_fw.bin
 
 #### Setup
 

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -142,7 +142,6 @@ On Raspberry Pi OS **Trixie**, the Hailo driver is no longer shipped with the ke
    
    Then locate the built-in kernel driver and rename it so it cannot be loaded.
    Renaming allows the original driver to be restored later if needed.
-
    First, locate the currently installed kernel module:
 
    ```bash

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -238,7 +238,7 @@ On Raspberry Pi OS **Trixie**, the Hailo driver is no longer shipped with the ke
    Verify the driver version:
    
    ```bash
-   modinfo hailo_pci | grep version
+   cat /sys/module/hailo_pci/version
    ```
    
    Verify that the firmware was installed correctly:

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -140,11 +140,31 @@ On Raspberry Pi OS **Trixie**, the Hailo driver is no longer shipped with the ke
    sudo modprobe -r hailo_pci
    ```
    
-   Then rename the built-in driver so it can be restored later if needed:
+   Then locate the built-in kernel driver and rename it so it cannot be loaded.
+   Renaming allows the original driver to be restored later if needed.
+
+   First, locate the currently installed kernel module:
+
+   ```bash
+   modinfo -n hailo_pci
+   ```
+
+   Example output:
+   
+   ```
+   /lib/modules/6.6.31+rpt-rpi-2712/kernel/drivers/media/pci/hailo/hailo_pci.ko.xz
+   ```
+
+   Save the module path to a variable:
+   
+   ```bash
+   BUILTIN=$(modinfo -n hailo_pci)
+   ```
+
+   And rename the module by appending .bak:
     
    ```bash
-   sudo mv /lib/modules/$(uname -r)/kernel/drivers/media/pci/hailo/hailo_pci.ko.xz \
-           /lib/modules/$(uname -r)/kernel/drivers/media/pci/hailo/hailo_pci.ko.xz.bak
+   sudo mv "$BUILTIN" "${BUILTIN}.bak"
    ```
    
    Now refresh the kernel module map so the system recognizes the change:
@@ -167,7 +187,7 @@ On Raspberry Pi OS **Trixie**, the Hailo driver is no longer shipped with the ke
 
    This command should return no results.
 
-2. **Run the installation script**:
+3. **Run the installation script**:
 
    Download the installation script:
 
@@ -195,7 +215,7 @@ On Raspberry Pi OS **Trixie**, the Hailo driver is no longer shipped with the ke
    - Download and install the required firmware
    - Set up udev rules
 
-3. **Reboot your system**:
+4. **Reboot your system**:
 
    After the script completes successfully, reboot to load the firmware:
 
@@ -203,7 +223,7 @@ On Raspberry Pi OS **Trixie**, the Hailo driver is no longer shipped with the ke
    sudo reboot
    ```
 
-4. **Verify the installation**:
+5. **Verify the installation**:
 
    After rebooting, verify that the Hailo device is available:
 


### PR DESCRIPTION
## Proposed change

This PR updates the Raspberry Pi Hailo-8 installation instructions and the user installation script to reflect the correct steps for both **Bookworm** and **Trixie** OS on RPi5 devices.  

All changes have been tested on fresh installations of **Bookworm** and **Trixie**.

### Root causes addressed in this PR

- Previous documentation and script often resulted in driver mismatches on both **Bookworm** and **Trixie**.  
- On **Bookworm**, the built-in kernel Hailo driver is loaded from `kernel/`, which has higher priority than the driver built by the installation script (installed in `extra/`). Simply blacklisting the kernel module prevented any driver from loading but did not resolve the priority issue.  
- On **Trixie**, the kernel no longer ships with the Hailo driver. The driver is installed via DKMS, so the previous conflict does not apply. However, the documentation and script were outdated and did not reflect this.  
- Documentation did not clearly distinguish between **Bookworm** and **Trixie** instructions.  

### Changes introduced

**Documentation**

- Split instructions by OS codename: **Bookworm** and **Trixie**.  
- Added verification steps to check driver version (`modinfo hailo_pci`) and firmware presence.
- Added optional fix for PCIe descriptor page size error
- On **Bookworm**:  
  - Removed module blacklisting and replaced it with **renaming the kernel module** (`hailo_pci.ko.xz → hailo_pci.ko.xz.bak`) so it can be restored if needed.  
  - Added `depmod -a` after renaming to refresh the kernel module map.  
- On **Trixie**:  
  - Clarified that no kernel driver exists, and **simply running the installation script is sufficient**.  

**Installation script**

- Ensures `linux-headers-$(uname -r)` is installed on all platforms.  
- Detects architecture (`aarch64`) and OS codename for Raspberry Pi.  
- Installs **DKMS only on Trixie**. For **x86**, the behavior is unchanged.  
- Added clear output about installed driver version (`modinfo -F version hailo_pci`).  

---

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- Related discussions: 
#21177 
#20621 
#20062 
#19531
#19481

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)