### PR TITLE
Add go2rtc streams to settings UI

### DIFF
--- a/frigate/config/camera/updater.py
+++ b/frigate/config/camera/updater.py
@@ -18,6 +18,7 @@ class CameraConfigUpdateEnum(str, Enum):
     detect = "detect"
     enabled = "enabled"
     ffmpeg = "ffmpeg"
+    live = "live"
     motion = "motion"  # includes motion and motion masks
     notifications = "notifications"
     objects = "objects"
@@ -107,6 +108,8 @@ class CameraConfigUpdateSubscriber:
             config.enabled = updated_config
         elif update_type == CameraConfigUpdateEnum.object_genai:
             config.objects.genai = updated_config
+        elif update_type == CameraConfigUpdateEnum.live:
+            config.live = updated_config
         elif update_type == CameraConfigUpdateEnum.motion:
             config.motion = updated_config
         elif update_type == CameraConfigUpdateEnum.notifications:

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -55,6 +55,7 @@
     "systemDetectorHardware": "Detector hardware",
     "systemDetectionModel": "Detection model",
     "systemMqtt": "MQTT",
+    "systemGo2rtcStreams": "go2rtc streams",
     "integrationSemanticSearch": "Semantic search",
     "integrationGenerativeAi": "Generative AI",
     "integrationFaceRecognition": "Face recognition",
@@ -1492,5 +1493,47 @@
   "unsavedChanges": "You have unsaved changes",
   "confirmReset": "Confirm Reset",
   "resetToDefaultDescription": "This will reset all settings in this section to their default values. This action cannot be undone.",
-  "resetToGlobalDescription": "This will reset the settings in this section to the global defaults. This action cannot be undone."
+  "resetToGlobalDescription": "This will reset the settings in this section to the global defaults. This action cannot be undone.",
+  "go2rtcStreams": {
+    "title": "go2rtc Streams",
+    "description": "Manage go2rtc stream configurations for camera restreaming. Each stream has a name and one or more source URLs.",
+    "addStream": "Add stream",
+    "addStreamDesc": "Enter a name for the new stream. This name will be used to reference the stream in your camera configuration.",
+    "addUrl": "Add URL",
+    "streamName": "Stream name",
+    "streamNamePlaceholder": "e.g., front_door",
+    "streamUrlPlaceholder": "e.g., rtsp://user:pass@192.168.1.100/stream",
+    "deleteStream": "Delete stream",
+    "deleteStreamConfirm": "Are you sure you want to delete the stream \"{{streamName}}\"? Cameras that reference this stream may stop working.",
+    "noStreams": "No go2rtc streams configured. Add a stream to get started.",
+    "validation": {
+      "nameRequired": "Stream name is required",
+      "nameDuplicate": "A stream with this name already exists",
+      "nameInvalid": "Stream name can only contain letters, numbers, underscores, and hyphens",
+      "urlRequired": "At least one URL is required"
+    },
+    "renameStream": "Rename stream",
+    "renameStreamDesc": "Enter a new name for this stream. Renaming a stream may break cameras or other streams that reference it by name.",
+    "newStreamName": "New stream name",
+    "ffmpeg": {
+      "useFfmpegModule": "Use compatibility mode (ffmpeg)",
+      "video": "Video",
+      "audio": "Audio",
+      "hardware": "Hardware acceleration",
+      "videoCopy": "Copy",
+      "videoH264": "Transcode to H.264",
+      "videoH265": "Transcode to H.265",
+      "videoExclude": "Exclude",
+      "audioCopy": "Copy",
+      "audioAac": "Transcode to AAC",
+      "audioOpus": "Transcode to Opus",
+      "audioPcmu": "Transcode to PCM μ-law",
+      "audioPcma": "Transcode to PCM A-law",
+      "audioPcm": "Transcode to PCM",
+      "audioMp3": "Transcode to MP3",
+      "audioExclude": "Exclude",
+      "hardwareNone": "No hardware acceleration",
+      "hardwareAuto": "Automatic hardware acceleration"
+    }
+  }
 }

--- a/web/src/components/config-form/theme/widgets/CameraPathWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/CameraPathWidget.tsx
@@ -8,6 +8,11 @@ import { Input } from "@/components/ui/input";
 import type { ConfigFormContext } from "@/types/configForm";
 import { cn } from "@/lib/utils";
 import { getSizedFieldClassName } from "../utils";
