### PR TITLE
fix: handle missing x-forwarded-for header in get_remote_addr

### DIFF
--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -244,7 +244,12 @@ rateLimiter = RateLimiter()
 
 
 def get_remote_addr(request: Request):
-    route = list(reversed(request.headers.get("x-forwarded-for").split(",")))
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for is None:
+        if hasattr(request, "remote_addr"):
+            return request.remote_addr or "127.0.0.1"
+        return "127.0.0.1"
+    route = list(reversed(forwarded_for.split(",")))
     logger.debug(f"IP Route: {[r for r in route]}")
     trusted_proxies = []
     for proxy in request.app.frigate_config.auth.trusted_proxies:


### PR DESCRIPTION
If you access Frigate directly without a reverse proxy, the `x-forwarded-for` header won't be set. `request.headers.get()` returns `None` and calling `.split(",")` on it raises `AttributeError`. Since this function is used as the rate limiter's `key_func`, every login attempt crashes with a 500.

Added a check for the missing header and falls back to `request.remote_addr` (same logic already used at the bottom of the function when the route is empty).