### PR TITLE
Allow API Events to be Detections or Alerts, depending on the Event Label

### DIFF
--- a/docs/static/frigate-api.yaml
+++ b/docs/static/frigate-api.yaml
@@ -3133,6 +3133,7 @@ paths:
                 duration: 30
                 include_recording: true
                 draw: {}
+                pre_capture: null
       responses:
         "200":
           description: Successful Response
@@ -4935,6 +4936,12 @@ components:
             - type: "null"
           title: Draw
           default: {}
+        pre_capture:
+          anyOf:
+            - type: integer
+            - type: "null"
+          title: Pre Capture Seconds
+          default: null
       type: object
       title: EventsCreateBody
     EventsDeleteBody:

--- a/frigate/api/defs/request/events_body.py
+++ b/frigate/api/defs/request/events_body.py
@@ -34,6 +34,7 @@ class EventsCreateBody(BaseModel):
     duration: Optional[int] = 30
     include_recording: Optional[bool] = True
     draw: Optional[dict] = {}
+    pre_capture: Optional[int] = None
 
 
 class EventsEndBody(BaseModel):

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -1622,6 +1622,7 @@ def create_event(
             body.duration,
             "api",
             body.draw,
+            body.pre_capture,
         ),
         EventMetadataTypeEnum.manual_event_create.value,
     )

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -394,7 +394,8 @@ class ReviewSegmentMaintainer(threading.Thread):
 
             if activity.has_activity_category(SeverityEnum.alert):
                 # update current time for last alert activity
-                segment.last_alert_time = frame_time
+                if frame_time > segment.last_alert_time:
+                    segment.last_alert_time = frame_time
 
                 if segment.severity != SeverityEnum.alert:
                     # if segment is not alert category but current activity is
@@ -404,7 +405,8 @@ class ReviewSegmentMaintainer(threading.Thread):
                     should_update_image = True
 
             if activity.has_activity_category(SeverityEnum.detection):
-                segment.last_detection_time = frame_time
+                if frame_time > segment.last_detection_time:
+                    segment.last_detection_time = frame_time
 
             for object in activity.get_all_objects():
                 # Alert-level objects should always be added (they extend/upgrade the segment)
@@ -484,57 +486,52 @@ class ReviewSegmentMaintainer(threading.Thread):
                 except FileNotFoundError:
                     return
 
