### PR TITLE
fix: check frame for None before accessing shape in latest_frame

### DIFF
--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -195,14 +195,14 @@ async def latest_frame(
 
                 frame = request.app.camera_error_image
 
-        height = int(params.height or str(frame.shape[0]))
-        width = int(height * frame.shape[1] / frame.shape[0])
-
         if frame is None:
             return JSONResponse(
                 content={"success": False, "message": "Unable to get valid frame"},
                 status_code=500,
             )
+
+        height = int(params.height or str(frame.shape[0]))
+        width = int(height * frame.shape[1] / frame.shape[0])
 
         if height < 1 or width < 1:
             return JSONResponse(


### PR DESCRIPTION
In `latest_frame`, `frame.shape` is accessed before the `if frame is None` check. If the camera error image file is missing from disk (or cv2.imread fails to read it), `frame` ends up as `None` and the shape access crashes with `AttributeError`.

The null check was already there, just a few lines too late. Moved it above the shape access.