### PR TITLE
Create snapshot functionality from History view and improve viewing and zooming when in History

### DIFF
--- a/web/__test__/test-setup.ts
+++ b/web/__test__/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/web/__test__/testing-library.js
+++ b/web/__test__/testing-library.js
@@ -1,0 +1,1 @@
+export * from "@testing-library/react";

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -369,6 +369,7 @@ export default function HlsVideoPlayer({
                 generateSnapshotFilename(
                   camera ?? "recording",
                   snapshotTimestamp,
+                  config?.ui?.timezone,
                 ),
               );
               toast.success(

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -38,6 +38,7 @@ export interface HlsSource {
 
 type HlsVideoPlayerProps = {
   videoRef: MutableRefObject<HTMLVideoElement | null>;
+  videoClassName?: string;
   containerRef?: React.MutableRefObject<HTMLDivElement | null>;
   visible: boolean;
   currentSource: HlsSource;
@@ -64,6 +65,7 @@ type HlsVideoPlayerProps = {
 
 export default function HlsVideoPlayer({
   videoRef,
+  videoClassName,
   containerRef,
   visible,
   currentSource,
@@ -441,7 +443,12 @@ export default function HlsVideoPlayer({
             )}
           <video
             ref={videoRef}
-            className={`size-full rounded-lg bg-black md:rounded-2xl ${loadedMetadata ? "" : "invisible"} cursor-pointer`}
+            className={cn(
+              "size-full rounded-lg bg-black md:rounded-2xl",
+              loadedMetadata ? "" : "invisible",
+              "cursor-pointer",
+              videoClassName,
+            )}
             preload="auto"
             autoPlay
             controls={!frigateControls}

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -97,6 +97,7 @@ export default function HlsVideoPlayer({
   const hlsRef = useRef<Hls>(undefined);
   const [useHlsCompat, setUseHlsCompat] = useState(false);
   const [loadedMetadata, setLoadedMetadata] = useState(false);
+  const metadataResolvedRef = useRef(false);
   const [bufferTimeout, setBufferTimeout] = useState<NodeJS.Timeout>();
 
   const applyVideoDimensions = useCallback(
@@ -113,10 +114,19 @@ export default function HlsVideoPlayer({
   );
 
   const handleLoadedMetadata = useCallback(() => {
-    setLoadedMetadata(true);
     if (!videoRef.current) {
       return;
     }
+
+    const markMetadataResolved = () => {
+      if (metadataResolvedRef.current) {
+        return;
+      }
+
+      metadataResolvedRef.current = true;
+      setLoadedMetadata(true);
+      onPlayerLoaded?.();
+    };
 
     const width = videoRef.current.videoWidth;
     const height = videoRef.current.videoHeight;
@@ -125,6 +135,7 @@ export default function HlsVideoPlayer({
     // Poll with requestAnimationFrame until dimensions become available (or timeout).
     if (width > 0 && height > 0) {
       applyVideoDimensions(width, height);
+      markMetadataResolved();
       return;
     }
 
@@ -136,15 +147,19 @@ export default function HlsVideoPlayer({
       const h = videoRef.current.videoHeight;
       if (w > 0 && h > 0) {
         applyVideoDimensions(w, h);
+        markMetadataResolved();
         return;
       }
       if (attempts < maxAttempts) {
         attempts += 1;
         requestAnimationFrame(tryGetDims);
+      } else {
+        // Fallback: avoid blocking playback forever if dimensions remain unavailable.
+        markMetadataResolved();
       }
     };
     requestAnimationFrame(tryGetDims);
-  }, [videoRef, applyVideoDimensions]);
+  }, [videoRef, applyVideoDimensions, onPlayerLoaded]);
 
   useEffect(() => {
     if (!videoRef.current) {
@@ -163,7 +178,10 @@ export default function HlsVideoPlayer({
       return;
     }
 
+    metadataResolvedRef.current = false;
     setLoadedMetadata(false);
+    setVideoDimensions({ width: 0, height: 0 });
+    setTallCamera(false);
 
     const currentPlaybackRate = videoRef.current.playbackRate;
 
@@ -273,6 +291,7 @@ export default function HlsVideoPlayer({
 
   return (
     <TransformWrapper
+      key={`${currentSource.playlist}-${currentSource.startPosition ?? "auto"}`}
       minScale={1.0}
       wheel={{ smoothStep: 0.005 }}
       onZoom={(zoom) => setZoomScale(zoom.state.scale)}
@@ -469,8 +488,7 @@ export default function HlsVideoPlayer({
                 onTimeUpdate(frameTime);
               }
             }}
-            onLoadedData={() => {
-              onPlayerLoaded?.();
+            onLoadedMetadata={() => {
               handleLoadedMetadata();
 
               if (videoRef.current) {
@@ -483,6 +501,7 @@ export default function HlsVideoPlayer({
                 }
               }
             }}
+            onLoadedData={handleLoadedMetadata}
             onEnded={() => {
               if (onClipEnded) {
                 onClipEnded(getVideoTime() ?? 0);
@@ -498,6 +517,7 @@ export default function HlsVideoPlayer({
                 setLoadedMetadata(false);
                 setUseHlsCompat(true);
               } else {
+                onError?.("startup");
                 toast.error(
                   // @ts-expect-error code does exist
                   `Failed to play recordings (error ${e.target.error.code}): ${e.target.error.message}`,

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -22,6 +22,11 @@ import { ASPECT_VERTICAL_LAYOUT, RecordingPlayerError } from "@/types/record";
 import { useTranslation } from "react-i18next";
 import ObjectTrackOverlay from "@/components/overlay/ObjectTrackOverlay";
 import { useIsAdmin } from "@/hooks/use-is-admin";
+import {
+  downloadSnapshot,
+  generateSnapshotFilename,
+  grabVideoSnapshot,
+} from "@/utils/snapshotUtil";
 
 // Android native hls does not seek correctly
 const USE_NATIVE_HLS = false;
@@ -89,7 +94,7 @@ export default function HlsVideoPlayer({
   currentTimeOverride,
   transformedOverlay,
 }: HlsVideoPlayerProps) {
-  const { t } = useTranslation("components/player");
+  const { t } = useTranslation(["components/player", "views/live"]);
   const { data: config } = useSWR<FrigateConfig>("config");
   const isAdmin = useIsAdmin();
 
@@ -317,6 +322,7 @@ export default function HlsVideoPlayer({
             seek: true,
             playbackRate: true,
             plusUpload: isAdmin && config?.plus?.enabled == true,
+            snapshot: true,
             fullscreen: supportsFullscreen,
           }}
           setControlsOpen={setControlsOpen}

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -51,6 +51,7 @@ type HlsVideoPlayerProps = {
   onTimeUpdate?: (time: number) => void;
   onPlaying?: () => void;
   onSeekToTime?: (timestamp: number, play?: boolean) => void;
+  onGetAbsoluteTimestamp?: (playerSeconds: number) => number | undefined;
   setFullResolution?: React.Dispatch<React.SetStateAction<VideoResolutionType>>;
   onUploadFrame?: (playTime: number) => Promise<AxiosResponse> | undefined;
   toggleFullscreen?: () => void;
@@ -76,6 +77,7 @@ export default function HlsVideoPlayer({
   onTimeUpdate,
   onPlaying,
   onSeekToTime,
+  onGetAbsoluteTimestamp,
   setFullResolution,
   onUploadFrame,
   toggleFullscreen,
@@ -282,7 +284,7 @@ export default function HlsVideoPlayer({
   const getVideoTime = useCallback(() => {
     const currentTime = videoRef.current?.currentTime;
 
-    if (!currentTime) {
+    if (currentTime == undefined) {
       return undefined;
     }
 
@@ -323,7 +325,7 @@ export default function HlsVideoPlayer({
           onSeek={(diff) => {
             const currentTime = videoRef.current?.currentTime;
 
-            if (!videoRef.current || !currentTime) {
+            if (!videoRef.current || currentTime == undefined) {
               return;
             }
 
@@ -339,7 +341,7 @@ export default function HlsVideoPlayer({
           onUploadFrame={async () => {
             const frameTime = getVideoTime();
 
-            if (frameTime && onUploadFrame) {
+            if (frameTime != undefined && onUploadFrame) {
               const resp = await onUploadFrame(frameTime);
 
               if (resp && resp.status == 200) {
@@ -353,6 +355,35 @@ export default function HlsVideoPlayer({
               }
             }
           }}
+          onSnapshot={async () => {
+            const frameTime = getVideoTime();
+            const snapshotTimestamp =
+              frameTime != undefined
+                ? (onGetAbsoluteTimestamp?.(frameTime) ?? frameTime)
+                : undefined;
+            const result = await grabVideoSnapshot(videoRef.current);
+
+            if (result.success) {
+              downloadSnapshot(
+                result.data.dataUrl,
+                generateSnapshotFilename(
+                  camera ?? "recording",
+                  snapshotTimestamp,
+                ),
+              );
+              toast.success(
+                t("snapshot.downloadStarted", { ns: "views/live" }),
+                {
+                  position: "top-center",
+                },
+              );
+            } else {
+              toast.error(t("snapshot.captureFailed", { ns: "views/live" }), {
+                position: "top-center",
+              });
+            }
+          }}
+          snapshotTitle={t("snapshot.takeSnapshot", { ns: "views/live" })}
           fullscreen={fullscreen}
           toggleFullscreen={toggleFullscreen}
           containerRef={containerRef}
@@ -484,7 +515,7 @@ export default function HlsVideoPlayer({
 
               const frameTime = getVideoTime();
 
-              if (frameTime) {
+              if (frameTime != undefined) {
                 onTimeUpdate(frameTime);
               }
             }}

--- a/web/src/components/player/VideoControls.tsx
+++ b/web/src/components/player/VideoControls.tsx
@@ -34,12 +34,14 @@ import {
 import { cn } from "@/lib/utils";
 import { FaCompress, FaExpand } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
+import { TbCameraDown } from "react-icons/tb";
 
 type VideoControls = {
   volume?: boolean;
   seek?: boolean;
   playbackRate?: boolean;
   plusUpload?: boolean;
+  snapshot?: boolean;
   fullscreen?: boolean;
 };
 
@@ -48,6 +50,7 @@ const CONTROLS_DEFAULT: VideoControls = {
   seek: true,
   playbackRate: true,
   plusUpload: false,
+  snapshot: false,
   fullscreen: false,
 };
 const PLAYBACK_RATE_DEFAULT = isSafari ? [0.5, 1, 2] : [0.5, 1, 2, 4, 8, 16];
@@ -71,6 +74,8 @@ type VideoControlsProps = {
   onSeek: (diff: number) => void;
   onSetPlaybackRate: (rate: number) => void;
   onUploadFrame?: () => void;
+  onSnapshot?: () => void;
+  snapshotTitle?: string;
   toggleFullscreen?: () => void;
   containerRef?: React.MutableRefObject<HTMLDivElement | null>;
 };
@@ -92,6 +97,8 @@ export default function VideoControls({
   onSeek,
   onSetPlaybackRate,
   onUploadFrame,
+  onSnapshot,
+  snapshotTitle,
   toggleFullscreen,
   containerRef,
 }: VideoControlsProps) {
@@ -290,6 +297,17 @@ export default function VideoControls({
           onUploadFrame={onUploadFrame}
           containerRef={containerRef}
           fullscreen={fullscreen}
+        />
+      )}
+      {features.snapshot && onSnapshot && (
+        <TbCameraDown
+          aria-label={snapshotTitle}
+          className="size-5 cursor-pointer"
+          title={snapshotTitle}
+          onClick={(e: React.MouseEvent<SVGElement>) => {
+            e.stopPropagation();
+            onSnapshot();
+          }}
         />
       )}
       {features.fullscreen && toggleFullscreen && (

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -406,6 +406,9 @@ export default function DynamicVideoPlayer({
               onSeekToTime(timestamp, play);
             }
           }}
+          onGetAbsoluteTimestamp={(playerSeconds) =>
+            controller ? controller.getProgress(playerSeconds) : undefined
+          }
           onPlaying={() => {
             if (isScrubbing) {
               playerRef.current?.pause();

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -83,6 +83,7 @@ function playbackSessionReducer(
  */
 type DynamicVideoPlayerProps = {
   className?: string;
+  videoClassName?: string;
   camera: string;
   timeRange: TimeRange;
   cameraPreviews: Preview[];
@@ -102,6 +103,7 @@ type DynamicVideoPlayerProps = {
 };
 export default function DynamicVideoPlayer({
   className,
+  videoClassName,
   camera,
   timeRange,
   cameraPreviews,
@@ -387,6 +389,7 @@ export default function DynamicVideoPlayer({
       {source && (
         <HlsVideoPlayer
           videoRef={playerRef}
+          videoClassName={videoClassName}
           containerRef={containerRef}
           visible={
             !isScrubbing &&

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
 } from "react";
@@ -26,6 +27,56 @@ import {
   calculateSeekPosition,
 } from "@/utils/videoUtil";
 import { isFirefox } from "react-device-detect";
+
+type PlaybackPhase =
+  | "idle"
+  | "loadingSource"
+  | "awaitingMetadata"
+  | "ready"
+  | "buffering"
+  | "error";
+
+type PlaybackSessionState = {
+  sessionId: number;
+  phase: PlaybackPhase;
+};
+
+type PlaybackSessionAction =
+  | {
+      type: "beginSession";
+      sessionId: number;
+      phase: Extract<PlaybackPhase, "loadingSource" | "awaitingMetadata">;
+    }
+  | {
+      type: "setPhase";
+      sessionId: number;
+      phase: PlaybackPhase;
+    };
+
+function playbackSessionReducer(
+  state: PlaybackSessionState,
+  action: PlaybackSessionAction,
+): PlaybackSessionState {
+  if (action.sessionId < state.sessionId) {
+    return state;
+  }
+
+  if (action.type === "beginSession") {
+    if (action.sessionId <= state.sessionId) {
+      return state;
+    }
+
+    return {
+      sessionId: action.sessionId,
+      phase: action.phase,
+    };
+  }
+
+  return {
+    sessionId: action.sessionId,
+    phase: action.phase,
+  };
+}
 
 /**
  * Dynamically switches between video playback and scrubbing preview player.
@@ -118,37 +169,46 @@ export default function DynamicVideoPlayer({
 
   // initial state
 
-  const [isLoading, setIsLoading] = useState(false);
-  const [isBuffering, setIsBuffering] = useState(false);
-  const [loadingTimeout, setLoadingTimeout] = useState<NodeJS.Timeout>();
+  const [playbackSession, dispatchPlaybackSession] = useReducer(
+    playbackSessionReducer,
+    {
+      sessionId: 0,
+      phase: "idle" as PlaybackPhase,
+    },
+  );
+  const playbackSessionCounterRef = useRef(0);
 
   // Don't set source until recordings load - we need accurate startPosition
   // to avoid hls.js clamping to video end when startPosition exceeds duration
   const [source, setSource] = useState<HlsSource | undefined>(undefined);
 
-  // start at correct time
+  const beginPlaybackSession = useCallback(
+    (phase: Extract<PlaybackPhase, "loadingSource" | "awaitingMetadata">) => {
+      playbackSessionCounterRef.current += 1;
+      const nextSessionId = playbackSessionCounterRef.current;
 
-  useEffect(() => {
-    if (!isScrubbing) {
-      setLoadingTimeout(setTimeout(() => setIsLoading(true), 1000));
-    }
-
-    return () => {
-      if (loadingTimeout) {
-        clearTimeout(loadingTimeout);
-      }
-    };
-    // we only want trigger when scrubbing state changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [camera, isScrubbing]);
+      dispatchPlaybackSession({
+        type: "beginSession",
+        sessionId: nextSessionId,
+        phase,
+      });
+    },
+    [],
+  );
 
   const onPlayerLoaded = useCallback(() => {
+    dispatchPlaybackSession({
+      type: "setPhase",
+      sessionId: playbackSession.sessionId,
+      phase: "ready",
+    });
+
     if (!controller || !startTimestamp) {
       return;
     }
 
     controller.seekToTimestamp(startTimestamp, true);
-  }, [startTimestamp, controller]);
+  }, [startTimestamp, controller, playbackSession.sessionId]);
 
   const onTimeUpdate = useCallback(
     (time: number) => {
@@ -156,17 +216,23 @@ export default function DynamicVideoPlayer({
         return;
       }
 
-      if (isLoading) {
-        setIsLoading(false);
-      }
-
-      if (isBuffering) {
-        setIsBuffering(false);
+      if (playbackSession.phase === "buffering") {
+        dispatchPlaybackSession({
+          type: "setPhase",
+          sessionId: playbackSession.sessionId,
+          phase: "ready",
+        });
       }
 
       onTimestampUpdate(controller.getProgress(time));
     },
-    [controller, onTimestampUpdate, isBuffering, isLoading, isScrubbing],
+    [
+      controller,
+      onTimestampUpdate,
+      isScrubbing,
+      playbackSession.phase,
+      playbackSession.sessionId,
+    ],
   );
 
   const onUploadFrameToPlus = useCallback(
@@ -196,11 +262,29 @@ export default function DynamicVideoPlayer({
   );
 
   useEffect(() => {
-    if (!recordings?.length) {
-      if (recordings?.length == 0) {
-        setNoRecording(true);
-      }
+    beginPlaybackSession("loadingSource");
+    setNoRecording(false);
+    setSource(undefined);
+  }, [
+    beginPlaybackSession,
+    camera,
+    recordingParams.after,
+    recordingParams.before,
+  ]);
 
+  useEffect(() => {
+    if (!recordings) {
+      return;
+    }
+
+    if (recordings.length == 0) {
+      setSource(undefined);
+      setNoRecording(true);
+      dispatchPlaybackSession({
+        type: "setPhase",
+        sessionId: playbackSession.sessionId,
+        phase: "idle",
+      });
       return;
     }
 
@@ -219,13 +303,21 @@ export default function DynamicVideoPlayer({
       );
     }
 
-    setSource({
+    const nextSource = {
       playlist: `${apiHost}vod/${camera}/start/${recordingParams.after}/end/${recordingParams.before}/master.m3u8`,
       startPosition,
+    };
+
+    setSource(nextSource);
+    setNoRecording(false);
+    dispatchPlaybackSession({
+      type: "setPhase",
+      sessionId: playbackSession.sessionId,
+      phase: "awaitingMetadata",
     });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [recordings]);
+  }, [recordings, playbackSession.sessionId]);
 
   useEffect(() => {
     if (!controller || !recordings?.length) {
@@ -235,8 +327,6 @@ export default function DynamicVideoPlayer({
     if (playerRef.current) {
       playerRef.current.autoplay = !isScrubbing;
     }
-
-    setLoadingTimeout(setTimeout(() => setIsLoading(true), 1000));
 
     controller.newPlayback({
       recordings: recordings ?? [],
@@ -279,13 +369,30 @@ export default function DynamicVideoPlayer({
     [onClipEnded, controller, recordings],
   );
 
+  const showPreview =
+    isScrubbing ||
+    (!noRecording &&
+      playbackSession.phase !== "ready" &&
+      playbackSession.phase !== "buffering");
+  const showLoadingIndicator =
+    !isScrubbing &&
+    !noRecording &&
+    (playbackSession.phase === "loadingSource" ||
+      playbackSession.phase === "awaitingMetadata" ||
+      playbackSession.phase === "buffering");
+  const showNoRecordings = !isScrubbing && noRecording;
+
   return (
     <>
       {source && (
         <HlsVideoPlayer
           videoRef={playerRef}
           containerRef={containerRef}
-          visible={!(isScrubbing || isLoading)}
+          visible={
+            !isScrubbing &&
+            (playbackSession.phase === "ready" ||
+              playbackSession.phase === "buffering")
+          }
           currentSource={source}
           hotKeys={hotKeys}
           supportsFullscreen={supportsFullscreen}
@@ -304,18 +411,31 @@ export default function DynamicVideoPlayer({
               playerRef.current?.pause();
             }
 
-            if (loadingTimeout) {
-              clearTimeout(loadingTimeout);
-            }
-
             setNoRecording(false);
+            if (playbackSession.phase === "buffering") {
+              dispatchPlaybackSession({
+                type: "setPhase",
+                sessionId: playbackSession.sessionId,
+                phase: "ready",
+              });
+            }
           }}
           setFullResolution={setFullResolution}
           onUploadFrame={onUploadFrameToPlus}
           toggleFullscreen={toggleFullscreen}
           onError={(error) => {
             if (error == "stalled" && !isScrubbing) {
-              setIsBuffering(true);
+              dispatchPlaybackSession({
+                type: "setPhase",
+                sessionId: playbackSession.sessionId,
+                phase: "buffering",
+              });
+            } else {
+              dispatchPlaybackSession({
+                type: "setPhase",
+                sessionId: playbackSession.sessionId,
+                phase: "error",
+              });
             }
           }}
           isDetailMode={isDetailMode}
@@ -325,10 +445,7 @@ export default function DynamicVideoPlayer({
         />
       )}
       <PreviewPlayer
-        className={cn(
-          className,
-          isScrubbing || isLoading ? "visible" : "hidden",
-        )}
+        className={cn(className, showPreview ? "visible" : "hidden")}
         camera={camera}
         timeRange={timeRange}
         cameraPreviews={cameraPreviews}
@@ -338,10 +455,10 @@ export default function DynamicVideoPlayer({
           setPreviewController(previewController)
         }
       />
-      {!isScrubbing && (isLoading || isBuffering) && !noRecording && (
+      {showLoadingIndicator && (
         <ActivityIndicator className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2" />
       )}
-      {!isScrubbing && !isLoading && noRecording && (
+      {showNoRecordings && (
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
           {t("noRecordingsFoundForThisTime")}
         </div>

--- a/web/src/utils/snapshotUtil.test.ts
+++ b/web/src/utils/snapshotUtil.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  downloadSnapshot,
+  generateSnapshotFilename,
+} from "@/utils/snapshotUtil";
+
+describe("generateSnapshotFilename", () => {
+  it("uses the provided playback timestamp in the filename", () => {
+    expect(generateSnapshotFilename("driveway", 1712592245, "UTC")).toBe(
+      "driveway_snapshot_2024-04-08T16-04-05.jpg",
+    );
+  });
+
+  it("uses the provided timezone so filename matches timeline-local time", () => {
+    expect(
+      generateSnapshotFilename("driveway", 1712592245, "America/Los_Angeles"),
+    ).toBe("driveway_snapshot_2024-04-08T09-04-05.jpg");
+  });
+
+  it("falls back to current time when no playback timestamp is provided", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-08-09T10:11:12Z"));
+
+    expect(generateSnapshotFilename("front_yard", undefined, "UTC")).toBe(
+      "front_yard_snapshot_2024-08-09T10-11-12.jpg",
+    );
+
+    vi.useRealTimers();
+  });
+});
+
+describe("downloadSnapshot", () => {
+  it("creates and clicks a temporary anchor for download", () => {
+    const appendSpy = vi.spyOn(document.body, "appendChild");
+    const removeSpy = vi.spyOn(document.body, "removeChild");
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    downloadSnapshot("data:image/jpeg;base64,abc123", "snapshot.jpg");
+
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+
+    const link = appendSpy.mock.calls[0]?.[0] as HTMLAnchorElement;
+    expect(link.download).toBe("snapshot.jpg");
+    expect(link.href).toContain("data:image/jpeg;base64,abc123");
+  });
+});

--- a/web/src/utils/snapshotUtil.ts
+++ b/web/src/utils/snapshotUtil.ts
@@ -1,4 +1,5 @@
 import { baseUrl } from "@/api/baseUrl";
+import { formatUnixTimestampToDateTime } from "@/utils/dateUtil";
 
 type SnapshotResponse = {
   dataUrl: string;
@@ -97,9 +98,25 @@ export function downloadSnapshot(dataUrl: string, filename: string): void {
   }
 }
 
-export function generateSnapshotFilename(cameraName: string): string {
-  const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, -5);
-  return `${cameraName}_snapshot_${timestamp}.jpg`;
+export function generateSnapshotFilename(
+  cameraName: string,
+  timestampSeconds?: number,
+  timezone?: string,
+): string {
+  const seconds = timestampSeconds ?? Date.now() / 1000;
+  const timestamp = formatUnixTimestampToDateTime(seconds, {
+    timezone,
+    date_format: "yyyy-MM-dd'T'HH-mm-ss",
+  });
+
+  const safeTimestamp =
+    timestamp === "Invalid time"
+      ? new Date(seconds * 1000)
+          .toISOString()
+          .replace(/[:.]/g, "-")
+          .slice(0, -5)
+      : timestamp;
+  return `${cameraName}_snapshot_${safeTimestamp}.jpg`;
 }
 
 export async function grabVideoSnapshot(): Promise<SnapshotResult> {

--- a/web/src/utils/snapshotUtil.ts
+++ b/web/src/utils/snapshotUtil.ts
@@ -119,12 +119,13 @@ export function generateSnapshotFilename(
   return `${cameraName}_snapshot_${safeTimestamp}.jpg`;
 }
 
-export async function grabVideoSnapshot(): Promise<SnapshotResult> {
+export async function grabVideoSnapshot(
+  targetVideo?: HTMLVideoElement | null,
+): Promise<SnapshotResult> {
   try {
-    // Find the video element in the player
-    const videoElement = document.querySelector(
-      "#player-container video",
-    ) as HTMLVideoElement;
+    const videoElement =
+      targetVideo ??
+      (document.querySelector("#player-container video") as HTMLVideoElement);
 
     if (!videoElement) {
       return {

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -257,6 +257,8 @@ export function RecordingView({
   const [scrubbing, setScrubbing] = useState(false);
   const [currentTime, setCurrentTime] = useState<number>(startTime);
   const [playerTime, setPlayerTime] = useState(startTime);
+  const wasScrubbingRef = useRef(false);
+  const pendingScrubSeekTimeRef = useRef<number | null>(null);
 
   const updateSelectedSegment = useCallback(
     (currentTime: number, updateStartTime: boolean) => {
@@ -346,6 +348,17 @@ export function RecordingView({
     // we only want to seek when current time doesn't match the player update time
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentTime, scrubbing]);
+
+  useEffect(() => {
+    // force an explicit seek when the user releases timeline scrubbing,
+    // and guard against old player time updates overwriting the new target.
+    if (wasScrubbingRef.current && !scrubbing) {
+      pendingScrubSeekTimeRef.current = currentTime;
+      mainControllerRef.current?.seekToTimestamp(currentTime, true);
+    }
+
+    wasScrubbingRef.current = scrubbing;
+  }, [scrubbing, currentTime]);
 
   const [fullResolution, setFullResolution] = useState<VideoResolutionType>({
     width: 0,
@@ -820,7 +833,19 @@ export function RecordingView({
                   fullscreen={fullscreen}
                   onTimestampUpdate={(timestamp) => {
                     setPlayerTime(timestamp);
-                    setCurrentTime(timestamp);
+
+                    const pendingScrubSeekTime =
+                      pendingScrubSeekTimeRef.current;
+                    if (pendingScrubSeekTime != null) {
+                      // keep the scrubbed target time anchored until playback catches up.
+                      if (Math.abs(timestamp - pendingScrubSeekTime) <= 1) {
+                        pendingScrubSeekTimeRef.current = null;
+                        setCurrentTime(timestamp);
+                      }
+                    } else {
+                      setCurrentTime(timestamp);
+                    }
+
                     Object.values(previewRefs.current ?? {}).forEach((prev) =>
                       prev.scrubToTimestamp(Math.floor(timestamp)),
                     );

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -13,6 +13,7 @@ import DetailStream from "@/components/timeline/DetailStream";
 import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useOverlayState } from "@/hooks/use-overlay-state";
+import { useUserPersistence } from "@/hooks/use-user-persistence";
 import { useResizeObserver } from "@/hooks/resize-observer";
 import { ExportMode } from "@/types/filter";
 import { FrigateConfig } from "@/types/frigateConfig";
@@ -29,6 +30,7 @@ import {
 import { getChunkedTimeDay } from "@/utils/timelineUtil";
 import {
   MutableRefObject,
+  PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
   useMemo,
@@ -79,6 +81,9 @@ import {
 } from "@/components/overlay/chip/GenAISummaryChip";
 
 const DATA_REFRESH_TIME = 600000; // 10 minutes
+const MOBILE_VIDEO_SPLIT_DEFAULT = 0.5;
+const MOBILE_VIDEO_SPLIT_MIN = 0.35;
+const MOBILE_VIDEO_SPLIT_MAX = 0.8;
 
 type RecordingViewProps = {
   startCamera: string;
@@ -383,6 +388,89 @@ export function RecordingView({
 
   const { fullscreen, toggleFullscreen, supportsFullScreen } =
     useFullscreen(mainLayoutRef);
+
+  // mobile portrait split between video and timeline
+
+  const [mobileVideoSplit, setMobileVideoSplit] = useUserPersistence<number>(
+    "recordingMobileVideoSplit",
+    MOBILE_VIDEO_SPLIT_DEFAULT,
+  );
+  const mobileVideoSplitSafe = useMemo(
+    () =>
+      Math.min(
+        MOBILE_VIDEO_SPLIT_MAX,
+        Math.max(
+          MOBILE_VIDEO_SPLIT_MIN,
+          mobileVideoSplit ?? MOBILE_VIDEO_SPLIT_DEFAULT,
+        ),
+      ),
+    [mobileVideoSplit],
+  );
+  const [isDraggingMobileSplit, setIsDraggingMobileSplit] = useState(false);
+  const [{ width: mainLayoutWidth, height: mainLayoutHeight }] =
+    useResizeObserver(mainLayoutRef);
+  const isMobilePortraitStacked = useMemo(
+    () => !isDesktop && mainLayoutHeight > mainLayoutWidth,
+    [mainLayoutHeight, mainLayoutWidth],
+  );
+
+  const updateMobileSplitFromClientY = useCallback(
+    (clientY: number) => {
+      if (!mainLayoutRef.current || !isMobilePortraitStacked) {
+        return;
+      }
+
+      const rect = mainLayoutRef.current.getBoundingClientRect();
+      if (rect.height <= 0) {
+        return;
+      }
+
+      const split = (clientY - rect.top) / rect.height;
+      const clampedSplit = Math.min(
+        MOBILE_VIDEO_SPLIT_MAX,
+        Math.max(MOBILE_VIDEO_SPLIT_MIN, split),
+      );
+      setMobileVideoSplit(clampedSplit);
+    },
+    [isMobilePortraitStacked, setMobileVideoSplit],
+  );
+
+  const onMobileSplitPointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLButtonElement>) => {
+      if (!isMobilePortraitStacked) {
+        return;
+      }
+
+      e.preventDefault();
+      setIsDraggingMobileSplit(true);
+      updateMobileSplitFromClientY(e.clientY);
+    },
+    [isMobilePortraitStacked, updateMobileSplitFromClientY],
+  );
+
+  useEffect(() => {
+    if (!isDraggingMobileSplit) {
+      return;
+    }
+
+    const onPointerMove = (e: PointerEvent) => {
+      updateMobileSplitFromClientY(e.clientY);
+    };
+
+    const onPointerUp = () => {
+      setIsDraggingMobileSplit(false);
+    };
+
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", onPointerUp);
+
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
+    };
+  }, [isDraggingMobileSplit, updateMobileSplitFromClientY]);
 
   // layout
 
@@ -778,8 +866,18 @@ export function RecordingView({
               "flex flex-1 flex-wrap overflow-hidden",
               isDesktop
                 ? "min-w-0 px-4"
-                : "portrait:max-h-[50dvh] portrait:flex-shrink-0 portrait:flex-grow-0 portrait:basis-auto",
+                : cn(
+                    "portrait:flex-shrink-0 portrait:flex-grow-0 portrait:basis-auto",
+                    isMobilePortraitStacked
+                      ? "portrait:flex-none"
+                      : "portrait:max-h-[50dvh]",
+                  ),
             )}
+            style={
+              isMobilePortraitStacked
+                ? { height: `${Math.round(mobileVideoSplitSafe * 100)}%` }
+                : undefined
+            }
           >
             <div
               className={cn(
@@ -923,6 +1021,19 @@ export function RecordingView({
               )}
             </div>
           </div>
+          {isMobilePortraitStacked && !fullscreen && (
+            <button
+              type="button"
+              aria-label="Resize video and timeline"
+              onPointerDown={onMobileSplitPointerDown}
+              className={cn(
+                "relative z-30 mx-auto h-4 w-full flex-shrink-0 touch-none",
+                isDraggingMobileSplit ? "cursor-grabbing" : "cursor-grab",
+              )}
+            >
+              <span className="absolute inset-x-1/2 top-1/2 h-1 w-14 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/60" />
+            </button>
+          )}
           <Timeline
             contentRef={contentRef}
             mainCamera={mainCamera}

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -413,6 +413,7 @@ export function RecordingView({
     () => !isDesktop && mainLayoutHeight > mainLayoutWidth,
     [mainLayoutHeight, mainLayoutWidth],
   );
+  const usePortraitSplitLayout = isMobilePortraitStacked && !fullscreen;
 
   const updateMobileSplitFromClientY = useCallback(
     (clientY: number) => {
@@ -897,17 +898,21 @@ export function RecordingView({
                       useHeightBased
                       ? "h-full"
                       : "w-full"
-                    : cn(
-                        "flex-shrink-0 portrait:w-full landscape:h-full",
-                        mainCameraAspect == "wide"
-                          ? "aspect-wide"
-                          : mainCameraAspect == "tall"
-                            ? "aspect-tall portrait:h-full"
-                            : "aspect-video",
-                      ),
+                    : usePortraitSplitLayout
+                      ? "size-full"
+                      : cn(
+                          "flex-shrink-0 portrait:w-full landscape:h-full",
+                          mainCameraAspect == "wide"
+                            ? "aspect-wide"
+                            : mainCameraAspect == "tall"
+                              ? "aspect-tall portrait:h-full"
+                              : "aspect-video",
+                        ),
                 )}
                 style={{
-                  aspectRatio: getCameraAspect(mainCamera),
+                  aspectRatio: usePortraitSplitLayout
+                    ? undefined
+                    : getCameraAspect(mainCamera),
                 }}
               >
                 {(isDesktop || isTablet) && (
@@ -921,6 +926,9 @@ export function RecordingView({
 
                 <DynamicVideoPlayer
                   className={grow}
+                  videoClassName={
+                    usePortraitSplitLayout ? "object-contain" : undefined
+                  }
                   camera={mainCamera}
                   timeRange={currentTimeRange}
                   cameraPreviews={allPreviews ?? []}


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change
This PR improves the History/Recording viewer in two areas:

1. **History snapshot support**
- Adds snapshot support directly in the History player controls.
- Captures snapshots from the active playback frame (video element), not from live camera snapshot endpoints.
- Uses timeline/playback time for snapshot naming, with timezone-aligned formatting so filenames match what users see in History.

2. **History viewer UI/UX improvements for viewing and zooming**
- Adds mobile-friendly layout controls for History viewing, including a draggable split between video and timeline.
- Improves zoom behavior in mobile History so zoom can first use newly available space from timeline resizing before normal pan/zoom behavior.

This is intended to make History playback and review workflows more usable, especially on mobile and for wide-aspect cameras.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## For new features

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link: [Add the ability to take snapshots when viewing history of cameras #22624](https://github.com/blakeblackshear/frigate/issues/22624)
  - Link: [Add an adjustable split between the video area and the timeline in mobile History view #22625](https://github.com/blakeblackshear/frigate/issues/22625)

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):  
ChatGPT/Codex

**How AI was used** (e.g., code generation, code review, debugging, documentation):  
Used for implementation assistance, refactoring, and debugging.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):  
AI assisted with specific components and targeted fixes; final scope decisions, validation, and merge selection were directed by me.

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.  
I manually reviewed changed files, validated branch scope before merge selection, and ran local frontend checks (`eslint`, `tsc --noEmit`, and test/build commands used during iteration). I also created docker containers from the changes and validated that the new features exhibit the proper behavior on both mobile and desktop.

## Testing

- Added frontend unit tests for snapshot behavior in `web/src/utils/snapshotUtil.test.ts`, including:
  - playback timestamp filename behavior
  - timezone-aligned filename behavior
  - fallback filename timestamp behavior
  - snapshot download link flow
- Added missing Vitest setup files for local web test execution:
  - `web/__test__/test-setup.ts`
  - `web/__test__/testing-library.js`
- Local commands run:
  - `cd web && npx eslint ...`
  - `cd web && npx tsc --noEmit`
  - `cd web && npm run test -- --run`
  - `cd web && npm run build`

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`) (N/A as no changes were to python files)
