### PR TITLE
Add ability to delete cameras

### DIFF
--- a/frigate/api/camera.py
+++ b/frigate/api/camera.py
@@ -1,8 +1,10 @@
 """Camera apis."""
 
+import asyncio
 import json
 import logging
 import re
+import traceback
 from importlib.util import find_spec
 from pathlib import Path
 from urllib.parse import quote_plus
@@ -11,7 +13,9 @@ import httpx
 import requests
 from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.responses import JSONResponse
+from filelock import FileLock, Timeout
 from onvif import ONVIFCamera, ONVIFError
+from ruamel.yaml import YAML
 from zeep.exceptions import Fault, TransportError
 from zeep.transports import AsyncTransport
 
@@ -21,8 +25,14 @@ from frigate.api.auth import (
     require_role,
 )
 from frigate.api.defs.tags import Tags
-from frigate.config.config import FrigateConfig
+from frigate.config import FrigateConfig
+from frigate.config.camera.updater import (
+    CameraConfigUpdateEnum,
+    CameraConfigUpdateTopic,
+)
 from frigate.util.builtin import clean_camera_user_pass
+from frigate.util.camera_cleanup import cleanup_camera_db, cleanup_camera_files
+from frigate.util.config import find_config_file
 from frigate.util.image import run_ffmpeg_snapshot
 from frigate.util.services import ffprobe_stream
 
