### PR TITLE
Temporarily mute WebRTC video at start to fix autoplay on mic toggle

### DIFF
--- a/web/src/components/player/WebRTCPlayer.tsx
+++ b/web/src/components/player/WebRTCPlayer.tsx
@@ -55,6 +55,7 @@ export default function WebRtcPlayer({
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [bufferTimeout, setBufferTimeout] = useState<NodeJS.Timeout>();
   const videoLoadTimeoutRef = useRef<NodeJS.Timeout>(undefined);
+  const [awaitingPlayback, setAwaitingPlayback] = useState(true);
 
   const PeerConnection = useCallback(
     async (media: string) => {
@@ -177,6 +178,8 @@ export default function WebRtcPlayer({
       return;
     }
 
+    setAwaitingPlayback(true);
+
     const aPc = PeerConnection(
       microphoneEnabled ? "video+audio+microphone" : "video+audio",
     );
@@ -241,6 +244,19 @@ export default function WebRtcPlayer({
       clearTimeout(videoLoadTimeoutRef.current);
     }
     onPlaying?.();
+
+    // Start muted so autoplay isn't blocked when the user gesture has
+    // expired (e.g. mic toggle). Cleared on the "playing" event.
+    // https://github.com/blakeblackshear/frigate-hass-addons/issues/274
+    if (awaitingPlayback && videoRef.current) {
+      videoRef.current.addEventListener(
+        "playing",
+        () => {
+          setAwaitingPlayback(false);
+        },
+        { once: true },
+      );
+    }
   };
 
   // stats
@@ -319,7 +335,7 @@ export default function WebRtcPlayer({
       controls={iOSCompatControls}
       autoPlay
       playsInline
-      muted={!audioEnabled}
+      muted={awaitingPlayback || !audioEnabled}
       onLoadedData={handleLoadedData}
       onProgress={
         onError != undefined


### PR DESCRIPTION

## Proposed change
Hi,

This fixes 2-way audio on the Home Assistant Android companion app: toggling the microphone causes the video feed to go black while audio continues working.

When the mic is toggled, the player switches from MSE to WebRTC, which creates a new PeerConnection and video stream. By the time the async WebRTC setup completes, the user gesture from the mic button click has expired under Android WebView's transient activation model, causing unmuted autoplay to be blocked.

Fix this by introducing an `awaitingPlayback` state that forces the video element to start muted (muted autoplay is always allowed). Once the `playing` event fires, the flag is cleared and the muted prop falls back to the normal `!audioEnabled` logic, preserving audio toggle functionality.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate-hass-addons/issues/274

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