+import {
+  isMaskedPath,
+  hasCredentials,
+  maskCredentials,
+} from "@/utils/credentialMask";
 
 type RawPathsResponse = {
   cameras?: Record<
@@ -22,9 +27,6 @@ type RawPathsResponse = {
   >;
 };
 
-const MASKED_AUTH_PATTERN = /:\/\/\*:\*@/i;
-const MASKED_QUERY_PATTERN = /(?:[?&])user=\*&password=\*/i;
-
 const getInputIndexFromWidgetId = (id: string): number | undefined => {
   const match = id.match(/_inputs_(\d+)_path$/);
   if (!match) {
@@ -33,44 +35,6 @@ const getInputIndexFromWidgetId = (id: string): number | undefined => {
 
   const index = Number(match[1]);
   return Number.isNaN(index) ? undefined : index;
-};
-
-const isMaskedPath = (value: string): boolean =>
-  MASKED_AUTH_PATTERN.test(value) || MASKED_QUERY_PATTERN.test(value);
-
-const hasCredentials = (value: string): boolean => {
-  if (!value) {
-    return false;
-  }
-
-  if (isMaskedPath(value)) {
-    return true;
-  }
-
-  try {
-    const parsed = new URL(value);
-    if (parsed.username || parsed.password) {
-      return true;
-    }
-
-    return (
-      parsed.searchParams.has("user") && parsed.searchParams.has("password")
-    );
-  } catch {
-    return /:\/\/[^:@/\s]+:[^@/\s]+@/.test(value);
-  }
-};
-
-const maskCredentials = (value: string): string => {
-  if (!value) {
-    return value;
-  }
-
-  const maskedAuth = value.replace(/:\/\/[^:@/\s]+:[^@/\s]*@/g, "://*:*@");
-
-  return maskedAuth
-    .replace(/([?&]user=)[^&]*/gi, "$1*")
-    .replace(/([?&]password=)[^&]*/gi, "$1*");
 };
 
 export function CameraPathWidget(props: WidgetProps) {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -47,6 +47,7 @@ import ProfilesView from "@/views/settings/ProfilesView";
 import FrigatePlusSettingsView from "@/views/settings/FrigatePlusSettingsView";
 import MediaSyncSettingsView from "@/views/settings/MediaSyncSettingsView";
 import RegionGridSettingsView from "@/views/settings/RegionGridSettingsView";
+import Go2RtcStreamsSettingsView from "@/views/settings/Go2RtcStreamsSettingsView";
 import SystemDetectionModelSettingsView from "@/views/settings/SystemDetectionModelSettingsView";
 import {
   SingleSectionPage,
@@ -132,6 +133,7 @@ const allSettingsViews = [
   "systemDetectorHardware",
   "systemDetectionModel",
   "systemMqtt",
+  "systemGo2rtcStreams",
   "integrationSemanticSearch",
   "integrationGenerativeAi",
   "integrationFaceRecognition",
@@ -415,6 +417,10 @@ const settingsGroups = [
     label: "system",
     items: [
       {
+        key: "systemGo2rtcStreams",
+        component: Go2RtcStreamsSettingsView,
+      },
+      {
         key: "systemDetectorHardware",
         component: SystemDetectorHardwareSettingsPage,
       },
@@ -562,6 +568,7 @@ const ENRICHMENTS_SECTION_MAPPING: Record<string, SettingsType> = {
 };
 
 const SYSTEM_SECTION_MAPPING: Record<string, SettingsType> = {
+  go2rtc_streams: "systemGo2rtcStreams",
   database: "systemDatabase",
   mqtt: "systemMqtt",
   tls: "systemTls",

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -486,7 +486,7 @@ export interface FrigateConfig {
   };
 
   go2rtc: {
-    streams: string[];
+    streams: Record<string, string | string[]>;
     webrtc: {
       candidates: string[];
     };

--- a/web/src/utils/credentialMask.ts
+++ b/web/src/utils/credentialMask.ts
@@ -1,0 +1,40 @@
+const MASKED_AUTH_PATTERN = /:\/\/\*:\*@/i;
+const MASKED_QUERY_PATTERN = /(?:[?&])user=\*&password=\*/i;
+
+export const isMaskedPath = (value: string): boolean =>
+  MASKED_AUTH_PATTERN.test(value) || MASKED_QUERY_PATTERN.test(value);
+
+export const hasCredentials = (value: string): boolean => {
+  if (!value) {
+    return false;
+  }
+
+  if (isMaskedPath(value)) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.username || parsed.password) {
+      return true;
+    }
+
+    return (
+      parsed.searchParams.has("user") && parsed.searchParams.has("password")
+    );
+  } catch {
+    return /:\/\/[^:@/\s]+:[^@/\s]+@/.test(value);
+  }
+};
+
+export const maskCredentials = (value: string): string => {
+  if (!value) {
+    return value;
+  }
+
+  const maskedAuth = value.replace(/:\/\/[^:@/\s]+:[^@/\s]*@/g, "://*:*@");
+
+  return maskedAuth
+    .replace(/([?&]user=)[^&]*/gi, "$1*")
+    .replace(/([?&]password=)[^&]*/gi, "$1*");
+};

--- a/web/src/utils/go2rtcFfmpeg.ts
+++ b/web/src/utils/go2rtcFfmpeg.ts
@@ -1,0 +1,137 @@
+export type FfmpegVideoOption = "copy" | "h264" | "h265" | "exclude";
+export type FfmpegAudioOption =
+  | "copy"
+  | "aac"
+  | "opus"
+  | "pcmu"
+  | "pcma"
+  | "pcm"
+  | "mp3"
+  | "exclude";
+export type FfmpegHardwareOption = "none" | "auto";
+
+export type ParsedFfmpegUrl = {
+  isFfmpeg: boolean;
+  baseUrl: string;
+  video: FfmpegVideoOption;
+  audio: FfmpegAudioOption;
+  hardware: FfmpegHardwareOption;
+  extraFragments: string[];
+};
+
+const VIDEO_VALUES = new Set(["copy", "h264", "h265"]);
+const AUDIO_VALUES = new Set([
+  "copy",
+  "aac",
+  "opus",
+  "pcmu",
+  "pcma",
+  "pcm",
+  "mp3",
+]);
+const HARDWARE_SPECIFIC = new Set([
+  "vaapi",
+  "cuda",
+  "v4l2m2m",
+  "dxva2",
+  "videotoolbox",
+]);
+
+export function parseFfmpegUrl(url: string): ParsedFfmpegUrl {
+  if (!url.startsWith("ffmpeg:")) {
+    return {
+      isFfmpeg: false,
+      baseUrl: url,
+      video: "copy",
+      audio: "copy",
+      hardware: "none",
+      extraFragments: [],
+    };
+  }
+
+  const withoutPrefix = url.slice(7);
+  const parts = withoutPrefix.split("#");
+  const baseUrl = parts[0];
+  const fragments = parts.slice(1);
+
+  let video: FfmpegVideoOption | null = null;
+  let audio: FfmpegAudioOption | null = null;
+  let hardware: FfmpegHardwareOption = "none";
+  const extraFragments: string[] = [];
+
+  for (const frag of fragments) {
+    if (frag.startsWith("video=")) {
+      const val = frag.slice(6);
+      if (VIDEO_VALUES.has(val)) {
+        video = val as FfmpegVideoOption;
+      } else {
+        extraFragments.push(frag);
+      }
+    } else if (frag.startsWith("audio=")) {
+      const val = frag.slice(6);
+      if (AUDIO_VALUES.has(val)) {
+        audio = val as FfmpegAudioOption;
+      } else {
+        extraFragments.push(frag);
+      }
+    } else if (frag === "hardware") {
+      hardware = "auto";
+    } else if (frag.startsWith("hardware=")) {
+      const val = frag.slice(9);
+      if (HARDWARE_SPECIFIC.has(val)) {
+        hardware = "auto";
+      } else {
+        extraFragments.push(frag);
+      }
+    } else {
+      extraFragments.push(frag);
+    }
+  }
+
+  const hasAnyKnownFragment = video !== null || audio !== null;
+
+  return {
+    isFfmpeg: true,
+    baseUrl,
+    video: video ?? (hasAnyKnownFragment ? "exclude" : "copy"),
+    audio: audio ?? (hasAnyKnownFragment ? "exclude" : "copy"),
+    hardware,
+    extraFragments,
+  };
+}
+
+export function buildFfmpegUrl(parsed: ParsedFfmpegUrl): string {
+  let url = `ffmpeg:${parsed.baseUrl}`;
+
+  if (parsed.video !== "exclude") {
+    url += `#video=${parsed.video}`;
+  }
+  if (parsed.audio !== "exclude") {
+    url += `#audio=${parsed.audio}`;
+  }
+  if (parsed.hardware === "auto") {
+    url += "#hardware";
+  }
+  for (const frag of parsed.extraFragments) {
+    url += `#${frag}`;
+  }
+
+  return url;
+}
+
+export function toggleFfmpegMode(url: string, enable: boolean): string {
+  if (enable) {
+    if (url.startsWith("ffmpeg:")) {
+      return url;
+    }
+    return `ffmpeg:${url}#video=copy#audio=copy`;
+  }
+
+  if (!url.startsWith("ffmpeg:")) {
+    return url;
+  }
+
+  const withoutPrefix = url.slice(7);
+  const baseUrl = withoutPrefix.split("#")[0];
+  return baseUrl;
+}

--- a/web/src/views/settings/Go2RtcStreamsSettingsView.tsx
+++ b/web/src/views/settings/Go2RtcStreamsSettingsView.tsx
@@ -1,0 +1,1005 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import useSWR from "swr";
+import axios from "axios";
+import isEqual from "lodash/isEqual";
+import { toast } from "sonner";
+import {
+  LuChevronDown,
+  LuExternalLink,
+  LuEye,
+  LuEyeOff,
+  LuPencil,
+  LuPlus,
+  LuTrash2,
+} from "react-icons/lu";
+import { Link } from "react-router-dom";
+import Heading from "@/components/ui/heading";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import ActivityIndicator from "@/components/indicators/activity-indicator";
+import { useDocDomain } from "@/hooks/use-doc-domain";
+import { FrigateConfig } from "@/types/frigateConfig";
+import { cn } from "@/lib/utils";
+import {
+  isMaskedPath,
+  hasCredentials,
+  maskCredentials,
+} from "@/utils/credentialMask";
+import {
+  parseFfmpegUrl,
+  buildFfmpegUrl,
+  toggleFfmpegMode,
+  type FfmpegVideoOption,
+  type FfmpegAudioOption,
+  type FfmpegHardwareOption,
+} from "@/utils/go2rtcFfmpeg";
+
+type RawPathsResponse = {
+  cameras: Record<
+    string,
+    { ffmpeg: { inputs: { path: string; roles: string[] }[] } }
+  >;
+  go2rtc: { streams: Record<string, string | string[]> };
+};
+
+type Go2RtcStreamsSettingsViewProps = {
+  setUnsavedChanges: React.Dispatch<React.SetStateAction<boolean>>;
+  onSectionStatusChange?: (
+    sectionKey: string,
+    level: "global" | "camera",
+    status: {
+      hasChanges: boolean;
+      isOverridden: boolean;
+      hasValidationErrors: boolean;
+    },
+  ) => void;
+};
+
+const STREAM_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function normalizeStreams(
+  streams: Record<string, string | string[]> | undefined,
+): Record<string, string[]> {
+  if (!streams) return {};
+  const result: Record<string, string[]> = {};
+  for (const [name, urls] of Object.entries(streams)) {
+    result[name] = Array.isArray(urls) ? urls : [urls];
+  }
+  return result;
+}
+
+export default function Go2RtcStreamsSettingsView({
+  setUnsavedChanges,
+  onSectionStatusChange,
+}: Go2RtcStreamsSettingsViewProps) {
+  const { t } = useTranslation(["views/settings", "common"]);
+  const { getLocaleDocUrl } = useDocDomain();
+  const { data: config, mutate: updateConfig } =
+    useSWR<FrigateConfig>("config");
+  const { data: rawPaths, mutate: updateRawPaths } =
+    useSWR<RawPathsResponse>("config/raw_paths");
+
+  const [editedStreams, setEditedStreams] = useState<Record<string, string[]>>(
+    {},
+  );
+  const [serverStreams, setServerStreams] = useState<Record<string, string[]>>(
+    {},
+  );
+  const [initialized, setInitialized] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [credentialVisibility, setCredentialVisibility] = useState<
+    Record<string, boolean>
+  >({});
+  const [deleteDialog, setDeleteDialog] = useState<string | null>(null);
+  const [renameDialog, setRenameDialog] = useState<string | null>(null);
+  const [addStreamDialogOpen, setAddStreamDialogOpen] = useState(false);
+  const [newlyAdded, setNewlyAdded] = useState<Set<string>>(new Set());
+
+  // Initialize from config — wait for both config and rawPaths to avoid
+  // a mismatch when rawPaths arrives after config with different data
+  useEffect(() => {
+    if (!config || !rawPaths) return;
+
+    // Always use rawPaths for go2rtc streams — the /config endpoint masks
+    // credentials, so using config.go2rtc.streams would save masked values
+    const normalized = normalizeStreams(rawPaths.go2rtc?.streams);
+
+    setServerStreams(normalized);
+    if (!initialized) {
+      setEditedStreams(normalized);
+      setInitialized(true);
+    }
+  }, [config, rawPaths, initialized]);
+
+  // Track unsaved changes
+  const hasChanges = useMemo(
+    () => initialized && !isEqual(editedStreams, serverStreams),
+    [editedStreams, serverStreams, initialized],
+  );
+
+  useEffect(() => {
+    setUnsavedChanges(hasChanges);
+  }, [hasChanges, setUnsavedChanges]);
+
+  const hasValidationErrors = useMemo(() => {
+    const names = Object.keys(editedStreams);
+    const seenNames = new Set<string>();
+
+    for (const name of names) {
+      if (!name.trim() || !STREAM_NAME_PATTERN.test(name)) return true;
+      if (seenNames.has(name)) return true;
+      seenNames.add(name);
+
+      const urls = editedStreams[name];
+      if (!urls || urls.length === 0 || urls.every((u) => !u.trim()))
+        return true;
+    }
+
+    return false;
+  }, [editedStreams]);
+
+  // Report status to parent for sidebar red dot
+  useEffect(() => {
+    onSectionStatusChange?.("go2rtc_streams", "global", {
+      hasChanges: hasChanges,
+      isOverridden: false,
+      hasValidationErrors,
+    });
+  }, [hasChanges, hasValidationErrors, onSectionStatusChange]);
+
+  // Save handler
+  const saveToConfig = useCallback(async () => {
+    setIsLoading(true);
+
+    try {
+      const streamsPayload: Record<string, string[] | string> = {
+        ...editedStreams,
+      };
+      const deletedStreamNames = Object.keys(serverStreams).filter(
+        (name) => !(name in editedStreams),
+      );
+      for (const deleted of deletedStreamNames) {
+        streamsPayload[deleted] = "";
+      }
+
+      await axios.put("config/set", {
+        requires_restart: 0,
+        config_data: { go2rtc: { streams: streamsPayload } },
+      });
+
+      // Update running go2rtc instance
+      const go2rtcUpdates: Promise<unknown>[] = [];
+      for (const [streamName, urls] of Object.entries(editedStreams)) {
+        if (urls[0]) {
+          go2rtcUpdates.push(
+            axios.put(
+              `go2rtc/streams/${streamName}?src=${encodeURIComponent(urls[0])}`,
+            ),
+          );
+        }
+      }
+      for (const deleted of deletedStreamNames) {
+        go2rtcUpdates.push(axios.delete(`go2rtc/streams/${deleted}`));
+      }
+      await Promise.allSettled(go2rtcUpdates);
+
+      toast.success(
+        t("toast.success", {
+          ns: "views/settings",
+          defaultValue: "Settings saved successfully",
+        }),
+      );
+
+      setServerStreams(editedStreams);
+      updateConfig();
+      updateRawPaths();
+    } catch {
+      toast.error(
+        t("toast.error", {
+          ns: "views/settings",
+          defaultValue: "Failed to save settings",
+        }),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [editedStreams, serverStreams, t, updateConfig, updateRawPaths]);
+
+  // Reset handler
+  const onReset = useCallback(() => {
+    setEditedStreams(serverStreams);
+    setCredentialVisibility({});
+  }, [serverStreams]);
+
+  // Stream CRUD operations
+  const addStream = useCallback((name: string) => {
+    setEditedStreams((prev) => ({ ...prev, [name]: [""] }));
+    setNewlyAdded((prev) => new Set(prev).add(name));
+    setAddStreamDialogOpen(false);
+  }, []);
+
+  const deleteStream = useCallback((streamName: string) => {
+    setEditedStreams((prev) => {
+      const { [streamName]: _, ...rest } = prev;
+      return rest;
+    });
+    setDeleteDialog(null);
+  }, []);
+
+  const renameStream = useCallback((oldName: string, newName: string) => {
+    if (oldName === newName || !newName.trim()) return;
+
+    setEditedStreams((prev) => {
+      const urls = prev[oldName];
+      if (!urls) return prev;
+
+      const entries = Object.entries(prev);
+      const result: Record<string, string[]> = {};
+      for (const [key, value] of entries) {
+        if (key === oldName) {
+          result[newName] = value;
+        } else {
+          result[key] = value;
+        }
+      }
+      return result;
+    });
+  }, []);
+
+  const updateUrl = useCallback(
+    (streamName: string, urlIndex: number, newUrl: string) => {
+      setEditedStreams((prev) => {
+        const urls = [...(prev[streamName] || [])];
+        urls[urlIndex] = newUrl;
+        return { ...prev, [streamName]: urls };
+      });
+    },
+    [],
+  );
+
+  const addUrl = useCallback((streamName: string) => {
+    setEditedStreams((prev) => {
+      const urls = [...(prev[streamName] || []), ""];
+      return { ...prev, [streamName]: urls };
+    });
+  }, []);
+
+  const removeUrl = useCallback((streamName: string, urlIndex: number) => {
+    setEditedStreams((prev) => {
+      const urls = (prev[streamName] || []).filter((_, i) => i !== urlIndex);
+      return { ...prev, [streamName]: urls.length > 0 ? urls : [""] };
+    });
+  }, []);
+
+  const toggleCredentialVisibility = useCallback((key: string) => {
+    setCredentialVisibility((prev) => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+
+  if (!config) return null;
+
+  const streamEntries = Object.entries(editedStreams);
+
+  return (
+    <div className="flex size-full flex-col lg:pr-2">
+      <div className="max-w-4xl">
+        <div className="mb-5 flex flex-col">
+          <Heading as="h4">{t("go2rtcStreams.title")}</Heading>
+          <div className="my-1 text-sm text-muted-foreground">
+            {t("go2rtcStreams.description")}
+          </div>
+          <div className="flex items-center text-sm text-primary-variant">
+            <Link
+              to={getLocaleDocUrl("guides/configuring_go2rtc")}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline"
+            >
+              {t("readTheDocumentation", { ns: "common" })}
+              <LuExternalLink className="ml-2 inline-flex size-3" />
+            </Link>
+          </div>
+        </div>
+
+        {streamEntries.length === 0 && (
+          <div className="my-8 text-center text-sm text-muted-foreground">
+            {t("go2rtcStreams.noStreams")}
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {streamEntries.map(([streamName, urls]) => (
+            <StreamCard
+              key={streamName}
+              streamName={streamName}
+              urls={urls}
+              credentialVisibility={credentialVisibility}
+              defaultOpen={newlyAdded.has(streamName)}
+              onRename={() => setRenameDialog(streamName)}
+              onDelete={() => setDeleteDialog(streamName)}
+              onUpdateUrl={updateUrl}
+              onAddUrl={() => addUrl(streamName)}
+              onRemoveUrl={(urlIndex) => removeUrl(streamName, urlIndex)}
+              onToggleCredentialVisibility={toggleCredentialVisibility}
+            />
+          ))}
+        </div>
+
+        <Button
+          type="button"
+          onClick={() => setAddStreamDialogOpen(true)}
+          variant="outline"
+          className="my-4"
+        >
+          <LuPlus className="mr-2 size-4" />
+          {t("go2rtcStreams.addStream")}
+        </Button>
+      </div>
+
+      {/* Sticky save/undo buttons */}
+      <div className="sticky bottom-0 z-50 w-full border-t border-secondary bg-background pt-0">
+        <div
+          className={cn(
+            "flex flex-col items-center gap-4 pt-2 md:flex-row",
+            hasChanges ? "justify-between" : "justify-end",
+          )}
+        >
+          {hasChanges && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-danger">{t("unsavedChanges")}</span>
+            </div>
+          )}
+          <div className="flex w-full items-center gap-2 md:w-auto">
+            {hasChanges && (
+              <Button
+                onClick={onReset}
+                variant="outline"
+                disabled={isLoading}
+                className="flex min-w-36 flex-1 gap-2"
+              >
+                {t("button.undo", { ns: "common" })}
+              </Button>
+            )}
+            <Button
+              onClick={saveToConfig}
+              variant="select"
+              disabled={!hasChanges || isLoading || hasValidationErrors}
+              className="flex min-w-36 flex-1 gap-2"
+            >
+              {isLoading ? (
+                <>
+                  <ActivityIndicator className="h-4 w-4" />
+                  {t("button.saving", { ns: "common" })}
+                </>
+              ) : (
+                t("button.save", { ns: "common" })
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Delete confirmation dialog */}
+      <AlertDialog
+        open={deleteDialog !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteDialog(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("go2rtcStreams.deleteStream")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("go2rtcStreams.deleteStreamConfirm", {
+                streamName: deleteDialog ?? "",
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              {t("button.cancel", { ns: "common" })}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deleteDialog && deleteStream(deleteDialog)}
+            >
+              {t("go2rtcStreams.deleteStream")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Rename dialog */}
+      <RenameStreamDialog
+        open={renameDialog !== null}
+        streamName={renameDialog ?? ""}
+        allStreamNames={Object.keys(editedStreams)}
+        onRename={(oldName, newName) => {
+          renameStream(oldName, newName);
+          setRenameDialog(null);
+        }}
+        onClose={() => setRenameDialog(null)}
+      />
+
+      <AddStreamDialog
+        open={addStreamDialogOpen}
+        allStreamNames={Object.keys(editedStreams)}
+        onAdd={addStream}
+        onClose={() => setAddStreamDialogOpen(false)}
+      />
+    </div>
+  );
+}
+
+// --- RenameStreamDialog ---
+
+type RenameStreamDialogProps = {
+  open: boolean;
+  streamName: string;
+  allStreamNames: string[];
+  onRename: (oldName: string, newName: string) => void;
+  onClose: () => void;
+};
+
+function RenameStreamDialog({
+  open,
+  streamName,
+  allStreamNames,
+  onRename,
+  onClose,
+}: RenameStreamDialogProps) {
+  const { t } = useTranslation(["views/settings", "common"]);
+  const [newName, setNewName] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setNewName(streamName);
+    }
+  }, [open, streamName]);
+
+  const nameError = useMemo(() => {
+    if (!newName.trim()) {
+      return t("go2rtcStreams.validation.nameRequired");
+    }
+    if (!STREAM_NAME_PATTERN.test(newName)) {
+      return t("go2rtcStreams.validation.nameInvalid");
+    }
+    if (newName !== streamName && allStreamNames.includes(newName)) {
+      return t("go2rtcStreams.validation.nameDuplicate");
+    }
+    return null;
+  }, [newName, streamName, allStreamNames, t]);
+
+  const canSubmit = !nameError && newName !== streamName;
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("go2rtcStreams.renameStream")}</DialogTitle>
+          <DialogDescription>
+            {t("go2rtcStreams.renameStreamDesc")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2 py-2">
+          <Label>{t("go2rtcStreams.newStreamName")}</Label>
+          <Input
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && canSubmit) {
+                onRename(streamName, newName);
+              }
+            }}
+            autoFocus
+          />
+          {nameError && newName !== streamName && (
+            <p className="text-xs text-destructive">{nameError}</p>
+          )}
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button>{t("button.cancel", { ns: "common" })}</Button>
+          </DialogClose>
+          <Button
+            variant="select"
+            disabled={!canSubmit}
+            onClick={() => onRename(streamName, newName)}
+          >
+            {t("go2rtcStreams.renameStream")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+type AddStreamDialogProps = {
+  open: boolean;
+  allStreamNames: string[];
+  onAdd: (name: string) => void;
+  onClose: () => void;
+};
+
+function AddStreamDialog({
+  open,
+  allStreamNames,
+  onAdd,
+  onClose,
+}: AddStreamDialogProps) {
+  const { t } = useTranslation(["views/settings", "common"]);
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setName("");
+    }
+  }, [open]);
+
+  const nameError = useMemo(() => {
+    if (!name.trim()) {
+      return t("go2rtcStreams.validation.nameRequired");
+    }
+    if (!STREAM_NAME_PATTERN.test(name)) {
+      return t("go2rtcStreams.validation.nameInvalid");
+    }
+    if (allStreamNames.includes(name)) {
+      return t("go2rtcStreams.validation.nameDuplicate");
+    }
+    return null;
+  }, [name, allStreamNames, t]);
+
+  const canSubmit = !nameError;
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("go2rtcStreams.addStream")}</DialogTitle>
+          <DialogDescription>
+            {t("go2rtcStreams.addStreamDesc")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2 py-2">
+          <Label>{t("go2rtcStreams.streamName")}</Label>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && canSubmit) {
+                onAdd(name);
+              }
+            }}
+            placeholder="camera_name"
+            autoFocus
+          />
+          {nameError && name.length > 0 && (
+            <p className="text-xs text-destructive">{nameError}</p>
+          )}
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button>{t("button.cancel", { ns: "common" })}</Button>
+          </DialogClose>
+          <Button
+            variant="select"
+            disabled={!canSubmit}
+            onClick={() => onAdd(name)}
+          >
+            {t("go2rtcStreams.addStream")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+type StreamCardProps = {
+  streamName: string;
+  urls: string[];
+  credentialVisibility: Record<string, boolean>;
+  onRename: () => void;
+  onDelete: () => void;
+  onUpdateUrl: (streamName: string, urlIndex: number, newUrl: string) => void;
+  onAddUrl: () => void;
+  onRemoveUrl: (urlIndex: number) => void;
+  onToggleCredentialVisibility: (key: string) => void;
+  defaultOpen?: boolean;
+};
+
+function StreamCard({
+  streamName,
+  urls,
+  credentialVisibility,
+  onRename,
+  onDelete,
+  onUpdateUrl,
+  onAddUrl,
+  onRemoveUrl,
+  onToggleCredentialVisibility,
+  defaultOpen = false,
+}: StreamCardProps) {
+  const { t } = useTranslation("views/settings");
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <Card className="bg-secondary text-primary">
+      <CardContent className="p-0">
+        <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+          <div className="flex items-center justify-between px-4 py-3">
+            <div className="flex items-center gap-2">
+              <h4 className="font-medium">{streamName}</h4>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onRename}
+                className="size-7 p-0 text-muted-foreground hover:text-primary"
+              >
+                <LuPencil className="size-3.5" />
+              </Button>
+            </div>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onDelete}
+                className="text-secondary-foreground hover:text-secondary-foreground"
+              >
+                <LuTrash2 className="size-5" />
+              </Button>
+              <CollapsibleTrigger asChild>
+                <Button variant="ghost" size="sm">
+                  <LuChevronDown
+                    className={cn(
+                      "size-5 transition-transform",
+                      isOpen && "rotate-180",
+                    )}
+                  />
+                </Button>
+              </CollapsibleTrigger>
+            </div>
+          </div>
+          <CollapsibleContent>
+            <div className="space-y-3 px-4 pb-4">
+              {urls.map((url, urlIndex) => (
+                <StreamUrlEntry
+                  key={urlIndex}
+                  streamName={streamName}
+                  url={url}
+                  urlIndex={urlIndex}
+                  canRemove={urls.length > 1}
+                  showCredentials={
+                    credentialVisibility[`${streamName}-${urlIndex}`] ?? false
+                  }
+                  onUpdateUrl={onUpdateUrl}
+                  onRemoveUrl={() => onRemoveUrl(urlIndex)}
+                  onToggleCredentialVisibility={() =>
+                    onToggleCredentialVisibility(`${streamName}-${urlIndex}`)
+                  }
+                />
+              ))}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onAddUrl}
+                className="w-fit"
+              >
+                <LuPlus className="mr-2 size-4" />
+                {t("go2rtcStreams.addUrl")}
+              </Button>
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      </CardContent>
+    </Card>
+  );
+}
+
+// --- StreamUrlEntry sub-component ---
+
+type StreamUrlEntryProps = {
+  streamName: string;
+  url: string;
+  urlIndex: number;
+  canRemove: boolean;
+  showCredentials: boolean;
+  onUpdateUrl: (streamName: string, urlIndex: number, newUrl: string) => void;
+  onRemoveUrl: () => void;
+  onToggleCredentialVisibility: () => void;
+};
+
+function StreamUrlEntry({
+  streamName,
+  url,
+  urlIndex,
+  canRemove,
+  showCredentials,
+  onUpdateUrl,
+  onRemoveUrl,
+  onToggleCredentialVisibility,
+}: StreamUrlEntryProps) {
+  const { t } = useTranslation("views/settings");
+  const [isFocused, setIsFocused] = useState(false);
+  const parsed = useMemo(() => parseFfmpegUrl(url), [url]);
+
+  const rawBaseUrl = parsed.isFfmpeg ? parsed.baseUrl : url;
+  const canToggleCredentials =
+    hasCredentials(rawBaseUrl) && !isMaskedPath(rawBaseUrl);
+
+  const baseUrlForDisplay = useMemo(() => {
+    // Never mask while the input is focused — the user may be typing credentials
+    if (isFocused) return rawBaseUrl;
+    if (!showCredentials && hasCredentials(rawBaseUrl)) {
+      return maskCredentials(rawBaseUrl);
+    }
+    return rawBaseUrl;
+  }, [rawBaseUrl, showCredentials, isFocused]);
+
+  const isTranscodingVideo =
+    parsed.isFfmpeg && parsed.video !== "copy" && parsed.video !== "exclude";
+
+  const handleBaseUrlChange = useCallback(
+    (newBaseUrl: string) => {
+      if (parsed.isFfmpeg) {
+        const newUrl = buildFfmpegUrl({ ...parsed, baseUrl: newBaseUrl });
+        onUpdateUrl(streamName, urlIndex, newUrl);
+      } else {
+        onUpdateUrl(streamName, urlIndex, newBaseUrl);
+      }
+    },
+    [parsed, streamName, urlIndex, onUpdateUrl],
+  );
+
+  const handleFfmpegToggle = useCallback(
+    (enabled: boolean) => {
+      const newUrl = toggleFfmpegMode(url, enabled);
+      onUpdateUrl(streamName, urlIndex, newUrl);
+    },
+    [url, streamName, urlIndex, onUpdateUrl],
+  );
+
+  const handleFfmpegOptionChange = useCallback(
+    (
+      field: "video" | "audio" | "hardware",
+      value: FfmpegVideoOption | FfmpegAudioOption | FfmpegHardwareOption,
+    ) => {
+      const updated = { ...parsed, [field]: value };
+      // Clear hardware when switching away from transcoding video
+      if (field === "video" && (value === "copy" || value === "exclude")) {
+        updated.hardware = "none";
+      }
+      const newUrl = buildFfmpegUrl(updated);
+      onUpdateUrl(streamName, urlIndex, newUrl);
+    },
+    [parsed, streamName, urlIndex, onUpdateUrl],
+  );
+
+  const audioDisplayLabel = useMemo(() => {
+    const labels: Record<string, string> = {
+      copy: t("go2rtcStreams.ffmpeg.audioCopy"),
+      aac: t("go2rtcStreams.ffmpeg.audioAac"),
+      opus: t("go2rtcStreams.ffmpeg.audioOpus"),
+      pcmu: t("go2rtcStreams.ffmpeg.audioPcmu"),
+      pcma: t("go2rtcStreams.ffmpeg.audioPcma"),
+      pcm: t("go2rtcStreams.ffmpeg.audioPcm"),
+      mp3: t("go2rtcStreams.ffmpeg.audioMp3"),
+      exclude: t("go2rtcStreams.ffmpeg.audioExclude"),
+    };
+    return labels[parsed.audio] || parsed.audio;
+  }, [parsed.audio, t]);
+
+  return (
+    <div className="space-y-2 rounded-lg bg-background p-3">
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Input
+            className="h-8 pr-10"
+            value={baseUrlForDisplay}
+            onChange={(e) => handleBaseUrlChange(e.target.value)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            placeholder={t("go2rtcStreams.streamUrlPlaceholder")}
+          />
+          {canToggleCredentials && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
+              onClick={onToggleCredentialVisibility}
+            >
+              {showCredentials ? (
+                <LuEyeOff className="size-4" />
+              ) : (
+                <LuEye className="size-4" />
+              )}
+            </Button>
+          )}
+        </div>
+        {canRemove && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onRemoveUrl}
+            className="text-secondary-foreground hover:text-secondary-foreground"
+          >
+            <LuTrash2 className="size-4" />
+          </Button>
+        )}
+      </div>
+
+      {/* ffmpeg module toggle */}
+      <div className="flex items-center space-x-2">
+        <Switch
+          checked={parsed.isFfmpeg}
+          onCheckedChange={handleFfmpegToggle}
+        />
+        <Label className="text-sm">
+          {t("go2rtcStreams.ffmpeg.useFfmpegModule")}
+        </Label>
+      </div>
+
+      {/* ffmpeg options */}
+      {parsed.isFfmpeg && (
+        <div
+          className={cn(
+            "grid grid-cols-1 gap-3 pl-4",
+            isTranscodingVideo ? "sm:grid-cols-3" : "sm:grid-cols-2",
+          )}
+        >
+          {/* Video */}
+          <div className="space-y-1">
+            <Label className="text-xs font-medium">
+              {t("go2rtcStreams.ffmpeg.video")}
+            </Label>
+            <Select
+              value={parsed.video}
+              onValueChange={(v) =>
+                handleFfmpegOptionChange("video", v as FfmpegVideoOption)
+              }
+            >
+              <SelectTrigger className="h-8">
+                {parsed.video === "copy"
+                  ? t("go2rtcStreams.ffmpeg.videoCopy")
+                  : parsed.video === "h264"
+                    ? t("go2rtcStreams.ffmpeg.videoH264")
+                    : parsed.video === "h265"
+                      ? t("go2rtcStreams.ffmpeg.videoH265")
+                      : t("go2rtcStreams.ffmpeg.videoExclude")}
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value="copy">
+                    {t("go2rtcStreams.ffmpeg.videoCopy")}
+                  </SelectItem>
+                  <SelectItem value="h264">
+                    {t("go2rtcStreams.ffmpeg.videoH264")}
+                  </SelectItem>
+                  <SelectItem value="h265">
+                    {t("go2rtcStreams.ffmpeg.videoH265")}
+                  </SelectItem>
+                  <SelectItem value="exclude">
+                    {t("go2rtcStreams.ffmpeg.videoExclude")}
+                  </SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Audio */}
+          <div className="space-y-1">
+            <Label className="text-xs font-medium">
+              {t("go2rtcStreams.ffmpeg.audio")}
+            </Label>
+            <Select
+              value={parsed.audio}
+              onValueChange={(v) =>
+                handleFfmpegOptionChange("audio", v as FfmpegAudioOption)
+              }
+            >
+              <SelectTrigger className="h-8">{audioDisplayLabel}</SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value="copy">
+                    {t("go2rtcStreams.ffmpeg.audioCopy")}
+                  </SelectItem>
+                  <SelectItem value="aac">
+                    {t("go2rtcStreams.ffmpeg.audioAac")}
+                  </SelectItem>
+                  <SelectItem value="opus">
+                    {t("go2rtcStreams.ffmpeg.audioOpus")}
+                  </SelectItem>
+                  <SelectItem value="pcmu">
+                    {t("go2rtcStreams.ffmpeg.audioPcmu")}
+                  </SelectItem>
+                  <SelectItem value="pcma">
+                    {t("go2rtcStreams.ffmpeg.audioPcma")}
+                  </SelectItem>
+                  <SelectItem value="pcm">
+                    {t("go2rtcStreams.ffmpeg.audioPcm")}
+                  </SelectItem>
+                  <SelectItem value="mp3">
+                    {t("go2rtcStreams.ffmpeg.audioMp3")}
+                  </SelectItem>
+                  <SelectItem value="exclude">
+                    {t("go2rtcStreams.ffmpeg.audioExclude")}
+                  </SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Hardware acceleration - only when transcoding video */}
+          {isTranscodingVideo && (
+            <div className="space-y-1">
+              <Label className="text-xs font-medium">
+                {t("go2rtcStreams.ffmpeg.hardware")}
+              </Label>
+              <Select
+                value={parsed.hardware}
+                onValueChange={(v) =>
+                  handleFfmpegOptionChange(
+                    "hardware",
+                    v as FfmpegHardwareOption,
+                  )
+                }
+              >
+                <SelectTrigger className="h-8">
+                  {parsed.hardware === "auto"
+                    ? t("go2rtcStreams.ffmpeg.hardwareAuto")
+                    : t("go2rtcStreams.ffmpeg.hardwareNone")}
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectItem value="none">
+                      {t("go2rtcStreams.ffmpeg.hardwareNone")}
+                    </SelectItem>
+                    <SelectItem value="auto">
+                      {t("go2rtcStreams.ffmpeg.hardwareAuto")}
+                    </SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/views/settings/Go2RtcStreamsSettingsView.tsx
+++ b/web/src/views/settings/Go2RtcStreamsSettingsView.tsx
@@ -731,8 +731,6 @@ function StreamCard({
   );
 }
 
-// --- StreamUrlEntry sub-component ---
-
 type StreamUrlEntryProps = {
   streamName: string;
   url: string;

--- a/web/src/views/settings/Go2RtcStreamsSettingsView.tsx
+++ b/web/src/views/settings/Go2RtcStreamsSettingsView.tsx
@@ -15,7 +15,7 @@ import {
 } from "react-icons/lu";
 import { Link } from "react-router-dom";
 import Heading from "@/components/ui/heading";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
@@ -436,6 +436,10 @@ export default function Go2RtcStreamsSettingsView({
               {t("button.cancel", { ns: "common" })}
             </AlertDialogCancel>
             <AlertDialogAction
+              className={cn(
+                buttonVariants({ variant: "destructive" }),
+                "text-white",
+              )}
               onClick={() => deleteDialog && deleteStream(deleteDialog)}
             >
               {t("go2rtcStreams.deleteStream")}

--- a/web/src/views/settings/Go2RtcStreamsSettingsView.tsx
+++ b/web/src/views/settings/Go2RtcStreamsSettingsView.tsx
@@ -523,6 +523,7 @@ function RenameStreamDialog({
         <div className="space-y-2 py-2">
           <Label>{t("go2rtcStreams.newStreamName")}</Label>
           <Input
+            className="text-md"
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
             onKeyDown={(e) => {
@@ -536,7 +537,7 @@ function RenameStreamDialog({
             <p className="text-xs text-destructive">{nameError}</p>
           )}
         </div>
-        <DialogFooter>
+        <DialogFooter className="gap-2 sm:justify-end md:gap-0">
           <DialogClose asChild>
             <Button>{t("button.cancel", { ns: "common" })}</Button>
           </DialogClose>
@@ -603,6 +604,7 @@ function AddStreamDialog({
           <Label>{t("go2rtcStreams.streamName")}</Label>
           <Input
             value={name}
+            className="text-md"
             onChange={(e) => setName(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "Enter" && canSubmit) {
@@ -616,7 +618,7 @@ function AddStreamDialog({
             <p className="text-xs text-destructive">{nameError}</p>
           )}
         </div>
-        <DialogFooter>
+        <DialogFooter className="gap-2 sm:justify-end md:gap-0">
           <DialogClose asChild>
             <Button>{t("button.cancel", { ns: "common" })}</Button>
           </DialogClose>
@@ -831,7 +833,7 @@ function StreamUrlEntry({
       <div className="flex items-center gap-2">
         <div className="relative flex-1">
           <Input
-            className="h-8 pr-10"
+            className="text-md h-8 pr-10"
             value={baseUrlForDisplay}
             onChange={(e) => handleBaseUrlChange(e.target.value)}
             onFocus={() => setIsFocused(true)}


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change
<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR adds a new go2rtc streams settings page for managing go2rtc stream configurations directly from the UI
- Add, rename, delete streams and edit source URLs with credential masking and an inline ffmpeg module builder (video/audio codec, hardware acceleration)
- Add live topic to the camera config updater so live settings can be updated at runtime without restart

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [ ] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
