### PR TITLE
Restrict raw config endpoint to admin role

### DIFF
--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -218,7 +218,7 @@ def config_raw_paths(request: Request):
     return JSONResponse(content=raw_paths)
 
 
-@router.get("/config/raw", dependencies=[Depends(allow_any_authenticated())])
+@router.get("/config/raw", dependencies=[Depends(require_role(["admin"]))])
 def config_raw():
     config_file = find_config_file()
 

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -67,7 +67,6 @@ def require_admin_by_default():
         "/stats",
         "/stats/history",
         "/config",
-        "/config/raw",
         "/vainfo",
         "/nvinfo",
         "/labels",


### PR DESCRIPTION
## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->
This PR restricts access to the `/api/config/raw` to admin only instead of admin and authenticated users with a custom viewer role.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
