### PR TITLE
fix(stats): recognise -hwaccel cuda and nvdec as NVIDIA GPU args

### DIFF
--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -234,7 +234,7 @@ async def set_gpu_stats(
         if args in hwaccel_errors:
             # known erroring args should automatically return as error
             stats["error-gpu"] = {"gpu": "", "mem": ""}
-        elif "cuvid" in args or "nvidia" in args:
+        elif "cuvid" in args or "nvidia" in args or "cuda" in args or "nvdec" in args:
             # nvidia GPU
             nvidia_usage = get_nvidia_gpu_stats()
 


### PR DESCRIPTION
## Proposed change

Upstream only checks for `cuvid` or `nvidia` in hwaccel args when deciding whether to collect NVIDIA GPU stats. On NVIDIA driver 580+, `-hwaccel cuvid` breaks RTSP decoding and must be replaced with `-hwaccel cuda`. When using `cuda` (or `nvdec`), the condition is never true and the GPU usage panel in the Frigate UI stays empty even though the GPU is actively being used for decoding.

This extends the check to also match `cuda` and `nvdec`, so GPU stats are reported regardless of which NVDEC entry-point is configured.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR is related to issue: NVIDIA driver 580 / NVENC SDK 13 compatibility (`-hwaccel cuvid` regression)

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.