### PR TITLE
fix: correct or operator in review maintainer topic check

### DIFF
--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -642,7 +642,7 @@ class ReviewSegmentMaintainer(threading.Thread):
                     _,
                     audio_detections,
                 ) = data
-            elif topic == DetectionTypeEnum.api.value or DetectionTypeEnum.lpr.value:
+            elif topic == DetectionTypeEnum.api.value or topic == DetectionTypeEnum.lpr.value:
                 (
                     camera,
                     frame_time,

--- a/frigate/review/maintainer.py
+++ b/frigate/review/maintainer.py
@@ -642,7 +642,10 @@ class ReviewSegmentMaintainer(threading.Thread):
                     _,
                     audio_detections,
                 ) = data
-            elif topic == DetectionTypeEnum.api.value or topic == DetectionTypeEnum.lpr.value:
+            elif (
+                topic == DetectionTypeEnum.api.value
+                or topic == DetectionTypeEnum.lpr.value
+            ):
                 (
                     camera,
                     frame_time,


### PR DESCRIPTION
Same issue as the one I fixed in `record/maintainer.py` (#22471) — the condition:

```python
elif topic == DetectionTypeEnum.api.value or DetectionTypeEnum.lpr.value:
```

evaluates as `(topic == api.value) or ("lpr")`, which is always truthy because the bare string is never falsy. So any topic that falls through the earlier conditions hits this branch and tries to unpack `data` as a 3-tuple, which blows up if the data doesn't match.

Changed to `topic == DetectionTypeEnum.api.value or topic == DetectionTypeEnum.lpr.value`.