### PR TITLE
Hide set password menu option when native auth is disabled

### DIFF
--- a/web/src/components/menu/AccountSettings.tsx
+++ b/web/src/components/menu/AccountSettings.tsx
@@ -126,19 +126,21 @@ export default function AccountSettings({ className }: AccountSettingsProps) {
 
           <DropdownMenuSeparator className={isDesktop ? "my-2" : "my-2"} />
 
-          {profile?.username && profile.username !== "anonymous" && (
-            <MenuItem
-              className={cn(
-                "flex w-full items-center gap-2",
-                isDesktop ? "cursor-pointer" : "p-2 text-sm",
-              )}
-              aria-label={t("menu.user.setPassword", { ns: "common" })}
-              onClick={() => setPasswordDialogOpen(true)}
-            >
-              <LuSquarePen className="mr-2 size-4" />
-              <span>{t("menu.user.setPassword", { ns: "common" })}</span>
-            </MenuItem>
-          )}
+          {config?.auth?.enabled !== false &&
+            profile?.username &&
+            profile.username !== "anonymous" && (
+              <MenuItem
+                className={cn(
+                  "flex w-full items-center gap-2",
+                  isDesktop ? "cursor-pointer" : "p-2 text-sm",
+                )}
+                aria-label={t("menu.user.setPassword", { ns: "common" })}
+                onClick={() => setPasswordDialogOpen(true)}
+              >
+                <LuSquarePen className="mr-2 size-4" />
+                <span>{t("menu.user.setPassword", { ns: "common" })}</span>
+              </MenuItem>
+            )}
 
           <MenuItem
             className={cn(

--- a/web/src/components/menu/GeneralSettings.tsx
+++ b/web/src/components/menu/GeneralSettings.tsx
@@ -225,20 +225,24 @@ export default function GeneralSettings({ className }: GeneralSettingsProps) {
                 <DropdownMenuSeparator
                   className={isDesktop ? "mt-3" : "mt-1"}
                 />
-                {profile?.username && profile.username !== "anonymous" && (
-                  <MenuItem
-                    className={
-                      isDesktop
-                        ? "cursor-pointer"
-                        : "flex items-center p-2 text-sm"
-                    }
-                    aria-label={t("menu.user.setPassword", { ns: "common" })}
-                    onClick={() => setPasswordDialogOpen(true)}
-                  >
-                    <LuSquarePen className="mr-2 size-4" />
-                    <span>{t("menu.user.setPassword", { ns: "common" })}</span>
-                  </MenuItem>
-                )}
+                {config?.auth?.enabled !== false &&
+                  profile?.username &&
+                  profile.username !== "anonymous" && (
+                    <MenuItem
+                      className={
+                        isDesktop
+                          ? "cursor-pointer"
+                          : "flex items-center p-2 text-sm"
+                      }
+                      aria-label={t("menu.user.setPassword", { ns: "common" })}
+                      onClick={() => setPasswordDialogOpen(true)}
+                    >
+                      <LuSquarePen className="mr-2 size-4" />
+                      <span>
+                        {t("menu.user.setPassword", { ns: "common" })}
+                      </span>
+                    </MenuItem>
+                  )}
                 <MenuItem
                   className={
                     isDesktop

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -346,6 +346,7 @@ export interface FrigateConfig {
   };
 
   auth: {
+    enabled: boolean;
     roles: {
       [roleName: string]: string[];
     };


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Proxy auth users don't have user accounts in the Frigate db, so trying to set a password would result in "user not found". This PR just hides the set password option from the menus (as is already done for anonymous users).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
