### PR TITLE
 Filter push notifications by user role camera access

### DIFF
--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -837,6 +837,7 @@ def create_user(
             User.notification_tokens: [],
         }
     ).execute()
+    request.app.config_publisher.publisher.publish("config/auth", None)
     return JSONResponse(content={"username": body.username})
 
 
@@ -854,6 +855,7 @@ def delete_user(request: Request, username: str):
         )
 
     User.delete_by_id(username)
+    request.app.config_publisher.publisher.publish("config/auth", None)
     return JSONResponse(content={"success": True})
 
 
@@ -973,6 +975,7 @@ async def update_role(
         )
 
     User.set_by_id(username, {User.role: body.role})
+    request.app.config_publisher.publisher.publish("config/auth", None)
     return JSONResponse(content={"success": True})
 
 

--- a/frigate/comms/webpush.py
+++ b/frigate/comms/webpush.py
@@ -17,6 +17,7 @@ from titlecase import titlecase
 from frigate.comms.base_communicator import Communicator
 from frigate.comms.config_updater import ConfigSubscriber
 from frigate.config import FrigateConfig
+from frigate.config.auth import AuthConfig
 from frigate.config.camera.updater import (
     CameraConfigUpdateEnum,
     CameraConfigUpdateSubscriber,
@@ -174,7 +175,7 @@ class WebPushClient(Communicator):
             if config_topic == "config/notifications" and config_payload:
                 self.config.notifications = config_payload
             elif config_topic == "config/auth":
-                if config_payload:
+                if isinstance(config_payload, AuthConfig):
                     self.config.auth = config_payload
                 self._refresh_user_cameras()
 
@@ -301,17 +302,16 @@ class WebPushClient(Communicator):
         """Rebuild the user-to-cameras access cache from the database."""
         all_camera_names = set(self.config.cameras.keys())
         roles_dict = self.config.auth.roles
-        users: list[dict[str, Any]] = (
-            User.select(User.username, User.role).dicts().iterator()
-        )
         updated: dict[str, set[str]] = {}
-        for user in users:
+        for user in User.select(User.username, User.role).dicts().iterator():
             allowed = User.get_allowed_cameras(
                 user["role"], roles_dict, all_camera_names
             )
             updated[user["username"]] = set(allowed)
             logger.debug(
-                f"User {user['username']} has access to cameras: {', '.join(allowed)}"
+                "User %s has access to cameras: %s",
+                user["username"],
+                ", ".join(allowed),
             )
         self.user_cameras = updated
 

--- a/frigate/comms/webpush.py
+++ b/frigate/comms/webpush.py
@@ -58,6 +58,7 @@ class WebPushClient(Communicator):
             for c in self.config.cameras.values()
         }
         self.last_notification_time: float = 0
+        self.user_cameras: dict[str, set[str]] = {}
         self.notification_queue: queue.Queue[PushNotification] = queue.Queue()
         self.notification_thread = threading.Thread(
             target=self._process_notifications, daemon=True
@@ -78,13 +79,12 @@ class WebPushClient(Communicator):
             for sub in user["notification_tokens"]:
                 self.web_pushers[user["username"]].append(WebPusher(sub))
 
-        # notification config updater
-        self.global_config_subscriber = ConfigSubscriber(
-            "config/notifications", exact=True
-        )
+        # notification and auth config updater
+        self.global_config_subscriber = ConfigSubscriber("config/")
         self.config_subscriber = CameraConfigUpdateSubscriber(
             self.config, self.config.cameras, [CameraConfigUpdateEnum.notifications]
         )
+        self._refresh_user_cameras()
 
     def subscribe(self, receiver: Callable) -> None:
         """Wrapper for allowing dispatcher to subscribe."""
@@ -164,13 +164,19 @@ class WebPushClient(Communicator):
 
     def publish(self, topic: str, payload: Any, retain: bool = False) -> None:
         """Wrapper for publishing when client is in valid state."""
-        # check for updated notification config
-        _, updated_notification_config = (
-            self.global_config_subscriber.check_for_update()
-        )
-
-        if updated_notification_config:
-            self.config.notifications = updated_notification_config
+        # check for updated global config (notifications, auth)
+        while True:
+            config_topic, config_payload = (
+                self.global_config_subscriber.check_for_update()
+            )
+            if config_topic is None:
+                break
+            if config_topic == "config/notifications" and config_payload:
+                self.config.notifications = config_payload
+            elif config_topic == "config/auth":
+                if config_payload:
+                    self.config.auth = config_payload
+                self._refresh_user_cameras()
 
         updates = self.config_subscriber.check_for_updates()
 
@@ -290,6 +296,32 @@ class WebPushClient(Communicator):
                 continue
             except Exception as e:
                 logger.error(f"Error processing notification: {str(e)}")
+
+    def _refresh_user_cameras(self) -> None:
+        """Rebuild the user-to-cameras access cache from the database."""
+        all_camera_names = set(self.config.cameras.keys())
+        roles_dict = self.config.auth.roles
+        users: list[dict[str, Any]] = (
+            User.select(User.username, User.role).dicts().iterator()
+        )
+        updated: dict[str, set[str]] = {}
+        for user in users:
+            allowed = User.get_allowed_cameras(
+                user["role"], roles_dict, all_camera_names
+            )
+            updated[user["username"]] = set(allowed)
+            logger.debug(
+                f"User {user['username']} has access to cameras: {', '.join(allowed)}"
+            )
+        self.user_cameras = updated
+
+    def _user_has_camera_access(self, username: str, camera: str) -> bool:
+        """Check if a user has access to a specific camera based on cached roles."""
+        allowed = self.user_cameras.get(username)
+        if allowed is None:
+            logger.debug(f"No camera access information found for user {username}")
+            return False
+        return camera in allowed
 
     def _within_cooldown(self, camera: str) -> bool:
         now = datetime.datetime.now().timestamp()
@@ -418,6 +450,14 @@ class WebPushClient(Communicator):
         logger.debug(f"Sending push notification for {camera}, review ID {reviewId}")
 
         for user in self.web_pushers:
+            if not self._user_has_camera_access(user, camera):
+                logger.debug(
+                    "Skipping notification for user %s - no access to camera %s",
+                    user,
+                    camera,
+                )
+                continue
+
             self.send_push_notification(
                 user=user,
                 payload=payload,
@@ -465,6 +505,14 @@ class WebPushClient(Communicator):
         )
 
         for user in self.web_pushers:
+            if not self._user_has_camera_access(user, camera):
+                logger.debug(
+                    "Skipping notification for user %s - no access to camera %s",
+                    user,
+                    camera,
+                )
+                continue
+
             self.send_push_notification(
                 user=user,
                 payload=payload,


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
- Fix webpush notifications to respect user role camera restrictions instead of sending alerts for all cameras to all users
- User-to-camera access is cached in memory and refreshed via ZMQ `config/auth` subscriber when roles or auth config change, reuses existing subscriber with prefix matching to avoid adding a second ZMQ socket

Note: Proxy-authenticated users (via proxy headers) are not stored in the database and therefore cannot be filtered by role for notifications

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/22382
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
