### PR TITLE
Add drag-to-zoom for PTZ cameras using RelativeMove

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -218,11 +218,10 @@ class OnvifController:
         move_request.ProfileToken = profile.token
         self.cams[camera_name]["move_request"] = move_request
 
-        # extra setup for autotracking cameras
-        if (
-            self.config.cameras[camera_name].onvif.autotracking.enabled_in_config
-            and self.config.cameras[camera_name].onvif.autotracking.enabled
-        ):
+        # Probe PTZ configuration options for RelativeMove/AbsoluteMove support.
+        # This is needed for click-to-move, drag-to-zoom, and autotracking.
+        fov_space_id = None
+        try:
             request = ptz.create_type("GetConfigurationOptions")
             request.ConfigurationToken = profile.PTZConfiguration.token
             ptz_config = await ptz.GetConfigurationOptions(request)
@@ -244,7 +243,7 @@ class OnvifController:
                 None,
             )
 
-            # status request for autotracking and filling ptz-parameters
+            # status request for position reporting
             status_request = ptz.create_type("GetStatus")
             status_request.ProfileToken = profile.token
             self.cams[camera_name]["status_request"] = status_request
@@ -255,76 +254,65 @@ class OnvifController:
                 logger.warning(f"Unable to get status from camera: {camera_name}: {e}")
                 status = None
 
-            # autotracking relative panning/tilting needs a relative zoom value set to 0
-            # if camera supports relative movement
-            if (
-                self.config.cameras[camera_name].onvif.autotracking.zooming
-                != ZoomingModeEnum.disabled
-            ):
-                zoom_space_id = next(
-                    (
-                        i
-                        for i, space in enumerate(
-                            ptz_config.Spaces.RelativeZoomTranslationSpace
-                        )
-                        if "TranslationGenericSpace" in space["URI"]
-                    ),
-                    None,
-                )
+            # Check for relative zoom support
+            zoom_space_id = next(
+                (
+                    i
+                    for i, space in enumerate(
+                        ptz_config.Spaces.RelativeZoomTranslationSpace
+                    )
+                    if "TranslationGenericSpace" in space["URI"]
+                ),
+                None,
+            )
 
-            # setup relative moving request for autotracking
-            move_request = ptz.create_type("RelativeMove")
-            move_request.ProfileToken = profile.token
-            logger.debug(f"{camera_name}: Relative move request: {move_request}")
-            if move_request.Translation is None and fov_space_id is not None:
-                move_request.Translation = status.Position
-                move_request.Translation.PanTilt.space = ptz_config["Spaces"][
-                    "RelativePanTiltTranslationSpace"
-                ][fov_space_id]["URI"]
+            # setup relative moving request (for click-to-move, drag-to-zoom, and autotracking)
+            if fov_space_id is not None:
+                move_request = ptz.create_type("RelativeMove")
+                move_request.ProfileToken = profile.token
+                logger.debug(f"{camera_name}: Relative move request: {move_request}")
+                if move_request.Translation is None:
+                    move_request.Translation = status.Position
+                    move_request.Translation.PanTilt.space = ptz_config["Spaces"][
+                        "RelativePanTiltTranslationSpace"
+                    ][fov_space_id]["URI"]
 
-            # try setting relative zoom translation space
-            try:
-                if (
-                    self.config.cameras[camera_name].onvif.autotracking.zooming
-                    != ZoomingModeEnum.disabled
-                ):
+                # set up relative zoom translation space if supported
+                try:
                     if zoom_space_id is not None:
                         move_request.Translation.Zoom.space = ptz_config["Spaces"][
                             "RelativeZoomTranslationSpace"
                         ][zoom_space_id]["URI"]
