### PR TITLE
Add avx check to startup

### DIFF
--- a/frigate/__main__.py
+++ b/frigate/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import faulthandler
 import multiprocessing as mp
+import platform
 import signal
 import sys
 import threading
@@ -15,7 +16,44 @@ from frigate.log import setup_logging
 from frigate.util.config import find_config_file
 
 
+def check_cpu_flags() -> None:
+    """Check that the CPU supports required instruction sets on x86_64."""
+    if platform.machine() not in ("x86_64", "AMD64"):
+        return
+
+    try:
+        with open("/proc/cpuinfo", "r") as f:
+            cpuinfo = f.read()
+    except OSError:
+        return
+
+    flags = set()
+    for line in cpuinfo.splitlines():
+        if line.startswith("flags"):
+            flags = set(line.split(":")[1].split())
+            break
+
+    if "avx" in flags and "avx2" not in flags:
+        print(
+            "Your CPU supports AVX but not AVX2. "
+            "Frigate requires AVX2 when running on x86_64 systems. "
+            "Detected CPU flags include 'avx' but not 'avx2'."
+        )
+        sys.exit(1)
+
+    if "avx" not in flags:
+        print(
+            "Your CPU does not support AVX instructions. "
+            "Frigate requires AVX when running on x86_64 systems. "
+            "Detected CPU flags do not include 'avx'."
+        )
+        sys.exit(1)
+
+
 def main() -> None:
+    # Check CPU compatibility before importing any compiled dependencies
+    check_cpu_flags()
+
     manager = mp.Manager()
     faulthandler.enable()
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR adds a check for AVX and AVX2 instructions for x86/amd64 CPUs and bails if unsupported.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
