### PR TITLE
fix: prevent MQTT connected state on failed connections

### DIFF
--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -199,6 +199,7 @@ class MqttClient(Communicator):
                     "Unable to connect to MQTT server: Connection refused. Error code: "
                     + reason_code.getName()
                 )
+            return
 
         self.connected = True
         logger.debug("MQTT connected")


### PR DESCRIPTION
When the broker rejects a connection (bad credentials, not authorized, server unavailable, etc), `_on_connect` logs the error but falls through to `self.connected = True`, subscribes to topics, and calls `_set_initial_topics()`. This means `publish()` will keep trying to send messages into a dead connection.

Added an early return after the error logging so the client stays in a disconnected state and lets the reconnect logic handle it properly.