### PR TITLE
fix: WebSocket leaked on WebRTC player cleanup

### DIFF
--- a/web/src/components/player/WebRTCPlayer.tsx
+++ b/web/src/components/player/WebRTCPlayer.tsx
@@ -52,6 +52,7 @@ export default function WebRtcPlayer({
   // camera states
 
   const pcRef = useRef<RTCPeerConnection | undefined>(undefined);
+  const wsRef = useRef<WebSocket | null>(null);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [bufferTimeout, setBufferTimeout] = useState<NodeJS.Timeout>();
   const videoLoadTimeoutRef = useRef<NodeJS.Timeout>(undefined);
@@ -129,7 +130,8 @@ export default function WebRtcPlayer({
       }
 
       pcRef.current = await aPc;
-      const ws = new WebSocket(wsURL);
+      wsRef.current = new WebSocket(wsURL);
+      const ws = wsRef.current;
 
       ws.addEventListener("open", () => {
         pcRef.current?.addEventListener("icecandidate", (ev) => {
@@ -183,6 +185,10 @@ export default function WebRtcPlayer({
     connect(aPc);
 
     return () => {
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
       if (pcRef.current) {
         pcRef.current.close();
         pcRef.current = undefined;


### PR DESCRIPTION
## The Problem

In `WebRTCPlayer.tsx`, the `connect()` function creates a WebSocket but never stores the reference:

```typescript
const ws = new WebSocket(wsURL);  // local variable only
```

The `useEffect` cleanup only closes the `RTCPeerConnection` via `pcRef`:

```typescript
return () => {
  if (pcRef.current) {
    pcRef.current.close();  // PeerConnection closed
    pcRef.current = undefined;
  }
  // WebSocket never closed
};
```

Every time the effect re-runs (camera change, playback toggle, microphone toggle), a new WebSocket is opened without closing the previous one.

## The Fix

Store the WebSocket in a ref and close it in the cleanup function alongside the PeerConnection.