@@ -995,3 +1005,155 @@ async def onvif_probe(
                     await onvif_camera.close()
             except Exception as e:
                 logger.debug(f"Error closing ONVIF camera session: {e}")
+
+
+@router.delete(
+    "/cameras/{camera_name}",
+    dependencies=[Depends(require_role(["admin"]))],
+)
+async def delete_camera(
+    request: Request,
+    camera_name: str,
+    delete_exports: bool = Query(default=False),
+):
+    """Delete a camera and all its associated data.
+
+    Removes the camera from config, stops processes, and cleans up
+    all database entries and media files.
+
+    Args:
+        camera_name: Name of the camera to delete
+        delete_exports: Whether to also delete exports for this camera
+    """
+    frigate_config: FrigateConfig = request.app.frigate_config
+
+    if camera_name not in frigate_config.cameras:
+        return JSONResponse(
+            content={
+                "success": False,
+                "message": f"Camera {camera_name} not found",
+            },
+            status_code=404,
+        )
+
+    old_camera_config = frigate_config.cameras[camera_name]
+    config_file = find_config_file()
+    lock = FileLock(f"{config_file}.lock", timeout=5)
+
+    try:
+        with lock:
+            with open(config_file, "r") as f:
+                old_raw_config = f.read()
+
+            try:
+                yaml = YAML()
+                yaml.indent(mapping=2, sequence=4, offset=2)
+
+                with open(config_file, "r") as f:
+                    data = yaml.load(f)
+
+                # Remove camera from config
+                if "cameras" in data and camera_name in data["cameras"]:
+                    del data["cameras"][camera_name]
+
+                # Remove camera from auth roles
+                auth = data.get("auth", {})
+                if auth and "roles" in auth:
+                    empty_roles = []
+                    for role_name, cameras_list in auth["roles"].items():
+                        if (
+                            isinstance(cameras_list, list)
+                            and camera_name in cameras_list
+                        ):
+                            cameras_list.remove(camera_name)
+                            # Custom roles can't be empty; mark for removal
+                            if not cameras_list and role_name not in (
+                                "admin",
+                                "viewer",
+                            ):
+                                empty_roles.append(role_name)
+                    for role_name in empty_roles:
+                        del auth["roles"][role_name]
+
+                with open(config_file, "w") as f:
+                    yaml.dump(data, f)
+
+                with open(config_file, "r") as f:
+                    new_raw_config = f.read()
+
+                try:
+                    config = FrigateConfig.parse(new_raw_config)
+                except Exception:
+                    with open(config_file, "w") as f:
+                        f.write(old_raw_config)
+                    logger.error(
+                        "Config error after removing camera %s:\n%s",
+                        camera_name,
+                        traceback.format_exc(),
+                    )
+                    return JSONResponse(
+                        content={
+                            "success": False,
+                            "message": "Error parsing config after camera removal",
+                        },
+                        status_code=400,
+                    )
+            except Exception as e:
+                logger.error(
+                    "Error updating config to remove camera %s: %s", camera_name, e
+                )
+                return JSONResponse(
+                    content={
+                        "success": False,
+                        "message": "Error updating config",
+                    },
+                    status_code=500,
+                )
+
+            # Update runtime config
+            request.app.frigate_config = config
+            request.app.genai_manager.update_config(config)
+
+            # Publish removal to stop ffmpeg processes and clean up runtime state
+            request.app.config_publisher.publish_update(
+                CameraConfigUpdateTopic(CameraConfigUpdateEnum.remove, camera_name),
+                old_camera_config,
+            )
+
+    except Timeout:
+        return JSONResponse(
+            content={
+                "success": False,
+                "message": "Another process is currently updating the config",
+            },
+            status_code=409,
+        )
+
+    # Clean up database entries
+    counts, export_paths = await asyncio.to_thread(
+        cleanup_camera_db, camera_name, delete_exports
+    )
+
+    # Clean up media files in background thread
+    await asyncio.to_thread(
+        cleanup_camera_files, camera_name, export_paths if delete_exports else None
+    )
+
+    # Best-effort go2rtc stream removal
+    try:
+        requests.delete(
+            "http://127.0.0.1:1984/api/streams",
+            params={"src": camera_name},
+            timeout=5,
+        )
+    except Exception:
+        logger.debug("Failed to remove go2rtc stream for %s", camera_name)
+
+    return JSONResponse(
+        content={
+            "success": True,
+            "message": f"Camera {camera_name} has been deleted",
+            "cleanup": counts,
+        },
+        status_code=200,
+    )

--- a/frigate/api/camera.py
+++ b/frigate/api/camera.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import logging
 import re
-import traceback
 from importlib.util import find_spec
 from pathlib import Path
 from urllib.parse import quote_plus
@@ -1086,10 +1085,9 @@ async def delete_camera(
                 except Exception:
                     with open(config_file, "w") as f:
                         f.write(old_raw_config)
-                    logger.error(
-                        "Config error after removing camera %s:\n%s",
+                    logger.exception(
+                        "Config error after removing camera %s",
                         camera_name,
-                        traceback.format_exc(),
                     )
                     return JSONResponse(
                         content={

--- a/frigate/debug_replay.py
+++ b/frigate/debug_replay.py
@@ -21,7 +21,8 @@ from frigate.const import (
     REPLAY_DIR,
     THUMB_DIR,
 )
-from frigate.models import Event, Recordings, ReviewSegment, Timeline
+from frigate.models import Recordings
+from frigate.util.camera_cleanup import cleanup_camera_db, cleanup_camera_files
 from frigate.util.config import find_config_file
 
 logger = logging.getLogger(__name__)
@@ -357,43 +358,13 @@ class DebugReplayManager:
 
     def _cleanup_db(self, camera_name: str) -> None:
         """Defensively remove any database rows for the replay camera."""
-        try:
-            Event.delete().where(Event.camera == camera_name).execute()
-        except Exception as e:
-            logger.error("Failed to delete replay events: %s", e)
-
-        try:
-            Timeline.delete().where(Timeline.camera == camera_name).execute()
-        except Exception as e:
-            logger.error("Failed to delete replay timeline: %s", e)
-
-        try:
-            Recordings.delete().where(Recordings.camera == camera_name).execute()
-        except Exception as e:
-            logger.error("Failed to delete replay recordings: %s", e)
-
-        try:
-            ReviewSegment.delete().where(ReviewSegment.camera == camera_name).execute()
-        except Exception as e:
-            logger.error("Failed to delete replay review segments: %s", e)
+        cleanup_camera_db(camera_name)
 
     def _cleanup_files(self, camera_name: str) -> None:
         """Remove filesystem artifacts for the replay camera."""
-        dirs_to_clean = [
-            os.path.join(RECORD_DIR, camera_name),
-            os.path.join(CLIPS_DIR, camera_name),
-            os.path.join(THUMB_DIR, camera_name),
-        ]
+        cleanup_camera_files(camera_name)
 
-        for dir_path in dirs_to_clean:
-            if os.path.exists(dir_path):
-                try:
-                    shutil.rmtree(dir_path)
-                    logger.debug("Removed replay directory: %s", dir_path)
-                except Exception as e:
-                    logger.error("Failed to remove %s: %s", dir_path, e)
-
-        # Remove replay clip and any related files
+        # Remove replay-specific cache directory
         if os.path.exists(REPLAY_DIR):
             try:
                 shutil.rmtree(REPLAY_DIR)

--- a/frigate/util/camera_cleanup.py
+++ b/frigate/util/camera_cleanup.py
@@ -1,0 +1,153 @@
+"""Utilities for cleaning up camera data from database and filesystem."""
+
+import glob
+import logging
+import os
+import shutil
+
+from frigate.const import CLIPS_DIR, RECORD_DIR, THUMB_DIR
+from frigate.models import (
+    Event,
+    Export,
+    Previews,
+    Recordings,
+    Regions,
+    ReviewSegment,
+    Timeline,
+    Trigger,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def cleanup_camera_db(
+    camera_name: str, delete_exports: bool = False
+) -> tuple[dict[str, int], list[str]]:
+    """Remove all database rows for a camera.
+
+    Args:
+        camera_name: The camera name to clean up
+        delete_exports: Whether to also delete export records
+
+    Returns:
+        Tuple of (deletion counts dict, list of export file paths to remove)
+    """
+    counts: dict[str, int] = {}
+    export_paths: list[str] = []
+
+    try:
+        counts["events"] = Event.delete().where(Event.camera == camera_name).execute()
+    except Exception as e:
+        logger.error("Failed to delete events for camera %s: %s", camera_name, e)
+
+    try:
+        counts["timeline"] = (
+            Timeline.delete().where(Timeline.camera == camera_name).execute()
+        )
+    except Exception as e:
+        logger.error("Failed to delete timeline for camera %s: %s", camera_name, e)
+
+    try:
+        counts["recordings"] = (
+            Recordings.delete().where(Recordings.camera == camera_name).execute()
+        )
+    except Exception as e:
+        logger.error("Failed to delete recordings for camera %s: %s", camera_name, e)
+
+    try:
+        counts["review_segments"] = (
+            ReviewSegment.delete().where(ReviewSegment.camera == camera_name).execute()
+        )
+    except Exception as e:
+        logger.error(
+            "Failed to delete review segments for camera %s: %s", camera_name, e
+        )
+
+    try:
+        counts["previews"] = (
+            Previews.delete().where(Previews.camera == camera_name).execute()
+        )
+    except Exception as e:
+        logger.error("Failed to delete previews for camera %s: %s", camera_name, e)
+
+    try:
+        counts["regions"] = (
+            Regions.delete().where(Regions.camera == camera_name).execute()
+        )
+    except Exception as e:
+        logger.error("Failed to delete regions for camera %s: %s", camera_name, e)
+
+    try:
+        counts["triggers"] = (
+            Trigger.delete().where(Trigger.camera == camera_name).execute()
+        )
+    except Exception as e:
+        logger.error("Failed to delete triggers for camera %s: %s", camera_name, e)
+
+    if delete_exports:
+        try:
+            exports = Export.select(Export.video_path, Export.thumb_path).where(
+                Export.camera == camera_name
+            )
+            for export in exports:
+                export_paths.append(export.video_path)
+                export_paths.append(export.thumb_path)
+
+            counts["exports"] = (
+                Export.delete().where(Export.camera == camera_name).execute()
+            )
+        except Exception as e:
+            logger.error("Failed to delete exports for camera %s: %s", camera_name, e)
+
+    return counts, export_paths
+
+
+def cleanup_camera_files(
+    camera_name: str, export_paths: list[str] | None = None
+) -> None:
+    """Remove filesystem artifacts for a camera.
+
+    Args:
+        camera_name: The camera name to clean up
+        export_paths: Optional list of export file paths to remove
+    """
+    dirs_to_clean = [
+        os.path.join(RECORD_DIR, camera_name),
+        os.path.join(CLIPS_DIR, camera_name),
+        os.path.join(THUMB_DIR, camera_name),
+        os.path.join(CLIPS_DIR, "previews", camera_name),
+    ]
+
+    for dir_path in dirs_to_clean:
+        if os.path.exists(dir_path):
+            try:
+                shutil.rmtree(dir_path)
+                logger.debug("Removed directory: %s", dir_path)
+            except Exception as e:
+                logger.error("Failed to remove %s: %s", dir_path, e)
+
+    # Remove event snapshot files
+    for snapshot in glob.glob(os.path.join(CLIPS_DIR, f"{camera_name}-*.jpg")):
+        try:
+            os.remove(snapshot)
+        except Exception as e:
+            logger.error("Failed to remove snapshot %s: %s", snapshot, e)
+
+    # Remove review thumbnail files
+    for thumb in glob.glob(
+        os.path.join(CLIPS_DIR, "review", f"thumb-{camera_name}-*.webp")
+    ):
+        try:
+            os.remove(thumb)
+        except Exception as e:
+            logger.error("Failed to remove review thumbnail %s: %s", thumb, e)
+
+    # Remove export files if requested
+    if export_paths:
+        for path in export_paths:
+            if path and os.path.exists(path):
+                try:
+                    os.remove(path)
+                    logger.debug("Removed export file: %s", path)
+                except Exception as e:
+                    logger.error("Failed to remove export file %s: %s", path, e)

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -422,6 +422,18 @@
   "cameraManagement": {
     "title": "Manage Cameras",
     "addCamera": "Add New Camera",
+    "deleteCamera": "Delete Camera",
+    "deleteCameraDialog": {
+      "title": "Delete Camera",
+      "description": "Deleting a camera will permanently remove all recordings, tracked objects, and configuration for that camera. Any go2rtc streams associated with this camera may still need to be manually removed.",
+      "selectPlaceholder": "Choose camera...",
+      "confirmTitle": "Are you sure?",
+      "confirmWarning": "Deleting <strong>{{cameraName}}</strong> cannot be undone.",
+      "deleteExports": "Also delete exports for this camera",
+      "confirmButton": "Delete Permanently",
+      "success": "Camera {{cameraName}} deleted successfully",
+      "error": "Failed to delete camera {{cameraName}}"
+    },
     "editCamera": "Edit Camera:",
     "selectCamera": "Select a Camera",
     "backToSettings": "Back to Camera Settings",

--- a/web/src/components/overlay/dialog/DeleteCameraDialog.tsx
+++ b/web/src/components/overlay/dialog/DeleteCameraDialog.tsx
@@ -1,0 +1,215 @@
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Trans } from "react-i18next";
+import axios from "axios";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import ActivityIndicator from "@/components/indicators/activity-indicator";
+import { Switch } from "@/components/ui/switch";
+
+type DeleteCameraDialogProps = {
+  show: boolean;
+  cameras: string[];
+  onClose: () => void;
+  onDeleted: () => void;
+};
+
+export default function DeleteCameraDialog({
+  show,
+  cameras,
+  onClose,
+  onDeleted,
+}: DeleteCameraDialogProps) {
+  const { t } = useTranslation(["views/settings", "common"]);
+  const [phase, setPhase] = useState<"select" | "confirm">("select");
+  const [selectedCamera, setSelectedCamera] = useState<string>("");
+  const [deleteExports, setDeleteExports] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleClose = useCallback(() => {
+    if (isDeleting) return;
+    setPhase("select");
+    setSelectedCamera("");
+    setDeleteExports(false);
+    onClose();
+  }, [isDeleting, onClose]);
+
+  const handleDelete = useCallback(() => {
+    setPhase("confirm");
+  }, []);
+
+  const handleBack = useCallback(() => {
+    setPhase("select");
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!selectedCamera || isDeleting) return;
+
+    setIsDeleting(true);
+
+    try {
+      await axios.delete(
+        `cameras/${selectedCamera}?delete_exports=${deleteExports}`,
+      );
+      toast.success(
+        t("cameraManagement.deleteCameraDialog.success", {
+          cameraName: selectedCamera,
+        }),
+        { position: "top-center" },
+      );
+      setPhase("select");
+      setSelectedCamera("");
+      setDeleteExports(false);
+      onDeleted();
+    } catch (error) {
+      const errorMessage =
+        axios.isAxiosError(error) &&
+        (error.response?.data?.message || error.response?.data?.detail)
+          ? error.response?.data?.message || error.response?.data?.detail
+          : t("cameraManagement.deleteCameraDialog.error", {
+              cameraName: selectedCamera,
+            });
+
+      toast.error(errorMessage, { position: "top-center" });
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [selectedCamera, deleteExports, isDeleting, onDeleted, t]);
+
+  return (
+    <Dialog open={show} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[425px]">
+        {phase === "select" ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>
+                {t("cameraManagement.deleteCameraDialog.title")}
+              </DialogTitle>
+              <DialogDescription>
+                {t("cameraManagement.deleteCameraDialog.description")}
+              </DialogDescription>
+            </DialogHeader>
+            <Select value={selectedCamera} onValueChange={setSelectedCamera}>
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={t(
+                    "cameraManagement.deleteCameraDialog.selectPlaceholder",
+                  )}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {cameras.map((camera) => (
+                  <SelectItem key={camera} value={camera}>
+                    {camera}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <DialogFooter className="flex gap-3 sm:justify-end">
+              <div className="flex flex-1 flex-col justify-end">
+                <div className="flex flex-row gap-2 pt-5">
+                  <Button
+                    className="flex flex-1"
+                    aria-label={t("button.cancel", { ns: "common" })}
+                    onClick={handleClose}
+                    type="button"
+                  >
+                    {t("button.cancel", { ns: "common" })}
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    aria-label={t("button.delete", { ns: "common" })}
+                    className="flex flex-1 text-white"
+                    onClick={handleDelete}
+                    disabled={!selectedCamera}
+                  >
+                    {t("button.delete", { ns: "common" })}
+                  </Button>
+                </div>
+              </div>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>
+                {t("cameraManagement.deleteCameraDialog.confirmTitle")}
+              </DialogTitle>
+              <DialogDescription>
+                <Trans
+                  ns="views/settings"
+                  values={{ cameraName: selectedCamera }}
+                  components={{ strong: <span className="font-medium" /> }}
+                >
+                  cameraManagement.deleteCameraDialog.confirmWarning
+                </Trans>
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex items-center space-x-2">
+              <Switch
+                id="delete-exports"
+                checked={deleteExports}
+                onCheckedChange={(checked) =>
+                  setDeleteExports(checked === true)
+                }
+              />
+              <Label htmlFor="delete-exports" className="cursor-pointer">
+                {t("cameraManagement.deleteCameraDialog.deleteExports")}
+              </Label>
+            </div>
+            <DialogFooter className="flex gap-3 sm:justify-end">
+              <div className="flex flex-1 flex-col justify-end">
+                <div className="flex flex-row gap-2 pt-5">
+                  <Button
+                    className="flex flex-1"
+                    aria-label={t("button.back", { ns: "common" })}
+                    onClick={handleBack}
+                    type="button"
+                    disabled={isDeleting}
+                  >
+                    {t("button.back", { ns: "common" })}
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    className="flex flex-1 text-white"
+                    onClick={handleConfirmDelete}
+                    disabled={isDeleting}
+                  >
+                    {isDeleting ? (
+                      <div className="flex flex-row items-center gap-2">
+                        <ActivityIndicator />
+                        <span>
+                          {t(
+                            "cameraManagement.deleteCameraDialog.confirmButton",
+                          )}
+                        </span>
+                      </div>
+                    ) : (
+                      t("cameraManagement.deleteCameraDialog.confirmButton")
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/views/settings/CameraManagementView.tsx
+++ b/web/src/views/settings/CameraManagementView.tsx
@@ -13,7 +13,8 @@ import { FrigateConfig } from "@/types/frigateConfig";
 import { useTranslation } from "react-i18next";
 import CameraEditForm from "@/components/settings/CameraEditForm";
 import CameraWizardDialog from "@/components/settings/CameraWizardDialog";
-import { LuPlus } from "react-icons/lu";
+import DeleteCameraDialog from "@/components/overlay/dialog/DeleteCameraDialog";
+import { LuPlus, LuTrash2 } from "react-icons/lu";
 import { IoMdArrowRoundBack } from "react-icons/io";
 import { isDesktop } from "react-device-detect";
 import { CameraNameLabel } from "@/components/camera/FriendlyNameLabel";
@@ -45,6 +46,7 @@ export default function CameraManagementView({
     undefined,
   ); // Track camera being edited
   const [showWizard, setShowWizard] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   // State for restart dialog when enabling a disabled camera
   const [restartDialogOpen, setRestartDialogOpen] = useState(false);
@@ -98,14 +100,26 @@ export default function CameraManagementView({
               </Heading>
 
               <div className="w-full max-w-5xl space-y-6">
-                <Button
-                  variant="select"
-                  onClick={() => setShowWizard(true)}
-                  className="mb-2 flex max-w-48 items-center gap-2"
-                >
-                  <LuPlus className="h-4 w-4" />
-                  {t("cameraManagement.addCamera")}
-                </Button>
+                <div className="flex gap-2">
+                  <Button
+                    variant="select"
+                    onClick={() => setShowWizard(true)}
+                    className="mb-2 flex max-w-48 items-center gap-2"
+                  >
+                    <LuPlus className="h-4 w-4" />
+                    {t("cameraManagement.addCamera")}
+                  </Button>
+                  {enabledCameras.length + disabledCameras.length > 0 && (
+                    <Button
+                      variant="destructive"
+                      onClick={() => setShowDeleteDialog(true)}
+                      className="mb-2 flex max-w-48 items-center gap-2 text-white"
+                    >
+                      <LuTrash2 className="h-4 w-4" />
+                      {t("cameraManagement.deleteCamera")}
+                    </Button>
+                  )}
+                </div>
 
                 {enabledCameras.length > 0 && (
                   <SettingsGroupCard
@@ -220,6 +234,15 @@ export default function CameraManagementView({
       <CameraWizardDialog
         open={showWizard}
         onClose={() => setShowWizard(false)}
+      />
+      <DeleteCameraDialog
+        show={showDeleteDialog}
+        cameras={[...enabledCameras, ...disabledCameras]}
+        onClose={() => setShowDeleteDialog(false)}
+        onDeleted={() => {
+          setShowDeleteDialog(false);
+          updateConfig();
+        }}
       />
       <RestartDialog
         isOpen={restartDialogOpen}


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR adds the ability to easily delete cameras from Frigate.
- Add API endpoint `/api/cameras/{camera_name}` that removes a camera from the config, stops ffmpeg processes, and cleans up all db records and media files. Users will still need to manually remove any go2rtc config entries associated with a deleted camera.
- Refactor camera cleanup logic from debug replay into a reusable utility
- Frontend provides a double-confirmation dialog in the camera management pane in Settings with optional export deletion toggle


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
