### PR TITLE
Improve jsmpeg player websocket handling

### DIFF
--- a/frigate/api/classification.py
+++ b/frigate/api/classification.py
@@ -71,7 +71,7 @@ def get_faces():
         face_dict[name] = []
 
         for file in filter(
-            lambda f: (f.lower().endswith((".webp", ".png", ".jpg", ".jpeg"))),
+            lambda f: f.lower().endswith((".webp", ".png", ".jpg", ".jpeg")),
             os.listdir(face_dir),
         ):
             face_dict[name].append(file)
@@ -580,7 +580,7 @@ def get_classification_dataset(name: str):
         dataset_dict[category_name] = []
 
         for file in filter(
-            lambda f: (f.lower().endswith((".webp", ".png", ".jpg", ".jpeg"))),
+            lambda f: f.lower().endswith((".webp", ".png", ".jpg", ".jpeg")),
             os.listdir(category_dir),
         ):
             dataset_dict[category_name].append(file)
@@ -638,7 +638,7 @@ def get_classification_images(name: str):
         status_code=200,
         content=list(
             filter(
-                lambda f: (f.lower().endswith((".webp", ".png", ".jpg", ".jpeg"))),
+                lambda f: f.lower().endswith((".webp", ".png", ".jpg", ".jpeg")),
                 os.listdir(train_dir),
             )
         ),

--- a/frigate/data_processing/real_time/custom_classification.py
+++ b/frigate/data_processing/real_time/custom_classification.py
@@ -642,7 +642,7 @@ def write_classification_attempt(
     # delete oldest face image if maximum is reached
     try:
         files = sorted(
-            filter(lambda f: (f.endswith(".webp")), os.listdir(folder)),
+            filter(lambda f: f.endswith(".webp"), os.listdir(folder)),
             key=lambda f: os.path.getctime(os.path.join(folder, f)),
             reverse=True,
         )

--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -539,7 +539,7 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
             cv2.imwrite(file, frame)
 
             files = sorted(
-                filter(lambda f: (f.endswith(".webp")), os.listdir(folder)),
+                filter(lambda f: f.endswith(".webp"), os.listdir(folder)),
                 key=lambda f: os.path.getctime(os.path.join(folder, f)),
                 reverse=True,
             )

--- a/frigate/log.py
+++ b/frigate/log.py
@@ -26,15 +26,16 @@ LOG_HANDLER.setFormatter(
 
 # filter out norfair warning
 LOG_HANDLER.addFilter(
-    lambda record: not record.getMessage().startswith(
-        "You are using a scalar distance function"
+    lambda record: (
+        not record.getMessage().startswith("You are using a scalar distance function")
     )
 )
 
 # filter out tflite logging
 LOG_HANDLER.addFilter(
-    lambda record: "Created TensorFlow Lite XNNPACK delegate for CPU."
-    not in record.getMessage()
+    lambda record: (
+        "Created TensorFlow Lite XNNPACK delegate for CPU." not in record.getMessage()
+    )
 )
 
 

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -194,8 +194,10 @@ class RecordingMaintainer(threading.Thread):
             processed_segment_count = len(
                 list(
                     filter(
-                        lambda r: r["start_time"].timestamp()
-                        < most_recently_processed_frame_time,
+                        lambda r: (
+                            r["start_time"].timestamp()
+                            < most_recently_processed_frame_time
+                        ),
                         grouped_recordings[camera],
                     )
                 )


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
- Prevent websocket console messages from appearing when player is destroyed
- Push reformatted files after ruff upgrade


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
