### PR TITLE
fix: escape_special_characters returns ValueError instead of raising it

### DIFF
--- a/frigate/util/builtin.py
+++ b/frigate/util/builtin.py
@@ -116,7 +116,7 @@ def clean_camera_user_pass(line: str) -> str:
 def escape_special_characters(path: str) -> str:
     """Cleans reserved characters to encodings for ffmpeg."""
     if len(path) > 1000:
-        return ValueError("Input too long to check")
+        raise ValueError("Input too long to check")
 
     try:
         found = re.search(REGEX_RTSP_CAMERA_USER_PASS, path).group(0)[3:-1]


### PR DESCRIPTION
## The Problem

In `util/builtin.py`, `escape_special_characters()` has:

```python
if len(path) > 1000:
    return ValueError("Input too long to check")
```

This **returns** a `ValueError` object as a normal value instead of **raising** it. The caller receives an exception object where it expects a string (the sanitized path), and it gets silently used downstream — `str(ValueError(...))` produces `"Input too long to check"` which would be passed to ffmpeg as a path.

## The Fix

```python
if len(path) > 1000:
    raise ValueError("Input too long to check")
```