### PR TITLE
Fix thumbnail encoding logic

### DIFF
--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -1186,11 +1186,12 @@ async def event_thumbnail(
             status_code=404,
         )
 
+    img_as_np = np.frombuffer(thumbnail_bytes, dtype=np.uint8)
+    img = cv2.imdecode(img_as_np, flags=1)
+
     # android notifications prefer a 2:1 ratio
     if format == "android":
-        img_as_np = np.frombuffer(thumbnail_bytes, dtype=np.uint8)
-        img = cv2.imdecode(img_as_np, flags=1)
-        thumbnail = cv2.copyMakeBorder(
+        img = cv2.copyMakeBorder(
             img,
             0,
             0,
@@ -1200,14 +1201,14 @@ async def event_thumbnail(
             (0, 0, 0),
         )
 
-        quality_params = None
-        if extension in (Extension.jpg, Extension.jpeg):
-            quality_params = [int(cv2.IMWRITE_JPEG_QUALITY), 70]
-        elif extension == Extension.webp:
-            quality_params = [int(cv2.IMWRITE_WEBP_QUALITY), 60]
+    quality_params = None
+    if extension in (Extension.jpg, Extension.jpeg):
+        quality_params = [int(cv2.IMWRITE_JPEG_QUALITY), 70]
+    elif extension == Extension.webp:
+        quality_params = [int(cv2.IMWRITE_WEBP_QUALITY), 60]
 
-        _, img = cv2.imencode(f".{extension.value}", thumbnail, quality_params)
-        thumbnail_bytes = img.tobytes()
+    _, encoded = cv2.imencode(f".{extension.value}", img, quality_params)
+    thumbnail_bytes = encoded.tobytes()
 
     return Response(
         thumbnail_bytes,


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Fix issue where re-encoding only happened when format was set to `android`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/22328
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
