### PR TITLE
Add verbose mode to Media Sync

### DIFF
--- a/docs/docs/configuration/record.md
+++ b/docs/docs/configuration/record.md
@@ -162,6 +162,8 @@ Normal operation may leave small numbers of orphaned files until Frigate's sched
 
 The Maintenance pane in the Frigate UI or an API endpoint `POST /api/media/sync` can be used to trigger a media sync. When using the API, a job ID is returned and the operation continues on the server. Status can be checked with the `/api/media/sync/status/{job_id}` endpoint.
 
+Setting `verbose: true` writes a detailed report of every orphaned file and database entry to `/config/media_sync/<job_id>.txt`. For recordings, the report separates orphaned database entries (DB records whose files are missing from disk) from orphaned files (files on disk with no corresponding database record).
+
 :::warning
 
 This operation uses considerable CPU resources and includes a safety threshold that aborts if more than 50% of files would be deleted. Only run when necessary. If you set `force: true` the safety threshold will be bypassed; do not use `force` unless you are certain the deletions are intended.

--- a/docs/static/frigate-api.yaml
+++ b/docs/static/frigate-api.yaml
@@ -6891,6 +6891,11 @@ components:
           title: Force
           description: "If True, bypass safety threshold checks"
           default: false
+        verbose:
+          type: boolean
+          title: Verbose
+          description: "If True, write full orphan file list to /config/media_sync/<job_id>.txt"
+          default: false
       type: object
       title: MediaSyncBody
     MotionSearchMetricsResponse:

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -864,7 +864,10 @@ def sync_media(body: MediaSyncBody = Body(...)):
         202 Accepted with job_id, or 409 Conflict if job already running.
     """
     job_id = start_media_sync_job(
-        dry_run=body.dry_run, media_types=body.media_types, force=body.force
+        dry_run=body.dry_run,
+        media_types=body.media_types,
+        force=body.force,
+        verbose=body.verbose,
     )
 
     if job_id is None:

--- a/frigate/api/defs/request/app_body.py
+++ b/frigate/api/defs/request/app_body.py
@@ -45,3 +45,7 @@ class MediaSyncBody(BaseModel):
     force: bool = Field(
         default=False, description="If True, bypass safety threshold checks"
     )
+    verbose: bool = Field(
+        default=False,
+        description="If True, write full orphan file list to disk",
+    )

--- a/frigate/jobs/media_sync.py
+++ b/frigate/jobs/media_sync.py
@@ -1,13 +1,14 @@
 """Media sync job management with background execution."""
 
 import logging
+import os
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
 
 from frigate.comms.inter_process import InterProcessRequestor
-from frigate.const import UPDATE_JOB_STATE
+from frigate.const import CONFIG_DIR, UPDATE_JOB_STATE
 from frigate.jobs.job import Job
 from frigate.jobs.manager import (
     get_current_job,
@@ -16,7 +17,7 @@ from frigate.jobs.manager import (
     set_current_job,
 )
 from frigate.types import JobStatusTypesEnum
-from frigate.util.media import sync_all_media
+from frigate.util.media import sync_all_media, write_orphan_report
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ class MediaSyncJob(Job):
     dry_run: bool = False
     media_types: list[str] = field(default_factory=lambda: ["all"])
     force: bool = False
+    verbose: bool = False
 
 
 class MediaSyncRunner(threading.Thread):
@@ -60,6 +62,21 @@ class MediaSyncRunner(threading.Thread):
                 media_types=self.job.media_types,
                 force=self.job.force,
             )
+
+            # Write verbose report if requested
+            if self.job.verbose:
+                report_dir = os.path.join(CONFIG_DIR, "media_sync")
+                os.makedirs(report_dir, exist_ok=True)
+                report_path = os.path.join(report_dir, f"{self.job.id}.txt")
+                write_orphan_report(
+                    results,
+                    report_path,
+                    job_id=self.job.id,
+                    dry_run=self.job.dry_run,
+                )
+                logger.info(
+                    "Media sync verbose orphan report written to %s", report_path
+                )
 
             # Store results and mark as complete
             self.job.results = results.to_dict()
@@ -95,6 +112,7 @@ def start_media_sync_job(
     dry_run: bool = False,
     media_types: Optional[list[str]] = None,
     force: bool = False,
+    verbose: bool = False,
 ) -> Optional[str]:
     """Start a new media sync job if none is currently running.
 
@@ -113,6 +131,7 @@ def start_media_sync_job(
         dry_run=dry_run,
         media_types=media_types or ["all"],
         force=force,
+        verbose=verbose,
     )
 
     logger.debug(f"Creating new media sync job: {job.id}")

--- a/frigate/util/media.py
+++ b/frigate/util/media.py
@@ -49,6 +49,7 @@ class SyncResult:
     orphans_found: int = 0
     orphans_deleted: int = 0
     orphan_paths: list[str] = field(default_factory=list)
