### PR TITLE
Update dev contrib docs with Python checks

### DIFF
--- a/docs/docs/development/contributing.md
+++ b/docs/docs/development/contributing.md
@@ -89,6 +89,14 @@ After closing VS Code, you may still have containers running. To close everythin
 
 ### Testing
 
+#### Unit Tests
+
+GitHub will execute unit tests on new PRs. You must ensure that all tests pass.
+
+```shell
+python3 -u -m unittest
+```
+
 #### FFMPEG Hardware Acceleration
 
 The following commands are used inside the container to ensure hardware acceleration is working properly.
@@ -123,6 +131,28 @@ ffmpeg -hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -hwaccel_output_format
 
 ```shell
 ffmpeg -c:v h264_qsv -re -stream_loop -1 -i https://streams.videolan.org/ffmpeg/incoming/720p60.mp4 -f rawvideo -pix_fmt yuv420p pipe: > /dev/null
+```
+
+### Submitting a pull request
+
+Code must be formatted, linted and type-tested. GitHub will run these checks on pull requests, so it is advised to run them yourself prior to opening.
+
+**Formatting**
+
+```shell
+ruff format frigate migrations docker *.py
+```
+
+**Linting**
+
+```shell
+ruff check frigate migrations docker *.py
+```
+
+**MyPy Static Typing**
+
+```shell
+python3 -u -m mypy --config-file frigate/mypy.ini frigate
 ```
 
 ## Web Interface


### PR DESCRIPTION
## Proposed change

GitHub CI runs a series of checks on new PRs (formatting, linting, type-checks) as well as unit tests, but these aren't mentioned in the developer documentation. Added the commands contributors should run to the docs.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
