### PR TITLE
Notification Fixes

### DIFF
--- a/web/public/notifications-worker.js
+++ b/web/public/notifications-worker.js
@@ -19,19 +19,40 @@ self.addEventListener("push", function (event) {
         break;
     }
 
+    const notificationOptions = {
+      body: data.message,
+      icon: "/images/maskable-icon.png",
+      image: data.image,
+      badge: "/images/maskable-badge.png",
+      tag: data.id,
+      data: { id: data.id, link: data.direct_url },
+      actions,
+    };
+
+    // iOS Safari does not auto-coalesce notifications by tag (WebKit bug #258922).
+    // On iOS 18.3+ close() works, so we manually close duplicates before showing.
+    // On other platforms, tag-based replacement works natively — skip the extra work.
+    const isIOS =
+      /iPad|iPhone|iPod/.test(navigator.userAgent) && !self.MSStream;
+
+    const show = () =>
+      // @ts-expect-error we know this exists
+      self.registration.showNotification(data.title, notificationOptions);
+
     // event.waitUntil is required on iOS Safari — without it, the browser
     // may consider this a "silent push" and revoke the subscription after 3 occurrences.
     event.waitUntil(
-      // @ts-expect-error we know this exists
-      self.registration.showNotification(data.title, {
-        body: data.message,
-        icon: "/images/maskable-icon.png",
-        image: data.image,
-        badge: "/images/maskable-badge.png",
-        tag: data.id,
-        data: { id: data.id, link: data.direct_url },
-        actions,
-      }), // eslint-disable-line comma-dangle
+      isIOS
+        ? // @ts-expect-error we know this exists
+          self.registration
+            .getNotifications({ tag: data.id })
+            .then((existing) => {
+              for (const n of existing) {
+                n.close();
+              }
+            })
+            .then(show)
+        : show(), // eslint-disable-line comma-dangle
     );
   } else {
     // pass

--- a/web/public/notifications-worker.js
+++ b/web/public/notifications-worker.js
@@ -19,16 +19,20 @@ self.addEventListener("push", function (event) {
         break;
     }
 
-    // @ts-expect-error we know this exists
-    self.registration.showNotification(data.title, {
-      body: data.message,
-      icon: "/images/maskable-icon.png",
-      image: data.image,
-      badge: "/images/maskable-badge.png",
-      tag: data.id,
-      data: { id: data.id, link: data.direct_url },
-      actions,
-    });
+    // event.waitUntil is required on iOS Safari — without it, the browser
+    // may consider this a "silent push" and revoke the subscription after 3 occurrences.
+    event.waitUntil(
+      // @ts-expect-error we know this exists
+      self.registration.showNotification(data.title, {
+        body: data.message,
+        icon: "/images/maskable-icon.png",
+        image: data.image,
+        badge: "/images/maskable-badge.png",
+        tag: data.id,
+        data: { id: data.id, link: data.direct_url },
+        actions,
+      }), // eslint-disable-line comma-dangle
+    );
   } else {
     // pass
     // This push event has no data

--- a/web/src/components/config-form/sectionExtras/NotificationsSettingsExtras.tsx
+++ b/web/src/components/config-form/sectionExtras/NotificationsSettingsExtras.tsx
@@ -126,6 +126,8 @@ export default function NotificationsSettingsExtras({
       .getRegistration(NOTIFICATION_SERVICE_WORKER)
       .then((worker) => {
         if (worker) {
+          // Trigger a check for an updated service worker script
+          worker.update().catch(() => {});
           setRegistration(worker);
         } else {
           setRegistration(null);
@@ -633,7 +635,9 @@ export default function NotificationsSettingsExtras({
                       Notification.requestPermission().then((permission) => {
                         if (permission === "granted") {
                           navigator.serviceWorker
-                            .register(NOTIFICATION_SERVICE_WORKER)
+                            .register(NOTIFICATION_SERVICE_WORKER, {
+                              updateViaCache: "none",
+                            })
                             .then((workerRegistration) => {
                               setRegistration(workerRegistration);
 

--- a/web/src/components/config-form/sectionExtras/NotificationsSettingsExtras.tsx
+++ b/web/src/components/config-form/sectionExtras/NotificationsSettingsExtras.tsx
@@ -58,7 +58,7 @@ import type { ConfigSectionData, JsonObject } from "@/types/configForm";
 import { sanitizeSectionData } from "@/utils/configUtil";
 import type { SectionRendererProps } from "./registry";
 
-const NOTIFICATION_SERVICE_WORKER = "/notification-worker.js";
+const NOTIFICATION_SERVICE_WORKER = "/notifications-worker.js";
 import {
   SettingsGroupCard,
   SPLIT_ROW_CLASS_NAME,


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change
<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

- Wrap in event.waitUntil so Safari does not revoke the subscription
- Automatically update the worker when the notification settings page is opened
- Don't cache worker when registering for notifications
- Attempt to close out existing notifications on iOS

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
