### PR TITLE
fix: active_cameras reset to list instead of set in error handler

### DIFF
--- a/frigate/output/birdseye.py
+++ b/frigate/output/birdseye.py
@@ -753,7 +753,7 @@ class BirdsEyeFrameManager:
             frame_changed, layout_changed = self.update_frame(frame)
         except Exception:
             frame_changed, layout_changed = False, False
-            self.active_cameras = []
+            self.active_cameras = set()
             self.camera_layout = []
             print(traceback.format_exc())
 


### PR DESCRIPTION
## The Problem

In `BirdsEyeFrameManager.update()`, the exception handler resets `self.active_cameras` to an empty list:

```python
except Exception:
    frame_changed, layout_changed = False, False
    self.active_cameras = []  # bug: should be set()
```

But `active_cameras` is initialized as `set()` and compared as a set throughout the code:

```python
self.active_cameras = set()  # line 323 (init)

# In update_frame():
active_cameras: set[str] = set([...])  # line 415
if self.active_cameras \!= active_cameras:  # line 470
```

Since `set() \!= []` evaluates to `True` even though both are empty, the comparison on line 470 will always detect a false layout change after an exception, triggering unnecessary frame rebuilds on every subsequent update until a real camera change resets it back to a proper set.

## The Fix

```python
self.active_cameras = set()
```