### PR TITLE
fix: birdseye crashes on custom logo without alpha channel

### DIFF
--- a/frigate/output/birdseye.py
+++ b/frigate/output/birdseye.py
@@ -303,12 +303,20 @@ class BirdsEyeFrameManager:
                 birdseye_logo = cv2.imread(logo_files[0], cv2.IMREAD_UNCHANGED)
 
         if birdseye_logo is not None:
-            transparent_layer = birdseye_logo[:, :, 3]
+            if birdseye_logo.ndim == 2:
+                # Grayscale image (no channels) — use directly as luminance
+                transparent_layer = birdseye_logo
+            elif birdseye_logo.shape[2] >= 4:
+                # RGBA — use alpha channel as luminance
+                transparent_layer = birdseye_logo[:, :, 3]
+            else:
+                # RGB or other format without alpha — convert to grayscale
+                transparent_layer = cv2.cvtColor(birdseye_logo, cv2.COLOR_BGR2GRAY)
             y_offset = height // 2 - transparent_layer.shape[0] // 2
             x_offset = width // 2 - transparent_layer.shape[1] // 2
             self.blank_frame[
-                y_offset : y_offset + transparent_layer.shape[1],
-                x_offset : x_offset + transparent_layer.shape[0],
+                y_offset : y_offset + transparent_layer.shape[0],
+                x_offset : x_offset + transparent_layer.shape[1],
             ] = transparent_layer
         else:
             logger.warning("Unable to read Frigate logo")


### PR DESCRIPTION
## The Problem

`BirdsEyeFrameManager.__init__()` loads the custom logo with `cv2.imread(path, cv2.IMREAD_UNCHANGED)` and then unconditionally indexes the alpha channel:

```python
transparent_layer = birdseye_logo[:, :, 3]
```

This assumes the image is always RGBA (4 channels), but crashes for:

- **Grayscale PNGs** (2D array, no channel dimension) → `IndexError: too many indices for array`
- **RGB PNGs** (3 channels, no index 3) → `IndexError: index 3 is out of bounds for axis 2 with size 3`
- **Grayscale + alpha PNGs** (2 channels) → same IndexError

The exception kills the birdseye output process silently. No frames reach the FIFO pipe, go2rtc times out, and the restream shows a black screen.

Reported in #4633 (Dec 2022, still open).

## The Fix

Check the image dimensions before extracting the luminance layer:

```python
if birdseye_logo.ndim == 2:
    transparent_layer = birdseye_logo
elif birdseye_logo.shape[2] >= 4:
    transparent_layer = birdseye_logo[:, :, 3]
else:
    transparent_layer = cv2.cvtColor(birdseye_logo, cv2.COLOR_BGR2GRAY)
```

This also includes the fix for the swapped `shape[0]`/`shape[1]` indices in the array slice (#6802, #7863) since it touches the same lines.

## How to Reproduce

1. Place a grayscale or RGB PNG (no alpha channel) at `/media/frigate/custom.png`
2. Enable birdseye
3. Start Frigate — birdseye output process crashes, restream is black

## Closes

- Fixes #4633