### PR TITLE
fix: object label/stationary updates silently dropped due to variable shadowing

### DIFF
--- a/web/src/hooks/use-camera-activity.ts
+++ b/web/src/hooks/use-camera-activity.ts
@@ -125,8 +125,6 @@ export function useCameraActivity(
           newObjects = [...(objects ?? []), newActiveObject];
         }
       } else {
-        const newObjects = [...(objects ?? [])];
-
         let label = updatedEvent.after.label;
 
         if (updatedEvent.after.sub_label) {


### PR DESCRIPTION
## The Problem

In `use-camera-activity.ts`, when an existing tracked object's label or stationary status is updated (e.g. sub_label from face recognition, or object becomes stationary), the update is silently discarded.

Line 106 declares the outer variable:
```typescript
let newObjects: ObjectType[] = [...(objects ?? [])];
```

Line 128, inside the `else` branch for existing objects, declares an inner variable that shadows it:
```typescript
const newObjects = [...(objects ?? [])];
```

The label and stationary mutations on lines 142-144 modify the inner `const newObjects`, but `handleSetObjects(newObjects)` on line 148 reads the outer `let newObjects` — which was never mutated.

## The Fix

Remove the inner `const newObjects` declaration on line 128. The outer variable already contains the correct spread copy.