### PR TITLE
Fix go2rtc stream alias auth

### DIFF
--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -986,15 +986,23 @@ async def require_camera_access(
 
     current_user = await get_current_user(request)
     if isinstance(current_user, JSONResponse):
-        return current_user
+        detail = "Authentication required"
+        try:
+            error_payload = json.loads(current_user.body)
+            detail = (
+                error_payload.get("message") or error_payload.get("detail") or detail
+            )
+        except Exception:
+            pass
+
+        raise HTTPException(status_code=current_user.status_code, detail=detail)
 
     role = current_user["role"]
     all_camera_names = set(request.app.frigate_config.cameras.keys())
     roles_dict = request.app.frigate_config.auth.roles
     allowed_cameras = User.get_allowed_cameras(role, roles_dict, all_camera_names)
 
-    # Admin or full access bypasses
-    if role == "admin" or not roles_dict.get(role):
+    if role == "admin":
         return
 
     if camera_name not in allowed_cameras:
@@ -1002,6 +1010,60 @@ async def require_camera_access(
             status_code=403,
             detail=f"Access denied to camera '{camera_name}'. Allowed: {allowed_cameras}",
         )
+
+
+def _get_stream_owner_cameras(request: Request, stream_name: str) -> set[str]:
+    owner_cameras: set[str] = set()
+
+    for camera_name, camera in request.app.frigate_config.cameras.items():
+        if stream_name == camera_name:
+            owner_cameras.add(camera_name)
+            continue
+
+        if stream_name in camera.live.streams.values():
+            owner_cameras.add(camera_name)
+
+    return owner_cameras
+
+
+async def require_go2rtc_stream_access(
+    stream_name: Optional[str] = None,
+    request: Request = None,
+):
+    """Dependency to enforce go2rtc stream access based on owning camera access."""
+    if stream_name is None:
+        return
+
+    current_user = await get_current_user(request)
+    if isinstance(current_user, JSONResponse):
+        detail = "Authentication required"
+        try:
+            error_payload = json.loads(current_user.body)
+            detail = (
+                error_payload.get("message") or error_payload.get("detail") or detail
+            )
+        except Exception:
+            pass
+
+        raise HTTPException(status_code=current_user.status_code, detail=detail)
+
+    role = current_user["role"]
+    all_camera_names = set(request.app.frigate_config.cameras.keys())
+    roles_dict = request.app.frigate_config.auth.roles
+    allowed_cameras = User.get_allowed_cameras(role, roles_dict, all_camera_names)
+
+    if role == "admin":
+        return
+
+    owner_cameras = _get_stream_owner_cameras(request, stream_name)
+
+    if owner_cameras & set(allowed_cameras):
+        return
+
+    raise HTTPException(
+        status_code=403,
+        detail=f"Access denied to camera '{stream_name}'. Allowed: {allowed_cameras}",
+    )
 
 
 async def get_allowed_cameras_for_filter(request: Request):

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -1002,7 +1002,8 @@ async def require_camera_access(
     roles_dict = request.app.frigate_config.auth.roles
     allowed_cameras = User.get_allowed_cameras(role, roles_dict, all_camera_names)
 
-    if role == "admin":
+    # Admin or full access bypasses
+    if role == "admin" or not roles_dict.get(role):
         return
 
     if camera_name not in allowed_cameras:
@@ -1052,7 +1053,8 @@ async def require_go2rtc_stream_access(
     roles_dict = request.app.frigate_config.auth.roles
     allowed_cameras = User.get_allowed_cameras(role, roles_dict, all_camera_names)
 
-    if role == "admin":
+    # Admin or full access bypasses
+    if role == "admin" or not roles_dict.get(role):
         return
 
     owner_cameras = _get_stream_owner_cameras(request, stream_name)

--- a/frigate/test/http_api/test_http_camera_access.py
+++ b/frigate/test/http_api/test_http_camera_access.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from fastapi import HTTPException, Request
+from fastapi.testclient import TestClient
 
 from frigate.api.auth import (
     get_allowed_cameras_for_filter,
@@ -8,6 +9,33 @@ from frigate.api.auth import (
 )
 from frigate.models import Event, Recordings, ReviewSegment
 from frigate.test.http_api.base_http_test import AuthTestClient, BaseTestHttp
+
+# Minimal multi-camera config used by go2rtc stream access tests.
+# front_door has a stream alias "front_door_main"; back_door uses its own name.
+# The "limited_user" role is restricted to front_door only.
+_MULTI_CAMERA_CONFIG = {
+    "mqtt": {"host": "mqtt"},
+    "auth": {
+        "roles": {
+            "limited_user": ["front_door"],
+        }
+    },
+    "cameras": {
+        "front_door": {
+            "ffmpeg": {
+                "inputs": [{"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}]
+            },
+            "detect": {"height": 1080, "width": 1920, "fps": 5},
+            "live": {"streams": {"default": "front_door_main"}},
+        },
+        "back_door": {
+            "ffmpeg": {
+                "inputs": [{"path": "rtsp://10.0.0.2:554/video", "roles": ["detect"]}]
+            },
+            "detect": {"height": 1080, "width": 1920, "fps": 5},
+        },
+    },
+}
 
 
 class TestCameraAccessEventReview(BaseTestHttp):
@@ -190,3 +218,179 @@ class TestCameraAccessEventReview(BaseTestHttp):
             resp = client.get("/events/summary")
             summary_list = resp.json()
             assert len(summary_list) == 2
+
+
+class TestGo2rtcStreamAccess(BaseTestHttp):
+    """Tests for require_go2rtc_stream_access — the auth dependency on
+    GET /go2rtc/streams/{stream_name}.
+
+    go2rtc is not running in unit tests, so an authorized request returns
+    500 (the proxy call fails), while an unauthorized request returns 401/403
+    before the proxy is ever reached.
+    """
+
+    def _make_app(self, config_override: dict | None = None):
+        """Build a test app, optionally replacing self.minimal_config."""
+        if config_override is not None:
+            self.minimal_config = config_override
+        app = super().create_app()
+
+        # Allow tests to control the current user via request headers.
+        async def mock_get_current_user(request: Request):
+            username = request.headers.get("remote-user")
+            role = request.headers.get("remote-role")
+            if not username or not role:
+                from fastapi.responses import JSONResponse
+
+                return JSONResponse(
+                    content={"message": "No authorization headers."},
+                    status_code=401,
+                )
+            return {"username": username, "role": role}
+
+        app.dependency_overrides[get_current_user] = mock_get_current_user
+        return app
+
+    def setUp(self):
+        super().setUp([Event, ReviewSegment, Recordings])
+
+    def tearDown(self):
+        super().tearDown()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_stream(
+        self, app, stream_name: str, role: str = "admin", user: str = "test"
+    ):
+        """Issue GET /go2rtc/streams/{stream_name} with the given role."""
+        with AuthTestClient(app) as client:
+            return client.get(
+                f"/go2rtc/streams/{stream_name}",
+                headers={"remote-user": user, "remote-role": role},
+            )
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_admin_can_access_any_stream(self):
+        """Admin role bypasses camera restrictions."""
+        app = self._make_app(_MULTI_CAMERA_CONFIG)
+        # front_door stream — go2rtc is not running so expect 500, not 401/403
+        resp = self._get_stream(app, "front_door", role="admin")
+        assert resp.status_code not in (401, 403), (
+            f"Admin should not be blocked; got {resp.status_code}"
+        )
+
+        # back_door stream
+        resp = self._get_stream(app, "back_door", role="admin")
+        assert resp.status_code not in (401, 403)
+
+    def test_missing_auth_headers_returns_401(self):
+        """Requests without auth headers must be rejected with 401."""
+        app = self._make_app(_MULTI_CAMERA_CONFIG)
+        # Use plain TestClient (not AuthTestClient) so no headers are injected.
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/go2rtc/streams/front_door")
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
+
+    def test_unconfigured_role_can_access_any_stream(self):
+        """When no camera restrictions are configured for a role the user
+        should have access to all streams (no roles_dict entry ⇒ no restriction)."""
+        no_roles_config = {
+            "mqtt": {"host": "mqtt"},
+            "cameras": {
+                "front_door": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}
+                        ]
+                    },
+                    "detect": {"height": 1080, "width": 1920, "fps": 5},
+                },
+                "back_door": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {"path": "rtsp://10.0.0.2:554/video", "roles": ["detect"]}
+                        ]
+                    },
+                    "detect": {"height": 1080, "width": 1920, "fps": 5},
+                },
+            },
+        }
+        app = self._make_app(no_roles_config)
+
+        # "myuser" role is not listed in roles_dict — should be allowed everywhere
+        for stream in ("front_door", "back_door"):
+            resp = self._get_stream(app, stream, role="myuser")
+            assert resp.status_code not in (401, 403), (
+                f"Unconfigured role should not be blocked on '{stream}'; "
+                f"got {resp.status_code}"
+            )
+
+    def test_restricted_role_can_access_allowed_camera(self):
+        """limited_user role (restricted to front_door) can access front_door stream."""
+        app = self._make_app(_MULTI_CAMERA_CONFIG)
+        resp = self._get_stream(app, "front_door", role="limited_user")
+        assert resp.status_code not in (401, 403), (
+            f"limited_user should be allowed on front_door; got {resp.status_code}"
+        )
+
+    def test_restricted_role_blocked_from_disallowed_camera(self):
+        """limited_user role (restricted to front_door) cannot access back_door stream."""
+        app = self._make_app(_MULTI_CAMERA_CONFIG)
+        resp = self._get_stream(app, "back_door", role="limited_user")
+        assert resp.status_code == 403, (
+            f"limited_user should be denied on back_door; got {resp.status_code}"
+        )
+
+    def test_stream_alias_allowed_for_owning_camera(self):
+        """Stream alias 'front_door_main' is owned by front_door; limited_user (who
+        is allowed front_door) should be permitted."""
+        app = self._make_app(_MULTI_CAMERA_CONFIG)
+        # front_door_main is the alias defined in live.streams for front_door
+        resp = self._get_stream(app, "front_door_main", role="limited_user")
+        assert resp.status_code not in (401, 403), (
+            f"limited_user should be allowed on alias front_door_main; "
+            f"got {resp.status_code}"
+        )
+
+    def test_stream_alias_blocked_when_owning_camera_disallowed(self):
+        """limited_user cannot access a stream alias that belongs to a camera they
+        are not allowed to see."""
+        # Give back_door a stream alias and restrict limited_user to front_door only
+        config = {
+            "mqtt": {"host": "mqtt"},
+            "auth": {
+                "roles": {
+                    "limited_user": ["front_door"],
+                }
+            },
+            "cameras": {
+                "front_door": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}
+                        ]
+                    },
+                    "detect": {"height": 1080, "width": 1920, "fps": 5},
+                },
+                "back_door": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {"path": "rtsp://10.0.0.2:554/video", "roles": ["detect"]}
+                        ]
+                    },
+                    "detect": {"height": 1080, "width": 1920, "fps": 5},
+                    "live": {"streams": {"default": "back_door_main"}},
+                },
+            },
+        }
+        app = self._make_app(config)
+        resp = self._get_stream(app, "back_door_main", role="limited_user")
+        assert resp.status_code == 403, (
+            f"limited_user should be denied on alias back_door_main; "
+            f"got {resp.status_code}"
+        )


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR fixes 403 errors when Live view requested stream aliases like `cam_xx_main` or `cam_xx_sub` for users scoped to camera names only. It also fixes stream selection logic so audio capability and live mode are computed from the active stream.

Live view requested metadata from `/api/go2rtc/streams/<camera_name>`, but auth checked `camera-name` membership literally, so `cam_xx_main` was denied even when `cam_xx` was allowed.

Backend:
- Added stream-aware access dependency in auth.py that maps a stream to owning camera(s) via each camera `live.streams` mapping and authorizes against allowed cameras
- Switched route dependency and parameter naming in camera.py to `stream_name` and kept go2rtc metadata lookup aligned to stream identity
- Dependency auth failures now raise `HTTPException` instead of returning `JSONResponse` objects to prevent dependency fail-open behavior
- go2rtc metadata request now uses encoded query params to safely handle stream names
- Add new tests

Frontend:
- Updated selected-stream restream checks in use-camera-live-mode.ts so live mode/audio support use the active stream (not only first stream), including reset behavior



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
