### PR TITLE
Zoom and Pan UX Improvements on Mobile in History Viewer

### DIFF
--- a/web/public/locales/en/views/events.json
+++ b/web/public/locales/en/views/events.json
@@ -45,7 +45,8 @@
   },
   "documentTitle": "Review - Frigate",
   "recordings": {
-    "documentTitle": "Recordings - Frigate"
+    "documentTitle": "Recordings - Frigate",
+    "resizeSplit": "Resize video and timeline"
   },
   "calendarFilter": {
     "last24Hours": "Last 24 Hours"

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -38,8 +38,10 @@ export interface HlsSource {
 
 type HlsVideoPlayerProps = {
   videoRef: MutableRefObject<HTMLVideoElement | null>;
+  videoClassName?: string;
   containerRef?: React.MutableRefObject<HTMLDivElement | null>;
   visible: boolean;
+  showControls?: boolean;
   currentSource: HlsSource;
   hotKeys: boolean;
   supportsFullscreen: boolean;
@@ -63,8 +65,10 @@ type HlsVideoPlayerProps = {
 
 export default function HlsVideoPlayer({
   videoRef,
+  videoClassName,
   containerRef,
   visible,
+  showControls = visible,
   currentSource,
   hotKeys,
   supportsFullscreen,
@@ -286,7 +290,7 @@ export default function HlsVideoPlayer({
           )}
           video={videoRef.current}
           isPlaying={isPlaying}
-          show={visible && (controls || controlsOpen)}
+          show={showControls && (controls || controlsOpen)}
           muted={muted}
           volume={volume}
           features={{
@@ -390,7 +394,12 @@ export default function HlsVideoPlayer({
             )}
           <video
             ref={videoRef}
-            className={`size-full rounded-lg bg-black md:rounded-2xl ${loadedMetadata ? "" : "invisible"} cursor-pointer`}
+            className={cn(
+              "size-full rounded-lg bg-black md:rounded-2xl",
+              loadedMetadata ? "" : "invisible",
+              "cursor-pointer",
+              videoClassName,
+            )}
             preload="auto"
             autoPlay
             controls={!frigateControls}

--- a/web/src/components/player/HlsVideoPlayer.tsx
+++ b/web/src/components/player/HlsVideoPlayer.tsx
@@ -68,7 +68,7 @@ export default function HlsVideoPlayer({
   videoClassName,
   containerRef,
   visible,
-  showControls = visible,
+  showControls = true,
   currentSource,
   hotKeys,
   supportsFullscreen,
@@ -290,7 +290,7 @@ export default function HlsVideoPlayer({
           )}
           video={videoRef.current}
           isPlaying={isPlaying}
-          show={showControls && (controls || controlsOpen)}
+          show={visible && showControls && (controls || controlsOpen)}
           muted={muted}
           volume={volume}
           features={{
@@ -395,9 +395,8 @@ export default function HlsVideoPlayer({
           <video
             ref={videoRef}
             className={cn(
-              "size-full rounded-lg bg-black md:rounded-2xl",
+              "size-full cursor-pointer rounded-lg bg-black md:rounded-2xl",
               loadedMetadata ? "" : "invisible",
-              "cursor-pointer",
               videoClassName,
             )}
             preload="auto"

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -32,6 +32,7 @@ import { isFirefox } from "react-device-detect";
  */
 type DynamicVideoPlayerProps = {
   className?: string;
+  videoClassName?: string;
   camera: string;
   timeRange: TimeRange;
   cameraPreviews: Preview[];
@@ -51,6 +52,7 @@ type DynamicVideoPlayerProps = {
 };
 export default function DynamicVideoPlayer({
   className,
+  videoClassName,
   camera,
   timeRange,
   cameraPreviews,
@@ -279,13 +281,33 @@ export default function DynamicVideoPlayer({
     [onClipEnded, controller, recordings],
   );
 
+  const showPreview = isScrubbing || isLoading;
+  const previewPlayer = (
+    <PreviewPlayer
+      className={cn(
+        source ? "pointer-events-none absolute inset-0 z-20" : className,
+        showPreview ? "visible" : "invisible",
+      )}
+      camera={camera}
+      timeRange={timeRange}
+      cameraPreviews={cameraPreviews}
+      startTime={startTimestamp}
+      isScrubbing={isScrubbing}
+      onControllerReady={(previewController) =>
+        setPreviewController(previewController)
+      }
+    />
+  );
+
   return (
     <>
       {source && (
         <HlsVideoPlayer
           videoRef={playerRef}
+          videoClassName={videoClassName}
           containerRef={containerRef}
-          visible={!(isScrubbing || isLoading)}
+          visible={true}
+          showControls={!isScrubbing && !isLoading}
           currentSource={source}
           hotKeys={hotKeys}
           supportsFullscreen={supportsFullscreen}
@@ -321,23 +343,15 @@ export default function DynamicVideoPlayer({
           isDetailMode={isDetailMode}
           camera={contextCamera || camera}
           currentTimeOverride={currentTime}
-          transformedOverlay={transformedOverlay}
+          transformedOverlay={
+            <>
+              {transformedOverlay}
+              {previewPlayer}
+            </>
+          }
         />
       )}
-      <PreviewPlayer
-        className={cn(
-          className,
-          isScrubbing || isLoading ? "visible" : "hidden",
-        )}
-        camera={camera}
-        timeRange={timeRange}
-        cameraPreviews={cameraPreviews}
-        startTime={startTimestamp}
-        isScrubbing={isScrubbing}
-        onControllerReady={(previewController) =>
-          setPreviewController(previewController)
-        }
-      />
+      {!source && previewPlayer}
       {!isScrubbing && (isLoading || isBuffering) && !noRecording && (
         <ActivityIndicator className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2" />
       )}

--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -282,12 +282,9 @@ export default function DynamicVideoPlayer({
   );
 
   const showPreview = isScrubbing || isLoading;
-  const previewPlayer = (
+  const renderPreviewPlayer = (previewClassName: string) => (
     <PreviewPlayer
-      className={cn(
-        source ? "pointer-events-none absolute inset-0 z-20" : className,
-        showPreview ? "visible" : "invisible",
-      )}
+      className={previewClassName}
       camera={camera}
       timeRange={timeRange}
       cameraPreviews={cameraPreviews}
@@ -298,6 +295,12 @@ export default function DynamicVideoPlayer({
       }
     />
   );
+  const previewOverlay = renderPreviewPlayer(
+    cn(
+      "pointer-events-none absolute inset-0 z-20",
+      showPreview ? "visible" : "invisible",
+    ),
+  );
 
   return (
     <>
@@ -306,6 +309,8 @@ export default function DynamicVideoPlayer({
           videoRef={playerRef}
           videoClassName={videoClassName}
           containerRef={containerRef}
+          // Keep transform wrapper mounted while scrubbing/loading
+          // so zoom and pan position are preserved.
           visible={true}
           showControls={!isScrubbing && !isLoading}
           currentSource={source}
@@ -346,12 +351,13 @@ export default function DynamicVideoPlayer({
           transformedOverlay={
             <>
               {transformedOverlay}
-              {previewPlayer}
+              {previewOverlay}
             </>
           }
         />
       )}
-      {!source && previewPlayer}
+      {!source &&
+        renderPreviewPlayer(cn(className, showPreview ? "visible" : "hidden"))}
       {!isScrubbing && (isLoading || isBuffering) && !noRecording && (
         <ActivityIndicator className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2" />
       )}

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -77,6 +77,7 @@ import {
   GenAISummaryDialog,
   GenAISummaryChip,
 } from "@/components/overlay/chip/GenAISummaryChip";
+import { useMobileVideoSplit } from "./useMobileVideoSplit";
 
 const DATA_REFRESH_TIME = 600000; // 10 minutes
 
@@ -370,6 +371,16 @@ export function RecordingView({
 
   const { fullscreen, toggleFullscreen, supportsFullScreen } =
     useFullscreen(mainLayoutRef);
+  const {
+    cameraSectionStyle,
+    isDraggingMobileSplit,
+    isMobilePortraitStacked,
+    onHandlePointerDown,
+    usePortraitSplitLayout,
+  } = useMobileVideoSplit({
+    fullscreen,
+    mainLayoutRef,
+  });
 
   // layout
 
@@ -765,8 +776,14 @@ export function RecordingView({
               "flex flex-1 flex-wrap overflow-hidden",
               isDesktop
                 ? "min-w-0 px-4"
-                : "portrait:max-h-[50dvh] portrait:flex-shrink-0 portrait:flex-grow-0 portrait:basis-auto",
+                : cn(
+                    "portrait:flex-shrink-0 portrait:flex-grow-0 portrait:basis-auto",
+                    isMobilePortraitStacked
+                      ? "portrait:flex-none"
+                      : "portrait:max-h-[50dvh]",
+                  ),
             )}
+            style={cameraSectionStyle}
           >
             <div
               className={cn(
@@ -786,17 +803,21 @@ export function RecordingView({
                       useHeightBased
                       ? "h-full"
                       : "w-full"
-                    : cn(
-                        "flex-shrink-0 portrait:w-full landscape:h-full",
-                        mainCameraAspect == "wide"
-                          ? "aspect-wide"
-                          : mainCameraAspect == "tall"
-                            ? "aspect-tall portrait:h-full"
-                            : "aspect-video",
-                      ),
+                    : usePortraitSplitLayout
+                      ? "size-full"
+                      : cn(
+                          "flex-shrink-0 portrait:w-full landscape:h-full",
+                          mainCameraAspect == "wide"
+                            ? "aspect-wide"
+                            : mainCameraAspect == "tall"
+                              ? "aspect-tall portrait:h-full"
+                              : "aspect-video",
+                        ),
                 )}
                 style={{
-                  aspectRatio: getCameraAspect(mainCamera),
+                  aspectRatio: usePortraitSplitLayout
+                    ? undefined
+                    : getCameraAspect(mainCamera),
                 }}
               >
                 {(isDesktop || isTablet) && (
@@ -810,6 +831,9 @@ export function RecordingView({
 
                 <DynamicVideoPlayer
                   className={grow}
+                  videoClassName={
+                    usePortraitSplitLayout ? "object-contain" : undefined
+                  }
                   camera={mainCamera}
                   timeRange={currentTimeRange}
                   cameraPreviews={allPreviews ?? []}
@@ -898,6 +922,19 @@ export function RecordingView({
               )}
             </div>
           </div>
+          {isMobilePortraitStacked && !fullscreen && (
+            <button
+              type="button"
+              aria-label={t("recordings.resizeSplit")}
+              onPointerDown={onHandlePointerDown}
+              className={cn(
+                "relative z-30 mx-auto h-4 w-full flex-shrink-0 touch-none",
+                isDraggingMobileSplit ? "cursor-grabbing" : "cursor-grab",
+              )}
+            >
+              <span className="absolute inset-x-1/2 top-1/2 h-1 w-14 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/60" />
+            </button>
+          )}
           <Timeline
             contentRef={contentRef}
             mainCamera={mainCamera}

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -374,7 +374,6 @@ export function RecordingView({
   const {
     cameraSectionStyle,
     isDraggingMobileSplit,
-    isMobilePortraitStacked,
     onHandlePointerDown,
     usePortraitSplitLayout,
   } = useMobileVideoSplit({
@@ -778,7 +777,7 @@ export function RecordingView({
                 ? "min-w-0 px-4"
                 : cn(
                     "portrait:flex-shrink-0 portrait:flex-grow-0 portrait:basis-auto",
-                    isMobilePortraitStacked
+                    usePortraitSplitLayout
                       ? "portrait:flex-none"
                       : "portrait:max-h-[50dvh]",
                   ),
@@ -922,7 +921,7 @@ export function RecordingView({
               )}
             </div>
           </div>
-          {isMobilePortraitStacked && !fullscreen && (
+          {usePortraitSplitLayout && (
             <button
               type="button"
               aria-label={t("recordings.resizeSplit")}

--- a/web/src/views/recording/useMobileVideoSplit.ts
+++ b/web/src/views/recording/useMobileVideoSplit.ts
@@ -1,0 +1,133 @@
+import { useResizeObserver } from "@/hooks/resize-observer";
+import { useUserPersistence } from "@/hooks/use-user-persistence";
+import {
+  CSSProperties,
+  MutableRefObject,
+  PointerEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { isDesktop } from "react-device-detect";
+
+const MOBILE_VIDEO_SPLIT_DEFAULT = 0.5;
+const MOBILE_VIDEO_SPLIT_MIN = 0.35;
+const MOBILE_VIDEO_SPLIT_MAX = 0.8;
+
+type UseMobileVideoSplitProps = {
+  fullscreen: boolean;
+  mainLayoutRef: MutableRefObject<HTMLDivElement | null>;
+};
+
+type UseMobileVideoSplitReturn = {
+  cameraSectionStyle: CSSProperties | undefined;
+  isDraggingMobileSplit: boolean;
+  isMobilePortraitStacked: boolean;
+  onHandlePointerDown: (event: PointerEvent<HTMLButtonElement>) => void;
+  usePortraitSplitLayout: boolean;
+};
+
+export function useMobileVideoSplit({
+  fullscreen,
+  mainLayoutRef,
+}: UseMobileVideoSplitProps): UseMobileVideoSplitReturn {
+  const [mobileVideoSplit, setMobileVideoSplit] = useUserPersistence<number>(
+    "recordingMobileVideoSplit",
+    MOBILE_VIDEO_SPLIT_DEFAULT,
+  );
+  const [isDraggingMobileSplit, setIsDraggingMobileSplit] = useState(false);
+  const [{ width: mainLayoutWidth, height: mainLayoutHeight }] =
+    useResizeObserver(mainLayoutRef);
+
+  const isMobilePortraitStacked = useMemo(
+    () => !isDesktop && mainLayoutHeight > mainLayoutWidth,
+    [mainLayoutHeight, mainLayoutWidth],
+  );
+  const usePortraitSplitLayout = isMobilePortraitStacked && !fullscreen;
+  const mobileVideoSplitSafe = useMemo(
+    () =>
+      Math.min(
+        MOBILE_VIDEO_SPLIT_MAX,
+        Math.max(
+          MOBILE_VIDEO_SPLIT_MIN,
+          mobileVideoSplit ?? MOBILE_VIDEO_SPLIT_DEFAULT,
+        ),
+      ),
+    [mobileVideoSplit],
+  );
+
+  const updateMobileSplitFromClientY = useCallback(
+    (clientY: number) => {
+      if (!mainLayoutRef.current || !isMobilePortraitStacked) {
+        return;
+      }
+
+      const rect = mainLayoutRef.current.getBoundingClientRect();
+      if (rect.height <= 0) {
+        return;
+      }
+
+      const split = (clientY - rect.top) / rect.height;
+      const clampedSplit = Math.min(
+        MOBILE_VIDEO_SPLIT_MAX,
+        Math.max(MOBILE_VIDEO_SPLIT_MIN, split),
+      );
+      setMobileVideoSplit(clampedSplit);
+    },
+    [isMobilePortraitStacked, mainLayoutRef, setMobileVideoSplit],
+  );
+
+  const onHandlePointerDown = useCallback(
+    (event: PointerEvent<HTMLButtonElement>) => {
+      if (!isMobilePortraitStacked) {
+        return;
+      }
+
+      event.preventDefault();
+      setIsDraggingMobileSplit(true);
+      updateMobileSplitFromClientY(event.clientY);
+    },
+    [isMobilePortraitStacked, updateMobileSplitFromClientY],
+  );
+
+  useEffect(() => {
+    if (!isDraggingMobileSplit) {
+      return;
+    }
+
+    const onPointerMove = (event: globalThis.PointerEvent) => {
+      updateMobileSplitFromClientY(event.clientY);
+    };
+
+    const onPointerUp = () => {
+      setIsDraggingMobileSplit(false);
+    };
+
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", onPointerUp);
+
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
+    };
+  }, [isDraggingMobileSplit, updateMobileSplitFromClientY]);
+
+  const cameraSectionStyle = useMemo(
+    () =>
+      isMobilePortraitStacked
+        ? { height: `${Math.round(mobileVideoSplitSafe * 100)}%` }
+        : undefined,
+    [isMobilePortraitStacked, mobileVideoSplitSafe],
+  );
+
+  return {
+    cameraSectionStyle,
+    isDraggingMobileSplit,
+    isMobilePortraitStacked,
+    onHandlePointerDown,
+    usePortraitSplitLayout,
+  };
+}

--- a/web/src/views/recording/useMobileVideoSplit.ts
+++ b/web/src/views/recording/useMobileVideoSplit.ts
@@ -23,7 +23,6 @@ type UseMobileVideoSplitProps = {
 type UseMobileVideoSplitReturn = {
   cameraSectionStyle: CSSProperties | undefined;
   isDraggingMobileSplit: boolean;
-  isMobilePortraitStacked: boolean;
   onHandlePointerDown: (event: PointerEvent<HTMLButtonElement>) => void;
   usePortraitSplitLayout: boolean;
 };
@@ -40,11 +39,10 @@ export function useMobileVideoSplit({
   const [{ width: mainLayoutWidth, height: mainLayoutHeight }] =
     useResizeObserver(mainLayoutRef);
 
-  const isMobilePortraitStacked = useMemo(
-    () => !isDesktop && mainLayoutHeight > mainLayoutWidth,
-    [mainLayoutHeight, mainLayoutWidth],
+  const usePortraitSplitLayout = useMemo(
+    () => !isDesktop && !fullscreen && mainLayoutHeight > mainLayoutWidth,
+    [fullscreen, mainLayoutHeight, mainLayoutWidth],
   );
-  const usePortraitSplitLayout = isMobilePortraitStacked && !fullscreen;
   const mobileVideoSplitSafe = useMemo(
     () =>
       Math.min(
@@ -59,7 +57,7 @@ export function useMobileVideoSplit({
 
   const updateMobileSplitFromClientY = useCallback(
     (clientY: number) => {
-      if (!mainLayoutRef.current || !isMobilePortraitStacked) {
+      if (!mainLayoutRef.current || !usePortraitSplitLayout) {
         return;
       }
 
@@ -75,12 +73,12 @@ export function useMobileVideoSplit({
       );
       setMobileVideoSplit(clampedSplit);
     },
-    [isMobilePortraitStacked, mainLayoutRef, setMobileVideoSplit],
+    [usePortraitSplitLayout, mainLayoutRef, setMobileVideoSplit],
   );
 
   const onHandlePointerDown = useCallback(
     (event: PointerEvent<HTMLButtonElement>) => {
-      if (!isMobilePortraitStacked) {
+      if (!usePortraitSplitLayout) {
         return;
       }
 
@@ -88,7 +86,7 @@ export function useMobileVideoSplit({
       setIsDraggingMobileSplit(true);
       updateMobileSplitFromClientY(event.clientY);
     },
-    [isMobilePortraitStacked, updateMobileSplitFromClientY],
+    [usePortraitSplitLayout, updateMobileSplitFromClientY],
   );
 
   useEffect(() => {
@@ -117,16 +115,15 @@ export function useMobileVideoSplit({
 
   const cameraSectionStyle = useMemo(
     () =>
-      isMobilePortraitStacked
+      usePortraitSplitLayout
         ? { height: `${Math.round(mobileVideoSplitSafe * 100)}%` }
         : undefined,
-    [isMobilePortraitStacked, mobileVideoSplitSafe],
+    [usePortraitSplitLayout, mobileVideoSplitSafe],
   );
 
   return {
     cameraSectionStyle,
     isDraggingMobileSplit,
-    isMobilePortraitStacked,
     onHandlePointerDown,
     usePortraitSplitLayout,
   };


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

This PR improves History/Recording viewing UX on mobile (portrait), especially for wide-aspect cameras.

- Adds a mobile portrait split control so users can drag the divider between video and timeline.
- Updates zoom behavior so zoom first consumes newly available layout space before normal pan/zoom behavior.
- Keeps changes scoped to History player behavior and UI.

This makes timeline review and zoomed inspection more practical on phones without requiring fullscreen-only workflows.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features): [Add an adjustable split between the video area and the timeline in mobile History view #22625](https://github.com/blakeblackshear/frigate/issues/22625)

## For new features

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link: [Add an adjustable split between the video area and the timeline in mobile History view #22625](https://github.com/blakeblackshear/frigate/issues/22625)

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):  
ChatGPT/Codex

**How AI was used** (e.g., code generation, code review, debugging, documentation):  
Used for implementation support, refactoring cleanup, and debugging targeted History UI behavior.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):  
AI assisted with specific components and targeted fixes; final scope decisions, validation, and merge selection were directed by me.

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.  
I manually reviewed changed files, validated branch scope before merge selection, and ran local frontend checks (eslint, tsc --noEmit, and test/build commands used during iteration). I also created docker containers from the changes and validated that the new features exhibit the proper behavior on both mobile and desktop.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`) [N/A]
