### PR TITLE
fix: parameterize SQL query in get_face_ids

### DIFF
--- a/frigate/embeddings/__init__.py
+++ b/frigate/embeddings/__init__.py
@@ -205,14 +205,14 @@ class EmbeddingsContext:
         )
 
     def get_face_ids(self, name: str) -> list[str]:
-        sql_query = f"""
+        sql_query = """
             SELECT
                 id
             FROM vec_descriptions
-            WHERE id LIKE '%{name}%'
+            WHERE id LIKE ?
         """
 
-        return self.db.execute_sql(sql_query).fetchall()
+        return self.db.execute_sql(sql_query, (f"%{name}%",)).fetchall()
 
     def reprocess_face(self, face_file: str) -> dict[str, Any]:
         return self.requestor.send_data(


### PR DESCRIPTION
The `name` parameter in `get_face_ids` was being interpolated directly into the SQL query via f-string. Since this is called from the API layer where `name` comes from user input, a crafted value could break the query or inject SQL.

Switched to a parameterized query with `?` placeholder.