### PR TITLE
ffmpeg Preview Segment Optimization for "high" and "very_high"

### DIFF
--- a/frigate/output/preview.py
+++ b/frigate/output/preview.py
@@ -47,6 +47,15 @@ PREVIEW_QUALITY_BIT_RATES = {
     RecordQualityEnum.high: 9864,
     RecordQualityEnum.very_high: 10096,
 }
+# the -qmax param for ffmpeg prevents the encoder from overly compressing frames while still trying to hit the bitrate target
+# lower values are higher quality. This is especially important for iniitial frames in the segment
+PREVIEW_QMAX_PARAM = {
+    RecordQualityEnum.very_low: '',
+    RecordQualityEnum.low: '',
+    RecordQualityEnum.medium: '',
+    RecordQualityEnum.high: '-qmax 25',
+    RecordQualityEnum.very_high: '-qmax 25',
+}
 
 
 def get_cache_image_name(camera: str, frame_time: float) -> str:
@@ -125,7 +134,7 @@ class FFMpegConverter(threading.Thread):
             config.ffmpeg.ffmpeg_path,
             "default",
             input="-f concat -y -protocol_whitelist pipe,file -safe 0 -threads 1 -i /dev/stdin",
-            output=f"-threads 1 -g {PREVIEW_KEYFRAME_INTERVAL} -bf 0 -b:v {PREVIEW_QUALITY_BIT_RATES[self.config.record.preview.quality]} {FPS_VFR_PARAM} -movflags +faststart -pix_fmt yuv420p {self.path}",
+            output=f"-threads 1 -g {PREVIEW_KEYFRAME_INTERVAL} -bf 0 -b:v {PREVIEW_QUALITY_BIT_RATES[self.config.record.preview.quality]} {PREVIEW_QMAX_PARAM[self.config.record.preview.quality]} {FPS_VFR_PARAM} -movflags +faststart -pix_fmt yuv420p {self.path}",
             type=EncodeTypeEnum.preview,
         )
 

--- a/frigate/output/preview.py
+++ b/frigate/output/preview.py
@@ -53,8 +53,8 @@ PREVIEW_QMAX_PARAM = {
     RecordQualityEnum.very_low: "",
     RecordQualityEnum.low: "",
     RecordQualityEnum.medium: "",
-    RecordQualityEnum.high: "-qmax 25",
-    RecordQualityEnum.very_high: "-qmax 25",
+    RecordQualityEnum.high: " -qmax 25",
+    RecordQualityEnum.very_high: " -qmax 25",
 }
 
 
@@ -134,7 +134,7 @@ class FFMpegConverter(threading.Thread):
             config.ffmpeg.ffmpeg_path,
             "default",
             input="-f concat -y -protocol_whitelist pipe,file -safe 0 -threads 1 -i /dev/stdin",
-            output=f"-threads 1 -g {PREVIEW_KEYFRAME_INTERVAL} -bf 0 -b:v {PREVIEW_QUALITY_BIT_RATES[self.config.record.preview.quality]} {PREVIEW_QMAX_PARAM[self.config.record.preview.quality]} {FPS_VFR_PARAM} -movflags +faststart -pix_fmt yuv420p {self.path}",
+            output=f"-threads 1 -g {PREVIEW_KEYFRAME_INTERVAL} -bf 0 -b:v {PREVIEW_QUALITY_BIT_RATES[self.config.record.preview.quality]}{PREVIEW_QMAX_PARAM[self.config.record.preview.quality]} {FPS_VFR_PARAM} -movflags +faststart -pix_fmt yuv420p {self.path}",
             type=EncodeTypeEnum.preview,
         )
 

--- a/frigate/output/preview.py
+++ b/frigate/output/preview.py
@@ -50,11 +50,11 @@ PREVIEW_QUALITY_BIT_RATES = {
 # the -qmax param for ffmpeg prevents the encoder from overly compressing frames while still trying to hit the bitrate target
 # lower values are higher quality. This is especially important for iniitial frames in the segment
 PREVIEW_QMAX_PARAM = {
-    RecordQualityEnum.very_low: '',
-    RecordQualityEnum.low: '',
-    RecordQualityEnum.medium: '',
-    RecordQualityEnum.high: '-qmax 25',
-    RecordQualityEnum.very_high: '-qmax 25',
+    RecordQualityEnum.very_low: "",
+    RecordQualityEnum.low: "",
+    RecordQualityEnum.medium: "",
+    RecordQualityEnum.high: "-qmax 25",
+    RecordQualityEnum.very_high: "-qmax 25",
 }
 
 


### PR DESCRIPTION
## Proposed change
For preview qualities `high` and `very_high` add the `-qmax 25` parameter to ffmpeg when generating hourly preview segments. This prevents ffmpeg from overly compressing the frames by setting a max quantizer value of 25 while still trying to hit the target bitrate. This is especially important for the initial frames that are otherwise a garbled mess and impossible to decipher.

More details and extensive testing in #21972 


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #21972 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
