### PR TITLE
fix: run Frigate+ API calls in thread pool to prevent event loop bloc…

### DIFF
--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -11,6 +11,7 @@ from functools import reduce
 from pathlib import Path
 from typing import List
 from urllib.parse import unquote
+import asyncio
 
 import cv2
 import numpy as np
@@ -1124,7 +1125,7 @@ async def send_to_plus(request: Request, event_id: str, body: SubmitPlusBody = N
         )
 
     try:
-        plus_id = request.app.frigate_config.plus_api.upload_image(image, event.camera)
+        plus_id = await asyncio.to_thread(request.app.frigate_config.plus_api.upload_image, image, event.camera)
     except Exception as ex:
         logger.exception(ex)
         return JSONResponse(
@@ -1140,7 +1141,8 @@ async def send_to_plus(request: Request, event_id: str, body: SubmitPlusBody = N
         box = event.data["box"]
 
         try:
-            request.app.frigate_config.plus_api.add_annotation(
+            await asyncio.to_thread(
+                request.app.frigate_config.plus_api.add_annotation,
                 event.plus_id,
                 box,
                 event.label,

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -1,5 +1,6 @@
 """Event apis."""
 
+import asyncio
 import base64
 import datetime
 import json
@@ -11,7 +12,6 @@ from functools import reduce
 from pathlib import Path
 from typing import List
 from urllib.parse import unquote
-import asyncio
 
 import cv2
 import numpy as np
@@ -1125,7 +1125,9 @@ async def send_to_plus(request: Request, event_id: str, body: SubmitPlusBody = N
         )
 
     try:
-        plus_id = await asyncio.to_thread(request.app.frigate_config.plus_api.upload_image, image, event.camera)
+        plus_id = await asyncio.to_thread(
+            request.app.frigate_config.plus_api.upload_image, image, event.camera
+        )
     except Exception as ex:
         logger.exception(ex)
         return JSONResponse(
@@ -1232,7 +1234,8 @@ async def false_positive(request: Request, event_id: str):
     )
 
     try:
-        request.app.frigate_config.plus_api.add_false_positive(
+        await asyncio.to_thread(
+            request.app.frigate_config.plus_api.add_false_positive,
             event.plus_id,
             region,
             box,


### PR DESCRIPTION
Problem
The send_to_plus and set_false_positive handlers in event.py are declared as async def but call synchronous methods from PlusApi (which uses the requests library) directly in the handler body. This blocks the FastAPI/uvicorn asyncio event loop for the duration of the Frigate+ cloud upload (typically 10-16 seconds).
While the event loop is blocked, all other HTTP requests to Frigate — snapshot loading, review lookups, config fetches — are stalled. In the browser, this manifests as ~4-6 second TTFB on requests that the server can otherwise fulfill in under 10ms.
Multiple users have reported this behavior in #16566. The symptom is that navigating between snapshots in the Explore view becomes slow immediately after submitting an image to Frigate+.
Fix
Wrap the three synchronous PlusApi method calls in asyncio.to_thread() so they execute in the default thread pool executor without blocking the event loop:

plus_api.upload_image() in send_to_plus
plus_api.add_annotation() in send_to_plus
plus_api.add_false_positive() in set_false_positive

Testing
Tested on a live Frigate 0.17.0 instance. Before the patch, submitting to Frigate+ caused the next snapshot load to take 4-6 seconds (verified via Firefox DevTools — TTFB was spent entirely in "Waiting"). After the patch, snapshots load in <10ms while Frigate+ uploads complete successfully in the background thread.


<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->


## Type of change

- [ ] Dependency upgrade
- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #16566
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ x ] The code change is tested and works locally.
- [ x ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ x ] The code has been formatted using Ruff (`ruff format frigate`)
