### PR TITLE
Validate preview filename and camera access

### DIFF
--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -1909,7 +1909,9 @@ async def preview_thumbnail(request: Request, file_name: str):
             content={"success": False, "message": "Invalid preview filename"},
             status_code=400,
         )
-    camera_name = file_name[len("preview_") :].split("-")[0]
+    # Use rsplit to handle camera names containing dashes (e.g. front-door)
+    name_part = file_name[len("preview_") :].rsplit(".", 1)[0]  # strip extension
+    camera_name = name_part.rsplit("-", 1)[0]  # split off timestamp
     await require_camera_access(camera_name, request=request)
 
     safe_file_name_current = sanitize_filename(file_name)

--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -1893,7 +1893,7 @@ async def review_preview(
     "/preview/{file_name}/thumbnail.webp",
     dependencies=[Depends(allow_any_authenticated())],
 )
-def preview_thumbnail(file_name: str):
+async def preview_thumbnail(request: Request, file_name: str):
     """Get a thumbnail from the cached preview frames."""
     if len(file_name) > 1000:
         return JSONResponse(
@@ -1902,6 +1902,15 @@ def preview_thumbnail(file_name: str):
             ),
             status_code=403,
         )
+
+    # Extract camera name from preview filename (format: preview_{camera}-{timestamp}.ext)
+    if not file_name.startswith("preview_"):
+        return JSONResponse(
+            content={"success": False, "message": "Invalid preview filename"},
+            status_code=400,
+        )
+    camera_name = file_name[len("preview_") :].split("-")[0]
+    await require_camera_access(camera_name, request=request)
 
     safe_file_name_current = sanitize_filename(file_name)
     preview_dir = os.path.join(CACHE_DIR, "preview_frames")


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change
<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
As a follow up to https://github.com/blakeblackshear/frigate/pull/22522, this PR validates the preview filename and checks camera auth based on the camera name in the filename (will always be in the format `preview_{camera_name}-{timestamp}.{ext}`

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [ ] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
