### PR TITLE
Clean up trailing whitespaces in cpu stats process cmdline

### DIFF
--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -121,7 +121,7 @@ def get_cpu_stats() -> dict[str, dict]:
         pid = str(process.info["pid"])
         try:
             cpu_percent = process.info["cpu_percent"]
-            cmdline = process.info["cmdline"]
+            cmdline = " ".join(process.info["cmdline"]).rstrip()
 
             with open(f"/proc/{pid}/stat", "r") as f:
                 stats = f.readline().split()
@@ -155,7 +155,7 @@ def get_cpu_stats() -> dict[str, dict]:
                 "cpu": str(cpu_percent),
                 "cpu_average": str(round(cpu_average_usage, 2)),
                 "mem": f"{mem_pct}",
-                "cmdline": clean_camera_user_pass(" ".join(cmdline)),
+                "cmdline": clean_camera_user_pass(cmdline),
             }
         except Exception:
             continue


### PR DESCRIPTION
The psutil library reads the process commandline as by opening /proc/pid/cmdline which returns a buffer that is larger than just the program cmdline due to rounded memory allocation sizes.

That means that if the library does not detect a Null-terminated string it keeps appending empty strings which add up as whitespaces when joined.

```
# cat /proc/3486303/cmdline | hexdump -C
00000000  66 72 69 67 61 74 65 2e  64 65 74 65 63 74 6f 72  |frigate.detector|
00000010  2e 63 6f 72 61 6c 00 00  00 00 00 00 00 00 00 00  |.coral..........|
00000020  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000050  00 00 00 00 00 00                                 |......|
00000056
```

```python
>>> psutil.Process(3486303).cmdline()
['frigate.detector.coral', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']
>>> " ".join(psutil.Process(3486303).cmdline())
'frigate.detector.coral                                                               '
```

This was visible in the Prometheus metric labels for cpu usage.

## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
