### PR TITLE
Fix go2rtc config handling

### DIFF
--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc/run
@@ -55,7 +55,7 @@ function setup_homekit_config() {
 
     if [[ ! -f "${config_path}" ]]; then
         echo "[INFO] Creating empty config file for HomeKit..."
-        echo '{}' > "${config_path}"
+        : > "${config_path}"
     fi
 
     # Convert YAML to JSON for jq processing
@@ -65,23 +65,25 @@ function setup_homekit_config() {
         return 0
     }
 
-    # Use jq to filter and keep only the homekit section
-    local cleaned_json="/tmp/cache/homekit_cleaned.json"
-    jq '
-        # Keep only the homekit section if it exists, otherwise empty object
-        if has("homekit") then {homekit: .homekit} else {} end
-    ' "${temp_json}" > "${cleaned_json}" 2>/dev/null || {
-        echo '{}' > "${cleaned_json}"
-    }
+    # Use jq to extract the homekit section, if it exists
+    local homekit_json
+    homekit_json=$(jq '
+        if has("homekit") then {homekit: .homekit} else null end
+    ' "${temp_json}" 2>/dev/null) || homekit_json="null"
 
-    # Convert back to YAML and write to the config file
-    yq eval -P "${cleaned_json}" > "${config_path}" 2>/dev/null || {
-        echo "[WARNING] Failed to convert cleaned config to YAML, creating minimal config"
-        echo '{}' > "${config_path}"
-    }
+    # If no homekit section, write an empty config file
+    if [[ "${homekit_json}" == "null" ]]; then
+        : > "${config_path}"
+    else
+        # Convert homekit JSON back to YAML and write to the config file
+        echo "${homekit_json}" | yq eval -P - > "${config_path}" 2>/dev/null || {
+            echo "[WARNING] Failed to convert cleaned config to YAML, creating minimal config"
+            : > "${config_path}"
+        }
+    fi
 
     # Clean up temp files
-    rm -f "${temp_json}" "${cleaned_json}"
+    rm -f "${temp_json}"
 }
 
 set_libva_version


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
We originally wrote `{}` to the homekit go2rtc config, but go2rtc fails to parse this as valid. This resulted in API errors when adding/removing go2rtc streams with the Add Camera Wizard. 

This PR just writes a blank `go2rtc_config.yaml` in the case that no `homekit:` config exists.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/22344
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
