### PR TITLE
fix: fix use http_proxy go2rtc service not work

### DIFF
--- a/frigate/api/camera.py
+++ b/frigate/api/camera.py
@@ -56,7 +56,9 @@ def _is_valid_host(host: str) -> bool:
 
 @router.get("/go2rtc/streams", dependencies=[Depends(allow_any_authenticated())])
 def go2rtc_streams():
-    r = requests.get("http://127.0.0.1:1984/api/streams")
+    r = requests.get(
+        "http://127.0.0.1:1984/api/streams", proxies={"http": None, "https": None}
+    )
     if not r.ok:
         logger.error("Failed to fetch streams from go2rtc")
         return JSONResponse(
@@ -75,7 +77,8 @@ def go2rtc_streams():
 )
 def go2rtc_camera_stream(request: Request, camera_name: str):
     r = requests.get(
-        f"http://127.0.0.1:1984/api/streams?src={camera_name}&video=all&audio=all&microphone"
+        f"http://127.0.0.1:1984/api/streams?src={camera_name}&video=all&audio=all&microphone",
+        proxies={"http": None, "https": None},
     )
     if not r.ok:
         camera_config = request.app.frigate_config.cameras.get(camera_name)
@@ -107,6 +110,7 @@ def go2rtc_add_stream(request: Request, stream_name: str, src: str = ""):
             "http://127.0.0.1:1984/api/streams",
             params=params,
             timeout=10,
+            proxies={"http": None, "https": None},
         )
         if not r.ok:
             logger.error(f"Failed to add go2rtc stream {stream_name}: {r.text}")
@@ -142,6 +146,7 @@ def go2rtc_delete_stream(stream_name: str):
             "http://127.0.0.1:1984/api/streams",
             params={"src": stream_name},
             timeout=10,
+            proxies={"http": None, "https": None},
         )
         if not r.ok:
             logger.error(f"Failed to delete go2rtc stream {stream_name}: {r.text}")

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -629,7 +629,11 @@ def auto_detect_hwaccel() -> str:
     try:
         cuda = False
         vaapi = False
-        resp = requests.get("http://127.0.0.1:1984/api/ffmpeg/hardware", timeout=3)
+        resp = requests.get(
+            "http://127.0.0.1:1984/api/ffmpeg/hardware",
+            timeout=3,
+            proxies={"http": None, "https": None},
+        )
 
         if resp.status_code == 200:
             data: dict[str, list[dict[str, str]]] = resp.json()


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

Fix where go2rtc functionality becomes unavailable after setting the HTTP_PROXY environment variable.
Considering that some users may have special network conditions and configure an HTTP_PROXY, this PR will prevent these users from being unable to use go2rtc properly.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
