### PR TITLE
fix: birdseye idle heartbeat never fires due to mismatched time sources

### DIFF
--- a/frigate/output/birdseye.py
+++ b/frigate/output/birdseye.py
@@ -854,7 +854,7 @@ class Birdseye:
                 coordinates = self.birdseye_manager.get_camera_coordinates()
                 self.requestor.send_data(UPDATE_BIRDSEYE_LAYOUT, coordinates)
         if self._idle_interval:
-            now = time.monotonic()
+            now = datetime.datetime.now().timestamp()
             is_idle = len(self.birdseye_manager.camera_layout) == 0
             if (
                 is_idle


### PR DESCRIPTION
## The Problem

The idle heartbeat check in `BirdsEyeOutputProcess.update()` uses `time.monotonic()` for `now`:

```python
now = time.monotonic()
is_idle = len(self.birdseye_manager.camera_layout) == 0
if is_idle and (now - self.birdseye_manager.last_output_time) >= self._idle_interval:
    self.__send_new_frame()
```

But `last_output_time` is set from `datetime.datetime.now().timestamp()` (Unix epoch seconds) in `BirdsEyeFrameManager.update()`:

```python
now = datetime.datetime.now().timestamp()
# ...
self.last_output_time = now
```

These are completely different time bases:
- `time.monotonic()` ≈ seconds since boot (e.g. ~50,000)
- `datetime.now().timestamp()` ≈ Unix epoch (e.g. ~1,710,000,000)

The subtraction `monotonic - epoch` produces a large negative number, so the idle heartbeat condition is never satisfied. This means birdseye stops outputting frames entirely when all cameras go idle, instead of continuing at `idle_heartbeat_fps`.

## The Fix

Use `datetime.datetime.now().timestamp()` consistently in the heartbeat check, matching how `last_output_time` is set.

## How to Reproduce

1. Enable birdseye with `idle_heartbeat_fps` configured
2. Wait for all cameras to become inactive (no detected objects)
3. Birdseye stream freezes on last frame instead of continuing at heartbeat FPS
4. go2rtc eventually times out the birdseye stream