### PR TITLE
Fix audio event maintainer

### DIFF
--- a/frigate/events/audio.py
+++ b/frigate/events/audio.py
@@ -321,6 +321,9 @@ class AudioEventMaintainer(threading.Thread):
             self.start_or_restart_ffmpeg()
 
         while not self.stop_event.is_set():
+            # check if there is an updated config
+            self.config_subscriber.check_for_updates()
+
             enabled = self.camera_config.enabled
             if enabled != self.was_enabled:
                 if enabled:
@@ -346,9 +349,6 @@ class AudioEventMaintainer(threading.Thread):
             if not enabled:
                 time.sleep(0.1)
                 continue
-
-            # check if there is an updated config
-            self.config_subscriber.check_for_updates()
 
             self.read_audio()
 


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Move config subscriber check to the top of the audio event maintainer loop so that camera re-enable events are processed even while the audio thread is in the disabled sleep state


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/22493
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
