### PR TITLE
fix: correct swapped shape indices in birdseye custom logo placement

### DIFF
--- a/frigate/output/birdseye.py
+++ b/frigate/output/birdseye.py
@@ -307,8 +307,8 @@ class BirdsEyeFrameManager:
             y_offset = height // 2 - transparent_layer.shape[0] // 2
             x_offset = width // 2 - transparent_layer.shape[1] // 2
             self.blank_frame[
-                y_offset : y_offset + transparent_layer.shape[1],
-                x_offset : x_offset + transparent_layer.shape[0],
+                y_offset : y_offset + transparent_layer.shape[0],
+                x_offset : x_offset + transparent_layer.shape[1],
             ] = transparent_layer
         else:
             logger.warning("Unable to read Frigate logo")


### PR DESCRIPTION
## The Problem

In `BirdsEyeFrameManager.__init__()`, the code that copies a custom logo onto the birdseye blank frame has `shape[0]` and `shape[1]` swapped in the numpy array slice:

```python
self.blank_frame[
    y_offset : y_offset + transparent_layer.shape[1],  # bug: width used for row range
    x_offset : x_offset + transparent_layer.shape[0],  # bug: height used for col range
] = transparent_layer
```

For numpy arrays, `shape[0]` = rows (height) and `shape[1]` = cols (width). The row slice should use `shape[0]` and the column slice should use `shape[1]`.

This bug is masked when using a square `custom.png` (since shape[0] == shape[1]), but any non-square image like a 1920x1080 photo produces:

```
ValueError: could not broadcast input array from shape (1080,1920) into shape (1620,1080)
```

This exception is raised during birdseye initialization, which silently kills the birdseye output process. No frames are written to the birdseye FIFO pipe (`/tmp/cache/birdseye`), go2rtc's exec ffmpeg source keeps timing out, and the birdseye restream shows a permanent black screen. There's no error visible in the Frigate UI.

Note: the offset *calculation* two lines above is correct (`y_offset` uses `shape[0]`, `x_offset` uses `shape[1]`). Only the slice assignment has the indices reversed.

## The Fix

```python
self.blank_frame[
    y_offset : y_offset + transparent_layer.shape[0],  # height for row range
    x_offset : x_offset + transparent_layer.shape[1],  # width for col range
] = transparent_layer
```

## How to Reproduce

1. Place a non-square image (e.g. 1920x1080) as `/media/frigate/custom.png`
2. Enable birdseye with restream
3. Start Frigate — birdseye restream is a black screen, no error in UI
4. Check container logs for the ValueError in birdseye output process

## Related Issues

- #6802 (wrong camera dimension calculation for birdseye)
- #7863 (birdseye errors with nonstandard aspect ratio)