### PR TITLE
fix: set onnxruntime thread options to avoid LXC pthread_setaffinity_np errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,10 @@ services:
     #                     capabilities: [gpu]
     environment:
       YOLO_MODELS: ""
+      # Set OMP_NUM_THREADS=1 when running in LXC containers (e.g. Proxmox) to prevent
+      # onnxruntime from calling pthread_setaffinity_np(), which fails in LXC with EINVAL.
+      # This affects face_recognition, semantic_search, and classification features.
+      # OMP_NUM_THREADS: "1"
     # devices:
       # - /dev/bus/usb:/dev/bus/usb # Uncomment for Google Coral USB
       # - /dev/dri:/dev/dri # for intel hwaccel, needs to be updated for your hardware

--- a/frigate/detectors/detection_runners.py
+++ b/frigate/detectors/detection_runners.py
@@ -24,23 +24,36 @@ def is_arm64_platform() -> bool:
 
 def get_ort_session_options(
     is_complex_model: bool = False,
-) -> ort.SessionOptions | None:
+) -> ort.SessionOptions:
     """Get ONNX Runtime session options with appropriate settings.
 
     Args:
         is_complex_model: Whether the model needs basic optimization to avoid graph fusion issues.
 
     Returns:
-        SessionOptions with appropriate optimization level, or None for default settings.
+        SessionOptions with appropriate optimization level and thread settings.
     """
+    sess_options = ort.SessionOptions()
+
+    # When OMP_NUM_THREADS=1 is set (recommended for LXC/container environments),
+    # or when running in a container where pthread_setaffinity_np is blocked,
+    # onnxruntime logs repeated errors like:
+    #   "pthread_setaffinity_np failed ... error code: 22 ... Invalid argument"
+    # Setting intra/inter_op_num_threads=1 prevents the thread pool from trying
+    # to set CPU affinity, eliminating the error spam in LXC containers (Proxmox, etc.).
+    import os
+
+    omp_threads = int(os.environ.get("OMP_NUM_THREADS", "0"))
+    if omp_threads == 1:
+        sess_options.intra_op_num_threads = 1
+        sess_options.inter_op_num_threads = 1
+
     if is_complex_model:
-        sess_options = ort.SessionOptions()
         sess_options.graph_optimization_level = (
             ort.GraphOptimizationLevel.ORT_ENABLE_BASIC
         )
-        return sess_options
 
-    return None
+    return sess_options
 
 
 # Import OpenVINO only when needed to avoid circular dependencies


### PR DESCRIPTION
## Summary

When running Frigate inside a **Proxmox LXC container** with `face_recognition`, `semantic_search`, or `classification` enabled, onnxruntime repeatedly logs:

```
[E:onnxruntime:Default, env.cc:228 ThreadMain] pthread_setaffinity_np failed for thread: <pid>, index: 2, mask: {3, }, error code: 22 error msg: Invalid argument.
```

## Root Cause

onnxruntime's thread pool calls `pthread_setaffinity_np()` to pin threads to CPU cores. Inside LXC containers this syscall fails with `EINVAL` because the container cgroup/namespace doesn't expose the full CPU topology.

## Fix

- In `get_ort_session_options()`: when `OMP_NUM_THREADS=1` env var is set, also set `intra_op_num_threads=1` and `inter_op_num_threads=1` on the `SessionOptions`. This prevents onnxruntime from spawning a thread pool that attempts to set CPU affinity.
- In `docker-compose.yml`: add a commented `OMP_NUM_THREADS: "1"` with documentation explaining when to use it.

## Testing

Tested on Proxmox LXC (privileged, Docker inside), Frigate 0.17.1, Coral USB TPU. After applying the fix + setting `OMP_NUM_THREADS=1`, the error messages are gone and `face_recognition` + `semantic_search` work correctly.

Closes #22620