### PR TITLE
fix: orphaned camera event snapshot cleanup never deletes files

### DIFF
--- a/frigate/events/cleanup.py
+++ b/frigate/events/cleanup.py
@@ -95,7 +95,8 @@ class EventCleanup(threading.Thread):
                 .namedtuples()
                 .iterator()
             )
-            logger.debug(f"{len(list(expired_events))} events can be expired")
+            expired_events = list(expired_events)
+            logger.debug(f"{len(expired_events)} events can be expired")
 
             # delete the media from disk
             for expired in expired_events:
@@ -220,7 +221,8 @@ class EventCleanup(threading.Thread):
             .namedtuples()
             .iterator()
         )
-        logger.debug(f"{len(list(expired_events))} events can be expired")
+        expired_events = list(expired_events)
+        logger.debug(f"{len(expired_events)} events can be expired")
         # delete the media from disk
         for expired in expired_events:
             media_name = f"{expired.camera}-{expired.id}"


### PR DESCRIPTION
## The Problem

In `events/cleanup.py`, both `expire_snapshots()` and `expire_clips()` have the same bug. The expired events query uses `.iterator()` for lazy evaluation:

```python
expired_events = (
    Event.select(...)
    .where(...)
    .namedtuples()
    .iterator()
)
logger.debug(f"{len(list(expired_events))} events can be expired")

for expired in expired_events:   # iterates over NOTHING
    delete_event_snapshot(expired)
```

`list(expired_events)` in the debug log **consumes the entire iterator**. The subsequent `for` loop iterates over the now-exhausted iterator and processes zero events. Media files for removed cameras are never deleted from disk.

## Impact

Gradual disk space exhaustion. Every time a camera is removed from the config, its old snapshots and clips remain on disk permanently since the cleanup loop never executes.

## The Fix

Materialize the iterator into a list before logging, then use that list for both the debug message and the cleanup loop:

```python
expired_events = list(expired_events)
logger.debug(f"{len(expired_events)} events can be expired")

for expired in expired_events:   # now iterates over the materialized list
```

Fixed in both `expire_snapshots()` (line 98) and `expire_clips()` (line 223).