### PR TITLE
"fix: correct ArcFace input format for RKNN runner"

### DIFF
--- a/frigate/detectors/detection_runners.py
+++ b/frigate/detectors/detection_runners.py
@@ -534,7 +534,9 @@ class RKNNModelRunner(BaseModelRunner):
                         if len(face_data.shape) == 4 and face_data.shape[1] == 3:
                             # Transpose from NCHW to NHWC
                             face_data = np.transpose(face_data, (0, 2, 3, 1))
-                        face_data = ((face_data + 1.0) * 127.5).clip(0, 255).astype(np.uint8)
+                        face_data = (
+                            ((face_data + 1.0) * 127.5).clip(0, 255).astype(np.uint8)
+                        )
                         rknn_inputs.append(face_data)
                     else:
                         rknn_inputs.append(inputs[name])

--- a/frigate/detectors/detection_runners.py
+++ b/frigate/detectors/detection_runners.py
@@ -527,6 +527,15 @@ class RKNNModelRunner(BaseModelRunner):
                             # Transpose from NCHW to NHWC
                             pixel_data = np.transpose(pixel_data, (0, 2, 3, 1))
                         rknn_inputs.append(pixel_data)
+                    elif name == "data":
+                        # ArcFace: undo Python normalisation to uint8 [0,255]
+                        # RKNN runtime applies mean=127.5/std=127.5 internally before first layer
+                        face_data = inputs[name]
+                        if len(face_data.shape) == 4 and face_data.shape[1] == 3:
+                            # Transpose from NCHW to NHWC
+                            face_data = np.transpose(face_data, (0, 2, 3, 1))
+                        face_data = ((face_data + 1.0) * 127.5).clip(0, 255).astype(np.uint8)
+                        rknn_inputs.append(face_data)
                     else:
                         rknn_inputs.append(inputs[name])
 


### PR DESCRIPTION
## Problem

ArcFace face recognition (`model_size: large`) produces wrong person labels
at 99-100% confidence on RK3588 with RKNN detector. All faces — including
non-face objects — are assigned the same label. The issue does not occur on
AMD/ROCm or CPU builds.

## Root cause

`RKNNModelRunner.run()` passes `float32 NCHW` tensors to `rknn.inference()`
for the ArcFace `"data"` input. The compiled `arcface.rknn` model has
`mean_values=[[127.5,127.5,127.5]]` and `std_values=[[127.5,127.5,127.5]]`
baked in at conversion time, meaning the RKNN runtime expects `uint8 NHWC
[0,255]` and applies `(x - 127.5) / 127.5` internally.

When pre-normalised `float32 [-1,+1]` arrives instead, the runtime applies
the normalisation a second time, collapsing the effective input range from
`[-1,+1]` to `[-1.008, -0.992]` — a 125x compression. Every embedding
produced is near-constant regardless of input.

The `pixel_values` (CLIP/Jina) branch in the same method already handles
the NCHW→NHWC transpose correctly. The `"data"` (ArcFace) branch was missing
the equivalent conversion.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #22058

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
```
ruff format --check frigate/detectors/detection_runners.py
1 file already formatted
```
