### PR TITLE
Fix export deadlock by replacing preexec_fn with nice command

### DIFF
--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -85,10 +85,6 @@ def validate_ffmpeg_args(args: str) -> tuple[bool, str]:
     return True, ""
 
 
-def lower_priority() -> None:
-    os.nice(PROCESS_PRIORITY_LOW)
-
-
 class PlaybackSourceEnum(str, Enum):
     recordings = "recordings"
     preview = "preview"
@@ -439,10 +435,9 @@ class RecordingExporter(threading.Thread):
             return
 
         p = sp.run(
-            ffmpeg_cmd,
+            ["nice", "-n", str(PROCESS_PRIORITY_LOW)] + ffmpeg_cmd,
             input="\n".join(playlist_lines),
             encoding="ascii",
-            preexec_fn=lower_priority,
             capture_output=True,
         )
 
@@ -467,10 +462,9 @@ class RecordingExporter(threading.Thread):
                 )
 
             p = sp.run(
-                ffmpeg_cmd,
+                ["nice", "-n", str(PROCESS_PRIORITY_LOW)] + ffmpeg_cmd,
                 input="\n".join(playlist_lines),
                 encoding="ascii",
-                preexec_fn=lower_priority,
                 capture_output=True,
             )
 


### PR DESCRIPTION
I've observed export deadlocking on my home server running Frigate in k3s on Proxmox.

Root cause: subprocess.run() with preexec_fn forces Python to use fork() instead of posix_spawn(). In Frigate's main process (75+ threads), fork() creates a child that inherits locked mutexes from other threads. The child may deadlocks e.g. on a pysqlite3 mutex before it can exec() ffmpeg.

This change replaces `preexec_fn=lower_priority` (which calls os.nice(19)) with prefixing the `ffmpeg` command with "nice -n 19", achieving the same priority reduction without requiring preexec_fn. This allows Python to use `posix_spawn()` which is safe in multithreaded processes.

Fixes both the primary export path and the CPU fallback retry path.

Fix for a similar issue in another project: https://opendev.org/zuul/zuul/commit/e02963f6e13127f4ad6d7d2aadd50544da732463
Also related: [cpython#82616 -- Start the deprecation cycle for subprocess preexec_fn](https://github.com/python/cpython/issues/82616)

_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [X] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):
Claude Code

**How AI was used** (e.g., code generation, code review, debugging, documentation):
I've used Claude Code to debug my Frigate instance deadlocking, to research the issue and make the patch.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):
Besides what I mentioned above, I've directed AI to research similar fixes in related projects, to make sure nothing is broken, to make a test deployment based on an image from the patched `dev` branch and verify that deadlock no longer occurs after the fix.

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.
I've made sure I fully understand the fix (every line of it), that the tests were run and that the patched deployment functions as expected. I've also made Claude Code delete the dead code it was about to leave behind, and to use a constant instead of `19` for `nice`.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale. -- no UI changes
- [X] The code has been formatted using Ruff (`ruff format frigate`)
