### PR TITLE
Browser will run at 100% if config has no restreams enabled.

### DIFF
--- a/web/src/hooks/use-deferred-stream-metadata.ts
+++ b/web/src/hooks/use-deferred-stream-metadata.ts
@@ -5,6 +5,7 @@ import { LiveStreamMetadata } from "@/types/live";
 
 const FETCH_TIMEOUT_MS = 10000;
 const DEFER_DELAY_MS = 2000;
+const EMPTY_METADATA: { [key: string]: LiveStreamMetadata } = {};
 
 /**
  * Hook that fetches go2rtc stream metadata with deferred loading.
@@ -77,7 +78,7 @@ export default function useDeferredStreamMetadata(streamNames: string[]) {
     return metadata;
   }, []);
 
-  const { data: metadata = {} } = useSWR<{
+  const { data: metadata = EMPTY_METADATA } = useSWR<{
     [key: string]: LiveStreamMetadata;
   }>(swrKey, fetcher, {
     revalidateOnFocus: false,


### PR DESCRIPTION
The `= {}` destructuring default in useDeferredStreamMetadata created a new object reference every render while the SWR key was null (during the 2-second defer delay). This triggered an infinite re-render loop through useCameraLiveMode's useEffect dependency on streamMetadata.

Replace with a module-level EMPTY_METADATA constant for referential stability.

Bug introduced in #21072 (97b29d17).

## Proposed change


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information


## AI disclosure

- [ ] No AI tools were used in this PR.
- [X] AI tools were used in this PR. Details below:

Claude was the debugging agent and wrote the code, we examine a few different code paths but none of them were fruitful. The fix was discovered as a bad data causing an infinite render loop. I reproduced the issue on 0.17.1 and then cherry-picked this fix from my dogfood branch, tested again to confirm the issue was resolved, and then created a PR based on master. 

Human reproduced issue, human tested fix, human created PR.

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)

## Before

<img width="676" height="409" alt="Screenshot From 2026-03-26 20-07-16" src="https://github.com/user-attachments/assets/34832515-6ef0-4d1b-970f-9e2600c4719e" />

Settings showing the exact build
<img width="676" height="409" alt="Screenshot From 2026-03-26 20-08-48" src="https://github.com/user-attachments/assets/b477365f-a381-4c4d-94ad-248508101b4b" />

## After with this one patch on master

<img width="676" height="409" alt="Screenshot From 2026-03-26 20-13-40" src="https://github.com/user-attachments/assets/44ca70f6-4104-4855-8179-6b22c5a508c1" />