+    orphan_db_paths: list[str] = field(default_factory=list)
     aborted: bool = False
     error: str | None = None
 
@@ -132,7 +133,7 @@ def sync_recordings(
                     )
 
         result.orphans_found += len(recordings_to_delete)
-        result.orphan_paths.extend(
+        result.orphan_db_paths.extend(
             [
                 recording["path"]
                 for recording in recordings_to_delete
@@ -771,6 +772,61 @@ class MediaSyncResults:
             "orphans_deleted": self.total_orphans_deleted,
         }
         return results
+
+
+def write_orphan_report(
+    results: "MediaSyncResults",
+    path: str,
+    job_id: str = "",
+    dry_run: bool = False,
+) -> None:
+    """Write a verbose orphan report file listing all orphan paths by media type.
+
+    Args:
+        results: The completed MediaSyncResults.
+        path: File path to write the report to.
+        job_id: Job ID for the report header.
+        dry_run: Whether the sync was a dry run, for the report header.
+    """
+    try:
+        with open(path, "w") as f:
+            f.write("# Media Sync Orphan Report\n")
+            f.write(f"# Job: {job_id}\n")
+            f.write(
+                f"# Date: {datetime.datetime.now().astimezone(datetime.timezone.utc).isoformat()}\n"
+            )
+            f.write(f"# Mode: dry_run={dry_run}\n\n")
+
+            for name, result in [
+                ("recordings", results.recordings),
+                ("event_snapshots", results.event_snapshots),
+                ("event_thumbnails", results.event_thumbnails),
+                ("review_thumbnails", results.review_thumbnails),
+                ("previews", results.previews),
+                ("exports", results.exports),
+            ]:
+                if result is None:
+                    continue
+
+                if result.orphan_db_paths:
+                    f.write(
+                        f"## {name} - orphaned db entries ({len(result.orphan_db_paths)})\n"
+                    )
+                    for orphan_path in result.orphan_db_paths:
+                        f.write(f"{orphan_path}\n")
+                    f.write("\n")
+
+                if result.orphan_paths:
+                    f.write(
+                        f"## {name} - orphaned files ({len(result.orphan_paths)})\n"
+                    )
+                    for orphan_path in result.orphan_paths:
+                        f.write(f"{orphan_path}\n")
+                    f.write("\n")
+
+        logger.debug("Wrote verbose orphan report to %s", path)
+    except OSError as e:
+        logger.error("Failed to write orphan report to %s: %s", path, e)
 
 
 def sync_all_media(

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -1253,6 +1253,8 @@
       "dryRunDisabled": "Files will be deleted",
       "force": "Force",
       "forceDesc": "Bypass safety threshold and complete sync even if more than 50% of the files would be deleted.",
+      "verbose": "Verbose",
+      "verboseDesc": "Write a full list of orphaned files to disk for review.",
       "running": "Sync Running...",
       "start": "Start Sync",
       "inProgress": "Sync is in progress. This page is disabled.",

--- a/web/src/views/settings/MediaSyncSettingsView.tsx
+++ b/web/src/views/settings/MediaSyncSettingsView.tsx
@@ -22,6 +22,7 @@ export default function MediaSyncSettingsView() {
   ]);
   const [dryRun, setDryRun] = useState(true);
   const [force, setForce] = useState(false);
+  const [verbose, setVerbose] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const MEDIA_TYPES = [
@@ -67,6 +68,7 @@ export default function MediaSyncSettingsView() {
           dry_run: dryRun,
           media_types: selectedMediaTypes,
           force: force,
+          verbose: verbose,
         },
         {
           headers: {
@@ -94,7 +96,7 @@ export default function MediaSyncSettingsView() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [selectedMediaTypes, dryRun, force, t]);
+  }, [selectedMediaTypes, dryRun, force, verbose, t]);
 
   return (
     <>
@@ -201,6 +203,25 @@ export default function MediaSyncSettingsView() {
                         id="force"
                         checked={force}
                         onCheckedChange={setForce}
+                        disabled={isJobRunning}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col">
+                    <div className="flex flex-row items-center justify-between gap-4">
+                      <div className="space-y-0.5">
+                        <Label htmlFor="verbose" className="cursor-pointer">
+                          {t("maintenance.sync.verbose")}
+                        </Label>
+                        <p className="text-xs text-muted-foreground">
+                          {t("maintenance.sync.verboseDesc")}
+                        </p>
+                      </div>
+                      <Switch
+                        id="verbose"
+                        checked={verbose}
+                        onCheckedChange={setVerbose}
                         disabled={isJobRunning}
                       />
                     </div>


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change
<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR adds a verbose mode to media sync that writes a full orphan report to `/config/media_sync/{job_id}.txt`, listing every file and database entry that would be deleted. The report separates orphaned DB entries (recordings with missing files) from orphaned files (files with no DB record), and can be toggled from the UI.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
