### PR TITLE
fix: off-by-one in GpuSelector.get_gpu_arg causes IndexError

### DIFF
--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -63,7 +63,7 @@ class LibvaGpuSelector:
         if not self._valid_gpus:
             return ""
 
-        if gpu <= len(self._valid_gpus):
+        if gpu < len(self._valid_gpus):
             return self._valid_gpus[gpu]
         else:
             logger.warning(f"Invalid GPU index {gpu}, using first valid GPU")


### PR DESCRIPTION
## The Problem

`get_gpu_arg()` in `ffmpeg_presets.py` line 66 uses:

```python
if gpu <= len(self._valid_gpus):
    return self._valid_gpus[gpu]
```

The list is zero-indexed, so requesting a GPU index equal to the list length passes the bounds check but causes an `IndexError`. For example, with 2 valid GPUs (indices 0 and 1), `gpu=2` passes `2 <= 2` but `self._valid_gpus[2]` is out of range.

## The Fix

```python
if gpu < len(self._valid_gpus):
```

Standard zero-indexed bounds check.

## How to Reproduce

1. System with 2+ GPUs where Frigate detects multiple render nodes
2. Reference the last GPU by index (e.g. `gpu: 2` with 2 GPUs)
3. Frigate crashes with `IndexError: list index out of range`