### PR TITLE
docs: Add documentation style guide for internal links (dev docs)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,56 @@ For installation and contributing instructions, please follow the [Contributing 
 
 1. Run `npm i` to install dependencies
 2. Run `npm run start` to start the website
+
+# Documentation Style Guide
+
+## Internal Links
+
+When adding or editing internal links, follow these conventions:
+
+### Do not include the `.md` extension
+
+Use paths without extensions. This avoids needing `index.md` for directory index pages and matches the web URL.
+
+```markdown
+<!-- Good -->
+[zones](/configuration/zones)
+[getting started](../guides/getting_started)
+
+<!-- Bad -->
+[zones](/configuration/zones.md)
+```
+
+### Use relative paths for same-directory links
+
+Use relative `./` paths for links to pages in the same directory.
+
+```markdown
+[zones](./zones)
+[masks](./masks)
+```
+
+### Use absolute paths for everything else
+
+For links outside the current directory, use absolute paths from the docs root. The exception is deeply nested subdirectories (e.g., `configuration/custom_classification/`) where `../` to the parent directory is acceptable.
+
+```markdown
+[object detectors](/configuration/object_detectors)
+[hardware](/frigate/hardware)
+[getting started](/guides/getting_started)
+
+<!-- Also OK from a nested subdirectory -->
+[zones](../zones)
+```
+
+### Never use full URLs for internal links
+
+```markdown
+<!-- Good -->
+[zones](/configuration/zones)
+
+<!-- Bad -->
+[zones](https://docs.frigate.video/configuration/zones)
+```
+
+> **Note:** Some existing links still use `.md` extensions. These should be updated when the file is being edited for other reasons.


### PR DESCRIPTION
## Proposed change
 Adds a documentation style guide to the developer docs/README.md covering internal link conventions

### Context
I noticed inconsistencies in how internal links are formatted. Some files use `.md` extensions, some don't, some use relative paths, some use absolute. Both styles work in Docusaurus, but it'd be nice to have a consistent convention going forward.

### Suggested Conventions
- No `.md` extension (avoids `index.md` references, matches web URLs)
- Relative `./` paths for same-directory links
- Absolute paths for cross-directory links
- `../` acceptable for deeply nested subdirectories linking to their parent

Absolutely no strong opinions here, open to other approaches if anyone feels differently. I just like guidelines. By convention it looks like using `.md` is used more often if that influences a decision.

## Type of change

- [x] Dev Documentation Update
