### PR TITLE
Settings UI tweaks

### DIFF
--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -1315,6 +1315,8 @@
       "preset": "Preset",
       "manual": "Manual arguments",
       "inherit": "Inherit from camera setting",
+      "none": "None",
+      "useGlobalSetting": "Inherit from global setting",
       "selectPreset": "Select preset",
       "manualPlaceholder": "Enter FFmpeg arguments"
     },

--- a/web/src/components/config-form/theme/widgets/FfmpegArgsWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/FfmpegArgsWidget.tsx
@@ -1,7 +1,9 @@
 import type { WidgetProps } from "@rjsf/utils";
 import useSWR from "swr";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import get from "lodash/get";
+import isEqual from "lodash/isEqual";
 import { Input } from "@/components/ui/input";
 import { ConfigFormContext } from "@/types/configForm";
 import {
@@ -22,7 +24,7 @@ type FfmpegPresetResponse = {
   };
 };
 
-type FfmpegArgsMode = "preset" | "manual" | "inherit";
+type FfmpegArgsMode = "preset" | "manual" | "inherit" | "none";
 
 type PresetField =
   | "hwaccel_args"
@@ -60,8 +62,8 @@ const resolveMode = (
   defaultMode: FfmpegArgsMode,
   allowInherit: boolean,
 ): FfmpegArgsMode => {
-  if (allowInherit && (value === null || value === undefined)) {
-    return "inherit";
+  if (value === null || value === undefined) {
+    return allowInherit ? "inherit" : "none";
   }
 
   if (allowInherit && Array.isArray(value) && value.length === 0) {
@@ -122,6 +124,19 @@ export function FfmpegArgsWidget(props: WidgetProps) {
   const hideDescription = options?.hideDescription === true;
   const useSplitLayout = options?.splitLayout !== false;
 
+  // Detect camera-level top-level fields (not inside inputs array).
+  // These should show "Use global setting" instead of "None".
+  const isInputScoped = id.includes("_inputs_");
+  const showUseGlobalSetting = isCameraLevel && !isInputScoped && !allowInherit;
+
+  // Extract the global value for this specific field to detect inheritance
+  const globalFieldValue = useMemo(() => {
+    if (!showUseGlobalSetting || !formContext?.globalValue || !presetField) {
+      return undefined;
+    }
+    return get(formContext.globalValue as Record<string, unknown>, presetField);
+  }, [showUseGlobalSetting, formContext?.globalValue, presetField]);
+
   const { data } = useSWR<FfmpegPresetResponse>("ffmpeg/presets");
 
   const presetOptions = useMemo(
@@ -132,14 +147,48 @@ export function FfmpegArgsWidget(props: WidgetProps) {
   const canUsePresets = presetOptions.length > 0;
   const defaultMode: FfmpegArgsMode = canUsePresets ? "preset" : "manual";
 
-  const detectedMode = useMemo(
-    () => resolveMode(value, presetOptions, defaultMode, allowInherit),
-    [value, presetOptions, defaultMode, allowInherit],
-  );
+  // Detect if this field's value is effectively inherited from the global
+  // config (i.e. the camera does not override it).
+  const isInheritedFromGlobal = useMemo(() => {
+    if (!showUseGlobalSetting) return false;
+    if (value === undefined || value === null) return true;
+    if (globalFieldValue === undefined || globalFieldValue === null)
+      return false;
+    return isEqual(value, globalFieldValue);
+  }, [showUseGlobalSetting, value, globalFieldValue]);
+
+  const detectedMode = useMemo(() => {
+    if (showUseGlobalSetting && isInheritedFromGlobal) {
+      return "inherit" as FfmpegArgsMode;
+    }
+    return resolveMode(value, presetOptions, defaultMode, allowInherit);
+  }, [
+    showUseGlobalSetting,
+    isInheritedFromGlobal,
+    value,
+    presetOptions,
+    defaultMode,
+    allowInherit,
+  ]);
 
   const [mode, setMode] = useState<FfmpegArgsMode>(detectedMode);
 
+  // Track whether the user has explicitly changed mode to prevent the
+  // detected-mode sync from snapping back (e.g. when a user-selected
+  // preset happens to match the global value).
+  const userSetModeRef = useRef(false);
+
+  const formIsClean = !formContext?.hasChanges;
+
+  // Reset tracking when the widget identity changes (camera switch)
+  // or when the form returns to a clean state (after a successful save).
   useEffect(() => {
+    userSetModeRef.current = false;
+  }, [id, formIsClean]);
+
+  useEffect(() => {
+    if (userSetModeRef.current) return;
+
     if (!canUsePresets && detectedMode === "preset") {
       setMode("manual");
       return;
@@ -150,9 +199,15 @@ export function FfmpegArgsWidget(props: WidgetProps) {
 
   const handleModeChange = useCallback(
     (nextMode: FfmpegArgsMode) => {
+      userSetModeRef.current = true;
       setMode(nextMode);
 
       if (nextMode === "inherit") {
+        onChange(undefined);
+        return;
+      }
+
+      if (nextMode === "none") {
         onChange(undefined);
         return;
       }
@@ -203,7 +258,6 @@ export function FfmpegArgsWidget(props: WidgetProps) {
       return undefined;
     }
 
-    const isInputScoped = id.includes("_inputs_");
     const prefix = isInputScoped ? "ffmpeg.inputs" : "ffmpeg";
 
     if (presetField === "hwaccel_args") {
@@ -227,7 +281,7 @@ export function FfmpegArgsWidget(props: WidgetProps) {
     }
 
     return undefined;
-  }, [id, presetField]);
+  }, [isInputScoped, presetField]);
 
   const translatedDescription =
     fallbackDescriptionKey &&
@@ -247,7 +301,25 @@ export function FfmpegArgsWidget(props: WidgetProps) {
         onValueChange={(next) => handleModeChange(next as FfmpegArgsMode)}
         className="gap-3"
       >
-        {allowInherit ? (
+        {showUseGlobalSetting ? (
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem
+              value="inherit"
+              id={`${id}-inherit`}
+              disabled={disabled || readonly}
+              className={
+                mode === "inherit"
+                  ? "bg-selected from-selected/50 to-selected/90 text-selected"
+                  : "bg-secondary from-secondary/50 to-secondary/90 text-secondary"
+              }
+            />
+            <label htmlFor={`${id}-inherit`} className="cursor-pointer text-sm">
+              {t("configForm.ffmpegArgs.useGlobalSetting", {
+                ns: "views/settings",
+              })}
+            </label>
+          </div>
+        ) : allowInherit ? (
           <div className="flex items-center space-x-2">
             <RadioGroupItem
               value="inherit"
@@ -263,7 +335,23 @@ export function FfmpegArgsWidget(props: WidgetProps) {
               {t("configForm.ffmpegArgs.inherit", { ns: "views/settings" })}
             </label>
           </div>
-        ) : null}
+        ) : (
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem
+              value="none"
+              id={`${id}-none`}
+              disabled={disabled || readonly}
+              className={
+                mode === "none"
+                  ? "bg-selected from-selected/50 to-selected/90 text-selected"
+                  : "bg-secondary from-secondary/50 to-secondary/90 text-secondary"
+              }
+            />
+            <label htmlFor={`${id}-none`} className="cursor-pointer text-sm">
+              {t("configForm.ffmpegArgs.none", { ns: "views/settings" })}
+            </label>
+          </div>
+        )}
         <div className="flex items-center space-x-2">
           <RadioGroupItem
             value="preset"
@@ -296,7 +384,8 @@ export function FfmpegArgsWidget(props: WidgetProps) {
         </div>
       </RadioGroup>
 
-      {mode === "inherit" ? null : mode === "preset" && canUsePresets ? (
+      {mode === "inherit" || mode === "none" ? null : mode === "preset" &&
+        canUsePresets ? (
         <Select
           value={presetValue}
           onValueChange={handlePresetChange}


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change
<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR makes minor changes to the ffmpeg sections in Settings in the UI. Camera-level ffmpeg args fields (hwaccel_args, input_args, output_args) now show "Use global setting" instead of displaying the inherited global value as if explicitly set, and global-level ffmpeg args fields show a "None" option to clear the setting.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
