### PR TITLE
Save detect dimensions to config on add camera wizard save

### DIFF
--- a/web/src/components/settings/CameraWizardDialog.tsx
+++ b/web/src/components/settings/CameraWizardDialog.tsx
@@ -20,7 +20,10 @@ import type {
   CameraConfigData,
   ConfigSetBody,
 } from "@/types/cameraWizard";
-import { processCameraName } from "@/utils/cameraUtil";
+import {
+  processCameraName,
+  calculateDetectDimensions,
+} from "@/utils/cameraUtil";
 import { cn } from "@/lib/utils";
 
 type WizardState = {
@@ -202,6 +205,25 @@ export default function CameraWizardDialog({
           },
         },
       };
+
+      // Calculate detect dimensions from the detect stream's probed resolution
+      const detectStream = wizardData.streams.find((stream) =>
+        stream.roles.includes("detect"),
+      );
+      if (detectStream?.testResult?.resolution) {
+        const [streamWidth, streamHeight] = detectStream.testResult.resolution
+          .split("x")
+          .map(Number);
+        if (streamWidth > 0 && streamHeight > 0) {
+          const detectDimensions = calculateDetectDimensions(
+            streamWidth,
+            streamHeight,
+          );
+          if (detectDimensions) {
+            configData.cameras[finalCameraName].detect = detectDimensions;
+          }
+        }
+      }
 
       // Add live.streams configuration for go2rtc streams
       if (wizardData.streams && wizardData.streams.length > 0) {

--- a/web/src/types/cameraWizard.ts
+++ b/web/src/types/cameraWizard.ts
@@ -162,6 +162,10 @@ export type CameraConfigData = {
           input_args?: string;
         }[];
       };
+      detect?: {
+        width: number;
+        height: number;
+      };
       live?: {
         streams: Record<string, string>;
       };

--- a/web/src/utils/cameraUtil.ts
+++ b/web/src/utils/cameraUtil.ts
@@ -125,6 +125,10 @@ export type CameraAudioFeatures = {
  * @param streamHeight - Native stream height in pixels
  * @returns Detect dimensions with even values, or null if inputs are invalid
  */
+
+// Target size for the smaller dimension (width or height) for detect streams
+export const DETECT_TARGET_PX = 720;
+
 export function calculateDetectDimensions(
   streamWidth: number,
   streamHeight: number,
@@ -139,7 +143,7 @@ export function calculateDetectDimensions(
   }
 
   const smallerDim = Math.min(streamWidth, streamHeight);
-  const target = Math.min(720, smallerDim);
+  const target = Math.min(DETECT_TARGET_PX, smallerDim);
   const scale = target / smallerDim;
 
   let width = Math.round(streamWidth * scale);

--- a/web/src/utils/cameraUtil.ts
+++ b/web/src/utils/cameraUtil.ts
@@ -115,6 +115,47 @@ export type CameraAudioFeatures = {
  * @param requireSecureContext - If true, two-way audio requires secure context (default: true)
  * @returns CameraAudioFeatures object with detected capabilities
  */
+/**
+ * Calculates optimal detect dimensions from stream resolution.
+ *
+ * Scales dimensions to an efficient size for object detection while
+ * preserving the stream's aspect ratio. Does not upscale.
+ *
+ * @param streamWidth - Native stream width in pixels
+ * @param streamHeight - Native stream height in pixels
+ * @returns Detect dimensions with even values, or null if inputs are invalid
+ */
+export function calculateDetectDimensions(
+  streamWidth: number,
+  streamHeight: number,
+): { width: number; height: number } | null {
+  if (
+    !Number.isFinite(streamWidth) ||
+    !Number.isFinite(streamHeight) ||
+    streamWidth <= 0 ||
+    streamHeight <= 0
+  ) {
+    return null;
+  }
+
+  const smallerDim = Math.min(streamWidth, streamHeight);
+  const target = Math.min(720, smallerDim);
+  const scale = target / smallerDim;
+
+  let width = Math.round(streamWidth * scale);
+  let height = Math.round(streamHeight * scale);
+
+  // Round down to even numbers (required for video processing)
+  width = width - (width % 2);
+  height = height - (height % 2);
+
+  if (width < 2 || height < 2) {
+    return null;
+  }
+
+  return { width, height };
+}
+
 export function detectCameraAudioFeatures(
   metadata: LiveStreamMetadata | null | undefined,
   requireSecureContext: boolean = true,


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Automatically calculate and save `detect.width` and `detect.height` when adding a camera via the wizard, scaling the smaller dimension to 720px while preserving the stream's aspect ratio. Dimensions are derived from the detect stream's probed resolution at save time.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
