### PR TITLE
fix: preserve other cameras' volume when adjusting one in LiveDashboardView

### DIFF
--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -570,9 +570,10 @@ export default function LiveDashboardView({
                       toggleStats={() => toggleStats(camera.name)}
                       volumeState={volumeStates[camera.name] ?? 1}
                       setVolumeState={(value) =>
-                        setVolumeStates({
+                        setVolumeStates((prev) => ({
+                          ...prev,
                           [camera.name]: value,
-                        })
+                        }))
                       }
                       muteAll={muteAll}
                       unmuteAll={unmuteAll}


### PR DESCRIPTION
setVolumeStates was replacing the entire state object with just the single camera's value, so adjusting volume on one camera would reset all others back to the default (1). The toggleAudio setter already uses the functional update pattern to preserve existing state — this just makes the volume setter consistent with that.