### PR TITLE
LPR: apply filters after clustering

### DIFF
--- a/frigate/data_processing/common/license_plate/mixin.py
+++ b/frigate/data_processing/common/license_plate/mixin.py
@@ -401,35 +401,10 @@ class LicensePlateProcessingMixin:
             all_confidences.append(flat_confidences)
             all_areas.append(combined_area)
 
-        # Step 3: Filter and sort the combined plates
+        # Step 3: Sort the combined plates
         if all_license_plates:
-            filtered_data = []
-            for plate, conf_list, area in zip(
-                all_license_plates, all_confidences, all_areas
-            ):
-                if len(plate) < self.lpr_config.min_plate_length:
-                    logger.debug(
-                        f"{camera}: Filtered out '{plate}' due to length ({len(plate)} < {self.lpr_config.min_plate_length})"
-                    )
-                    continue
-
-                if self.lpr_config.format:
-                    try:
-                        if not re.fullmatch(self.lpr_config.format, plate):
-                            logger.debug(
-                                f"{camera}: Filtered out '{plate}' due to format mismatch"
-                            )
-                            continue
-                    except re.error:
-                        # Skip format filtering if regex is invalid
-                        logger.error(
-                            f"{camera}: Invalid regex in LPR format configuration: {self.lpr_config.format}"
-                        )
-
-                filtered_data.append((plate, conf_list, area))
-
             sorted_data = sorted(
-                filtered_data,
+                zip(all_license_plates, all_confidences, all_areas),
                 key=lambda x: (x[2], len(x[0]), sum(x[1]) / len(x[1]) if x[1] else 0),
                 reverse=True,
             )
@@ -1556,6 +1531,27 @@ class LicensePlateProcessingMixin:
             logger.debug(
                 f"{camera}: Clustering changed top plate '{top_plate}' (conf: {avg_confidence:.3f}) to rep '{rep_plate}' (conf: {rep_conf:.3f})"
             )
+
+        # Apply length and format filters to the clustered representative
+        # rather than individual OCR readings, so noisy variants still
+        # contribute to clustering even when they don't pass on their own.
+        if len(rep_plate) < self.lpr_config.min_plate_length:
+            logger.debug(
+                f"{camera}: Filtered out clustered plate '{rep_plate}' due to length ({len(rep_plate)} < {self.lpr_config.min_plate_length})"
+            )
+            return
+
+        if self.lpr_config.format:
+            try:
+                if not re.fullmatch(self.lpr_config.format, rep_plate):
+                    logger.debug(
+                        f"{camera}: Filtered out clustered plate '{rep_plate}' due to format mismatch"
+                    )
+                    return
+            except re.error:
+                logger.error(
+                    f"{camera}: Invalid regex in LPR format configuration: {self.lpr_config.format}"
+                )
 
         # Update stored rep
         self.detected_license_plates[id].update(


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Rather than discarding invalid format or length plates after detection, let them run through the clustering algorithm and then check the final clustered result for length and format. 

This improves a data starvation issue for users that use LPR with the secondary pipeline, who don't have nearly as much data coming through the pipeline as native `license_plate` detecting model users, and will help with final sub label assignment when the `format` regex is restrictive as was the case in https://github.com/blakeblackshear/frigate/discussions/22231


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
