### PR TITLE
Add continuous rollover storage retention policy

### DIFF
--- a/frigate/api/record.py
+++ b/frigate/api/record.py
@@ -26,7 +26,7 @@ from frigate.api.defs.query.recordings_query_parameters import (
 from frigate.api.defs.response.generic_response import GenericResponse
 from frigate.api.defs.tags import Tags
 from frigate.const import RECORD_DIR
-from frigate.models import Event, Recordings
+from frigate.models import Event, Recordings, ReviewSegment
 from frigate.util.time import get_dst_transitions
 
 logger = logging.getLogger(__name__)
@@ -56,6 +56,117 @@ def get_recordings_storage_usage(request: Request):
             ) * 100
 
     return JSONResponse(content=camera_usages)
+
+
+@router.get(
+    "/recordings/storage/breakdown",
+    dependencies=[Depends(allow_any_authenticated())],
+)
+def get_recordings_storage_breakdown(request: Request):
+    """Return storage usage broken down by category: overwritable, event retention, and protected."""
+
+    now = datetime.now().timestamp()
+
+    # 1. Protected (indefinite): recordings overlapping retain_indefinitely events
+    retained_events = (
+        Event.select(Event.camera, Event.start_time, Event.end_time)
+        .where(Event.retain_indefinitely == True, Event.has_clip == True)
+        .namedtuples()
+    )
+
+    protected_size = 0.0
+    protected_recording_ids = set()
+    for event in retained_events:
+        end_time_clause = (
+            Recordings.start_time < event.end_time
+            if event.end_time is not None
+            else True
+        )
+        overlapping = (
+            Recordings.select(Recordings.id, Recordings.segment_size)
+            .where(
+                Recordings.camera == event.camera,
+                end_time_clause,
+                Recordings.end_time > event.start_time,
+                Recordings.segment_size > 0,
+            )
+            .namedtuples()
+        )
+        for rec in overlapping:
+            if rec.id not in protected_recording_ids:
+                protected_recording_ids.add(rec.id)
+                protected_size += rec.segment_size
+
+    # 2. Event retention (aging out): recordings overlapping non-expired review segments
+    config = request.app.frigate_config
+    alert_expire = now - timedelta(days=config.record.alerts.retain.days).total_seconds()
+    detection_expire = (
+        now - timedelta(days=config.record.detections.retain.days).total_seconds()
+    )
+
+    active_reviews = (
+        ReviewSegment.select(
+            ReviewSegment.camera,
+            ReviewSegment.start_time,
+            ReviewSegment.end_time,
+        )
+        .where(
+            (
+                (ReviewSegment.severity == "alert")
+                & (ReviewSegment.end_time >= alert_expire)
+            )
+            | (
+                (ReviewSegment.severity == "detection")
+                & (ReviewSegment.end_time >= detection_expire)
+            )
+        )
+        .namedtuples()
+    )
+
+    event_size = 0.0
+    event_recording_ids = set()
+    for review in active_reviews:
+        end_time_clause = (
+            Recordings.start_time < review.end_time
+            if review.end_time is not None
+            else True
+        )
+        overlapping = (
+            Recordings.select(Recordings.id, Recordings.segment_size)
+            .where(
+                Recordings.camera == review.camera,
+                end_time_clause,
+                Recordings.end_time > review.start_time,
+                Recordings.segment_size > 0,
+            )
+            .namedtuples()
+        )
+        for rec in overlapping:
+            if (
+                rec.id not in protected_recording_ids
+                and rec.id not in event_recording_ids
+            ):
+                event_recording_ids.add(rec.id)
+                event_size += rec.segment_size
+
+    # 3. Total recordings size
+    total_size = (
+        Recordings.select(fn.SUM(Recordings.segment_size))
+        .where(Recordings.segment_size > 0)
+        .scalar()
+    ) or 0.0
+
+    # Overwritable = total - protected - event
+    overwritable_size = max(0.0, total_size - protected_size - event_size)
+
+    return JSONResponse(
+        content={
+            "total": round(total_size, 2),
+            "overwritable": round(overwritable_size, 2),
+            "event_retention": round(event_size, 2),
+            "protected": round(protected_size, 2),
+        }
+    )
 
 
 @router.get("/recordings/summary", dependencies=[Depends(allow_any_authenticated())])

--- a/frigate/api/record.py
+++ b/frigate/api/record.py
@@ -63,91 +63,90 @@ def get_recordings_storage_usage(request: Request):
     dependencies=[Depends(allow_any_authenticated())],
 )
 def get_recordings_storage_breakdown(request: Request):
-    """Return storage usage broken down by category: overwritable, event retention, and protected."""
+    """Return storage usage in MB broken down by category: overwritable, event retention, and protected."""
 
     now = datetime.now().timestamp()
 
     # 1. Protected (indefinite): recordings overlapping retain_indefinitely events
