### PR TITLE
expose thresholds in ms for detectors to alter what is flaged as slow or an error

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -1052,6 +1052,12 @@ ui:
   # Optional: Set the unit system to either "imperial" or "metric" (default: metric)
   # Used in the UI and in MQTT topics
   unit_system: metric
+  # Optional: Thresholds in ms for detector inference speed warnings in the UI
+  inference_threshold:
+    # Optional: Inference speed in ms above which a warning is shown (default: shown below)
+    warning: 50
+    # Optional: Inference speed in ms above which an error is shown (default: shown below)
+    error: 100
 
 # Optional: Telemetry configuration
 telemetry:

--- a/frigate/config/ui.py
+++ b/frigate/config/ui.py
@@ -5,7 +5,13 @@ from pydantic import Field
 
 from .base import FrigateBaseModel
 
-__all__ = ["TimeFormatEnum", "DateTimeStyleEnum", "UnitSystemEnum", "UIConfig"]
+__all__ = [
+    "TimeFormatEnum",
+    "DateTimeStyleEnum",
+    "UnitSystemEnum",
+    "InferenceThresholdConfig",
+    "UIConfig",
+]
 
 
 class TimeFormatEnum(str, Enum):
@@ -24,6 +30,19 @@ class DateTimeStyleEnum(str, Enum):
 class UnitSystemEnum(str, Enum):
     imperial = "imperial"
     metric = "metric"
+
+
+class InferenceThresholdConfig(FrigateBaseModel):
+    warning: int = Field(
+        default=50,
+        title="Warning threshold (ms)",
+        description="Inference speed in ms above which a warning is shown in the UI.",
+    )
+    error: int = Field(
+        default=100,
+        title="Error threshold (ms)",
+        description="Inference speed in ms above which an error is shown in the UI.",
+    )
 
 
 class UIConfig(FrigateBaseModel):
@@ -51,4 +70,9 @@ class UIConfig(FrigateBaseModel):
         default=UnitSystemEnum.metric,
         title="Unit system",
         description="Unit system for display (metric or imperial) used in the UI and MQTT.",
+    )
+    inference_threshold: InferenceThresholdConfig = Field(
+        default_factory=InferenceThresholdConfig,
+        title="Inference threshold",
+        description="Thresholds for detector inference speed warnings in the UI.",
     )

--- a/web/src/hooks/use-stats.ts
+++ b/web/src/hooks/use-stats.ts
@@ -50,8 +50,14 @@ export default function useStats(stats: FrigateStats | undefined) {
     }
 
     // check detectors for high inference speeds
+    const inferenceThreshold = {
+      warning:
+        config?.ui?.inference_threshold?.warning ?? InferenceThreshold.warning,
+      error:
+        config?.ui?.inference_threshold?.error ?? InferenceThreshold.error,
+    };
     Object.entries(memoizedStats["detectors"]).forEach(([key, det]) => {
-      if (det["inference_speed"] > InferenceThreshold.error) {
+      if (det["inference_speed"] > inferenceThreshold.error) {
         problems.push({
           text: t("stats.detectIsVerySlow", {
             detect: capitalizeFirstLetter(key),
@@ -60,7 +66,7 @@ export default function useStats(stats: FrigateStats | undefined) {
           color: "text-danger",
           relevantLink: "/system#general",
         });
-      } else if (det["inference_speed"] > InferenceThreshold.warning) {
+      } else if (det["inference_speed"] > inferenceThreshold.warning) {
         problems.push({
           text: t("stats.detectIsSlow", {
             detect: capitalizeFirstLetter(key),

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -9,6 +9,10 @@ export interface UiConfig {
   dashboard: boolean;
   order: number;
   unit_system?: "metric" | "imperial";
+  inference_threshold?: {
+    warning: number;
+    error: number;
+  };
 }
 
 export interface BirdseyeConfig {

--- a/web/src/views/system/GeneralMetrics.tsx
+++ b/web/src/views/system/GeneralMetrics.tsx
@@ -1,4 +1,5 @@
 import useSWR from "swr";
+import { FrigateConfig } from "@/types/frigateConfig";
 import { FrigateStats, GpuInfo } from "@/types/stats";
 import { useEffect, useMemo, useState } from "react";
 import { useFrigateStats } from "@/api/ws";
@@ -34,6 +35,12 @@ export default function GeneralMetrics({
   // extra info
   const { t } = useTranslation(["views/system"]);
   const [showVainfo, setShowVainfo] = useState(false);
+  const { data: config } = useSWR<FrigateConfig>("config");
+  const inferenceThreshold = {
+    warning:
+      config?.ui?.inference_threshold?.warning ?? InferenceThreshold.warning,
+    error: config?.ui?.inference_threshold?.error ?? InferenceThreshold.error,
+  };
 
   // stats
 
@@ -626,7 +633,7 @@ export default function GeneralMetrics({
                   graphId={`${series.name}-inference`}
                   name={series.name}
                   unit="ms"
-                  threshold={InferenceThreshold}
+                  threshold={inferenceThreshold}
                   updateTimes={updateTimes}
                   data={[series]}
                 />


### PR DESCRIPTION
## Proposed change
For many object detection models the hard-coded 50ms "unhealthy" level is not appropriate. In my case I have raised it to 60/110 but others may want to lower the values is they use fast inference. 

This patch adds additional fields to the ui config to expose the inference thresholds in the config. These are optional and default to the current values of 50/100. This is often needed when running heavier models like yolov9m.

```
ui:
  unit_system: imperial
  inference_threshold:
    warning: 60
    error: 110
```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update

## Additional information



## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. `Ran 215 tests in 75.607s`
- [X] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale. -- N/A no UI text changes
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
