### PR TITLE
Show log when anonymous users log in

### DIFF
--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -32,6 +32,12 @@ from frigate.models import User
 
 logger = logging.getLogger(__name__)
 
+# In-memory cache to track which clients we've logged for an anonymous access event.
+# Keyed by a hashed value combining remote address + user-agent. The value is
+# an expiration timestamp (float).
+FIRST_LOAD_TTL_SECONDS = 60 * 60 * 24 * 7  # 7 days
+_first_load_seen: dict[str, float] = {}
+
 
 def require_admin_by_default():
     """
@@ -282,6 +288,15 @@ def get_remote_addr(request: Request):
         remote_addr = request.remote_addr
 
     return remote_addr or "127.0.0.1"
+
+
+def _cleanup_first_load_seen() -> None:
+    """Cleanup expired entries in the in-memory first-load cache."""
+    now = time.time()
+    # Build list for removal to avoid mutating dict during iteration
+    expired = [k for k, exp in _first_load_seen.items() if exp <= now]
+    for k in expired:
+        del _first_load_seen[k]
 
 
 def get_jwt_secret() -> str:
@@ -744,9 +759,29 @@ def profile(request: Request):
     roles_dict = request.app.frigate_config.auth.roles
     allowed_cameras = User.get_allowed_cameras(role, roles_dict, all_camera_names)
 
-    return JSONResponse(
+    response = JSONResponse(
         content={"username": username, "role": role, "allowed_cameras": allowed_cameras}
     )
+
+    if username == "anonymous":
+        try:
+            remote_addr = get_remote_addr(request)
+        except Exception:
+            remote_addr = (
+                request.client.host if hasattr(request, "client") else "unknown"
+            )
+
+        ua = request.headers.get("user-agent", "")
+        key_material = f"{remote_addr}|{ua}"
+        cache_key = hashlib.sha256(key_material.encode()).hexdigest()
+
+        _cleanup_first_load_seen()
+        now = time.time()
+        if cache_key not in _first_load_seen:
+            _first_load_seen[cache_key] = now + FIRST_LOAD_TTL_SECONDS
+            logger.info(f"Anonymous user access from {remote_addr} ua={ua[:200]}")
+
+    return response
 
 
 @router.get(


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
- Add a log message to the main Frigate log when an anonymous user accesses Frigate. This is a one-time log per user, based on a cache key built from `remote_addr` and user agent. The entry expires after 7 days. 


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: closes https://github.com/blakeblackshear/frigate/issues/20820
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
