### PR TITLE
fix: preset-http-jpeg-generic FPS placeholder never gets replaced

### DIFF
--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -436,7 +436,7 @@ def parse_preset_input(arg: Any, detect_fps: int) -> list[str]:
 
     if arg == "preset-http-jpeg-generic":
         input = PRESETS_INPUT[arg].copy()
-        input[len(_user_agent_args) + 1] = str(detect_fps)
+        input[1] = str(detect_fps)
         return input
 
     return PRESETS_INPUT.get(arg, None)


### PR DESCRIPTION
## The Problem

In `parse_preset_input()`, the FPS replacement for `preset-http-jpeg-generic` uses:

```python
input[len(_user_agent_args) + 1] = str(detect_fps)
```

But `preset-http-jpeg-generic` does **not** include `_user_agent_args` at the start of its argument list (only `preset-http-mjpeg-generic` does). The preset starts with:

```python
["-r", "{}", "-stream_loop", "-1", ...]
```

The FPS placeholder `"{}"` is at index 1. `len(_user_agent_args) + 1` evaluates to 3, which points at `"-1"` (the `-stream_loop` value). So:
- The `-stream_loop` value gets overwritten with the detect FPS
- The actual FPS placeholder `"{}"` is never replaced

## The Fix

```python
input[1] = str(detect_fps)
```

Directly index the FPS placeholder position in the preset.

## How to Reproduce

1. Configure a camera with `preset-http-jpeg-generic` input preset
2. The resulting ffmpeg command will have a literal `{}` as the `-r` value and the detect FPS as the `-stream_loop` value