### PR TITLE
fix: initialize result in generate_description_embedding

### DIFF
--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -1639,6 +1639,7 @@ def generate_description_embedding(
     body: EventsDescriptionBody,
 ):
     new_description = body.description
+    result = None
 
     # If semantic search is enabled, update the index
     if request.app.frigate_config.semantic_search.enabled:


### PR DESCRIPTION
`result` is only assigned inside `if semantic_search.enabled` and `if len(new_description) > 0`, but the return statement always references it. If either condition is false, you get an `UnboundLocalError`.

Initializes `result = None` before the conditional block so the response always has a valid value.