### PR TITLE
Fix event getting stuck due to only checking current clip / snapshot

### DIFF
--- a/frigate/events/maintainer.py
+++ b/frigate/events/maintainer.py
@@ -24,7 +24,7 @@ def should_update_db(prev_event: Event, current_event: Event) -> bool:
         and (prev_event["has_clip"] or prev_event["has_snapshot"])
     ):
         return True
-    
+
     if current_event["has_clip"] or current_event["has_snapshot"]:
         # if this is the first time has_clip or has_snapshot turned true
         if not prev_event["has_clip"] and not prev_event["has_snapshot"]:

--- a/frigate/events/maintainer.py
+++ b/frigate/events/maintainer.py
@@ -15,6 +15,16 @@ logger = logging.getLogger(__name__)
 
 def should_update_db(prev_event: Event, current_event: Event) -> bool:
     """If current_event has updated fields and (clip or snapshot)."""
+    # If event is ending and was previously saved, always update to set end_time
+    # This ensures events are properly ended even when alerts/detections are disabled
+    # mid-event (which can cause has_clip/has_snapshot to become False)
+    if (
+        prev_event["end_time"] is None
+        and current_event["end_time"] is not None
+        and (prev_event["has_clip"] or prev_event["has_snapshot"])
+    ):
+        return True
+    
     if current_event["has_clip"] or current_event["has_snapshot"]:
         # if this is the first time has_clip or has_snapshot turned true
         if not prev_event["has_clip"] and not prev_event["has_snapshot"]:


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

When all recording retention and snapshot retention features are turned off for a camera after an object was detected, it would get stuck because should_update_db would return false for the end message. This ensures that when an object is ended it will be updated to the DB in all cases where it was already put into the DB.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
