### PR TITLE
fix: don't reset has_snapshot on in-progress events during shutdown

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -606,9 +606,9 @@ class FrigateApp:
         self.stop_event.set()
 
         # set an end_time on entries without an end_time before exiting
-        Event.update(
-            end_time=datetime.datetime.now().timestamp(), has_snapshot=False
-        ).where(Event.end_time == None).execute()
+        Event.update(end_time=datetime.datetime.now().timestamp()).where(
+            Event.end_time == None
+        ).execute()
         ReviewSegment.update(end_time=datetime.datetime.now().timestamp()).where(
             ReviewSegment.end_time == None
         ).execute()


### PR DESCRIPTION
When Frigate shuts down, the cleanup query at app.py:609 sets end_time on all in-progress events — but it also unconditionally sets has_snapshot=False. If an event already has its snapshot saved but just hasn't ended yet, the shutdown wipes that flag and the snapshot is effectively lost from the UI.

The ReviewSegment cleanup right below only updates end_time without touching other fields, which seems like the intended pattern here too. Removed the has_snapshot=False from the Event update.