### PR TITLE
fix: upload_image parses response body before checking HTTP status

### DIFF
--- a/frigate/plus.py
+++ b/frigate/plus.py
@@ -105,7 +105,6 @@ class PlusApi:
 
     def upload_image(self, image: ndarray, camera: str) -> str:
         r = self._get("image/signed_urls")
-        
         if not r.ok:
             raise Exception("Unable to get signed urls")
         presigned_urls = r.json()

--- a/frigate/plus.py
+++ b/frigate/plus.py
@@ -105,9 +105,10 @@ class PlusApi:
 
     def upload_image(self, image: ndarray, camera: str) -> str:
         r = self._get("image/signed_urls")
-        presigned_urls = r.json()
+        
         if not r.ok:
             raise Exception("Unable to get signed urls")
+        presigned_urls = r.json()
 
         # resize and submit original
         files = {"file": get_jpg_bytes(image, 1920, 85)}


### PR DESCRIPTION
## The Problem

In `plus.py`, `upload_image()`:

```python
r = self._get("image/signed_urls")
presigned_urls = r.json()   # called BEFORE checking status
if not r.ok:
    raise Exception("Unable to get signed urls")
```

If the Frigate+ API returns an error (401, 500, etc) with a non-JSON body (HTML error page, empty body), `r.json()` raises `JSONDecodeError` before the `r.ok` check can provide a meaningful error message.

## The Fix

Check status before parsing:

```python
r = self._get("image/signed_urls")
if not r.ok:
    raise Exception("Unable to get signed urls")
presigned_urls = r.json()
```