### PR TITLE
fix: inverted condition causes division by zero in PTZ autotrack

### DIFF
--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -901,7 +901,7 @@ class PtzAutoTracker:
         # Check direction difference
         velocities = np.round(velocities)
         invalid_dirs = False
-        if not np.any(np.linalg.norm(velocities, axis=1)):
+        if np.all(np.linalg.norm(velocities, axis=1)):
             cosine_sim = np.dot(velocities[0], velocities[1]) / (
                 np.linalg.norm(velocities[0]) * np.linalg.norm(velocities[1])
             )
@@ -1067,7 +1067,7 @@ class PtzAutoTracker:
                 f"{camera}: Zoom test: below dimension threshold: {below_dimension_threshold} width: {bb_right - bb_left}, max width: {camera_width * (self.zoom_factor[camera] + 0.1)}, height: {bb_bottom - bb_top}, max height: {camera_height * (self.zoom_factor[camera] + 0.1)}"
             )
             logger.debug(
-                f"{camera}: Zoom test: below velocity threshold: {below_velocity_threshold} velocity x: {abs(average_velocity[0])}, x threshold: {velocity_threshold_x}, velocity y: {abs(average_velocity[0])}, y threshold: {velocity_threshold_y}"
+                f"{camera}: Zoom test: below velocity threshold: {below_velocity_threshold} velocity x: {abs(average_velocity[0])}, x threshold: {velocity_threshold_x}, velocity y: {abs(average_velocity[1])}, y threshold: {velocity_threshold_y}"
             )
             logger.debug(f"{camera}: Zoom test: at max zoom: {at_max_zoom}")
             logger.debug(f"{camera}: Zoom test: at min zoom: {at_min_zoom}")


### PR DESCRIPTION
## The Problem

In `ptz/autotrack.py`, the velocity direction check computes cosine similarity to determine if tracked objects are moving in opposite directions. The guard condition is inverted:

```python
if not np.any(np.linalg.norm(velocities, axis=1)):
    cosine_sim = np.dot(velocities[0], velocities[1]) / (
        np.linalg.norm(velocities[0]) * np.linalg.norm(velocities[1])
    )
```

`not np.any(norms)` is True when **all** norms are zero. The code then divides by those zero norms, producing division by zero (NaN or inf).

The intent is to only compute cosine similarity when velocities are non-zero — the condition should check that all norms are positive.

There's an earlier guard (`if np.all(np.round(velocities) == 0): return`) that catches exact-zero cases, but after rounding, near-zero velocities that round to zero can still reach this code path.

Also fixes a copy-paste error in the debug log at line 1070 where `average_velocity[0]` is shown for both x and y velocity (second should be `average_velocity[1]`).

## The Fix

```python
if np.all(np.linalg.norm(velocities, axis=1)):
```

Only enter the cosine similarity block when all velocity norms are non-zero.