### PR TITLE
Hide hidden camera alerts

### DIFF
--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -92,8 +92,15 @@ export default function LiveDashboardView({
   const eventUpdate = useFrigateReviews();
 
   const alertCameras = useMemo(() => {
-    if (!config || cameraGroup == "default") {
+    if (!config) {
       return null;
+    }
+
+    if (cameraGroup == "default") {
+      return Object.values(config.cameras)
+        .filter((cam) => cam.ui.dashboard)
+        .map((cam) => cam.name)
+        .join(",");
     }
 
     if (includeBirdseye && cameras.length == 0) {


### PR DESCRIPTION
## Proposed change

Cameras that have `ui.dashboard = false` config are hidden from the All Cameras "default" group, but their alerts still appear in the top row. This hides the alerts as well.

One can still view the hidden cameras and their alerts by making a custom camera group.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
