### PR TITLE
fix: operator precedence makes detection type check always true

### DIFF
--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -727,7 +727,8 @@ class RecordingMaintainer(threading.Thread):
                             )
                         )
                 elif (
-                    topic == DetectionTypeEnum.api.value or topic == DetectionTypeEnum.lpr.value
+                    topic == DetectionTypeEnum.api.value
+                    or topic == DetectionTypeEnum.lpr.value
                 ):
                     continue
 

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -727,7 +727,7 @@ class RecordingMaintainer(threading.Thread):
                             )
                         )
                 elif (
-                    topic == DetectionTypeEnum.api.value or DetectionTypeEnum.lpr.value
+                    topic == DetectionTypeEnum.api.value or topic == DetectionTypeEnum.lpr.value
                 ):
                     continue
 

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -642,7 +642,10 @@ class ReviewSegmentMaintainer(threading.Thread):
                     _,
                     audio_detections,
                 ) = data
-            elif topic == DetectionTypeEnum.api.value or DetectionTypeEnum.lpr.value:
+            elif (
+                topic == DetectionTypeEnum.api.value
+                or topic == DetectionTypeEnum.lpr.value
+            ):
                 (
                     camera,
                     frame_time,


### PR DESCRIPTION
## The Problem

In `record/maintainer.py`, the detection type check:

```python
elif (
    topic == DetectionTypeEnum.api.value or DetectionTypeEnum.lpr.value
):
    continue
```

evaluates as:

```python
(topic == DetectionTypeEnum.api.value) or (DetectionTypeEnum.lpr.value)
```

`DetectionTypeEnum.lpr.value` is a non-empty string, which is always truthy. This makes the entire condition always True for any topic that reaches this branch. In the current code this happens to produce the correct behavior (continue/skip for non-video/non-audio topics), but it would break silently if new detection types are added that need different handling.

## The Fix

```python
elif (
    topic == DetectionTypeEnum.api.value or topic == DetectionTypeEnum.lpr.value
):
```