### PR TITLE
fix: pass missing ffmpeg_path arg in birdseye encode preset fallback

### DIFF
--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -278,7 +278,7 @@ def parse_preset_hardware_acceleration_encode(
         arg_map = PRESETS_HW_ACCEL_ENCODE_TIMELAPSE
 
     if not isinstance(arg, str):
-        return arg_map["default"].format(input, output)
+        return arg_map["default"].format(ffmpeg_path, input, output)
 
     # Not all jetsons have HW encoders, so fall back to default SW encoder if not
     if arg.startswith("preset-jetson-") and not os.path.exists("/dev/nvhost-msenc"):


### PR DESCRIPTION
## The Problem

When `hwaccel_args` is configured as a list (e.g. for VAAPI):

```yaml
ffmpeg:
  hwaccel_args:
    - -hwaccel
    - vaapi
    - -hwaccel_device
    - /dev/dri/renderD128
```

...and birdseye restream is enabled, `parse_preset_hardware_acceleration_encode()` hits the `not isinstance(arg, str)` branch at line 281 of `ffmpeg_presets.py` and calls:

```python
return arg_map["default"].format(input, output)
```

But the default birdseye preset string contains three placeholders (`{0}`, `{1}`, `{2}`):

```
{0} -hide_banner {1} -c:v libx264 ... {2}
```

Only two args are passed (`input`, `output`), so `{2}` raises:

```
IndexError: Replacement index 2 out of range for positional args tuple
```

This crashes `create_config.py` which runs on every go2rtc start, preventing go2rtc from starting at all. Since go2rtc handles all camera restreams, **every camera stream goes down** — not just birdseye.

## The Fix

Pass `ffmpeg_path` as the first argument to `.format()`, matching the preset template that expects it at `{0}`:

```python
return arg_map["default"].format(ffmpeg_path, input, output)
```

The `ffmpeg_path` parameter is already available in the function signature but was not being used in this code path.

## How to Reproduce

1. Configure `hwaccel_args` as a list (not a preset string)
2. Enable `birdseye.restream: true`
3. Start Frigate — go2rtc enters a restart loop, all streams fail