-            # indefinite (manual) events should extend the segment until they end
-            if (
-                segment.camera not in self.indefinite_events
-                or len(self.indefinite_events[segment.camera]) == 0
+            if segment.severity == SeverityEnum.alert and frame_time > (
+                segment.last_alert_time + camera_config.review.alerts.cutoff_time
             ):
-                if segment.severity == SeverityEnum.alert and frame_time > (
-                    segment.last_alert_time + camera_config.review.alerts.cutoff_time
-                ):
-                    needs_new_detection = (
-                        segment.last_detection_time > segment.last_alert_time
-                        and (
-                            segment.last_detection_time
-                            + camera_config.review.detections.cutoff_time
-                        )
-                        > frame_time
+                needs_new_detection = (
+                    segment.last_detection_time > segment.last_alert_time
+                    and (
+                        segment.last_detection_time
+                        + camera_config.review.detections.cutoff_time
                     )
-                    last_detection_time = segment.last_detection_time
+                    > frame_time
+                )
+                last_detection_time = segment.last_detection_time
 
-                    end_time = self._publish_segment_end(segment, prev_data)
+                end_time = self._publish_segment_end(segment, prev_data)
 
-                    if needs_new_detection:
-                        new_detections: dict[str, str] = {}
-                        new_zones = set()
+                if needs_new_detection:
+                    new_detections: dict[str, str] = {}
+                    new_zones = set()
 
-                        for o in activity.categorized_objects["detections"]:
-                            new_detections[o["id"]] = o["label"]
-                            new_zones.update(o["current_zones"])
+                    for o in activity.categorized_objects["detections"]:
+                        new_detections[o["id"]] = o["label"]
+                        new_zones.update(o["current_zones"])
 
-                        if new_detections:
-                            self.active_review_segments[activity.camera_config.name] = (
-                                PendingReviewSegment(
-                                    activity.camera_config.name,
-                                    end_time,
-                                    SeverityEnum.detection,
-                                    new_detections,
-                                    sub_labels={},
-                                    audio=set(),
-                                    zones=list(new_zones),
-                                )
+                    if new_detections:
+                        self.active_review_segments[activity.camera_config.name] = (
+                            PendingReviewSegment(
+                                activity.camera_config.name,
+                                end_time,
+                                SeverityEnum.detection,
+                                new_detections,
+                                sub_labels={},
+                                audio=set(),
+                                zones=list(new_zones),
                             )
-                            self._publish_segment_start(
-                                self.active_review_segments[activity.camera_config.name]
-                            )
-                            self.active_review_segments[
-                                activity.camera_config.name
-                            ].last_detection_time = last_detection_time
-                elif segment.severity == SeverityEnum.detection and frame_time > (
-                    segment.last_detection_time
-                    + camera_config.review.detections.cutoff_time
-                ):
-                    self._publish_segment_end(segment, prev_data)
+                        )
+                        self._publish_segment_start(
+                            self.active_review_segments[activity.camera_config.name]
+                        )
+                        self.active_review_segments[
+                            activity.camera_config.name
+                        ].last_detection_time = last_detection_time
+            elif segment.severity == SeverityEnum.detection and frame_time > (
+                segment.last_detection_time
+                + camera_config.review.detections.cutoff_time
+            ):
+                self._publish_segment_end(segment, prev_data)
 
     def check_if_new_segment(
         self,

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -394,7 +394,10 @@ class ReviewSegmentMaintainer(threading.Thread):
 
             if activity.has_activity_category(SeverityEnum.alert):
                 # update current time for last alert activity
-                if frame_time > segment.last_alert_time:
+                if (
+                    segment.last_alert_time is None
+                    or frame_time > segment.last_alert_time
+                ):
                     segment.last_alert_time = frame_time
 
                 if segment.severity != SeverityEnum.alert:
@@ -405,7 +408,10 @@ class ReviewSegmentMaintainer(threading.Thread):
                     should_update_image = True
 
             if activity.has_activity_category(SeverityEnum.detection):
-                if frame_time > segment.last_detection_time:
+                if (
+                    segment.last_detection_time is None
+                    or frame_time > segment.last_detection_time
+                ):
                     segment.last_detection_time = frame_time
 
             for object in activity.get_all_objects():

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -704,6 +704,8 @@ class ReviewSegmentMaintainer(threading.Thread):
                             manual_info["label"]
                         )
                         if topic == DetectionTypeEnum.api:
+                            # manual_info["label"] contains 'label: sub_label'
+                            # so split out the label without modifying manual_info
                             if (
                                 self.config.cameras[camera].review.detections.enabled
                                 and manual_info["label"].split(": ")[0]
@@ -734,6 +736,8 @@ class ReviewSegmentMaintainer(threading.Thread):
                             topic == DetectionTypeEnum.api
                             and self.config.cameras[camera].review.alerts.enabled
                         ):
+                            # manual_info["label"] contains 'label: sub_label'
+                            # so split out the label without modifying manual_info
                             if (
                                 not self.config.cameras[
                                     camera
@@ -816,6 +820,8 @@ class ReviewSegmentMaintainer(threading.Thread):
                         )
                 elif topic == DetectionTypeEnum.api:
                     severity = None
+                    # manual_info["label"] contains 'label: sub_label'
+                    # so split out the label without modifying manual_info
                     if (
                         self.config.cameras[camera].review.detections.enabled
                         and manual_info["label"].split(": ")[0]

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -841,9 +841,6 @@ class ReviewSegmentMaintainer(threading.Thread):
                             self.active_review_segments[
                                 camera
                             ].last_detection_time = sys.maxsize
-                            self._publish_segment_start(
-                                self.active_review_segments[camera]
-                            )
                         elif manual_info["state"] == ManualEventState.complete:
                             self.active_review_segments[
                                 camera

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -484,52 +484,57 @@ class ReviewSegmentMaintainer(threading.Thread):
                 except FileNotFoundError:
                     return
 
-            if segment.severity == SeverityEnum.alert and frame_time > (
-                segment.last_alert_time + camera_config.review.alerts.cutoff_time
+            # indefinite (manual) events should extend the segment until they end
+            if (
+                segment.camera not in self.indefinite_events
+                or len(self.indefinite_events[segment.camera]) == 0
             ):
-                needs_new_detection = (
-                    segment.last_detection_time > segment.last_alert_time
-                    and (
-                        segment.last_detection_time
-                        + camera_config.review.detections.cutoff_time
+                if segment.severity == SeverityEnum.alert and frame_time > (
+                    segment.last_alert_time + camera_config.review.alerts.cutoff_time
+                ):
+                    needs_new_detection = (
+                        segment.last_detection_time > segment.last_alert_time
+                        and (
+                            segment.last_detection_time
+                            + camera_config.review.detections.cutoff_time
+                        )
+                        > frame_time
                     )
-                    > frame_time
-                )
-                last_detection_time = segment.last_detection_time
+                    last_detection_time = segment.last_detection_time
 
-                end_time = self._publish_segment_end(segment, prev_data)
+                    end_time = self._publish_segment_end(segment, prev_data)
 
-                if needs_new_detection:
-                    new_detections: dict[str, str] = {}
-                    new_zones = set()
+                    if needs_new_detection:
+                        new_detections: dict[str, str] = {}
+                        new_zones = set()
 
-                    for o in activity.categorized_objects["detections"]:
-                        new_detections[o["id"]] = o["label"]
-                        new_zones.update(o["current_zones"])
+                        for o in activity.categorized_objects["detections"]:
+                            new_detections[o["id"]] = o["label"]
+                            new_zones.update(o["current_zones"])
 
-                    if new_detections:
-                        self.active_review_segments[activity.camera_config.name] = (
-                            PendingReviewSegment(
-                                activity.camera_config.name,
-                                end_time,
-                                SeverityEnum.detection,
-                                new_detections,
-                                sub_labels={},
-                                audio=set(),
-                                zones=list(new_zones),
+                        if new_detections:
+                            self.active_review_segments[activity.camera_config.name] = (
+                                PendingReviewSegment(
+                                    activity.camera_config.name,
+                                    end_time,
+                                    SeverityEnum.detection,
+                                    new_detections,
+                                    sub_labels={},
+                                    audio=set(),
+                                    zones=list(new_zones),
+                                )
                             )
-                        )
-                        self._publish_segment_start(
-                            self.active_review_segments[activity.camera_config.name]
-                        )
-                        self.active_review_segments[
-                            activity.camera_config.name
-                        ].last_detection_time = last_detection_time
-            elif segment.severity == SeverityEnum.detection and frame_time > (
-                segment.last_detection_time
-                + camera_config.review.detections.cutoff_time
-            ):
-                self._publish_segment_end(segment, prev_data)
+                            self._publish_segment_start(
+                                self.active_review_segments[activity.camera_config.name]
+                            )
+                            self.active_review_segments[
+                                activity.camera_config.name
+                            ].last_detection_time = last_detection_time
+                elif segment.severity == SeverityEnum.detection and frame_time > (
+                    segment.last_detection_time
+                    + camera_config.review.detections.cutoff_time
+                ):
+                    self._publish_segment_end(segment, prev_data)
 
     def check_if_new_segment(
         self,
@@ -695,17 +700,26 @@ class ReviewSegmentMaintainer(threading.Thread):
                         current_segment.detections[manual_info["event_id"]] = (
                             manual_info["label"]
                         )
-                        if (
-                            topic == DetectionTypeEnum.api
-                            and self.config.cameras[camera].review.alerts.enabled
-                        ):
-                            current_segment.severity = SeverityEnum.alert
+                        if topic == DetectionTypeEnum.api:
+                            if (
+                                self.config.cameras[camera].review.detections.enabled
+                                and manual_info["label"].split(": ")[0]
+                                in self.config.cameras[camera].review.detections.labels
+                            ):
+                                current_segment.last_detection_time = manual_info[
+                                    "end_time"
+                                ]
+                            elif self.config.cameras[camera].review.alerts.enabled:
+                                current_segment.severity = SeverityEnum.alert
+                                current_segment.last_alert_time = manual_info[
+                                    "end_time"
+                                ]
                         elif (
                             topic == DetectionTypeEnum.lpr
                             and self.config.cameras[camera].review.detections.enabled
                         ):
                             current_segment.severity = SeverityEnum.detection
-                        current_segment.last_alert_time = manual_info["end_time"]
+                            current_segment.last_alert_time = manual_info["end_time"]
                     elif manual_info["state"] == ManualEventState.start:
                         self.indefinite_events[camera][manual_info["event_id"]] = (
                             manual_info["label"]
@@ -717,7 +731,16 @@ class ReviewSegmentMaintainer(threading.Thread):
                             topic == DetectionTypeEnum.api
                             and self.config.cameras[camera].review.alerts.enabled
                         ):
-                            current_segment.severity = SeverityEnum.alert
+                            if (
+                                not self.config.cameras[
+                                    camera
+                                ].review.detections.enabled
+                                or manual_info["label"].split(": ")[0]
+                                not in self.config.cameras[
+                                    camera
+                                ].review.detections.labels
+                            ):
+                                current_segment.severity = SeverityEnum.alert
                         elif (
                             topic == DetectionTypeEnum.lpr
                             and self.config.cameras[camera].review.detections.enabled
@@ -789,11 +812,21 @@ class ReviewSegmentMaintainer(threading.Thread):
                             detections,
                         )
                 elif topic == DetectionTypeEnum.api:
-                    if self.config.cameras[camera].review.alerts.enabled:
+                    severity = None
+                    if (
+                        self.config.cameras[camera].review.detections.enabled
+                        and manual_info["label"].split(": ")[0]
+                        in self.config.cameras[camera].review.detections.labels
+                    ):
+                        severity = SeverityEnum.detection
+                    elif self.config.cameras[camera].review.alerts.enabled:
+                        severity = SeverityEnum.alert
+
+                    if severity:
                         self.active_review_segments[camera] = PendingReviewSegment(
                             camera,
                             frame_time,
-                            SeverityEnum.alert,
+                            severity,
                             {manual_info["event_id"]: manual_info["label"]},
                             {},
                             [],
@@ -811,6 +844,9 @@ class ReviewSegmentMaintainer(threading.Thread):
                             self.active_review_segments[
                                 camera
                             ].last_detection_time = sys.maxsize
+                            self._publish_segment_start(
+                                self.active_review_segments[camera]
+                            )
                         elif manual_info["state"] == ManualEventState.complete:
                             self.active_review_segments[
                                 camera
@@ -820,7 +856,7 @@ class ReviewSegmentMaintainer(threading.Thread):
                             ].last_detection_time = manual_info["end_time"]
                     else:
                         logger.warning(
-                            f"Manual event API has been called for {camera}, but alerts are disabled. This manual event will not appear as an alert."
+                            f"Manual event API has been called for {camera}, but alerts and detections are disabled. This manual event will not appear as an alert or detection."
                         )
                 elif topic == DetectionTypeEnum.lpr:
                     if self.config.cameras[camera].review.detections.enabled:

--- a/frigate/track/object_processing.py
+++ b/frigate/track/object_processing.py
@@ -536,8 +536,7 @@ class TrackedObjectProcessor(threading.Thread):
                     "sub_label": sub_label,
                     "score": score,
                     "camera": camera_name,
-                    "start_time": frame_time
-                    - self.config.cameras[camera_name].record.event_pre_capture,
+                    "start_time": frame_time,
                     "end_time": end_time,
                     "has_clip": self.config.cameras[camera_name].record.enabled
                     and include_recording,

--- a/frigate/track/object_processing.py
+++ b/frigate/track/object_processing.py
@@ -515,6 +515,7 @@ class TrackedObjectProcessor(threading.Thread):
             duration,
             source_type,
             draw,
+            pre_capture,
         ) = payload
 
         # save the snapshot image
@@ -522,6 +523,7 @@ class TrackedObjectProcessor(threading.Thread):
             None, event_id, label, draw
         )
         end_time = frame_time + duration if duration is not None else None
+        start_time = frame_time - self.config.cameras[camera_name].record.event_pre_capture if pre_capture is None else frame_time - pre_capture
 
         # send event to event maintainer
         self.event_sender.publish(
@@ -536,7 +538,7 @@ class TrackedObjectProcessor(threading.Thread):
                     "sub_label": sub_label,
                     "score": score,
                     "camera": camera_name,
-                    "start_time": frame_time,
+                    "start_time": start_time,
                     "end_time": end_time,
                     "has_clip": self.config.cameras[camera_name].record.enabled
                     and include_recording,

--- a/frigate/track/object_processing.py
+++ b/frigate/track/object_processing.py
@@ -523,7 +523,11 @@ class TrackedObjectProcessor(threading.Thread):
             None, event_id, label, draw
         )
         end_time = frame_time + duration if duration is not None else None
-        start_time = frame_time - self.config.cameras[camera_name].record.event_pre_capture if pre_capture is None else frame_time - pre_capture
+        start_time = (
+            frame_time - self.config.cameras[camera_name].record.event_pre_capture
+            if pre_capture is None
+            else frame_time - pre_capture
+        )
 
         # send event to event maintainer
         self.event_sender.publish(


### PR DESCRIPTION
## Proposed change
As a former Blue Iris user that migrated to Frigate, the biggest issue I had was not being able to create detections via the API. I wanted to record a clip and have it show as a detection, instead of cluttering my Alerts view, for things like PIR sensors, door openings, literally anything. 

Currently, all API-created events are hardcoded to be alerts, this change fixes that. I added a `sensor` label to all of my cameras under review.detections.labels and use the sub-label to indicate which sensor was triggered.

- API created events will be alerts OR detections, depending on the event label, defaulting to alerts (no change in default behavior)
- Segments are upgraded to alerts if an alert object is detected during the segment, otherwise it will be a detection segment
- Indefinite API events will extend the recording segment until those events are ended
- API event start time is the actual start time, instead of having a pre-buffer of record.event_pre_capture (I couldn't find a reason for this as it appears the record pre_capture time is still respected like a standard detection/alert, and it caused all detections to start seconds, 15 in my case, before the actual sensor was triggered and for the timestamps on the events to be wrong)

I've been testing these changes locally for a couple of weeks. I'm able to get review segments with detail like this, which is exactly what I was looking for:
<img width="446" height="957" alt="image" src="https://github.com/user-attachments/assets/7698e7bc-7861-45d0-b411-c49fec81c729" />

This was my first time digging into the Frigate codebase so I'm very open to feedback, suggestions, improvements etc. 


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #21620

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
