### PR TITLE
fix: UnboundLocalError when frame not found in embeddings maintainer

### DIFF
--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -451,13 +451,13 @@ class EmbeddingMaintainer(threading.Thread):
             return
 
         # Create our own thumbnail based on the bounding box and the frame time
+        yuv_frame = None
         try:
             yuv_frame = self.frame_manager.get(
                 frame_name, camera_config.frame_shape_yuv
             )
         except FileNotFoundError:
             logger.debug(f"Frame {frame_name} not found for camera {camera}")
-            pass
 
         if yuv_frame is None:
             logger.debug(
@@ -672,6 +672,7 @@ class EmbeddingMaintainer(threading.Thread):
             # no active features that use this data
             return
 
+        yuv_frame = None
         try:
             yuv_frame = self.frame_manager.get(
                 frame_name, camera_config.frame_shape_yuv


### PR DESCRIPTION
## The Problem

Both `_process_updates()` and `_process_frame_updates()` in `embeddings/maintainer.py` have the same pattern:

```python
try:
    yuv_frame = self.frame_manager.get(frame_name, ...)
except FileNotFoundError:
    pass

if yuv_frame is None:    # UnboundLocalError if exception was raised
```

If `frame_manager.get()` raises `FileNotFoundError`, the assignment never completes and `yuv_frame` is never defined. The subsequent `if yuv_frame is None` check raises `UnboundLocalError` instead of gracefully handling the missing frame.

## The Fix

Initialize `yuv_frame = None` before each `try` block so the variable is always defined regardless of whether the exception fires.