### PR TITLE
Improve hwaccel UI config

### DIFF
--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -5,6 +5,7 @@ import copy
 import json
 import logging
 import os
+import platform
 import traceback
 import urllib
 from datetime import datetime, timedelta
@@ -246,19 +247,26 @@ def get_active_profile(request: Request):
 @router.get("/ffmpeg/presets", dependencies=[Depends(allow_any_authenticated())])
 def ffmpeg_presets():
     """Return available ffmpeg preset keys for config UI usage."""
+    machine = platform.machine().lower()
+    is_arm64 = machine in ("aarch64", "arm64", "armv8", "armv7l")
 
-    # Whitelist based on documented presets in ffmpeg_presets.md
-    hwaccel_presets = [
-        "preset-rpi-64-h264",
-        "preset-rpi-64-h265",
-        "preset-vaapi",
-        "preset-intel-qsv-h264",
-        "preset-intel-qsv-h265",
-        "preset-nvidia",
-        "preset-jetson-h264",
-        "preset-jetson-h265",
-        "preset-rkmpp",
-    ]
+    if is_arm64:
+        hwaccel_presets = [
+            "preset-rpi-64-h264",
+            "preset-rpi-64-h265",
+            "preset-jetson-h264",
+            "preset-jetson-h265",
+            "preset-rkmpp",
+            "preset-vaapi",
+        ]
+    else:
+        hwaccel_presets = [
+            "preset-vaapi",
+            "preset-intel-qsv-h264",
+            "preset-intel-qsv-h265",
+            "preset-nvidia",
+        ]
+
     input_presets = [
         "preset-http-jpeg-generic",
         "preset-http-mjpeg-generic",

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -1319,7 +1319,18 @@
       "none": "None",
       "useGlobalSetting": "Inherit from global setting",
       "selectPreset": "Select preset",
-      "manualPlaceholder": "Enter FFmpeg arguments"
+      "manualPlaceholder": "Enter FFmpeg arguments",
+      "presetLabels": {
+        "preset-rpi-64-h264": "Raspberry Pi 64-bit (H.264)",
+        "preset-rpi-64-h265": "Raspberry Pi 64-bit (H.265)",
+        "preset-vaapi": "VAAPI",
+        "preset-intel-qsv-h264": "Intel QSV (H.264)",
+        "preset-intel-qsv-h265": "Intel QSV (H.265)",
+        "preset-nvidia": "NVIDIA",
+        "preset-jetson-h264": "NVIDIA Jetson (H.264)",
+        "preset-jetson-h265": "NVIDIA Jetson (H.265)",
+        "preset-rkmpp": "Rockchip RKMPP"
+      }
     },
     "cameraInputs": {
       "itemTitle": "Stream {{index}}"

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -1321,12 +1321,12 @@
       "selectPreset": "Select preset",
       "manualPlaceholder": "Enter FFmpeg arguments",
       "presetLabels": {
-        "preset-rpi-64-h264": "Raspberry Pi 64-bit (H.264)",
-        "preset-rpi-64-h265": "Raspberry Pi 64-bit (H.265)",
-        "preset-vaapi": "VAAPI",
-        "preset-intel-qsv-h264": "Intel QSV (H.264)",
-        "preset-intel-qsv-h265": "Intel QSV (H.265)",
-        "preset-nvidia": "NVIDIA",
+        "preset-rpi-64-h264": "Raspberry Pi (H.264)",
+        "preset-rpi-64-h265": "Raspberry Pi (H.265)",
+        "preset-vaapi": "VAAPI (Intel/AMD GPU)",
+        "preset-intel-qsv-h264": "Intel QuickSync (H.264)",
+        "preset-intel-qsv-h265": "Intel QuickSync (H.265)",
+        "preset-nvidia": "NVIDIA GPU",
         "preset-jetson-h264": "NVIDIA Jetson (H.264)",
         "preset-jetson-h265": "NVIDIA Jetson (H.265)",
         "preset-rkmpp": "Rockchip RKMPP"

--- a/web/src/components/config-form/theme/widgets/FfmpegArgsWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/FfmpegArgsWidget.tsx
@@ -405,7 +405,10 @@ export function FfmpegArgsWidget(props: WidgetProps) {
           <SelectContent>
             {presetOptions.map((preset) => (
               <SelectItem key={preset} value={preset}>
-                {preset}
+                {t(`configForm.ffmpegArgs.presetLabels.${preset}`, {
+                  ns: "views/settings",
+                  defaultValue: preset,
+                })}
               </SelectItem>
             ))}
           </SelectContent>


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change
<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

This PR improves hwaccel UI configuration:
- Check platform and only show applicable hwaccel presets (ex: RPi is not applicable on AMD64 platform).
- Add i18n labels for the presets to be more clear

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