-    retained_events = (
-        Event.select(Event.camera, Event.start_time, Event.end_time)
-        .where(Event.retain_indefinitely == True, Event.has_clip == True)
+    # Uses a JOIN to avoid N+1 query problem
+    protected_query = (
+        Recordings.select(
+            Recordings.id,
+            Recordings.segment_size,
+        )
+        .join(
+            Event,
+            on=(
+                (Event.camera == Recordings.camera)
+                & (Event.start_time < Recordings.end_time)
+                & (
+                    (Event.end_time.is_null())
+                    | (Event.end_time > Recordings.start_time)
+                )
+            ),
+        )
+        .where(
+            Event.retain_indefinitely == True,
+            Event.has_clip == True,
+            Recordings.segment_size > 0,
+        )
+        .distinct()
         .namedtuples()
     )
 
     protected_size = 0.0
     protected_recording_ids = set()
-    for event in retained_events:
-        end_time_clause = (
-            Recordings.start_time < event.end_time
-            if event.end_time is not None
-            else True
-        )
-        overlapping = (
-            Recordings.select(Recordings.id, Recordings.segment_size)
-            .where(
-                Recordings.camera == event.camera,
-                end_time_clause,
-                Recordings.end_time > event.start_time,
-                Recordings.segment_size > 0,
-            )
-            .namedtuples()
-        )
-        for rec in overlapping:
-            if rec.id not in protected_recording_ids:
-                protected_recording_ids.add(rec.id)
-                protected_size += rec.segment_size
+    for rec in protected_query:
+        protected_recording_ids.add(rec.id)
+        protected_size += rec.segment_size
 
     # 2. Event retention (aging out): recordings overlapping non-expired review segments
+    # Use global config for expiry thresholds
     config = request.app.frigate_config
     alert_expire = now - timedelta(days=config.record.alerts.retain.days).total_seconds()
     detection_expire = (
         now - timedelta(days=config.record.detections.retain.days).total_seconds()
     )
 
-    active_reviews = (
-        ReviewSegment.select(
-            ReviewSegment.camera,
-            ReviewSegment.start_time,
-            ReviewSegment.end_time,
+    # Include in-progress reviews (end_time IS NULL) as they are not overwritable
+    event_query = (
+        Recordings.select(
+            Recordings.id,
+            Recordings.segment_size,
+        )
+        .join(
+            ReviewSegment,
+            on=(
+                (ReviewSegment.camera == Recordings.camera)
+                & (ReviewSegment.start_time < Recordings.end_time)
+                & (
+                    (ReviewSegment.end_time.is_null())
+                    | (ReviewSegment.end_time > Recordings.start_time)
+                )
+            ),
         )
         .where(
+            Recordings.segment_size > 0,
             (
-                (ReviewSegment.severity == "alert")
-                & (ReviewSegment.end_time >= alert_expire)
-            )
-            | (
-                (ReviewSegment.severity == "detection")
-                & (ReviewSegment.end_time >= detection_expire)
-            )
+                (ReviewSegment.end_time.is_null())
+                | (
+                    (ReviewSegment.severity == "alert")
+                    & (ReviewSegment.end_time >= alert_expire)
+                )
+                | (
+                    (ReviewSegment.severity == "detection")
+                    & (ReviewSegment.end_time >= detection_expire)
+                )
+            ),
         )
+        .distinct()
         .namedtuples()
     )
 
     event_size = 0.0
-    event_recording_ids = set()
-    for review in active_reviews:
-        end_time_clause = (
-            Recordings.start_time < review.end_time
-            if review.end_time is not None
-            else True
-        )
-        overlapping = (
-            Recordings.select(Recordings.id, Recordings.segment_size)
-            .where(
-                Recordings.camera == review.camera,
-                end_time_clause,
-                Recordings.end_time > review.start_time,
-                Recordings.segment_size > 0,
-            )
-            .namedtuples()
-        )
-        for rec in overlapping:
-            if (
-                rec.id not in protected_recording_ids
-                and rec.id not in event_recording_ids
-            ):
-                event_recording_ids.add(rec.id)
-                event_size += rec.segment_size
+    for rec in event_query:
+        if rec.id not in protected_recording_ids:
+            event_size += rec.segment_size
 
     # 3. Total recordings size
     total_size = (
@@ -159,12 +158,14 @@ def get_recordings_storage_breakdown(request: Request):
     # Overwritable = total - protected - event
     overwritable_size = max(0.0, total_size - protected_size - event_size)
 
+    # All values are in MB (matching segment_size column units)
     return JSONResponse(
         content={
             "total": round(total_size, 2),
             "overwritable": round(overwritable_size, 2),
             "event_retention": round(event_size, 2),
             "protected": round(protected_size, 2),
+            "units": "MB",
         }
     )
 

--- a/frigate/api/record.py
+++ b/frigate/api/record.py
@@ -103,7 +103,9 @@ def get_recordings_storage_breakdown(request: Request):
     # 2. Event retention (aging out): recordings overlapping non-expired review segments
     # Use global config for expiry thresholds
     config = request.app.frigate_config
-    alert_expire = now - timedelta(days=config.record.alerts.retain.days).total_seconds()
+    alert_expire = (
+        now - timedelta(days=config.record.alerts.retain.days).total_seconds()
+    )
     detection_expire = (
         now - timedelta(days=config.record.detections.retain.days).total_seconds()
     )

--- a/frigate/config/camera/record.py
+++ b/frigate/config/camera/record.py
@@ -17,6 +17,7 @@ __all__ = [
     "ReviewRetainConfig",
     "RecordRetainConfig",
     "RetainModeEnum",
+    "RetainPolicyEnum",
 ]
 
 
@@ -33,6 +34,11 @@ class RetainModeEnum(str, Enum):
     all = "all"
     motion = "motion"
     active_objects = "active_objects"
+
+
+class RetainPolicyEnum(str, Enum):
+    time = "time"
+    continuous_rollover = "continuous_rollover"
 
 
 class ReviewRetainConfig(FrigateBaseModel):
@@ -99,6 +105,11 @@ class RecordConfig(FrigateBaseModel):
         default=False,
         title="Enable recording",
         description="Enable or disable recording for all cameras; can be overridden per-camera.",
+    )
+    retain_policy: RetainPolicyEnum = Field(
+        default=RetainPolicyEnum.time,
+        title="Retention policy",
+        description="Storage retention policy. 'time' expires recordings after configured days. 'continuous_rollover' fills available disk space and overwrites oldest recordings when space is needed.",
     )
     expire_interval: int = Field(
         default=60,

--- a/frigate/config/camera/record.py
+++ b/frigate/config/camera/record.py
@@ -11,6 +11,10 @@ from ..base import FrigateBaseModel
 
 logger = logging.getLogger(__name__)
 
+# Module-level flag to prevent the rollover warning from firing N+1 times
+# (once per camera + once global) during config propagation.
+_rollover_warning_emitted = False
+
 __all__ = [
     "RecordConfig",
     "RecordExportConfig",
@@ -157,8 +161,13 @@ class RecordConfig(FrigateBaseModel):
 
     @model_validator(mode="after")
     def warn_rollover_with_days(self) -> "RecordConfig":
-        if self.retain_policy == RetainPolicyEnum.continuous_rollover:
+        global _rollover_warning_emitted
+        if (
+            not _rollover_warning_emitted
+            and self.retain_policy == RetainPolicyEnum.continuous_rollover
+        ):
             if self.continuous.days > 0 or self.motion.days > 0:
+                _rollover_warning_emitted = True
                 logger.warning(
                     "retain_policy is 'continuous_rollover' - continuous.days and "
                     "motion.days are ignored. Recordings will fill available disk "

--- a/frigate/config/camera/record.py
+++ b/frigate/config/camera/record.py
@@ -1,12 +1,15 @@
+import logging
 from enum import Enum
 from typing import Optional, Union
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from frigate.const import MAX_PRE_CAPTURE
 from frigate.review.types import SeverityEnum
 
 from ..base import FrigateBaseModel
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "RecordConfig",
@@ -151,6 +154,17 @@ class RecordConfig(FrigateBaseModel):
         title="Original recording state",
         description="Indicates whether recording was enabled in the original static configuration.",
     )
+
+    @model_validator(mode="after")
+    def warn_rollover_with_days(self) -> "RecordConfig":
+        if self.retain_policy == RetainPolicyEnum.continuous_rollover:
+            if self.continuous.days > 0 or self.motion.days > 0:
+                logger.warning(
+                    "retain_policy is 'continuous_rollover' - continuous.days and "
+                    "motion.days are ignored. Recordings will fill available disk "
+                    "space and oldest footage will be overwritten when needed."
+                )
+        return self
 
     @property
     def event_pre_capture(self) -> int:

--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -289,7 +289,11 @@ class RecordingCleanup(threading.Thread):
         # Handle deleted cameras
         logger.debug("Start deleted cameras.")
         if is_rollover:
-            # In rollover mode, delete recordings from removed cameras immediately
+            # In rollover mode, keep a 24-hour grace period for removed cameras
+            # so footage isn't lost if a camera is temporarily removed from config
+            rollover_expire_before = (
+                datetime.datetime.now() - datetime.timedelta(hours=24)
+            ).timestamp()
             no_camera_recordings: Recordings = (
                 Recordings.select(
                     Recordings.id,
@@ -297,6 +301,7 @@ class RecordingCleanup(threading.Thread):
                 )
                 .where(
                     Recordings.camera.not_in(list(self.config.cameras.keys())),
+                    Recordings.end_time < rollover_expire_before,
                 )
                 .namedtuples()
                 .iterator()
@@ -347,8 +352,13 @@ class RecordingCleanup(threading.Thread):
             # Always expire review segments (alerts/detections) regardless of policy
             maybe_empty_dirs |= self.expire_review_segments(config, now)
 
-            # Skip continuous/motion time-based expiry in rollover mode
-            if not is_rollover:
+            # Skip continuous/motion time-based expiry in rollover mode;
+            # StorageMaintainer handles space reclamation by deleting oldest recordings.
+            if is_rollover:
+                logger.debug(
+                    f"Skipping time-based expiry for {camera} (continuous_rollover mode)."
+                )
+            else:
                 continuous_expire_date = (
                     now - datetime.timedelta(days=config.record.continuous.days)
                 ).timestamp()

--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from playhouse.sqlite_ext import SqliteExtDatabase
 
-from frigate.config import CameraConfig, FrigateConfig, RetainModeEnum
+from frigate.config import CameraConfig, FrigateConfig, RetainModeEnum, RetainPolicyEnum
 from frigate.const import CACHE_DIR, CLIPS_DIR, MAX_WAL_SIZE, RECORD_DIR
 from frigate.models import Previews, Recordings, ReviewSegment, UserReviewStatus
 from frigate.util.builtin import clear_and_unlink
@@ -281,27 +281,45 @@ class RecordingCleanup(threading.Thread):
     def expire_recordings(self) -> set[Path]:
         """Delete recordings based on retention config."""
         logger.debug("Start expire recordings.")
-        logger.debug("Start deleted cameras.")
+
+        is_rollover = (
+            self.config.record.retain_policy == RetainPolicyEnum.continuous_rollover
+        )
 
         # Handle deleted cameras
-        expire_days = max(
-            self.config.record.continuous.days, self.config.record.motion.days
-        )
-        expire_before = (
-            datetime.datetime.now() - datetime.timedelta(days=expire_days)
-        ).timestamp()
-        no_camera_recordings: Recordings = (
-            Recordings.select(
-                Recordings.id,
-                Recordings.path,
+        logger.debug("Start deleted cameras.")
+        if is_rollover:
+            # In rollover mode, delete recordings from removed cameras immediately
+            no_camera_recordings: Recordings = (
+                Recordings.select(
+                    Recordings.id,
+                    Recordings.path,
+                )
+                .where(
+                    Recordings.camera.not_in(list(self.config.cameras.keys())),
+                )
+                .namedtuples()
+                .iterator()
             )
-            .where(
-                Recordings.camera.not_in(list(self.config.cameras.keys())),
-                Recordings.end_time < expire_before,
+        else:
+            expire_days = max(
+                self.config.record.continuous.days, self.config.record.motion.days
             )
-            .namedtuples()
-            .iterator()
-        )
+            expire_before = (
+                datetime.datetime.now() - datetime.timedelta(days=expire_days)
+            ).timestamp()
+            no_camera_recordings: Recordings = (
+                Recordings.select(
+                    Recordings.id,
+                    Recordings.path,
+                )
+                .where(
+                    Recordings.camera.not_in(list(self.config.cameras.keys())),
+                    Recordings.end_time < expire_before,
+                )
+                .namedtuples()
+                .iterator()
+            )
 
         maybe_empty_dirs = set()
 
@@ -313,7 +331,6 @@ class RecordingCleanup(threading.Thread):
             maybe_empty_dirs.add(recording_path.parent)
 
         logger.debug(f"Expiring {len(deleted_recordings)} recordings")
-        # delete up to 100,000 at a time
         max_deletes = 100000
         deleted_recordings_list = list(deleted_recordings)
         for i in range(0, len(deleted_recordings_list), max_deletes):
@@ -327,39 +344,41 @@ class RecordingCleanup(threading.Thread):
             logger.debug(f"Start camera: {camera}.")
             now = datetime.datetime.now()
 
+            # Always expire review segments (alerts/detections) regardless of policy
             maybe_empty_dirs |= self.expire_review_segments(config, now)
-            continuous_expire_date = (
-                now - datetime.timedelta(days=config.record.continuous.days)
-            ).timestamp()
-            motion_expire_date = (
-                now
-                - datetime.timedelta(
-                    days=max(
-                        config.record.motion.days, config.record.continuous.days
-                    )  # can't keep motion for less than continuous
-                )
-            ).timestamp()
 
-            # Get all the reviews to check against
-            reviews: ReviewSegment = (
-                ReviewSegment.select(
-                    ReviewSegment.start_time,
-                    ReviewSegment.end_time,
-                    ReviewSegment.severity,
-                )
-                .where(
-                    ReviewSegment.camera == camera,
-                    # need to ensure segments for all reviews starting
-                    # before the expire date are included
-                    ReviewSegment.start_time < motion_expire_date,
-                )
-                .order_by(ReviewSegment.start_time)
-                .namedtuples()
-            )
+            # Skip continuous/motion time-based expiry in rollover mode
+            if not is_rollover:
+                continuous_expire_date = (
+                    now - datetime.timedelta(days=config.record.continuous.days)
+                ).timestamp()
+                motion_expire_date = (
+                    now
+                    - datetime.timedelta(
+                        days=max(
+                            config.record.motion.days, config.record.continuous.days
+                        )
+                    )
+                ).timestamp()
 
-            maybe_empty_dirs |= self.expire_existing_camera_recordings(
-                continuous_expire_date, motion_expire_date, config, reviews
-            )
+                reviews: ReviewSegment = (
+                    ReviewSegment.select(
+                        ReviewSegment.start_time,
+                        ReviewSegment.end_time,
+                        ReviewSegment.severity,
+                    )
+                    .where(
+                        ReviewSegment.camera == camera,
+                        ReviewSegment.start_time < motion_expire_date,
+                    )
+                    .order_by(ReviewSegment.start_time)
+                    .namedtuples()
+                )
+
+                maybe_empty_dirs |= self.expire_existing_camera_recordings(
+                    continuous_expire_date, motion_expire_date, config, reviews
+                )
+
             logger.debug(f"End camera: {camera}.")
 
         logger.debug("End all cameras.")

--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -356,7 +356,8 @@ class RecordingCleanup(threading.Thread):
             # StorageMaintainer handles space reclamation by deleting oldest recordings.
             if is_rollover:
                 logger.debug(
-                    f"Skipping time-based expiry for {camera} (continuous_rollover mode)."
+                    "Skipping time-based expiry for %s (continuous_rollover mode).",
+                    camera,
                 )
             else:
                 continuous_expire_date = (

--- a/frigate/storage.py
+++ b/frigate/storage.py
@@ -1,15 +1,18 @@
 """Handle storage retention and usage."""
 
+import datetime
 import logging
 import shutil
 import threading
+from collections import defaultdict
+from datetime import timedelta
 from pathlib import Path
 
 from peewee import SQL, fn
 
-from frigate.config import FrigateConfig
+from frigate.config import FrigateConfig, RetainPolicyEnum
 from frigate.const import RECORD_DIR
-from frigate.models import Event, Recordings
+from frigate.models import Event, Recordings, ReviewSegment
 from frigate.util.builtin import clear_and_unlink
 
 logger = logging.getLogger(__name__)
@@ -108,8 +111,65 @@ class StorageMaintainer(threading.Thread):
         )
         return remaining_storage < hourly_bandwidth
 
+    def _finalize_deleted_recordings(self, deleted_recordings: list) -> None:
+        """Delete recording DB rows and update has_clip on affected events."""
+        logger.debug("Expiring %s recordings", len(deleted_recordings))
+        max_deletes = 100000
+
+        # Update has_clip for events that overlap with deleted recordings
+        if deleted_recordings:
+            # Group deleted recordings by camera
+            camera_recordings: dict[str, dict] = {}
+            for recording in deleted_recordings:
+                if recording.camera not in camera_recordings:
+                    camera_recordings[recording.camera] = {
+                        "min_start": recording.start_time,
+                        "max_end": recording.end_time,
+                    }
+                else:
+                    camera_recordings[recording.camera]["min_start"] = min(
+                        camera_recordings[recording.camera]["min_start"],
+                        recording.start_time,
+                    )
+                    camera_recordings[recording.camera]["max_end"] = max(
+                        camera_recordings[recording.camera]["max_end"],
+                        recording.end_time,
+                    )
+
+            # Find all events that overlap with deleted recordings time range per camera
+            events_to_update = []
+            for camera, time_range in camera_recordings.items():
+                overlapping_events = Event.select(Event.id).where(
+                    Event.camera == camera,
+                    Event.has_clip == True,
+                    Event.start_time < time_range["max_end"],
+                    Event.end_time > time_range["min_start"],
+                )
+
+                for event in overlapping_events:
+                    events_to_update.append(event.id)
+
+            # Update has_clip to False for overlapping events
+            if events_to_update:
+                for i in range(0, len(events_to_update), max_deletes):
+                    batch = events_to_update[i : i + max_deletes]
+                    Event.update(has_clip=False).where(Event.id << batch).execute()
+                logger.debug(
+                    "Updated has_clip to False for %s events",
+                    len(events_to_update),
+                )
+
+        deleted_recordings_list = [r.id for r in deleted_recordings]
+        for i in range(0, len(deleted_recordings_list), max_deletes):
+            Recordings.delete().where(
+                Recordings.id << deleted_recordings_list[i : i + max_deletes]
+            ).execute()
+
     def reduce_storage_consumption(self) -> None:
         """Remove oldest hour of recordings."""
+        if self.config.record.retain_policy == RetainPolicyEnum.continuous_rollover:
+            return self._reduce_storage_rollover()
+
         logger.debug("Starting storage cleanup.")
         deleted_segments_size = 0
         hourly_bandwidth = sum(
@@ -218,57 +278,209 @@ class StorageMaintainer(threading.Thread):
         else:
             logger.info(f"Cleaned up {deleted_segments_size} MB of recordings")
 
-        logger.debug(f"Expiring {len(deleted_recordings)} recordings")
-        # delete up to 100,000 at a time
-        max_deletes = 100000
+        self._finalize_deleted_recordings(deleted_recordings)
 
-        # Update has_clip for events that overlap with deleted recordings
-        if deleted_recordings:
-            # Group deleted recordings by camera
-            camera_recordings = {}
-            for recording in deleted_recordings:
-                if recording.camera not in camera_recordings:
-                    camera_recordings[recording.camera] = {
-                        "min_start": recording.start_time,
-                        "max_end": recording.end_time,
-                    }
-                else:
-                    camera_recordings[recording.camera]["min_start"] = min(
-                        camera_recordings[recording.camera]["min_start"],
-                        recording.start_time,
-                    )
-                    camera_recordings[recording.camera]["max_end"] = max(
-                        camera_recordings[recording.camera]["max_end"],
-                        recording.end_time,
-                    )
+    def _reduce_storage_rollover(self) -> None:
+        """Remove recordings using smart prioritized deletion for rollover mode.
 
-            # Find all events that overlap with deleted recordings time range per camera
-            events_to_update = []
-            for camera, time_range in camera_recordings.items():
-                overlapping_events = Event.select(Event.id).where(
-                    Event.camera == camera,
-                    Event.has_clip == True,
-                    Event.start_time < time_range["max_end"],
-                    Event.end_time > time_range["min_start"],
+        Deletion priority:
+        1. Overwritable: continuous recordings with no event/review overlap (oldest first)
+        2. Event retention: recordings overlapping active review segments (oldest first)
+        3. Protected: recordings overlapping retain_indefinitely events (emergency only)
+        """
+        logger.debug("Starting smart rollover storage cleanup.")
+        hourly_bandwidth = sum(
+            b["bandwidth"] for b in self.camera_storage_stats.values()
+        )
+        now = datetime.datetime.now().timestamp()
+
+        # Compute retention cutoffs for review segments
+        alert_cutoff = (
+            now - timedelta(days=self.config.record.alerts.retain.days).total_seconds()
+        )
+        detection_cutoff = (
+            now
+            - timedelta(days=self.config.record.detections.retain.days).total_seconds()
+        )
+
+        # Query 1: All recordings, oldest first
+        recordings: Recordings = (
+            Recordings.select(
+                Recordings.id,
+                Recordings.camera,
+                Recordings.start_time,
+                Recordings.end_time,
+                Recordings.segment_size,
+                Recordings.path,
+            )
+            .order_by(Recordings.start_time.asc())
+            .namedtuples()
+            .iterator()
+        )
+
+        # Query 2: Protected events (retain_indefinitely), sorted
+        # No camera filter — matches existing StorageMaintainer behavior
+        retained_events: list = list(
+            Event.select(
+                Event.start_time,
+                Event.end_time,
+            )
+            .where(
+                Event.retain_indefinitely == True,
+                Event.has_clip,
+            )
+            .order_by(Event.start_time.asc())
+            .namedtuples()
+        )
+
+        # Query 3: Non-expired review segments, sorted by start_time
+        # Camera-scoped: only protect recordings from the same camera
+        active_reviews_raw: list = list(
+            ReviewSegment.select(
+                ReviewSegment.camera,
+                ReviewSegment.start_time,
+                ReviewSegment.end_time,
+            )
+            .where(
+                (ReviewSegment.end_time.is_null())
+                | (
+                    (ReviewSegment.severity == "alert")
+                    & (ReviewSegment.end_time >= alert_cutoff)
                 )
-
-                for event in overlapping_events:
-                    events_to_update.append(event.id)
-
-            # Update has_clip to False for overlapping events
-            if events_to_update:
-                for i in range(0, len(events_to_update), max_deletes):
-                    batch = events_to_update[i : i + max_deletes]
-                    Event.update(has_clip=False).where(Event.id << batch).execute()
-                logger.debug(
-                    f"Updated has_clip to False for {len(events_to_update)} events"
+                | (
+                    (ReviewSegment.severity == "detection")
+                    & (ReviewSegment.end_time >= detection_cutoff)
                 )
+            )
+            .order_by(ReviewSegment.start_time.asc())
+            .namedtuples()
+        )
 
-        deleted_recordings_list = [r.id for r in deleted_recordings]
-        for i in range(0, len(deleted_recordings_list), max_deletes):
-            Recordings.delete().where(
-                Recordings.id << deleted_recordings_list[i : i + max_deletes]
-            ).execute()
+        # Group reviews by camera for camera-scoped overlap checking
+        reviews_by_camera: dict[str, list] = defaultdict(list)
+        for review in active_reviews_raw:
+            reviews_by_camera[review.camera].append(review)
+
+        # Classification pass: single iteration through recordings
+        overwritable: list = []
+        event_retention: list = []
+        protected: list = []
+
+        event_start = 0
+        review_start_by_camera: dict[str, int] = defaultdict(int)
+
+        for recording in recordings:
+            is_protected = False
+            is_event_retention = False
+
+            # Check if recording overlaps with any retain_indefinitely event
+            for idx in range(event_start, len(retained_events)):
+                event = retained_events[idx]
+
+                if event.start_time > recording.end_time:
+                    break
+
+                if event.end_time is None or event.end_time >= recording.start_time:
+                    is_protected = True
+                    break
+
+                if event.end_time < recording.start_time:
+                    event_start = idx
+
+            # If not protected, check if recording overlaps with active reviews
+            if not is_protected:
+                cam = recording.camera
+                cam_reviews = reviews_by_camera.get(cam, [])
+                cam_review_start = review_start_by_camera[cam]
+
+                for idx in range(cam_review_start, len(cam_reviews)):
+                    review = cam_reviews[idx]
+
+                    if review.start_time > recording.end_time:
+                        break
+
+                    if (
+                        review.end_time is None
+                        or review.end_time >= recording.start_time
+                    ):
+                        is_event_retention = True
+                        break
+
+                    if review.end_time < recording.start_time:
+                        review_start_by_camera[cam] = idx
+
+            # Classify
+            if is_protected:
+                protected.append(recording)
+            elif is_event_retention:
+                event_retention.append(recording)
+            else:
+                overwritable.append(recording)
+
+        logger.debug(
+            "Rollover classification: %s overwritable, %s event_retention, %s protected",
+            len(overwritable),
+            len(event_retention),
+            len(protected),
+        )
+
+        # Multi-phase deletion
+        deleted_segments_size = 0.0
+        deleted_recordings: list = []
+
+        # Phase 1: Delete overwritable recordings (oldest first)
+        for recording in overwritable:
+            if deleted_segments_size > hourly_bandwidth:
+                break
+            try:
+                clear_and_unlink(Path(recording.path), missing_ok=False)
+                deleted_recordings.append(recording)
+                deleted_segments_size += recording.segment_size
+            except FileNotFoundError:
+                pass
+
+        # Phase 2: Delete event-retention recordings if still needed
+        if deleted_segments_size < hourly_bandwidth:
+            logger.warning(
+                "Overwritable recordings insufficient (%.1f MB of %.1f MB needed). "
+                "Deleting event-retention recordings.",
+                deleted_segments_size,
+                hourly_bandwidth,
+            )
+            for recording in event_retention:
+                if deleted_segments_size > hourly_bandwidth:
+                    break
+                try:
+                    clear_and_unlink(Path(recording.path), missing_ok=False)
+                    deleted_recordings.append(recording)
+                    deleted_segments_size += recording.segment_size
+                except FileNotFoundError:
+                    pass
+
+        # Phase 3: Delete protected recordings as emergency last resort
+        if deleted_segments_size < hourly_bandwidth:
+            logger.error(
+                "Could not clear %.1f MB, currently %.1f MB cleared. "
+                "Protected retained recordings must be deleted.",
+                hourly_bandwidth,
+                deleted_segments_size,
+            )
+            for recording in protected:
+                if deleted_segments_size > hourly_bandwidth:
+                    break
+                try:
+                    clear_and_unlink(Path(recording.path), missing_ok=False)
+                    deleted_recordings.append(recording)
+                    deleted_segments_size += recording.segment_size
+                except FileNotFoundError:
+                    pass
+        else:
+            logger.info(
+                "Cleaned up %.1f MB of recordings (rollover mode)",
+                deleted_segments_size,
+            )
+
+        self._finalize_deleted_recordings(deleted_recordings)
 
     def run(self):
         """Check every 5 minutes if storage needs to be cleaned up."""

--- a/frigate/test/test_config_retain_policy.py
+++ b/frigate/test/test_config_retain_policy.py
@@ -1,0 +1,49 @@
+import unittest
+
+from frigate.config import FrigateConfig
+
+
+class TestRetainPolicyConfig(unittest.TestCase):
+    def setUp(self):
+        self.base_config = {
+            "mqtt": {"host": "mqtt"},
+            "cameras": {
+                "front_door": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}
+                        ]
+                    },
+                    "detect": {"height": 1080, "width": 1920, "fps": 5},
+                }
+            },
+        }
+
+    def test_default_retain_policy_is_time(self):
+        config = FrigateConfig(**self.base_config)
+        assert config.record.retain_policy.value == "time"
+
+    def test_continuous_rollover_policy(self):
+        self.base_config["record"] = {
+            "enabled": True,
+            "retain_policy": "continuous_rollover",
+        }
+        config = FrigateConfig(**self.base_config)
+        assert config.record.retain_policy.value == "continuous_rollover"
+
+    def test_continuous_rollover_ignores_continuous_days(self):
+        self.base_config["record"] = {
+            "enabled": True,
+            "retain_policy": "continuous_rollover",
+            "continuous": {"days": 30},
+        }
+        config = FrigateConfig(**self.base_config)
+        assert config.record.retain_policy.value == "continuous_rollover"
+        assert config.record.continuous.days == 30
+
+    def test_invalid_retain_policy_rejected(self):
+        self.base_config["record"] = {
+            "retain_policy": "invalid_value",
+        }
+        with self.assertRaises(Exception):
+            FrigateConfig(**self.base_config)

--- a/frigate/test/test_config_retain_policy.py
+++ b/frigate/test/test_config_retain_policy.py
@@ -1,49 +1,47 @@
 import unittest
 
-from frigate.config import FrigateConfig
+from pydantic import ValidationError
+
+from frigate.config.camera.record import RecordConfig, RetainPolicyEnum
 
 
 class TestRetainPolicyConfig(unittest.TestCase):
-    def setUp(self):
-        self.base_config = {
-            "mqtt": {"host": "mqtt"},
-            "cameras": {
-                "front_door": {
-                    "ffmpeg": {
-                        "inputs": [
-                            {"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}
-                        ]
-                    },
-                    "detect": {"height": 1080, "width": 1920, "fps": 5},
-                }
-            },
-        }
+    """Tests for the retain_policy field on RecordConfig."""
 
     def test_default_retain_policy_is_time(self):
-        config = FrigateConfig(**self.base_config)
-        assert config.record.retain_policy.value == "time"
+        config = RecordConfig()
+        assert config.retain_policy == RetainPolicyEnum.time
 
     def test_continuous_rollover_policy(self):
-        self.base_config["record"] = {
-            "enabled": True,
-            "retain_policy": "continuous_rollover",
-        }
-        config = FrigateConfig(**self.base_config)
-        assert config.record.retain_policy.value == "continuous_rollover"
+        config = RecordConfig(
+            enabled=True,
+            retain_policy="continuous_rollover",
+        )
+        assert config.retain_policy == RetainPolicyEnum.continuous_rollover
 
     def test_continuous_rollover_ignores_continuous_days(self):
-        self.base_config["record"] = {
-            "enabled": True,
-            "retain_policy": "continuous_rollover",
-            "continuous": {"days": 30},
-        }
-        config = FrigateConfig(**self.base_config)
-        assert config.record.retain_policy.value == "continuous_rollover"
-        assert config.record.continuous.days == 30
+        """continuous.days is preserved even in rollover mode (just unused by cleanup)."""
+        config = RecordConfig(
+            enabled=True,
+            retain_policy="continuous_rollover",
+            continuous={"days": 30},
+        )
+        assert config.retain_policy == RetainPolicyEnum.continuous_rollover
+        assert config.continuous.days == 30
 
     def test_invalid_retain_policy_rejected(self):
-        self.base_config["record"] = {
-            "retain_policy": "invalid_value",
-        }
-        with self.assertRaises(Exception):
-            FrigateConfig(**self.base_config)
+        with self.assertRaises(ValidationError):
+            RecordConfig(retain_policy="invalid_value")
+
+    def test_retain_policy_enum_values(self):
+        """Verify all expected enum values exist."""
+        assert RetainPolicyEnum.time.value == "time"
+        assert RetainPolicyEnum.continuous_rollover.value == "continuous_rollover"
+
+    def test_retain_policy_roundtrip(self):
+        """Config can be serialized and deserialized with retain_policy."""
+        config = RecordConfig(retain_policy="continuous_rollover")
+        dumped = config.model_dump()
+        assert dumped["retain_policy"] == "continuous_rollover"
+        restored = RecordConfig(**dumped)
+        assert restored.retain_policy == RetainPolicyEnum.continuous_rollover

--- a/frigate/test/test_storage.py
+++ b/frigate/test/test_storage.py
@@ -260,6 +260,31 @@ class TestHttp(unittest.TestCase):
         assert Recordings.get(Recordings.id == rec_k2_id)
         assert Recordings.get(Recordings.id == rec_k3_id)
 
+    def test_storage_cleanup_runs_in_rollover_mode(self):
+        """Ensure StorageMaintainer works correctly in rollover mode."""
+        self.minimal_config["record"] = {
+            "enabled": True,
+            "retain_policy": "continuous_rollover",
+        }
+        config = FrigateConfig(**self.minimal_config)
+        storage = StorageMaintainer(config, MagicMock())
+
+        # Insert old recordings that should be deleted when space is needed
+        time_old = datetime.datetime.now().timestamp() - 7200
+        for i in range(10):
+            rec_id = f"{100000 + i}.rollover"
+            _insert_mock_recording(
+                rec_id,
+                os.path.join(self.test_dir, f"{rec_id}.tmp"),
+                time_old + (i * 600),
+                time_old + ((i + 1) * 600),
+            )
+
+        storage.calculate_camera_bandwidth()
+        # StorageMaintainer should be able to run reduce_storage_consumption
+        # without errors in rollover mode
+        storage.reduce_storage_consumption()
+
 
 def _insert_mock_event(
     id: str,

--- a/frigate/test/test_storage.py
+++ b/frigate/test/test_storage.py
@@ -11,7 +11,7 @@ from playhouse.sqlite_ext import SqliteExtDatabase
 from playhouse.sqliteq import SqliteQueueDatabase
 
 from frigate.config import FrigateConfig
-from frigate.models import Event, Recordings
+from frigate.models import Event, Recordings, ReviewSegment
 from frigate.storage import StorageMaintainer
 from frigate.test.const import TEST_DB, TEST_DB_CLEANUPS
 
@@ -25,7 +25,7 @@ class TestHttp(unittest.TestCase):
         router.run()
         migrate_db.close()
         self.db = SqliteQueueDatabase(TEST_DB)
-        models = [Event, Recordings]
+        models = [Event, Recordings, ReviewSegment]
         self.db.bind(models)
         self.test_dir = tempfile.mkdtemp()
 
@@ -285,6 +285,198 @@ class TestHttp(unittest.TestCase):
         # without errors in rollover mode
         storage.reduce_storage_consumption()
 
+    def _get_rollover_config(self):
+        """Return a config dict with rollover mode and event retention settings."""
+        config = dict(self.minimal_config)
+        config["record"] = {
+            "enabled": True,
+            "retain_policy": "continuous_rollover",
+            "alerts": {"retain": {"days": 10}},
+            "detections": {"retain": {"days": 5}},
+        }
+        return config
+
+    def test_rollover_deletes_overwritable_before_event_retention(self):
+        """Overwritable recordings are deleted first; event-retention survive."""
+        config = FrigateConfig(**self._get_rollover_config())
+        storage = StorageMaintainer(config, MagicMock())
+
+        now = datetime.datetime.now().timestamp()
+        time_old = now - 7200
+
+        # Insert overwritable recordings (no review overlap) — old, should be deleted
+        for i in range(60):
+            rec_id = f"{200000 + i}.overwritable"
+            _insert_mock_recording(
+                rec_id,
+                os.path.join(self.test_dir, f"{rec_id}.tmp"),
+                time_old + (i * 10),
+                time_old + ((i + 1) * 10),
+            )
+
+        # Insert event-retention recordings (overlap with active review segment)
+        time_event = now - 3600
+        _insert_mock_review_segment(
+            "review_001",
+            time_event,
+            time_event + 30,
+            severity="alert",
+        )
+        rec_event_id = "300000.event_retention"
+        _insert_mock_recording(
+            rec_event_id,
+            os.path.join(self.test_dir, f"{rec_event_id}.tmp"),
+            time_event,
+            time_event + 10,
+        )
+
+        storage.calculate_camera_bandwidth()
+        storage.reduce_storage_consumption()
+
+        # Event-retention recording should survive
+        assert Recordings.get(Recordings.id == rec_event_id)
+
+    def test_rollover_falls_through_to_event_retention(self):
+        """When overwritable is insufficient, event-retention recordings are deleted."""
+        config = FrigateConfig(**self._get_rollover_config())
+        storage = StorageMaintainer(config, MagicMock())
+
+        now = datetime.datetime.now().timestamp()
+        time_old = now - 7200
+
+        # Insert only 1 small overwritable recording (not enough to meet bandwidth)
+        rec_ow_id = "400000.overwritable"
+        _insert_mock_recording(
+            rec_ow_id,
+            os.path.join(self.test_dir, f"{rec_ow_id}.tmp"),
+            time_old,
+            time_old + 10,
+            seg_size=1,
+        )
+
+        # Insert many event-retention recordings
+        time_event = now - 3600
+        _insert_mock_review_segment(
+            "review_002",
+            time_event,
+            time_event + 600,
+            severity="detection",
+        )
+        for i in range(60):
+            rec_id = f"{400100 + i}.event_ret"
+            _insert_mock_recording(
+                rec_id,
+                os.path.join(self.test_dir, f"{rec_id}.tmp"),
+                time_event + (i * 10),
+                time_event + ((i + 1) * 10),
+            )
+
+        storage.calculate_camera_bandwidth()
+        storage.reduce_storage_consumption()
+
+        # Overwritable should be deleted
+        with self.assertRaises(DoesNotExist):
+            Recordings.get(Recordings.id == rec_ow_id)
+
+        # Some event-retention recordings should also be deleted
+        remaining = Recordings.select().count()
+        assert remaining < 61  # started with 61 total
+
+    def test_rollover_protects_retained_events_last(self):
+        """Protected recordings are only deleted as emergency last resort."""
+        config = FrigateConfig(**self._get_rollover_config())
+        storage = StorageMaintainer(config, MagicMock())
+
+        now = datetime.datetime.now().timestamp()
+        time_old = now - 7200
+
+        # Insert protected recording (overlaps with retain_indefinitely event)
+        _insert_mock_event(
+            "evt_protected",
+            time_old,
+            time_old + 30,
+            retain=True,
+        )
+        rec_protected_id = "500000.protected"
+        _insert_mock_recording(
+            rec_protected_id,
+            os.path.join(self.test_dir, f"{rec_protected_id}.tmp"),
+            time_old,
+            time_old + 10,
+        )
+
+        # Insert enough overwritable recordings to satisfy bandwidth
+        for i in range(60):
+            rec_id = f"{500100 + i}.overwritable"
+            _insert_mock_recording(
+                rec_id,
+                os.path.join(self.test_dir, f"{rec_id}.tmp"),
+                time_old + 100 + (i * 10),
+                time_old + 100 + ((i + 1) * 10),
+            )
+
+        storage.calculate_camera_bandwidth()
+        storage.reduce_storage_consumption()
+
+        # Protected recording should survive when overwritable is sufficient
+        assert Recordings.get(Recordings.id == rec_protected_id)
+
+    def test_rollover_keeps_protected_when_overwritable_suffices(self):
+        """Both protected and event-retention survive when overwritable frees enough."""
+        config = FrigateConfig(**self._get_rollover_config())
+        storage = StorageMaintainer(config, MagicMock())
+
+        now = datetime.datetime.now().timestamp()
+        time_old = now - 7200
+
+        # Protected recording
+        _insert_mock_event(
+            "evt_keep",
+            time_old,
+            time_old + 30,
+            retain=True,
+        )
+        rec_prot_id = "600000.protected"
+        _insert_mock_recording(
+            rec_prot_id,
+            os.path.join(self.test_dir, f"{rec_prot_id}.tmp"),
+            time_old,
+            time_old + 10,
+        )
+
+        # Event-retention recording
+        time_event = now - 3600
+        _insert_mock_review_segment(
+            "review_003",
+            time_event,
+            time_event + 30,
+            severity="alert",
+        )
+        rec_evt_id = "600100.event_ret"
+        _insert_mock_recording(
+            rec_evt_id,
+            os.path.join(self.test_dir, f"{rec_evt_id}.tmp"),
+            time_event,
+            time_event + 10,
+        )
+
+        # Plenty of overwritable recordings
+        for i in range(60):
+            rec_id = f"{600200 + i}.overwritable"
+            _insert_mock_recording(
+                rec_id,
+                os.path.join(self.test_dir, f"{rec_id}.tmp"),
+                time_old + 100 + (i * 10),
+                time_old + 100 + ((i + 1) * 10),
+            )
+
+        storage.calculate_camera_bandwidth()
+        storage.reduce_storage_consumption()
+
+        # Both protected and event-retention should survive
+        assert Recordings.get(Recordings.id == rec_prot_id)
+        assert Recordings.get(Recordings.id == rec_evt_id)
+
 
 def _insert_mock_event(
     id: str,
@@ -338,4 +530,23 @@ def _insert_mock_recording(
         motion=True,
         objects=True,
         segment_size=seg_size,
+    ).execute()
+
+
+def _insert_mock_review_segment(
+    id: str,
+    start: float,
+    end: float,
+    severity: str = "alert",
+    camera: str = "front_door",
+) -> None:
+    """Inserts a basic review segment model with a given id."""
+    ReviewSegment.insert(
+        id=id,
+        camera=camera,
+        start_time=start,
+        end_time=end,
+        severity=severity,
+        thumb_path=f"/tmp/{id}.jpg",
+        data={},
     ).execute()

--- a/web/public/locales/en/views/system.json
+++ b/web/public/locales/en/views/system.json
@@ -110,6 +110,11 @@
       "title": "SHM (shared memory) allocation",
       "warning": "The current SHM size of {{total}}MB is too small. Increase it to at least {{min_shm}}MB."
     },
+    "breakdown": {
+      "overwritable": "Continuous (overwritable)",
+      "eventRetention": "Events (aging out)",
+      "protected": "Protected (indefinite)"
+    },
     "cameraStorage": {
       "title": "Camera Storage",
       "camera": "Camera",

--- a/web/src/components/config-form/section-configs/record.ts
+++ b/web/src/components/config-form/section-configs/record.ts
@@ -44,6 +44,7 @@ const record: SectionConfigOverrides = {
   },
   camera: {
     restartRequired: [],
+    hiddenFields: ["retain_policy"],
   },
 };
 

--- a/web/src/components/config-form/section-configs/record.ts
+++ b/web/src/components/config-form/section-configs/record.ts
@@ -6,6 +6,7 @@ const record: SectionConfigOverrides = {
     restartRequired: [],
     fieldOrder: [
       "enabled",
+      "retain_policy",
       "expire_interval",
       "continuous",
       "motion",
@@ -15,7 +16,7 @@ const record: SectionConfigOverrides = {
       "export",
     ],
     fieldGroups: {
-      retention: ["enabled", "continuous", "motion"],
+      retention: ["enabled", "retain_policy", "continuous", "motion"],
       events: ["alerts", "detections"],
     },
     hiddenFields: ["enabled_in_config", "sync_recordings"],
@@ -31,6 +32,7 @@ const record: SectionConfigOverrides = {
   global: {
     restartRequired: [
       "enabled",
+      "retain_policy",
       "expire_interval",
       "continuous",
       "motion",

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -191,7 +191,6 @@ export interface CameraConfig {
   record: {
     enabled: boolean;
     enabled_in_config: boolean;
-    retain_policy: "time" | "continuous_rollover";
     alerts: {
       post_capture: number;
       pre_capture: number;
@@ -625,4 +624,5 @@ export type StorageBreakdown = {
   overwritable: number;
   event_retention: number;
   protected: number;
+  units: string;
 };

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -191,6 +191,7 @@ export interface CameraConfig {
   record: {
     enabled: boolean;
     enabled_in_config: boolean;
+    retain_policy: "time" | "continuous_rollover";
     alerts: {
       post_capture: number;
       pre_capture: number;
@@ -617,3 +618,10 @@ export interface FrigateConfig {
 
   ui: UiConfig;
 }
+
+export type StorageBreakdown = {
+  total: number;
+  overwritable: number;
+  event_retention: number;
+  protected: number;
+};

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -543,6 +543,7 @@ export interface FrigateConfig {
   record: {
     enabled: boolean;
     enabled_in_config: boolean | null;
+    retain_policy: "time" | "continuous_rollover";
     events: {
       objects: string[] | null;
       post_capture: number;

--- a/web/src/views/system/StorageMetrics.tsx
+++ b/web/src/views/system/StorageMetrics.tsx
@@ -1,5 +1,6 @@
 import { CombinedStorageGraph } from "@/components/graph/CombinedStorageGraph";
 import { StorageGraph } from "@/components/graph/StorageGraph";
+import { getUnitSize } from "@/utils/storageUtil";
 import { FrigateStats } from "@/types/stats";
 import { useMemo } from "react";
 import {
@@ -35,12 +36,14 @@ export default function StorageMetrics({
 }: StorageMetricsProps) {
   const { data: cameraStorage } = useSWR<CameraStorage>("recordings/storage");
   const { data: stats } = useSWR<FrigateStats>("stats");
-  const { data: storageBreakdown } = useSWR<StorageBreakdown>(
-    "recordings/storage/breakdown",
-  );
   const { data: config } = useSWR<FrigateConfig>("config", {
     revalidateOnFocus: false,
   });
+  const isRollover =
+    config?.record?.retain_policy === "continuous_rollover";
+  const { data: storageBreakdown } = useSWR<StorageBreakdown>(
+    isRollover ? "recordings/storage/breakdown" : null,
+  );
   const { t } = useTranslation(["views/system"]);
   const timezone = useTimezone(config);
   const { getLocaleDocUrl } = useDocDomain();
@@ -131,7 +134,7 @@ export default function StorageMetrics({
             used={totalStorage.camera}
             total={totalStorage.total}
           />
-          {storageBreakdown && (
+          {storageBreakdown && storageBreakdown.total > 0 && (
             <div className="mt-3 space-y-1 text-xs">
               <div className="flex justify-between text-primary-variant">
                 <span>
@@ -140,9 +143,7 @@ export default function StorageMetrics({
                     "Continuous (overwritable)",
                   )}
                 </span>
-                <span>
-                  {(storageBreakdown.overwritable / 1024).toFixed(1)} GB
-                </span>
+                <span>{getUnitSize(storageBreakdown.overwritable)}</span>
               </div>
               <div className="flex justify-between text-primary-variant">
                 <span>
@@ -151,9 +152,7 @@ export default function StorageMetrics({
                     "Events (aging out)",
                   )}
                 </span>
-                <span>
-                  {(storageBreakdown.event_retention / 1024).toFixed(1)} GB
-                </span>
+                <span>{getUnitSize(storageBreakdown.event_retention)}</span>
               </div>
               <div className="flex justify-between text-primary-variant">
                 <span>
@@ -162,9 +161,7 @@ export default function StorageMetrics({
                     "Protected (indefinite)",
                   )}
                 </span>
-                <span>
-                  {(storageBreakdown.protected / 1024).toFixed(1)} GB
-                </span>
+                <span>{getUnitSize(storageBreakdown.protected)}</span>
               </div>
             </div>
           )}

--- a/web/src/views/system/StorageMetrics.tsx
+++ b/web/src/views/system/StorageMetrics.tsx
@@ -138,28 +138,19 @@ export default function StorageMetrics({
             <div className="mt-3 space-y-1 text-xs">
               <div className="flex justify-between text-primary-variant">
                 <span>
-                  {t(
-                    "storage.breakdown.overwritable",
-                    "Continuous (overwritable)",
-                  )}
+                  {t("storage.breakdown.overwritable")}
                 </span>
                 <span>{getUnitSize(storageBreakdown.overwritable)}</span>
               </div>
               <div className="flex justify-between text-primary-variant">
                 <span>
-                  {t(
-                    "storage.breakdown.eventRetention",
-                    "Events (aging out)",
-                  )}
+                  {t("storage.breakdown.eventRetention")}
                 </span>
                 <span>{getUnitSize(storageBreakdown.event_retention)}</span>
               </div>
               <div className="flex justify-between text-primary-variant">
                 <span>
-                  {t(
-                    "storage.breakdown.protected",
-                    "Protected (indefinite)",
-                  )}
+                  {t("storage.breakdown.protected")}
                 </span>
                 <span>{getUnitSize(storageBreakdown.protected)}</span>
               </div>

--- a/web/src/views/system/StorageMetrics.tsx
+++ b/web/src/views/system/StorageMetrics.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/ui/popover";
 import useSWR from "swr";
 import { CiCircleAlert } from "react-icons/ci";
-import { FrigateConfig } from "@/types/frigateConfig";
+import { FrigateConfig, StorageBreakdown } from "@/types/frigateConfig";
 import { useFormattedTimestamp, useTimezone } from "@/hooks/use-date-utils";
 import { RecordingsSummary } from "@/types/review";
 import { useTranslation } from "react-i18next";
@@ -35,6 +35,9 @@ export default function StorageMetrics({
 }: StorageMetricsProps) {
   const { data: cameraStorage } = useSWR<CameraStorage>("recordings/storage");
   const { data: stats } = useSWR<FrigateStats>("stats");
+  const { data: storageBreakdown } = useSWR<StorageBreakdown>(
+    "recordings/storage/breakdown",
+  );
   const { data: config } = useSWR<FrigateConfig>("config", {
     revalidateOnFocus: false,
   });
@@ -128,6 +131,43 @@ export default function StorageMetrics({
             used={totalStorage.camera}
             total={totalStorage.total}
           />
+          {storageBreakdown && (
+            <div className="mt-3 space-y-1 text-xs">
+              <div className="flex justify-between text-primary-variant">
+                <span>
+                  {t(
+                    "storage.breakdown.overwritable",
+                    "Continuous (overwritable)",
+                  )}
+                </span>
+                <span>
+                  {(storageBreakdown.overwritable / 1024).toFixed(1)} GB
+                </span>
+              </div>
+              <div className="flex justify-between text-primary-variant">
+                <span>
+                  {t(
+                    "storage.breakdown.eventRetention",
+                    "Events (aging out)",
+                  )}
+                </span>
+                <span>
+                  {(storageBreakdown.event_retention / 1024).toFixed(1)} GB
+                </span>
+              </div>
+              <div className="flex justify-between text-primary-variant">
+                <span>
+                  {t(
+                    "storage.breakdown.protected",
+                    "Protected (indefinite)",
+                  )}
+                </span>
+                <span>
+                  {(storageBreakdown.protected / 1024).toFixed(1)} GB
+                </span>
+              </div>
+            </div>
+          )}
           {earliestDate && (
             <div className="mt-2 text-xs text-primary-variant">
               <span className="font-medium">


### PR DESCRIPTION
## Proposed change

Adds a new `retain_policy: continuous_rollover` option that lets Frigate behave like a traditional NVR — recordings fill available disk space and the oldest footage is automatically overwritten when space runs low, instead of expiring after a fixed number of days.

This is useful for users who want to maximize recording history without manually tuning retention days to match their disk size. Frigate will keep as much footage as physically fits and only delete the oldest segments when the disk reaches its configured usage threshold.

### What's included

**Backend**
- New `RetainPolicyEnum` with values `time` (default, existing behavior) and `continuous_rollover`
- `retain_policy` field on `RecordConfig` (global-level setting)
- `RecordingCleanup` skips time-based expiry in rollover mode (review segment expiry still runs normally)
- `StorageMaintainer` already handles space-based deletion — no changes needed there
- New `/api/recordings/storage/breakdown` endpoint that categorizes storage into overwritable, event-retention, and protected segments
- 24-hour grace period for deleted camera recordings in rollover mode to prevent data loss during temporary config changes

**Frontend**
- `retain_policy` appears in global recording settings (hidden from per-camera settings since it's a global policy)
- Storage metrics page shows a breakdown of overwritable vs. event-retention vs. protected recordings when rollover mode is active

**Tests**
- Unit tests for `RetainPolicyEnum` and `RecordConfig` validation
- `StorageMaintainer` rollover-mode integration test

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR is related to issue: Users requesting NVR-style continuous recording without manual retention tuning

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)