### PR TITLE
fix: use image_inference_speed in batch_embed_thumbnail

### DIFF
--- a/frigate/embeddings/embeddings.py
+++ b/frigate/embeddings/embeddings.py
@@ -266,7 +266,7 @@ class Embeddings:
             )
 
         duration = datetime.datetime.now().timestamp() - start
-        self.text_inference_speed.update(duration / len(valid_ids))
+        self.image_inference_speed.update(duration / len(valid_ids))
 
         return embeddings
 


### PR DESCRIPTION
`batch_embed_thumbnail` processes image thumbnails but was reporting its timing to `self.text_inference_speed` instead of `self.image_inference_speed`. This meant image embedding speed was never tracked for batch operations and the text speed metric was getting polluted with image timing data.