### PR TITLE
Don't try to run storage cleanup if frigate is in safe mode

### DIFF
--- a/frigate/events/cleanup.py
+++ b/frigate/events/cleanup.py
@@ -324,6 +324,10 @@ class EventCleanup(threading.Thread):
         return events_to_update
 
     def run(self) -> None:
+        if self.config.safe_mode:
+            logger.info("Safe mode enabled, skipping event cleanup")
+            return
+
         # only expire events every 5 minutes
         while not self.stop_event.wait(300):
             events_with_expired_clips = self.expire_clips()

--- a/frigate/record/cleanup.py
+++ b/frigate/record/cleanup.py
@@ -350,6 +350,10 @@ class RecordingCleanup(threading.Thread):
         logger.debug("End expire recordings.")
 
     def run(self) -> None:
+        if self.config.safe_mode:
+            logger.info("Safe mode enabled, skipping recording cleanup")
+            return
+
         # on startup sync recordings with disk if enabled
         if self.config.record.sync_recordings:
             sync_recordings(limited=False)

--- a/frigate/storage.py
+++ b/frigate/storage.py
@@ -272,6 +272,10 @@ class StorageMaintainer(threading.Thread):
 
     def run(self):
         """Check every 5 minutes if storage needs to be cleaned up."""
+        if self.config.safe_mode:
+            logger.info("Safe mode enabled, skipping storage maintenance")
+            return
+
         self.calculate_camera_bandwidth()
         while not self.stop_event.wait(300):
             if not self.camera_storage_stats or True in [


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Check if we're in safe mode to prevent recording cleanup, event cleanup, and the storage maintainer from running

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/22491
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
