### PR TITLE
[Feat] Add X-Frame-Time HTTP header to the snapshot API response

### DIFF
--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -761,7 +761,7 @@ async def event_snapshot(
                 if event_id in camera_state.tracked_objects:
                     tracked_obj = camera_state.tracked_objects.get(event_id)
                     if tracked_obj is not None:
-                        jpg_bytes = tracked_obj.get_img_bytes(
+                        jpg_bytes, frame_time = tracked_obj.get_img_bytes(
                             ext="jpg",
                             timestamp=params.timestamp,
                             bounding_box=params.bbox,
@@ -790,6 +790,7 @@ async def event_snapshot(
     headers = {
         "Content-Type": "image/jpeg",
         "Cache-Control": "private, max-age=31536000" if event_complete else "no-store",
+        "X-Frame-Time": frame_time,
     }
 
     if params.download:

--- a/frigate/track/object_processing.py
+++ b/frigate/track/object_processing.py
@@ -185,7 +185,7 @@ class TrackedObjectProcessor(threading.Thread):
         def snapshot(camera: str, obj: TrackedObject) -> bool:
             mqtt_config: CameraMqttConfig = self.config.cameras[camera].mqtt
             if mqtt_config.enabled and self.should_mqtt_snapshot(camera, obj):
-                jpg_bytes = obj.get_img_bytes(
+                jpg_bytes, _ = obj.get_img_bytes(
                     ext="jpg",
                     timestamp=mqtt_config.timestamp,
                     bounding_box=mqtt_config.bounding_box,

--- a/frigate/track/tracked_object.py
+++ b/frigate/track/tracked_object.py
@@ -422,7 +422,7 @@ class TrackedObject:
         return count > (self.camera_config.detect.stationary.threshold or 50)
 
     def get_thumbnail(self, ext: str) -> bytes | None:
-        img_bytes = self.get_img_bytes(
+        img_bytes, _ = self.get_img_bytes(
             ext, timestamp=False, bounding_box=False, crop=True, height=175
         )
 
@@ -463,20 +463,21 @@ class TrackedObject:
         crop: bool = False,
         height: int | None = None,
         quality: int | None = None,
-    ) -> bytes | None:
+    ) -> tuple[bytes | None, float | None]:
         if self.thumbnail_data is None:
-            return None
+            return None, None
 
         try:
+            frame_time = self.thumbnail_data["frame_time"]
             best_frame = cv2.cvtColor(
-                self.frame_cache[self.thumbnail_data["frame_time"]]["frame"],
+                self.frame_cache[frame_time]["frame"],
                 cv2.COLOR_YUV2BGR_I420,
             )
         except KeyError:
             logger.warning(
-                f"Unable to create jpg because frame {self.thumbnail_data['frame_time']} is not in the cache"
+                f"Unable to create jpg because frame {frame_time} is not in the cache"
             )
-            return None
+            return None, None
 
         if bounding_box:
             thickness = 2
@@ -558,13 +559,13 @@ class TrackedObject:
         ret, jpg = cv2.imencode(f".{ext}", best_frame, quality_params)
 
         if ret:
-            return jpg.tobytes()
+            return jpg.tobytes(), frame_time
         else:
-            return None
+            return None, None
 
     def write_snapshot_to_disk(self) -> None:
         snapshot_config: SnapshotsConfig = self.camera_config.snapshots
-        jpg_bytes = self.get_img_bytes(
+        jpg_bytes, _ = self.get_img_bytes(
             ext="jpg",
             timestamp=snapshot_config.timestamp,
             bounding_box=snapshot_config.bounding_box,


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->

This PR introduces a new `X-Frame-Time` HTTP header to the snapshot API response.

The header allows clients to verify that the retrieved snapshot corresponds to the expected frame - for example, when requesting a snapshot triggered by an MQTT event.

See the related discussion [#19309](https://github.com/blakeblackshear/frigate/discussions/19309)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information



## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
