### PR TITLE
Fix cross-camera auth in timeline and media endpoints

### DIFF
--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -732,7 +732,12 @@ def get_recognized_license_plates(
 
 
 @router.get("/timeline", dependencies=[Depends(allow_any_authenticated())])
-def timeline(camera: str = "all", limit: int = 100, source_id: Optional[str] = None):
+def timeline(
+    camera: str = "all",
+    limit: int = 100,
+    source_id: Optional[str] = None,
+    allowed_cameras: List[str] = Depends(get_allowed_cameras_for_filter),
+):
     clauses = []
 
     selected_columns = [
@@ -754,6 +759,9 @@ def timeline(camera: str = "all", limit: int = 100, source_id: Optional[str] = N
         else:
             clauses.append((Timeline.source_id.in_(source_ids)))
 
+    # Enforce per-camera access control
+    clauses.append((Timeline.camera << allowed_cameras))
+
     if len(clauses) == 0:
         clauses.append((True))
 
@@ -769,7 +777,10 @@ def timeline(camera: str = "all", limit: int = 100, source_id: Optional[str] = N
 
 
 @router.get("/timeline/hourly", dependencies=[Depends(allow_any_authenticated())])
-def hourly_timeline(params: AppTimelineHourlyQueryParameters = Depends()):
+def hourly_timeline(
+    params: AppTimelineHourlyQueryParameters = Depends(),
+    allowed_cameras: List[str] = Depends(get_allowed_cameras_for_filter),
+):
     """Get hourly summary for timeline."""
     cameras = params.cameras
     labels = params.labels
@@ -786,6 +797,9 @@ def hourly_timeline(params: AppTimelineHourlyQueryParameters = Depends()):
     if cameras != "all":
         camera_list = cameras.split(",")
         clauses.append((Timeline.camera << camera_list))
+
+    # Enforce per-camera access control
+    clauses.append((Timeline.camera << allowed_cameras))
 
     if labels != "all":
         label_list = labels.split(",")

--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -1142,7 +1142,6 @@ async def event_snapshot(
 
 @router.get(
     "/events/{event_id}/thumbnail.{extension}",
-    dependencies=[Depends(require_camera_access)],
 )
 async def event_thumbnail(
     request: Request,
@@ -1344,12 +1343,14 @@ def grid_snapshot(
 
 @router.get(
     "/events/{event_id}/snapshot-clean.webp",
-    dependencies=[Depends(require_camera_access)],
 )
-def event_snapshot_clean(request: Request, event_id: str, download: bool = False):
+async def event_snapshot_clean(
+    request: Request, event_id: str, download: bool = False
+):
     webp_bytes = None
     try:
         event = Event.get(Event.id == event_id)
+        await require_camera_access(event.camera, request=request)
         snapshot_config = request.app.frigate_config.cameras[event.camera].snapshots
         if not (snapshot_config.enabled and event.has_snapshot):
             return JSONResponse(
@@ -1470,7 +1471,7 @@ def event_snapshot_clean(request: Request, event_id: str, download: bool = False
 
 
 @router.get(
-    "/events/{event_id}/clip.mp4", dependencies=[Depends(require_camera_access)]
+    "/events/{event_id}/clip.mp4",
 )
 async def event_clip(
     request: Request,
@@ -1483,6 +1484,8 @@ async def event_clip(
         return JSONResponse(
             content={"success": False, "message": "Event not found"}, status_code=404
         )
+
+    await require_camera_access(event.camera, request=request)
 
     if not event.has_clip:
         return JSONResponse(
@@ -1500,15 +1503,17 @@ async def event_clip(
 
 
 @router.get(
-    "/events/{event_id}/preview.gif", dependencies=[Depends(require_camera_access)]
+    "/events/{event_id}/preview.gif",
 )
-def event_preview(request: Request, event_id: str):
+async def event_preview(request: Request, event_id: str):
     try:
         event: Event = Event.get(Event.id == event_id)
     except DoesNotExist:
         return JSONResponse(
             content={"success": False, "message": "Event not found"}, status_code=404
         )
+
+    await require_camera_access(event.camera, request=request)
 
     start_ts = event.start_time
     end_ts = start_ts + (
@@ -1854,8 +1859,8 @@ def preview_mp4(
     )
 
 
-@router.get("/review/{event_id}/preview", dependencies=[Depends(require_camera_access)])
-def review_preview(
+@router.get("/review/{event_id}/preview")
+async def review_preview(
     request: Request,
     event_id: str,
     format: str = Query(default="gif", enum=["gif", "mp4"]),
@@ -1867,6 +1872,8 @@ def review_preview(
             content=({"success": False, "message": "Review segment not found"}),
             status_code=404,
         )
+
+    await require_camera_access(review.camera, request=request)
 
     padding = 8
     start_ts = review.start_time - padding
@@ -1881,10 +1888,12 @@ def review_preview(
 
 
 @router.get(
-    "/preview/{file_name}/thumbnail.jpg", dependencies=[Depends(require_camera_access)]
+    "/preview/{file_name}/thumbnail.jpg",
+    dependencies=[Depends(allow_any_authenticated())],
 )
 @router.get(
-    "/preview/{file_name}/thumbnail.webp", dependencies=[Depends(require_camera_access)]
+    "/preview/{file_name}/thumbnail.webp",
+    dependencies=[Depends(allow_any_authenticated())],
 )
 def preview_thumbnail(file_name: str):
     """Get a thumbnail from the cached preview frames."""

--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -1344,9 +1344,7 @@ def grid_snapshot(
 @router.get(
     "/events/{event_id}/snapshot-clean.webp",
 )
-async def event_snapshot_clean(
-    request: Request, event_id: str, download: bool = False
-):
+async def event_snapshot_clean(request: Request, event_id: str, download: bool = False):
     webp_bytes = None
     try:
         event = Event.get(Event.id == event_id)


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
Authenticated custom viewer role users could use the API to enumerate event IDs from cameras they did not have access to. This PR enforces per-camera access control on `/api/timeline`, `/api/timeline/hourly`, and event media endpoints (`snapshot-clean.webp`, `clip.mp4`, `preview.gif`, review preview) that previously bypassed `require_camera_access` due to missing `camera_name` path parameters.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
