### PR TITLE
feat: add auth_mode option to ONVIF config for Hikvision HTTP Digest support

### DIFF
--- a/frigate/config/camera/onvif.py
+++ b/frigate/config/camera/onvif.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from pydantic import Field, field_validator
 
@@ -116,6 +116,11 @@ class OnvifConfig(FrigateBaseModel):
         default=False,
         title="Disable TLS verify",
         description="Skip TLS verification and disable digest auth for ONVIF (unsafe; use in safe networks only).",
+    )
+    auth_mode: Literal["auto", "digest", "wsse"] = Field(
+        default="auto",
+        title="ONVIF authentication mode",
+        description="Authentication mode for ONVIF connections. 'auto' tries WSSE first (default behavior). 'digest' forces HTTP Digest auth at the transport level — required for some Hikvision cameras that reject WSSE wsUsername tokens and return 401. 'wsse' forces WSSE UsernameToken only.",
     )
     autotracking: PtzAutotrackConfig = Field(
         default_factory=PtzAutotrackConfig,

--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -9,6 +9,7 @@ from importlib.util import find_spec
 from pathlib import Path
 from typing import Any
 
+import aiohttp
 import numpy
 from onvif import ONVIFCamera, ONVIFError, ONVIFService
 from zeep.exceptions import Fault, TransportError
@@ -104,6 +105,20 @@ class OnvifController:
             if password is not None and isinstance(password, bytes):
                 password = password.decode("utf-8")
 
+            # Build extra kwargs for digest auth mode (Hikvision and similar cameras
+            # that reject WSSE wsUsername tokens and require HTTP Digest at transport level).
+            onvif_extra: dict[str, Any] = {}
+            if cam.onvif.auth_mode == "digest" and user and password:
+                try:
+                    onvif_extra["middlewares"] = [
+                        aiohttp.DigestAuthMiddleware(user, password)
+                    ]
+                except AttributeError:
+                    logger.warning(
+                        f"DigestAuthMiddleware not available in installed aiohttp version "
+                        f"for camera {cam_name}; falling back to default auth."
+                    )
+
             self.cams[cam_name] = {
                 "onvif": ONVIFCamera(
                     cam.onvif.host,
@@ -113,6 +128,7 @@ class OnvifController:
                     wsdl_dir=str(Path(find_spec("onvif").origin).parent / "wsdl"),
                     adjust_time=cam.onvif.ignore_time_mismatch,
                     encrypt=not cam.onvif.tls_insecure,
+                    **onvif_extra,
                 ),
                 "init": False,
                 "active": False,


### PR DESCRIPTION
## Summary

Closes #22622

Some Hikvision PTZ cameras (e.g. DS-2SE4C425MWG-E) reject WSSE `wsUsername` tokens and return **401** on `/onvif/Media` and `/onvif/PTZ` endpoints. They require **HTTP Digest authentication** at the transport layer before processing any SOAP body.

## Changes

### `frigate/config/camera/onvif.py`
- Added `auth_mode: Literal['auto', 'digest', 'wsse']` field to `OnvifConfig` (default: `'auto'`)
  - `auto`: existing behavior (WSSE only)
  - `digest`: inject `aiohttp.DigestAuthMiddleware` — for Hikvision and cameras that require HTTP Digest at transport level
  - `wsse`: explicit WSSE-only (current default, kept for clarity)

### `frigate/ptz/onvif.py`
- When `auth_mode == 'digest'`, build `middlewares=[aiohttp.DigestAuthMiddleware(user, password)]` and pass via `**kwargs` to `ONVIFCamera`
- Graceful fallback with warning if `DigestAuthMiddleware` is unavailable in older aiohttp versions

## Usage

```yaml
cameras:
  jojoya_tower_ptz:
    onvif:
      host: 192.168.31.86
      port: 80
      user: admin
      password: yourpassword
      auth_mode: digest   # <-- new field
      autotracking:
        enabled: true
```

## Testing

Tested on Proxmox LXC, Frigate 0.17.1, Hikvision DS-2SE4C425MWG-E. With `auth_mode: digest`:
- ONVIF connects successfully (no more 401/HTML response)
- PTZ moves and presets work
- Autotracking calibrates to 100%

Without the fix, the camera returns an HTML 401 page which zeep can't parse:
```
Onvif connection failed: The XML returned by the server does not contain a valid Envelope root element. The root element found is html
```