-                else:
-                    if (
-                        move_request["Translation"] is not None
-                        and "Zoom" in move_request["Translation"]
-                    ):
-                        del move_request["Translation"]["Zoom"]
-                    if (
-                        move_request["Speed"] is not None
-                        and "Zoom" in move_request["Speed"]
-                    ):
-                        del move_request["Speed"]["Zoom"]
-                    logger.debug(
-                        f"{camera_name}: Relative move request after deleting zoom: {move_request}"
+                    else:
+                        if (
+                            move_request["Translation"] is not None
+                            and "Zoom" in move_request["Translation"]
+                        ):
+                            del move_request["Translation"]["Zoom"]
+                        if (
+                            move_request["Speed"] is not None
+                            and "Zoom" in move_request["Speed"]
+                        ):
+                            del move_request["Speed"]["Zoom"]
+                except Exception as e:
+                    logger.warning(
+                        f"Relative zoom not supported for {camera_name}: {e}"
                     )
-            except Exception as e:
-                self.config.cameras[
-                    camera_name
-                ].onvif.autotracking.zooming = ZoomingModeEnum.disabled
-                logger.warning(
-                    f"Disabling autotracking zooming for {camera_name}: Relative zoom not supported. Exception: {e}"
+
+                if move_request.Speed is None:
+                    move_request.Speed = configs.DefaultPTZSpeed if configs else None
+                logger.debug(
+                    f"{camera_name}: Relative move request after setup: {move_request}"
                 )
+                self.cams[camera_name]["relative_move_request"] = move_request
 
-            if move_request.Speed is None:
-                move_request.Speed = configs.DefaultPTZSpeed if configs else None
-            logger.debug(
-                f"{camera_name}: Relative move request after setup: {move_request}"
-            )
-            self.cams[camera_name]["relative_move_request"] = move_request
-
-            # setup absolute moving request for autotracking zooming
+            # setup absolute moving request (for zoom positioning)
             move_request = ptz.create_type("AbsoluteMove")
             move_request.ProfileToken = profile.token
             self.cams[camera_name]["absolute_move_request"] = move_request
+
+        except (Fault, ONVIFError, TransportError, Exception) as e:
+            logger.debug(f"PTZ configuration options not available for {camera_name}: {e}")
 
         # setup existing presets
         try:
@@ -417,9 +405,7 @@ class OnvifController:
                 logger.debug(f"Focus not supported for {camera_name}: {e}")
 
         if (
-            self.config.cameras[camera_name].onvif.autotracking.enabled_in_config
-            and self.config.cameras[camera_name].onvif.autotracking.enabled
-            and fov_space_id is not None
+            fov_space_id is not None
             and configs.DefaultRelativePanTiltTranslationSpace is not None
         ):
             supported_features.append("pt-r-fov")
@@ -550,8 +536,11 @@ class OnvifController:
 
         if (
             "zoom-r" in self.cams[camera_name]["features"]
-            and self.config.cameras[camera_name].onvif.autotracking.zooming
-            == ZoomingModeEnum.relative
+            and (
+                zoom != 0
+                or self.config.cameras[camera_name].onvif.autotracking.zooming
+                == ZoomingModeEnum.relative
+            )
         ):
             move_request.Speed = {
                 "PanTilt": {
@@ -561,6 +550,19 @@ class OnvifController:
                 "Zoom": {"x": speed},
             }
             move_request.Translation.Zoom.x = zoom
+        else:
+            move_request.Speed = {
+                "PanTilt": {
+                    "x": speed,
+                    "y": speed,
+                },
+            }
+            # Ensure no residual zoom from previous calls
+            try:
+                if move_request.Translation is not None:
+                    move_request.Translation.Zoom = None
+            except (AttributeError, KeyError):
+                pass
 
         await self.cams[camera_name]["ptz"].RelativeMove(move_request)
 
@@ -568,12 +570,11 @@ class OnvifController:
         move_request.Translation.PanTilt.x = 0
         move_request.Translation.PanTilt.y = 0
 
-        if (
-            "zoom-r" in self.cams[camera_name]["features"]
-            and self.config.cameras[camera_name].onvif.autotracking.zooming
-            == ZoomingModeEnum.relative
-        ):
-            move_request.Translation.Zoom.x = 0
+        try:
+            if move_request.Translation.Zoom is not None:
+                move_request.Translation.Zoom.x = 0
+        except (AttributeError, KeyError):
+            pass
 
         self.cams[camera_name]["active"] = False
 
@@ -717,8 +718,10 @@ class OnvifController:
             elif command == OnvifCommandEnum.preset:
                 await self._move_to_preset(camera_name, param)
             elif command == OnvifCommandEnum.move_relative:
-                _, pan, tilt = param.split("_")
-                await self._move_relative(camera_name, float(pan), float(tilt), 0, 1)
+                parts = param.split("_")
+                _, pan, tilt = parts[0], parts[1], parts[2]
+                zoom = float(parts[3]) if len(parts) > 3 else 0
+                await self._move_relative(camera_name, float(pan), float(tilt), zoom, 1)
             elif command in (OnvifCommandEnum.zoom_in, OnvifCommandEnum.zoom_out):
                 await self._zoom(camera_name, command)
             elif command in (OnvifCommandEnum.focus_in, OnvifCommandEnum.focus_out):

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -255,15 +255,22 @@ class OnvifController:
                 status = None
 
             # Check for relative zoom support
-            zoom_space_id = next(
-                (
-                    i
-                    for i, space in enumerate(
-                        ptz_config.Spaces.RelativeZoomTranslationSpace
-                    )
-                    if "TranslationGenericSpace" in space["URI"]
-                ),
+            zoom_spaces = getattr(
+                getattr(ptz_config, "Spaces", None),
+                "RelativeZoomTranslationSpace",
                 None,
+            )
+            zoom_space_id = (
+                next(
+                    (
+                        i
+                        for i, space in enumerate(zoom_spaces)
+                        if "TranslationGenericSpace" in space["URI"]
+                    ),
+                    None,
+                )
+                if zoom_spaces
+                else None
             )
 
             # setup relative moving request (for click-to-move, drag-to-zoom, and autotracking)
@@ -271,7 +278,7 @@ class OnvifController:
                 move_request = ptz.create_type("RelativeMove")
                 move_request.ProfileToken = profile.token
                 logger.debug(f"{camera_name}: Relative move request: {move_request}")
-                if move_request.Translation is None:
+                if move_request.Translation is None and status is not None:
                     move_request.Translation = status.Position
                     move_request.Translation.PanTilt.space = ptz_config["Spaces"][
                         "RelativePanTiltTranslationSpace"

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -542,14 +542,25 @@ class OnvifController:
                 == ZoomingModeEnum.relative
             )
         ):
-            move_request.Speed = {
-                "PanTilt": {
-                    "x": speed,
-                    "y": speed,
-                },
-                "Zoom": {"x": speed},
-            }
-            move_request.Translation.Zoom.x = zoom
+            try:
+                move_request.Speed = {
+                    "PanTilt": {
+                        "x": speed,
+                        "y": speed,
+                    },
+                    "Zoom": {"x": speed},
+                }
+                move_request.Translation.Zoom.x = zoom
+            except (AttributeError, KeyError):
+                logger.warning(
+                    f"{camera_name}: zoom translation not available, sending pan/tilt only"
+                )
+                move_request.Speed = {
+                    "PanTilt": {
+                        "x": speed,
+                        "y": speed,
+                    },
+                }
         else:
             move_request.Speed = {
                 "PanTilt": {

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -319,7 +319,9 @@ class OnvifController:
             self.cams[camera_name]["absolute_move_request"] = move_request
 
         except (Fault, ONVIFError, TransportError, Exception) as e:
-            logger.debug(f"PTZ configuration options not available for {camera_name}: {e}")
+            logger.debug(
+                f"PTZ configuration options not available for {camera_name}: {e}"
+            )
 
         # setup existing presets
         try:
@@ -541,13 +543,10 @@ class OnvifController:
         move_request.Translation.PanTilt.x = pan
         move_request.Translation.PanTilt.y = tilt
 
-        if (
-            "zoom-r" in self.cams[camera_name]["features"]
-            and (
-                zoom != 0
-                or self.config.cameras[camera_name].onvif.autotracking.zooming
-                == ZoomingModeEnum.relative
-            )
+        if "zoom-r" in self.cams[camera_name]["features"] and (
+            zoom != 0
+            or self.config.cameras[camera_name].onvif.autotracking.zooming
+            == ZoomingModeEnum.relative
         ):
             try:
                 move_request.Speed = {

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -295,6 +295,13 @@ class OnvifController:
                         ):
                             del move_request["Speed"]["Zoom"]
                 except Exception as e:
+                    if (
+                        self.config.cameras[camera_name].onvif.autotracking.zooming
+                        == ZoomingModeEnum.relative
+                    ):
+                        self.config.cameras[
+                            camera_name
+                        ].onvif.autotracking.zooming = ZoomingModeEnum.disabled
                     logger.warning(
                         f"Relative zoom not supported for {camera_name}: {e}"
                     )

--- a/frigate/test/test_ptz_commands.py
+++ b/frigate/test/test_ptz_commands.py
@@ -1,4 +1,22 @@
+from enum import Enum
 from unittest import TestCase, main
+
+
+class OnvifCommandEnum(str, Enum):
+    """Subset of commands needed for testing (avoids importing onvif module)."""
+
+    init = "init"
+    move_down = "move_down"
+    move_left = "move_left"
+    move_relative = "move_relative"
+    move_right = "move_right"
+    move_up = "move_up"
+    preset = "preset"
+    stop = "stop"
+    zoom_in = "zoom_in"
+    zoom_out = "zoom_out"
+    focus_in = "focus_in"
+    focus_out = "focus_out"
 
 
 class TestMoveRelativeParsing(TestCase):
@@ -34,6 +52,227 @@ class TestMoveRelativeParsing(TestCase):
         self.assertAlmostEqual(pan, -1.0)
         self.assertAlmostEqual(tilt, -1.0)
         self.assertAlmostEqual(zoom, 0.5)
+
+
+class TestDispatcherPtzParsing(TestCase):
+    """Test the dispatcher's _on_ptz_command parsing pipeline.
+
+    Replicates the logic from FrigateDispatcher._on_ptz_command to verify
+    that MQTT payloads are correctly decomposed into command + param.
+    """
+
+    def _parse_ptz_payload(self, payload: str):
+        """Replicate dispatcher parsing from _on_ptz_command."""
+        preset = payload.lower()
+
+        if "preset" in preset:
+            command = OnvifCommandEnum.preset
+            param = preset[preset.index("_") + 1 :]
+        elif "move_relative" in preset:
+            command = OnvifCommandEnum.move_relative
+            param = preset[preset.index("_") + 1 :]
+        else:
+            command = OnvifCommandEnum[preset]
+            param = ""
+
+        return command, param
+
+    def test_move_relative_pan_tilt(self):
+        command, param = self._parse_ptz_payload("move_relative_0.5_-0.3")
+        self.assertEqual(command, OnvifCommandEnum.move_relative)
+        self.assertEqual(param, "relative_0.5_-0.3")
+
+    def test_move_relative_pan_tilt_zoom(self):
+        command, param = self._parse_ptz_payload("move_relative_0.5_-0.3_0.8")
+        self.assertEqual(command, OnvifCommandEnum.move_relative)
+        self.assertEqual(param, "relative_0.5_-0.3_0.8")
+
+    def test_simple_commands(self):
+        for cmd_name in ["move_up", "move_down", "move_left", "move_right",
+                         "stop", "zoom_in", "zoom_out"]:
+            command, param = self._parse_ptz_payload(cmd_name)
+            self.assertEqual(command, OnvifCommandEnum[cmd_name])
+            self.assertEqual(param, "")
+
+    def test_preset_command(self):
+        command, param = self._parse_ptz_payload("preset_home")
+        self.assertEqual(command, OnvifCommandEnum.preset)
+        self.assertEqual(param, "home")
+
+    def test_full_pipeline_pan_tilt_only(self):
+        """Verify dispatcher param flows correctly into onvif parsing."""
+        _, param = self._parse_ptz_payload("move_relative_0.5_-0.3")
+        # Now parse as onvif.handle_command_async would
+        parts = param.split("_")
+        _, pan, tilt = parts[0], parts[1], parts[2]
+        zoom = float(parts[3]) if len(parts) > 3 else 0
+        self.assertAlmostEqual(float(pan), 0.5)
+        self.assertAlmostEqual(float(tilt), -0.3)
+        self.assertAlmostEqual(zoom, 0)
+
+    def test_full_pipeline_with_zoom(self):
+        """Verify dispatcher param flows correctly into onvif parsing with zoom."""
+        _, param = self._parse_ptz_payload("move_relative_-0.2_0.7_0.65")
+        parts = param.split("_")
+        _, pan, tilt = parts[0], parts[1], parts[2]
+        zoom = float(parts[3]) if len(parts) > 3 else 0
+        self.assertAlmostEqual(float(pan), -0.2)
+        self.assertAlmostEqual(float(tilt), 0.7)
+        self.assertAlmostEqual(zoom, 0.65)
+
+
+class TestDragToZoomCalculation(TestCase):
+    """Test the drag-to-zoom math from LiveCameraView.
+
+    Replicates the zoom calculation logic from handleOverlayMouseUp:
+    given a drag rectangle on the video overlay, compute the pan, tilt,
+    and zoom values sent to the backend.
+    """
+
+    def _calculate_drag_zoom(self, drag_start, drag_end, rect_left, rect_top,
+                             rect_width, rect_height):
+        """Replicate the drag-to-zoom calculation from LiveCameraView."""
+        x1 = min(drag_start[0], drag_end[0])
+        y1 = min(drag_start[1], drag_end[1])
+        x2 = max(drag_start[0], drag_end[0])
+        y2 = max(drag_start[1], drag_end[1])
+
+        norm_x1 = (x1 - rect_left) / rect_width
+        norm_y1 = (y1 - rect_top) / rect_height
+        norm_x2 = (x2 - rect_left) / rect_width
+        norm_y2 = (y2 - rect_top) / rect_height
+
+        box_w = norm_x2 - norm_x1
+        box_h = norm_y2 - norm_y1
+
+        frame_aspect = rect_width / rect_height
+        box_aspect = box_w / box_h
+        if box_aspect > frame_aspect:
+            box_h = box_w / frame_aspect
+        else:
+            box_w = box_h * frame_aspect
+
+        center_x = (norm_x1 + norm_x2) / 2
+        center_y = (norm_y1 + norm_y2) / 2
+        pan = (center_x - 0.5) * 2
+        tilt = (0.5 - center_y) * 2
+
+        zoom = 1 - max(box_w, box_h)
+        clamped_zoom = max(0, min(1, zoom))
+
+        return pan, tilt, clamped_zoom
+
+    def test_center_drag_half_frame(self):
+        """Drag a box covering the center 50% of a 2:1 frame.
+
+        Box is 500x250 = 0.5x0.5 normalized, but frame is 2:1.
+        Aspect correction expands width: box_w = 0.5 * 2.0 = 1.0.
+        zoom = 1 - max(1.0, 0.5) = 0.0.
+        """
+        pan, tilt, zoom = self._calculate_drag_zoom(
+            (250, 125), (750, 375), 0, 0, 1000, 500)
+        self.assertAlmostEqual(pan, 0.0)
+        self.assertAlmostEqual(tilt, 0.0)
+        self.assertAlmostEqual(zoom, 0.0)
+
+    def test_center_drag_proportional_box(self):
+        """Drag a box matching the frame's 2:1 aspect ratio at 50% size."""
+        # Frame 1000x500, box 500x125 at center = 0.5 x 0.25 normalized
+        # box_aspect = 0.5/0.25 = 2.0 = frame_aspect, no expansion
+        # zoom = 1 - max(0.5, 0.25) = 0.5
+        pan, tilt, zoom = self._calculate_drag_zoom(
+            (250, 187), (750, 312), 0, 0, 1000, 500)
+        self.assertAlmostEqual(pan, 0.0)
+        self.assertAlmostEqual(tilt, 0.002)  # slight offset due to rounding
+        self.assertAlmostEqual(zoom, 0.5)
+
+    def test_top_left_drag(self):
+        """Drag a box in the top-left quadrant of a 2:1 frame.
+
+        Box is 0.5x0.5 normalized, aspect correction expands to 1.0 wide.
+        """
+        pan, tilt, zoom = self._calculate_drag_zoom(
+            (0, 0), (500, 250), 0, 0, 1000, 500)
+        self.assertAlmostEqual(pan, -0.5)
+        self.assertAlmostEqual(tilt, 0.5)
+        self.assertAlmostEqual(zoom, 0.0)
+
+    def test_bottom_right_drag(self):
+        """Drag a box in the bottom-right quadrant of a 2:1 frame."""
+        pan, tilt, zoom = self._calculate_drag_zoom(
+            (500, 250), (1000, 500), 0, 0, 1000, 500)
+        self.assertAlmostEqual(pan, 0.5)
+        self.assertAlmostEqual(tilt, -0.5)
+        self.assertAlmostEqual(zoom, 0.0)
+
+    def test_full_frame_drag_no_zoom(self):
+        """Dragging the entire frame should produce zero zoom."""
+        pan, tilt, zoom = self._calculate_drag_zoom(
+            (0, 0), (1000, 500), 0, 0, 1000, 500)
+        self.assertAlmostEqual(pan, 0.0)
+        self.assertAlmostEqual(tilt, 0.0)
+        self.assertAlmostEqual(zoom, 0.0)
+
+    def test_small_box_high_zoom(self):
+        """A small box should produce high zoom."""
+        # 10% box at center of 1000x500 frame
+        # box is 100x50px = 0.1 x 0.1 normalized
+        # box_aspect = 1.0 < frame_aspect 2.0, expand width: 0.1 * 2.0 = 0.2
+        # zoom = 1 - max(0.2, 0.1) = 0.8
+        pan, tilt, zoom = self._calculate_drag_zoom(
+            (450, 225), (550, 275), 0, 0, 1000, 500)
+        self.assertAlmostEqual(pan, 0.0)
+        self.assertAlmostEqual(tilt, 0.0)
+        self.assertAlmostEqual(zoom, 0.8)
+
+    def test_aspect_ratio_correction_tall_box(self):
+        """A tall narrow box should be expanded to match frame aspect ratio."""
+        # Frame is 1000x500 (2:1 aspect)
+        # Drag a tall box: 100px wide x 250px tall at center
+        pan, tilt, zoom = self._calculate_drag_zoom(
+            (450, 125), (550, 375), 0, 0, 1000, 500)
+        # Raw box: 0.1 wide x 0.5 tall
+        # box_aspect = 0.1/0.5 = 0.2, frame_aspect = 2.0
+        # box is taller -> expand width: box_w = 0.5 * 2.0 = 1.0
+        # zoom = 1 - max(1.0, 0.5) = 0.0
+        self.assertAlmostEqual(pan, 0.0)
+        self.assertAlmostEqual(tilt, 0.0)
+        self.assertAlmostEqual(zoom, 0.0)
+
+    def test_aspect_ratio_correction_wide_box(self):
+        """A wide short box should be expanded to match frame aspect ratio."""
+        # Frame is 1000x500 (2:1 aspect)
+        # Drag a wide box: 800px wide x 100px tall at center
+        pan, tilt, zoom = self._calculate_drag_zoom(
+            (100, 200), (900, 300), 0, 0, 1000, 500)
+        # Raw box: 0.8 wide x 0.2 tall
+        # box_aspect = 0.8/0.2 = 4.0 > frame_aspect 2.0
+        # box is wider -> expand height: box_h = 0.8/2.0 = 0.4
+        # zoom = 1 - max(0.8, 0.4) = 0.2
+        self.assertAlmostEqual(pan, 0.0)
+        self.assertAlmostEqual(tilt, 0.0)
+        self.assertAlmostEqual(zoom, 0.2)
+
+    def test_offset_frame(self):
+        """Frame not at origin (simulating element offset on page)."""
+        # Frame at (100, 50), size 800x400 (2:1 aspect)
+        # Drag center half: (300, 150) to (700, 350)
+        # Normalized: 0.5x0.5, aspect correction expands width to 1.0
+        # zoom = 1 - 1.0 = 0.0
+        pan, tilt, zoom = self._calculate_drag_zoom(
+            (300, 150), (700, 350), 100, 50, 800, 400)
+        self.assertAlmostEqual(pan, 0.0)
+        self.assertAlmostEqual(tilt, 0.0)
+        self.assertAlmostEqual(zoom, 0.0)
+
+    def test_reversed_drag_direction(self):
+        """Dragging bottom-right to top-left should give same result as top-left to bottom-right."""
+        result1 = self._calculate_drag_zoom(
+            (250, 125), (750, 375), 0, 0, 1000, 500)
+        result2 = self._calculate_drag_zoom(
+            (750, 375), (250, 125), 0, 0, 1000, 500)
+        for a, b in zip(result1, result2):
+            self.assertAlmostEqual(a, b)
 
 
 if __name__ == "__main__":

--- a/frigate/test/test_ptz_commands.py
+++ b/frigate/test/test_ptz_commands.py
@@ -20,7 +20,12 @@ class OnvifCommandEnum(str, Enum):
 
 
 class TestMoveRelativeParsing(TestCase):
-    """Test the move_relative command parameter parsing logic."""
+    """Test the move_relative command parameter parsing logic.
+
+    NOTE: _parse_move_relative replicates logic from
+    OnvifController.handle_command_async (frigate/ptz/onvif.py).
+    If that parsing changes, this helper must be updated to match.
+    """
 
     def _parse_move_relative(self, param: str):
         """Replicate the parsing logic from OnvifController.handle_command_async."""
@@ -57,8 +62,10 @@ class TestMoveRelativeParsing(TestCase):
 class TestDispatcherPtzParsing(TestCase):
     """Test the dispatcher's _on_ptz_command parsing pipeline.
 
-    Replicates the logic from FrigateDispatcher._on_ptz_command to verify
-    that MQTT payloads are correctly decomposed into command + param.
+    Replicates the logic from FrigateDispatcher._on_ptz_command
+    (frigate/comms/dispatcher.py) to verify that MQTT payloads are
+    correctly decomposed into command + param.
+    If that parsing changes, this helper must be updated to match.
     """
 
     def _parse_ptz_payload(self, payload: str):

--- a/frigate/test/test_ptz_commands.py
+++ b/frigate/test/test_ptz_commands.py
@@ -35,25 +35,25 @@ class TestMoveRelativeParsing(TestCase):
         return float(pan), float(tilt), zoom
 
     def test_pan_tilt_only(self):
-        pan, tilt, zoom = self._parse_move_relative("move_0.5_-0.3")
+        pan, tilt, zoom = self._parse_move_relative("relative_0.5_-0.3")
         self.assertAlmostEqual(pan, 0.5)
         self.assertAlmostEqual(tilt, -0.3)
         self.assertAlmostEqual(zoom, 0)
 
     def test_pan_tilt_with_zoom(self):
-        pan, tilt, zoom = self._parse_move_relative("move_0.5_-0.3_0.8")
+        pan, tilt, zoom = self._parse_move_relative("relative_0.5_-0.3_0.8")
         self.assertAlmostEqual(pan, 0.5)
         self.assertAlmostEqual(tilt, -0.3)
         self.assertAlmostEqual(zoom, 0.8)
 
     def test_zero_zoom(self):
-        pan, tilt, zoom = self._parse_move_relative("move_0.0_0.0_0.0")
+        pan, tilt, zoom = self._parse_move_relative("relative_0.0_0.0_0.0")
         self.assertAlmostEqual(pan, 0.0)
         self.assertAlmostEqual(tilt, 0.0)
         self.assertAlmostEqual(zoom, 0.0)
 
     def test_negative_values(self):
-        pan, tilt, zoom = self._parse_move_relative("move_-1.0_-1.0_0.5")
+        pan, tilt, zoom = self._parse_move_relative("relative_-1.0_-1.0_0.5")
         self.assertAlmostEqual(pan, -1.0)
         self.assertAlmostEqual(tilt, -1.0)
         self.assertAlmostEqual(zoom, 0.5)

--- a/frigate/test/test_ptz_commands.py
+++ b/frigate/test/test_ptz_commands.py
@@ -95,8 +95,15 @@ class TestDispatcherPtzParsing(TestCase):
         self.assertEqual(param, "relative_0.5_-0.3_0.8")
 
     def test_simple_commands(self):
-        for cmd_name in ["move_up", "move_down", "move_left", "move_right",
-                         "stop", "zoom_in", "zoom_out"]:
+        for cmd_name in [
+            "move_up",
+            "move_down",
+            "move_left",
+            "move_right",
+            "stop",
+            "zoom_in",
+            "zoom_out",
+        ]:
             command, param = self._parse_ptz_payload(cmd_name)
             self.assertEqual(command, OnvifCommandEnum[cmd_name])
             self.assertEqual(param, "")
@@ -136,8 +143,9 @@ class TestDragToZoomCalculation(TestCase):
     and zoom values sent to the backend.
     """
 
-    def _calculate_drag_zoom(self, drag_start, drag_end, rect_left, rect_top,
-                             rect_width, rect_height):
+    def _calculate_drag_zoom(
+        self, drag_start, drag_end, rect_left, rect_top, rect_width, rect_height
+    ):
         """Replicate the drag-to-zoom calculation from LiveCameraView."""
         x1 = min(drag_start[0], drag_end[0])
         y1 = min(drag_start[1], drag_end[1])
@@ -177,7 +185,8 @@ class TestDragToZoomCalculation(TestCase):
         zoom = 1 - max(1.0, 0.5) = 0.0.
         """
         pan, tilt, zoom = self._calculate_drag_zoom(
-            (250, 125), (750, 375), 0, 0, 1000, 500)
+            (250, 125), (750, 375), 0, 0, 1000, 500
+        )
         self.assertAlmostEqual(pan, 0.0)
         self.assertAlmostEqual(tilt, 0.0)
         self.assertAlmostEqual(zoom, 0.0)
@@ -188,7 +197,8 @@ class TestDragToZoomCalculation(TestCase):
         # box_aspect = 0.5/0.25 = 2.0 = frame_aspect, no expansion
         # zoom = 1 - max(0.5, 0.25) = 0.5
         pan, tilt, zoom = self._calculate_drag_zoom(
-            (250, 187), (750, 312), 0, 0, 1000, 500)
+            (250, 187), (750, 312), 0, 0, 1000, 500
+        )
         self.assertAlmostEqual(pan, 0.0)
         self.assertAlmostEqual(tilt, 0.002)  # slight offset due to rounding
         self.assertAlmostEqual(zoom, 0.5)
@@ -198,8 +208,7 @@ class TestDragToZoomCalculation(TestCase):
 
         Box is 0.5x0.5 normalized, aspect correction expands to 1.0 wide.
         """
-        pan, tilt, zoom = self._calculate_drag_zoom(
-            (0, 0), (500, 250), 0, 0, 1000, 500)
+        pan, tilt, zoom = self._calculate_drag_zoom((0, 0), (500, 250), 0, 0, 1000, 500)
         self.assertAlmostEqual(pan, -0.5)
         self.assertAlmostEqual(tilt, 0.5)
         self.assertAlmostEqual(zoom, 0.0)
@@ -207,7 +216,8 @@ class TestDragToZoomCalculation(TestCase):
     def test_bottom_right_drag(self):
         """Drag a box in the bottom-right quadrant of a 2:1 frame."""
         pan, tilt, zoom = self._calculate_drag_zoom(
-            (500, 250), (1000, 500), 0, 0, 1000, 500)
+            (500, 250), (1000, 500), 0, 0, 1000, 500
+        )
         self.assertAlmostEqual(pan, 0.5)
         self.assertAlmostEqual(tilt, -0.5)
         self.assertAlmostEqual(zoom, 0.0)
@@ -215,7 +225,8 @@ class TestDragToZoomCalculation(TestCase):
     def test_full_frame_drag_no_zoom(self):
         """Dragging the entire frame should produce zero zoom."""
         pan, tilt, zoom = self._calculate_drag_zoom(
-            (0, 0), (1000, 500), 0, 0, 1000, 500)
+            (0, 0), (1000, 500), 0, 0, 1000, 500
+        )
         self.assertAlmostEqual(pan, 0.0)
         self.assertAlmostEqual(tilt, 0.0)
         self.assertAlmostEqual(zoom, 0.0)
@@ -227,7 +238,8 @@ class TestDragToZoomCalculation(TestCase):
         # box_aspect = 1.0 < frame_aspect 2.0, expand width: 0.1 * 2.0 = 0.2
         # zoom = 1 - max(0.2, 0.1) = 0.8
         pan, tilt, zoom = self._calculate_drag_zoom(
-            (450, 225), (550, 275), 0, 0, 1000, 500)
+            (450, 225), (550, 275), 0, 0, 1000, 500
+        )
         self.assertAlmostEqual(pan, 0.0)
         self.assertAlmostEqual(tilt, 0.0)
         self.assertAlmostEqual(zoom, 0.8)
@@ -237,7 +249,8 @@ class TestDragToZoomCalculation(TestCase):
         # Frame is 1000x500 (2:1 aspect)
         # Drag a tall box: 100px wide x 250px tall at center
         pan, tilt, zoom = self._calculate_drag_zoom(
-            (450, 125), (550, 375), 0, 0, 1000, 500)
+            (450, 125), (550, 375), 0, 0, 1000, 500
+        )
         # Raw box: 0.1 wide x 0.5 tall
         # box_aspect = 0.1/0.5 = 0.2, frame_aspect = 2.0
         # box is taller -> expand width: box_w = 0.5 * 2.0 = 1.0
@@ -251,7 +264,8 @@ class TestDragToZoomCalculation(TestCase):
         # Frame is 1000x500 (2:1 aspect)
         # Drag a wide box: 800px wide x 100px tall at center
         pan, tilt, zoom = self._calculate_drag_zoom(
-            (100, 200), (900, 300), 0, 0, 1000, 500)
+            (100, 200), (900, 300), 0, 0, 1000, 500
+        )
         # Raw box: 0.8 wide x 0.2 tall
         # box_aspect = 0.8/0.2 = 4.0 > frame_aspect 2.0
         # box is wider -> expand height: box_h = 0.8/2.0 = 0.4
@@ -267,17 +281,16 @@ class TestDragToZoomCalculation(TestCase):
         # Normalized: 0.5x0.5, aspect correction expands width to 1.0
         # zoom = 1 - 1.0 = 0.0
         pan, tilt, zoom = self._calculate_drag_zoom(
-            (300, 150), (700, 350), 100, 50, 800, 400)
+            (300, 150), (700, 350), 100, 50, 800, 400
+        )
         self.assertAlmostEqual(pan, 0.0)
         self.assertAlmostEqual(tilt, 0.0)
         self.assertAlmostEqual(zoom, 0.0)
 
     def test_reversed_drag_direction(self):
         """Dragging bottom-right to top-left should give same result as top-left to bottom-right."""
-        result1 = self._calculate_drag_zoom(
-            (250, 125), (750, 375), 0, 0, 1000, 500)
-        result2 = self._calculate_drag_zoom(
-            (750, 375), (250, 125), 0, 0, 1000, 500)
+        result1 = self._calculate_drag_zoom((250, 125), (750, 375), 0, 0, 1000, 500)
+        result2 = self._calculate_drag_zoom((750, 375), (250, 125), 0, 0, 1000, 500)
         for a, b in zip(result1, result2):
             self.assertAlmostEqual(a, b)
 

--- a/frigate/test/test_ptz_commands.py
+++ b/frigate/test/test_ptz_commands.py
@@ -1,0 +1,40 @@
+from unittest import TestCase, main
+
+
+class TestMoveRelativeParsing(TestCase):
+    """Test the move_relative command parameter parsing logic."""
+
+    def _parse_move_relative(self, param: str):
+        """Replicate the parsing logic from OnvifController.handle_command_async."""
+        parts = param.split("_")
+        _, pan, tilt = parts[0], parts[1], parts[2]
+        zoom = float(parts[3]) if len(parts) > 3 else 0
+        return float(pan), float(tilt), zoom
+
+    def test_pan_tilt_only(self):
+        pan, tilt, zoom = self._parse_move_relative("move_0.5_-0.3")
+        self.assertAlmostEqual(pan, 0.5)
+        self.assertAlmostEqual(tilt, -0.3)
+        self.assertAlmostEqual(zoom, 0)
+
+    def test_pan_tilt_with_zoom(self):
+        pan, tilt, zoom = self._parse_move_relative("move_0.5_-0.3_0.8")
+        self.assertAlmostEqual(pan, 0.5)
+        self.assertAlmostEqual(tilt, -0.3)
+        self.assertAlmostEqual(zoom, 0.8)
+
+    def test_zero_zoom(self):
+        pan, tilt, zoom = self._parse_move_relative("move_0.0_0.0_0.0")
+        self.assertAlmostEqual(pan, 0.0)
+        self.assertAlmostEqual(tilt, 0.0)
+        self.assertAlmostEqual(zoom, 0.0)
+
+    def test_negative_values(self):
+        pan, tilt, zoom = self._parse_move_relative("move_-1.0_-1.0_0.5")
+        self.assertAlmostEqual(pan, -1.0)
+        self.assertAlmostEqual(tilt, -1.0)
+        self.assertAlmostEqual(zoom, 0.5)
+
+
+if __name__ == "__main__":
+    main(verbosity=2)

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -338,9 +338,6 @@ export default function LiveCameraView({
         const zoom = 1 - Math.max(boxW, boxH);
         const clampedZoom = Math.max(0, Math.min(1, zoom));
 
-        // Send single command with pan, tilt, and zoom.
-        // The proxy translates this to a Set3DPos command for
-        // atomic pan+tilt+zoom in one camera movement.
         sendPtz(`move_relative_${pan}_${tilt}_${clampedZoom}`);
       }
 

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -131,6 +131,9 @@ type LiveCameraViewProps = {
   toggleFullscreen: () => void;
 };
 
+/** Minimum drag distance (px) to distinguish a drag-to-zoom from a click-to-move. */
+const MIN_DRAG_DISTANCE = 20;
+
 function getClientPos(
   e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
 ): { x: number; y: number } | null {
@@ -293,8 +296,7 @@ export default function LiveCameraView({
       const dx = Math.abs(pos.x - dragStart.x);
       const dy = Math.abs(pos.y - dragStart.y);
 
-      // Minimum drag distance of 20px to distinguish from click
-      if (dx < 20 && dy < 20) {
+      if (dx < MIN_DRAG_DISTANCE && dy < MIN_DRAG_DISTANCE) {
         // Click (not drag) — move to point without zoom
         const normalizedX = (pos.x - rect.left) / rect.width;
         const normalizedY = (pos.y - rect.top) / rect.height;
@@ -352,7 +354,7 @@ export default function LiveCameraView({
     if (!isDragging || !clickOverlayRef.current) return null;
     const dx = Math.abs(dragCurrent.x - dragStart.x);
     const dy = Math.abs(dragCurrent.y - dragStart.y);
-    if (dx < 20 && dy < 20) return null; // Don't show rectangle for small movements
+    if (dx < MIN_DRAG_DISTANCE && dy < MIN_DRAG_DISTANCE) return null;
 
     const rect = clickOverlayRef.current.getBoundingClientRect();
     const x1 = Math.min(dragStart.x, dragCurrent.x) - rect.left;
@@ -762,6 +764,10 @@ export default function LiveCameraView({
                     onMouseDown={handleOverlayMouseDown}
                     onMouseMove={handleOverlayMouseMove}
                     onMouseUp={handleOverlayMouseUp}
+                    onMouseLeave={() => {
+                      setDragStart(null);
+                      setDragCurrent(null);
+                    }}
                     onTouchStart={handleOverlayMouseDown}
                     onTouchMove={handleOverlayMouseMove}
                     onTouchEnd={handleOverlayMouseUp}

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -243,7 +243,9 @@ export default function LiveCameraView({
   };
 
   const handleOverlayMouseDown = useCallback(
-    (e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
+    (
+      e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
+    ) => {
       if (!clickOverlay || !clickOverlayRef.current) return;
       e.preventDefault();
       const pos = getClientPos(e);
@@ -256,7 +258,9 @@ export default function LiveCameraView({
   );
 
   const handleOverlayMouseMove = useCallback(
-    (e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
+    (
+      e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
+    ) => {
       if (!dragStart) return;
       e.preventDefault();
       const pos = getClientPos(e);
@@ -268,7 +272,9 @@ export default function LiveCameraView({
   );
 
   const handleOverlayMouseUp = useCallback(
-    (e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
+    (
+      e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
+    ) => {
       if (!clickOverlay || !clickOverlayRef.current || !dragStart) {
         setDragStart(null);
         setDragCurrent(null);

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -130,6 +130,19 @@ type LiveCameraViewProps = {
   fullscreen: boolean;
   toggleFullscreen: () => void;
 };
+
+function getClientPos(
+  e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
+): { x: number; y: number } | null {
+  if ("TouchEvent" in window && e.nativeEvent instanceof TouchEvent) {
+    const touch = e.nativeEvent.touches[0] || e.nativeEvent.changedTouches[0];
+    if (touch) return { x: touch.clientX, y: touch.clientY };
+  } else if (e.nativeEvent instanceof MouseEvent) {
+    return { x: e.nativeEvent.clientX, y: e.nativeEvent.clientY };
+  }
+  return null;
+}
+
 export default function LiveCameraView({
   config,
   camera,
@@ -229,18 +242,6 @@ export default function LiveCameraView({
     y: number;
   } | null>(null);
   const isDragging = dragStart !== null && dragCurrent !== null;
-
-  const getClientPos = (
-    e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
-  ): { x: number; y: number } | null => {
-    if ("TouchEvent" in window && e.nativeEvent instanceof TouchEvent) {
-      const touch = e.nativeEvent.touches[0] || e.nativeEvent.changedTouches[0];
-      if (touch) return { x: touch.clientX, y: touch.clientY };
-    } else if (e.nativeEvent instanceof MouseEvent) {
-      return { x: e.nativeEvent.clientX, y: e.nativeEvent.clientY };
-    }
-    return null;
-  };
 
   const handleOverlayMouseDown = useCallback(
     (

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -760,7 +760,7 @@ export default function LiveCameraView({
               >
                 {clickOverlay && (
                   <div
-                    className="absolute inset-0 z-40 cursor-crosshair select-none"
+                    className="absolute inset-0 z-40 cursor-crosshair select-none touch-none"
                     onMouseDown={handleOverlayMouseDown}
                     onMouseMove={handleOverlayMouseMove}
                     onMouseUp={handleOverlayMouseUp}

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -753,15 +753,15 @@ export default function LiveCameraView({
               }}
             >
               <div
-                className={`flex flex-col items-center justify-center ${growClassName}`}
+                className={`relative flex flex-col items-center justify-center ${growClassName}`}
                 ref={clickOverlayRef}
                 style={{
                   aspectRatio: constrainedAspectRatio,
-                  position: "relative",
                 }}
               >
                 {clickOverlay && (
                   <div
+                    className="absolute inset-0 z-40 cursor-crosshair select-none"
                     onMouseDown={handleOverlayMouseDown}
                     onMouseMove={handleOverlayMouseMove}
                     onMouseUp={handleOverlayMouseUp}
@@ -769,30 +769,16 @@ export default function LiveCameraView({
                     onTouchMove={handleOverlayMouseMove}
                     onTouchEnd={handleOverlayMouseUp}
                     onDragStart={(e) => e.preventDefault()}
-                    style={{
-                      position: "absolute",
-                      top: 0,
-                      left: 0,
-                      width: "100%",
-                      height: "100%",
-                      zIndex: 40,
-                      cursor: "crosshair",
-                      userSelect: "none",
-                    }}
                   />
                 )}
                 {isDragging && dragRect && clickOverlay && (
                   <div
+                    className="pointer-events-none absolute z-50 border-2 border-blue-500/80 bg-blue-500/15"
                     style={{
-                      position: "absolute",
                       left: dragRect.left,
                       top: dragRect.top,
                       width: dragRect.width,
                       height: dragRect.height,
-                      border: "2px solid rgba(59, 130, 246, 0.8)",
-                      backgroundColor: "rgba(59, 130, 246, 0.15)",
-                      pointerEvents: "none",
-                      zIndex: 50,
                     }}
                   />
                 )}

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -213,44 +213,155 @@ export default function LiveCameraView({
     };
   }, [audioTranscriptionState, sendTranscription]);
 
-  // click overlay for ptzs
+  // click/drag overlay for ptzs
 
   const [clickOverlay, setClickOverlay] = useState(false);
   const clickOverlayRef = useRef<HTMLDivElement>(null);
   const { send: sendPtz } = usePtzCommand(camera.name);
 
-  const handleOverlayClick = useCallback(
-    (
-      e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
-    ) => {
-      if (!clickOverlay) {
+  // Drag-to-zoom state
+  const [dragStart, setDragStart] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+  const [dragCurrent, setDragCurrent] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+  const isDragging = dragStart !== null && dragCurrent !== null;
+
+  const getClientPos = (
+    e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
+  ): { x: number; y: number } | null => {
+    if ("TouchEvent" in window && e.nativeEvent instanceof TouchEvent) {
+      const touch = e.nativeEvent.touches[0] || e.nativeEvent.changedTouches[0];
+      if (touch) return { x: touch.clientX, y: touch.clientY };
+    } else if (e.nativeEvent instanceof MouseEvent) {
+      return { x: e.nativeEvent.clientX, y: e.nativeEvent.clientY };
+    }
+    return null;
+  };
+
+  const handleOverlayMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
+      if (!clickOverlay || !clickOverlayRef.current) return;
+      e.preventDefault();
+      const pos = getClientPos(e);
+      if (pos) {
+        setDragStart(pos);
+        setDragCurrent(pos);
+      }
+    },
+    [clickOverlay],
+  );
+
+  const handleOverlayMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
+      if (!dragStart) return;
+      e.preventDefault();
+      const pos = getClientPos(e);
+      if (pos) {
+        setDragCurrent(pos);
+      }
+    },
+    [dragStart],
+  );
+
+  const handleOverlayMouseUp = useCallback(
+    (e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
+      if (!clickOverlay || !clickOverlayRef.current || !dragStart) {
+        setDragStart(null);
+        setDragCurrent(null);
         return;
       }
 
-      let clientX;
-      let clientY;
-      if ("TouchEvent" in window && e.nativeEvent instanceof TouchEvent) {
-        clientX = e.nativeEvent.touches[0].clientX;
-        clientY = e.nativeEvent.touches[0].clientY;
-      } else if (e.nativeEvent instanceof MouseEvent) {
-        clientX = e.nativeEvent.clientX;
-        clientY = e.nativeEvent.clientY;
+      const pos = getClientPos(e);
+      if (!pos) {
+        setDragStart(null);
+        setDragCurrent(null);
+        return;
       }
 
-      if (clickOverlayRef.current && clientX && clientY) {
-        const rect = clickOverlayRef.current.getBoundingClientRect();
+      const rect = clickOverlayRef.current.getBoundingClientRect();
+      const dx = Math.abs(pos.x - dragStart.x);
+      const dy = Math.abs(pos.y - dragStart.y);
 
-        const normalizedX = (clientX - rect.left) / rect.width;
-        const normalizedY = (clientY - rect.top) / rect.height;
-
+      // Minimum drag distance of 20px to distinguish from click
+      if (dx < 20 && dy < 20) {
+        // Click (not drag) — move to point without zoom
+        const normalizedX = (pos.x - rect.left) / rect.width;
+        const normalizedY = (pos.y - rect.top) / rect.height;
         const pan = (normalizedX - 0.5) * 2;
         const tilt = (0.5 - normalizedY) * 2;
-
         sendPtz(`move_relative_${pan}_${tilt}`);
+      } else {
+        // Drag — zoom to rectangle
+        const x1 = Math.min(dragStart.x, pos.x);
+        const y1 = Math.min(dragStart.y, pos.y);
+        const x2 = Math.max(dragStart.x, pos.x);
+        const y2 = Math.max(dragStart.y, pos.y);
+
+        // Normalize to 0-1 within the overlay
+        const normX1 = (x1 - rect.left) / rect.width;
+        const normY1 = (y1 - rect.top) / rect.height;
+        const normX2 = (x2 - rect.left) / rect.width;
+        const normY2 = (y2 - rect.top) / rect.height;
+
+        let boxW = normX2 - normX1;
+        let boxH = normY2 - normY1;
+
+        // Expand box to match camera aspect ratio
+        const frameAspect = rect.width / rect.height;
+        const boxAspect = boxW / boxH;
+        if (boxAspect > frameAspect) {
+          // Box is wider than frame aspect — expand height
+          boxH = boxW / frameAspect;
+        } else {
+          // Box is taller — expand width
+          boxW = boxH * frameAspect;
+        }
+
+        // Center of the box
+        const centerX = (normX1 + normX2) / 2;
+        const centerY = (normY1 + normY2) / 2;
+        const pan = (centerX - 0.5) * 2;
+        const tilt = (0.5 - centerY) * 2;
+
+        // Zoom: ratio of box to frame (smaller box = more zoom)
+        const zoom = 1 - Math.max(boxW, boxH);
+        const clampedZoom = Math.max(0, Math.min(1, zoom));
+
+        // Send single command with pan, tilt, and zoom.
+        // The proxy translates this to a Set3DPos command for
+        // atomic pan+tilt+zoom in one camera movement.
+        sendPtz(`move_relative_${pan}_${tilt}_${clampedZoom}`);
       }
+
+      setDragStart(null);
+      setDragCurrent(null);
     },
-    [clickOverlayRef, clickOverlay, sendPtz],
+    [clickOverlayRef, clickOverlay, dragStart, sendPtz],
   );
+
+  // Calculate drag rectangle for rendering
+  const dragRect = React.useMemo(() => {
+    if (!isDragging || !clickOverlayRef.current) return null;
+    const dx = Math.abs(dragCurrent.x - dragStart.x);
+    const dy = Math.abs(dragCurrent.y - dragStart.y);
+    if (dx < 20 && dy < 20) return null; // Don't show rectangle for small movements
+
+    const rect = clickOverlayRef.current.getBoundingClientRect();
+    const x1 = Math.min(dragStart.x, dragCurrent.x) - rect.left;
+    const y1 = Math.min(dragStart.y, dragCurrent.y) - rect.top;
+    const x2 = Math.max(dragStart.x, dragCurrent.x) - rect.left;
+    const y2 = Math.max(dragStart.y, dragCurrent.y) - rect.top;
+    return {
+      left: x1,
+      top: y1,
+      width: x2 - x1,
+      height: y2 - y1,
+    };
+  }, [isDragging, dragStart, dragCurrent]);
 
   // pip state
 
@@ -440,7 +551,8 @@ export default function LiveCameraView({
     <TransformWrapper
       minScale={1.0}
       wheel={{ smoothStep: 0.005 }}
-      disabled={debug}
+      disabled={debug || clickOverlay}
+      panning={{ disabled: clickOverlay }}
     >
       <Toaster position="top-center" closeButton={true} />
       <div
@@ -636,11 +748,47 @@ export default function LiveCameraView({
               <div
                 className={`flex flex-col items-center justify-center ${growClassName}`}
                 ref={clickOverlayRef}
-                onClick={handleOverlayClick}
                 style={{
                   aspectRatio: constrainedAspectRatio,
+                  position: "relative",
                 }}
               >
+                {clickOverlay && (
+                  <div
+                    onMouseDown={handleOverlayMouseDown}
+                    onMouseMove={handleOverlayMouseMove}
+                    onMouseUp={handleOverlayMouseUp}
+                    onTouchStart={handleOverlayMouseDown}
+                    onTouchMove={handleOverlayMouseMove}
+                    onTouchEnd={handleOverlayMouseUp}
+                    onDragStart={(e) => e.preventDefault()}
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: "100%",
+                      height: "100%",
+                      zIndex: 40,
+                      cursor: "crosshair",
+                      userSelect: "none",
+                    }}
+                  />
+                )}
+                {isDragging && dragRect && clickOverlay && (
+                  <div
+                    style={{
+                      position: "absolute",
+                      left: dragRect.left,
+                      top: dragRect.top,
+                      width: dragRect.width,
+                      height: dragRect.height,
+                      border: "2px solid rgba(59, 130, 246, 0.8)",
+                      backgroundColor: "rgba(59, 130, 246, 0.15)",
+                      pointerEvents: "none",
+                      zIndex: 50,
+                    }}
+                  />
+                )}
                 <LivePlayer
                   key={camera.name}
                   className={`${fullscreen ? "*:rounded-none" : ""}`}


### PR DESCRIPTION
## Proposed change

Adds drag-to-zoom to the live view PTZ overlay and enables click-to-move for all PTZ cameras that support RelativeMove (FOV), removing the requirement that autotracking be enabled.

**What changed:**

- **Backend (`onvif.py`):** RelativeMove/AbsoluteMove setup now runs for any camera with FOV-relative pan/tilt support, not only when autotracking is enabled. The `move_relative` command accepts an optional zoom parameter (`move_relative_{pan}_{tilt}_{zoom}`), defaulting to 0 for backward compatibility.
- **Frontend (`LiveCameraView.tsx`):** The click-to-move overlay now supports drag-to-zoom. Clicking still re-centers (unchanged behavior). Dragging a rectangle calculates pan, tilt, and zoom from the selection box's position and size relative to the frame, with aspect-ratio correction, and sends a single `move_relative` command.
- **Tests (`test_ptz_commands.py`):** 20 new tests covering command parsing, the dispatcher pipeline, and drag-to-zoom math.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #22430
- This PR is related to issue:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
- [ ] Documentation updated in [frigate-docs](https://github.com/blakeblackshear/frigate-docs) to describe drag-to-zoom behavior and the extended `move_relative` command format