### PR TITLE
fix(record): replace asyncio.SubprocessError with sp.SubprocessError

### DIFF
--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -779,7 +779,7 @@ async def get_video_properties(
             duration = float(duration_str) if duration_str else -1.0
 
             return True, width, height, codec, duration
-        except (json.JSONDecodeError, ValueError, KeyError, asyncio.SubprocessError):
+        except (json.JSONDecodeError, ValueError, KeyError, sp.SubprocessError):
             return False, 0, 0, None, -1
 
     def probe_with_cv2(url: str) -> tuple[bool, int, int, Optional[str], float]:


### PR DESCRIPTION
## Proposed change

`asyncio.SubprocessError` does not exist — Python's `asyncio` module has no such class. The correct exception is `subprocess.SubprocessError`, available via the existing `import subprocess as sp` alias already present in this file.

The invalid exception reference causes the `except` clause to raise a `NameError` rather than catching the intended exception.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.