### PR TITLE
Improve process watchdog

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -529,7 +529,7 @@ class FrigateApp:
             if not hasattr(self, attr):
                 continue
 
-            def on_restart(proc: FrigateProcess, _attr=attr, _key=key) -> None:
+            def on_restart(proc: FrigateProcess, _attr: str = attr, _key: str = key) -> None:
                 setattr(self, _attr, proc)
                 self.processes[_key] = proc.pid or 0
 

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -529,7 +529,9 @@ class FrigateApp:
             if not hasattr(self, attr):
                 continue
 
-            def on_restart(proc: FrigateProcess, _attr: str = attr, _key: str = key) -> None:
+            def on_restart(
+                proc: FrigateProcess, _attr: str = attr, _key: str = key
+            ) -> None:
                 setattr(self, _attr, proc)
                 self.processes[_key] = proc.pid or 0
 

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -8,7 +8,7 @@ from multiprocessing import Queue
 from multiprocessing.managers import DictProxy, SyncManager
 from multiprocessing.synchronize import Event as MpEvent
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import psutil
 import uvicorn
@@ -81,6 +81,7 @@ from frigate.timeline import TimelineProcessor
 from frigate.track.object_processing import TrackedObjectProcessor
 from frigate.util.builtin import empty_and_close_queue
 from frigate.util.image import UntrackedSharedMemory
+from frigate.util.process import FrigateProcess
 from frigate.util.services import set_file_limit
 from frigate.version import VERSION
 from frigate.watchdog import FrigateWatchdog
@@ -497,6 +498,45 @@ class FrigateApp:
 
     def start_watchdog(self) -> None:
         self.frigate_watchdog = FrigateWatchdog(self.detectors, self.stop_event)
+
+        # (attribute on self, key in self.processes, factory)
+        specs: list[tuple[str, str, Callable[[], FrigateProcess]]] = [
+            (
+                "embedding_process",
+                "embeddings",
+                lambda: EmbeddingProcess(
+                    self.config, self.embeddings_metrics, self.stop_event
+                ),
+            ),
+            (
+                "recording_process",
+                "recording",
+                lambda: RecordProcess(self.config, self.stop_event),
+            ),
+            (
+                "review_segment_process",
+                "review_segment",
+                lambda: ReviewProcess(self.config, self.stop_event),
+            ),
+            (
+                "output_processor",
+                "output",
+                lambda: OutputProcess(self.config, self.stop_event),
+            ),
+        ]
+
+        for attr, key, factory in specs:
+            if not hasattr(self, attr):
+                continue
+
+            def on_restart(proc: FrigateProcess, _attr=attr, _key=key) -> None:
+                setattr(self, _attr, proc)
+                self.processes[_key] = proc.pid or 0
+
+            self.frigate_watchdog.register(
+                key, getattr(self, attr), factory, on_restart
+            )
+
         self.frigate_watchdog.start()
 
     def init_auth(self) -> None:

--- a/frigate/watchdog.py
+++ b/frigate/watchdog.py
@@ -2,19 +2,111 @@ import datetime
 import logging
 import threading
 import time
+from collections import deque
+from dataclasses import dataclass, field
 from multiprocessing.synchronize import Event as MpEvent
+from typing import Callable
 
 from frigate.object_detection.base import ObjectDetectProcess
+from frigate.util.process import FrigateProcess
 from frigate.util.services import restart_frigate
 
 logger = logging.getLogger(__name__)
 
+MAX_RESTARTS = 5
+RESTART_WINDOW_S = 60
+
+
+@dataclass
+class MonitoredProcess:
+    """A process monitored by the watchdog for automatic restart."""
+
+    name: str
+    process: FrigateProcess
+    factory: Callable[[], FrigateProcess]
+    on_restart: Callable[[FrigateProcess], None] | None = None
+    restart_timestamps: deque[float] = field(
+        default_factory=lambda: deque(maxlen=MAX_RESTARTS)
+    )
+
+    def is_restarting_too_fast(self, now: float) -> bool:
+        while (
+            self.restart_timestamps
+            and now - self.restart_timestamps[0] > RESTART_WINDOW_S
+        ):
+            self.restart_timestamps.popleft()
+        return len(self.restart_timestamps) >= MAX_RESTARTS
+
 
 class FrigateWatchdog(threading.Thread):
-    def __init__(self, detectors: dict[str, ObjectDetectProcess], stop_event: MpEvent):
+    def __init__(
+        self,
+        detectors: dict[str, ObjectDetectProcess],
+        stop_event: MpEvent,
+    ):
         super().__init__(name="frigate_watchdog")
         self.detectors = detectors
         self.stop_event = stop_event
+        self._monitored: list[MonitoredProcess] = []
+
+    def register(
+        self,
+        name: str,
+        process: FrigateProcess,
+        factory: Callable[[], FrigateProcess],
+        on_restart: Callable[[FrigateProcess], None] | None = None,
+    ) -> None:
+        """Register a FrigateProcess for monitoring and automatic restart."""
+        self._monitored.append(
+            MonitoredProcess(
+                name=name,
+                process=process,
+                factory=factory,
+                on_restart=on_restart,
+            )
+        )
+
+    def _check_process(self, entry: MonitoredProcess) -> None:
+        if entry.process.is_alive():
+            return
+
+        exitcode = entry.process.exitcode
+        if exitcode == 0:
+            logger.info("Process %s exited cleanly, not restarting", entry.name)
+            return
+
+        logger.warning(
+            "Process %s (PID %s) exited with code %s",
+            entry.name,
+            entry.process.pid,
+            exitcode,
+        )
+
+        now = datetime.datetime.now().timestamp()
+
+        if entry.is_restarting_too_fast(now):
+            logger.error(
+                "Process %s restarting too frequently (%d times in %ds), backing off",
+                entry.name,
+                MAX_RESTARTS,
+                RESTART_WINDOW_S,
+            )
+            return
+
+        try:
+            entry.process.close()
+            new_process = entry.factory()
+            new_process.start()
+
+            entry.process = new_process
+            entry.restart_timestamps.append(now)
+
+            if entry.on_restart:
+                entry.on_restart(new_process)
+
+            logger.info("Restarted %s (PID %s)", entry.name, new_process.pid)
+        except Exception:
+            logger.exception("Failed to restart %s", entry.name)
 
     def run(self) -> None:
         time.sleep(10)
@@ -37,5 +129,8 @@ class FrigateWatchdog(threading.Thread):
                 ):
                     logger.info("Detection appears to have stopped. Exiting Frigate...")
                     restart_frigate()
+
+            for entry in self._monitored:
+                self._check_process(entry)
 
         logger.info("Exiting watchdog...")


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change
<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
The existing watchdog only monitors detector processes. This PR adds monitoring for the four other `FrigateProcess` subprocesses (embeddings, recording, review, output) so they automatically restart if they crash.

Each process is registered with a factory function that knows how to create a fresh replacement. Every 10 seconds the watchdog checks if any registered process has died. If so, it restarts it using the factory, with rate limiting (max 5 restarts per 60s) to prevent crash loops. 

Logs indicate when this happens, so it should improve the situation where an operating system's OOM killer kills the embeddings process and enrichments stop working.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
