### PR TITLE
Review labels widget

### DIFF
--- a/frigate/config/camera/review.py
+++ b/frigate/config/camera/review.py
@@ -188,7 +188,7 @@ class ReviewConfig(FrigateBaseModel):
     detections: DetectionsConfig = Field(
         default_factory=DetectionsConfig,
         title="Detections config",
-        description="Settings for creating detection events (non-alert) and how long to keep them.",
+        description="Settings for which tracked objects generate detections (non-alert) and how detections are retained.",
     )
     genai: GenAIReviewConfig = Field(
         default_factory=GenAIReviewConfig,

--- a/web/public/locales/en/config/cameras.json
+++ b/web/public/locales/en/config/cameras.json
@@ -529,7 +529,7 @@
     },
     "detections": {
       "label": "Detections config",
-      "description": "Settings for creating detection events (non-alert) and how long to keep them.",
+      "description": "Settings for which tracked objects generate detections (non-alert) and how detections are retained.",
       "enabled": {
         "label": "Enable detections",
         "description": "Enable or disable detection events for this camera."

--- a/web/public/locales/en/config/global.json
+++ b/web/public/locales/en/config/global.json
@@ -1044,7 +1044,7 @@
     },
     "detections": {
       "label": "Detections config",
-      "description": "Settings for creating detection events (non-alert) and how long to keep them.",
+      "description": "Settings for which tracked objects generate detections (non-alert) and how detections are retained.",
       "enabled": {
         "label": "Enable detections",
         "description": "Enable or disable detection events for all cameras; can be overridden per-camera."

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -1478,7 +1478,8 @@
     "timestamp_style": {
       "title": "Timestamp Settings"
     },
-    "searchPlaceholder": "Search..."
+    "searchPlaceholder": "Search...",
+    "addCustomLabel": "Add custom label..."
   },
   "globalConfig": {
     "title": "Global Configuration",

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -1433,7 +1433,8 @@
     },
     "reviewLabels": {
       "summary": "{{count}} labels selected",
-      "empty": "No labels available"
+      "empty": "No labels available",
+      "allNonAlertDetections": "All non-alert activity will be included as detections."
     },
     "filters": {
       "objectFieldLabel": "{{field}} for {{label}}"

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -1431,6 +1431,10 @@
       "summary": "{{count}} object types selected",
       "empty": "No object labels available"
     },
+    "reviewLabels": {
+      "summary": "{{count}} labels selected",
+      "empty": "No labels available"
+    },
     "filters": {
       "objectFieldLabel": "{{field}} for {{label}}"
     },

--- a/web/src/components/config-form/section-configs/review.ts
+++ b/web/src/components/config-form/section-configs/review.ts
@@ -8,9 +8,7 @@ const review: SectionConfigOverrides = {
     fieldGroups: {},
     hiddenFields: [
       "enabled_in_config",
-      "alerts.labels",
       "alerts.enabled_in_config",
-      "detections.labels",
       "detections.enabled_in_config",
       "genai.enabled_in_config",
     ],
@@ -18,11 +16,23 @@ const review: SectionConfigOverrides = {
     uiSchema: {
       alerts: {
         "ui:before": { render: "CameraReviewStatusToggles" },
+        labels: {
+          "ui:widget": "reviewLabels",
+          "ui:options": {
+            suppressMultiSchema: true,
+          },
+        },
         required_zones: {
           "ui:widget": "hidden",
         },
       },
       detections: {
+        labels: {
+          "ui:widget": "reviewLabels",
+          "ui:options": {
+            suppressMultiSchema: true,
+          },
+        },
         required_zones: {
           "ui:widget": "hidden",
         },

--- a/web/src/components/config-form/section-configs/review.ts
+++ b/web/src/components/config-form/section-configs/review.ts
@@ -3,6 +3,10 @@ import type { SectionConfigOverrides } from "./types";
 const review: SectionConfigOverrides = {
   base: {
     sectionDocs: "/configuration/review",
+    fieldDocs: {
+      "alerts.labels": "/configuration/review/#alerts-and-detections",
+      "detections.labels": "/configuration/review/#alerts-and-detections",
+    },
     restartRequired: [],
     fieldOrder: ["alerts", "detections", "genai"],
     fieldGroups: {},

--- a/web/src/components/config-form/section-configs/review.ts
+++ b/web/src/components/config-form/section-configs/review.ts
@@ -35,6 +35,8 @@ const review: SectionConfigOverrides = {
           "ui:widget": "reviewLabels",
           "ui:options": {
             suppressMultiSchema: true,
+            emptySelectionHintKey:
+              "configForm.reviewLabels.allNonAlertDetections",
           },
         },
         required_zones: {

--- a/web/src/components/config-form/theme/frigateTheme.ts
+++ b/web/src/components/config-form/theme/frigateTheme.ts
@@ -20,6 +20,7 @@ import { TextareaWidget } from "./widgets/TextareaWidget";
 import { SwitchesWidget } from "./widgets/SwitchesWidget";
 import { ObjectLabelSwitchesWidget } from "./widgets/ObjectLabelSwitchesWidget";
 import { AudioLabelSwitchesWidget } from "./widgets/AudioLabelSwitchesWidget";
+import { ReviewLabelSwitchesWidget } from "./widgets/ReviewLabelSwitchesWidget";
 import { ZoneSwitchesWidget } from "./widgets/ZoneSwitchesWidget";
 import { ArrayAsTextWidget } from "./widgets/ArrayAsTextWidget";
 import { FfmpegArgsWidget } from "./widgets/FfmpegArgsWidget";
@@ -76,6 +77,7 @@ export const frigateTheme: FrigateTheme = {
     switches: SwitchesWidget,
     objectLabels: ObjectLabelSwitchesWidget,
     audioLabels: AudioLabelSwitchesWidget,
+    reviewLabels: ReviewLabelSwitchesWidget,
     zoneNames: ZoneSwitchesWidget,
     timezoneSelect: TimezoneSelectWidget,
     optionalField: OptionalFieldWidget,

--- a/web/src/components/config-form/theme/widgets/ReviewLabelSwitchesWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/ReviewLabelSwitchesWidget.tsx
@@ -20,11 +20,16 @@ function getReviewLabels(context: FormContext): string[] {
     trackLabels.forEach((label: string) => labels.add(label));
   }
 
-  // Audio labels from listen config (camera-level, falling back to global)
-  const audioLabels =
-    fullCameraConfig?.audio?.listen ?? fullConfig?.audio?.listen;
-  if (Array.isArray(audioLabels)) {
-    audioLabels.forEach((label: string) => labels.add(label));
+  // Audio labels from listen config, only if audio detection is enabled
+  const audioEnabled =
+    fullCameraConfig?.audio?.enabled_in_config ??
+    fullConfig?.audio?.enabled_in_config;
+  if (audioEnabled) {
+    const audioLabels =
+      fullCameraConfig?.audio?.listen ?? fullConfig?.audio?.listen;
+    if (Array.isArray(audioLabels)) {
+      audioLabels.forEach((label: string) => labels.add(label));
+    }
   }
 
   // Include any labels already in the review form data (alerts + detections)

--- a/web/src/components/config-form/theme/widgets/ReviewLabelSwitchesWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/ReviewLabelSwitchesWidget.tsx
@@ -75,6 +75,7 @@ export function ReviewLabelSwitchesWidget(props: WidgetProps) {
         getEntities: getReviewLabels,
         getDisplayLabel: getReviewLabelDisplayName,
         i18nKey: "reviewLabels",
+        allowCustomEntries: true,
         listClassName:
           "relative max-h-none overflow-visible md:max-h-64 md:overflow-y-auto md:overscroll-contain md:scrollbar-container",
       }}

--- a/web/src/components/config-form/theme/widgets/ReviewLabelSwitchesWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/ReviewLabelSwitchesWidget.tsx
@@ -1,0 +1,78 @@
+// Review Label Switches Widget - For selecting review alert/detection labels via switches.
+// Combines object labels (from objects.track) and audio labels (from audio.listen)
+// since review labels can include both types.
+import type { WidgetProps } from "@rjsf/utils";
+import { SwitchesWidget } from "./SwitchesWidget";
+import type { FormContext } from "./SwitchesWidget";
+import { getTranslatedLabel } from "@/utils/i18n";
+import type { FrigateConfig } from "@/types/frigateConfig";
+import type { JsonObject } from "@/types/configForm";
+
+function getReviewLabels(context: FormContext): string[] {
+  const labels = new Set<string>();
+  const fullConfig = context.fullConfig as FrigateConfig | undefined;
+  const fullCameraConfig = context.fullCameraConfig;
+
+  // Object labels from tracked objects (camera-level, falling back to global)
+  const trackLabels =
+    fullCameraConfig?.objects?.track ?? fullConfig?.objects?.track;
+  if (Array.isArray(trackLabels)) {
+    trackLabels.forEach((label: string) => labels.add(label));
+  }
+
+  // Audio labels from listen config (camera-level, falling back to global)
+  const audioLabels =
+    fullCameraConfig?.audio?.listen ?? fullConfig?.audio?.listen;
+  if (Array.isArray(audioLabels)) {
+    audioLabels.forEach((label: string) => labels.add(label));
+  }
+
+  // Include any labels already in the review form data (alerts + detections)
+  // so that previously saved labels remain visible even if tracking config changed
+  if (context.formData && typeof context.formData === "object") {
+    const formData = context.formData as JsonObject;
+    for (const section of ["alerts", "detections"] as const) {
+      const sectionData = formData[section];
+      if (sectionData && typeof sectionData === "object") {
+        const sectionLabels = (sectionData as JsonObject).labels;
+        if (Array.isArray(sectionLabels)) {
+          sectionLabels.forEach((label) => {
+            if (typeof label === "string") {
+              labels.add(label);
+            }
+          });
+        }
+      }
+    }
+  }
+
+  return [...labels].sort();
+}
+
+function getReviewLabelDisplayName(
+  label: string,
+  context?: FormContext,
+): string {
+  const fullCameraConfig = context?.fullCameraConfig;
+  const fullConfig = context?.fullConfig as FrigateConfig | undefined;
+  const audioLabels =
+    fullCameraConfig?.audio?.listen ?? fullConfig?.audio?.listen;
+  const isAudio = Array.isArray(audioLabels) && audioLabels.includes(label);
+  return getTranslatedLabel(label, isAudio ? "audio" : "object");
+}
+
+export function ReviewLabelSwitchesWidget(props: WidgetProps) {
+  return (
+    <SwitchesWidget
+      {...props}
+      options={{
+        ...props.options,
+        getEntities: getReviewLabels,
+        getDisplayLabel: getReviewLabelDisplayName,
+        i18nKey: "reviewLabels",
+        listClassName:
+          "relative max-h-none overflow-visible md:max-h-64 md:overflow-y-auto md:overscroll-contain md:scrollbar-container",
+      }}
+    />
+  );
+}

--- a/web/src/components/config-form/theme/widgets/SwitchesWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/SwitchesWidget.tsx
@@ -180,7 +180,7 @@ export function SwitchesWidget(props: WidgetProps) {
           </Button>
         </CollapsibleTrigger>
 
-        <CollapsibleContent className="rounded-lg border border-input bg-secondary p-2 pr-0 md:max-w-md">
+        <CollapsibleContent className="rounded-lg border border-input bg-secondary pb-1 pr-0 pt-2 md:max-w-md">
           {availableEntities.length === 0 ? (
             <div className="text-sm text-muted-foreground">{emptyMessage}</div>
           ) : (

--- a/web/src/components/config-form/theme/widgets/SwitchesWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/SwitchesWidget.tsx
@@ -1,6 +1,6 @@
 // Generic Switches Widget - Reusable component for selecting from any list of entities
 import { WidgetProps } from "@rjsf/utils";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -43,6 +43,8 @@ export type SwitchesWidgetOptions = {
   listClassName?: string;
   /** Enable search input to filter the list */
   enableSearch?: boolean;
+  /** Allow users to add custom entries not in the predefined list */
+  allowCustomEntries?: boolean;
 };
 
 function normalizeValue(value: unknown): string[] {
@@ -122,20 +124,46 @@ export function SwitchesWidget(props: WidgetProps) {
     [props.options],
   );
 
+  const allowCustomEntries = useMemo(
+    () => props.options?.allowCustomEntries as boolean | undefined,
+    [props.options],
+  );
+
   const selectedEntities = useMemo(() => normalizeValue(value), [value]);
   const [isOpen, setIsOpen] = useState(selectedEntities.length > 0);
   const [searchTerm, setSearchTerm] = useState("");
+  const [customEntries, setCustomEntries] = useState<string[]>([]);
+  const [customInput, setCustomInput] = useState("");
+
+  const allEntities = useMemo(() => {
+    if (customEntries.length === 0) {
+      return availableEntities;
+    }
+    const merged = new Set([...availableEntities, ...customEntries]);
+    return [...merged].sort();
+  }, [availableEntities, customEntries]);
 
   const filteredEntities = useMemo(() => {
     if (!enableSearch || !searchTerm.trim()) {
-      return availableEntities;
+      return allEntities;
     }
     const term = searchTerm.toLowerCase();
-    return availableEntities.filter((entity) => {
+    return allEntities.filter((entity) => {
       const displayLabel = getDisplayLabel(entity, context);
       return displayLabel.toLowerCase().includes(term);
     });
-  }, [availableEntities, searchTerm, enableSearch, getDisplayLabel, context]);
+  }, [allEntities, searchTerm, enableSearch, getDisplayLabel, context]);
+
+  const addCustomEntry = useCallback(() => {
+    const trimmed = customInput.trim().toLowerCase();
+    if (!trimmed || allEntities.includes(trimmed)) {
+      setCustomInput("");
+      return;
+    }
+    setCustomEntries((prev) => [...prev, trimmed]);
+    onChange([...selectedEntities, trimmed]);
+    setCustomInput("");
+  }, [customInput, allEntities, selectedEntities, onChange]);
 
   const toggleEntity = (entity: string, enabled: boolean) => {
     if (enabled) {
@@ -181,7 +209,7 @@ export function SwitchesWidget(props: WidgetProps) {
         </CollapsibleTrigger>
 
         <CollapsibleContent className="rounded-lg border border-input bg-secondary pb-1 pr-0 pt-2 md:max-w-md">
-          {availableEntities.length === 0 ? (
+          {allEntities.length === 0 && !allowCustomEntries ? (
             <div className="text-sm text-muted-foreground">{emptyMessage}</div>
           ) : (
             <>
@@ -223,6 +251,26 @@ export function SwitchesWidget(props: WidgetProps) {
                   );
                 })}
               </div>
+              {allowCustomEntries && !disabled && !readonly && (
+                <div className="mx-2 mt-2 pb-1">
+                  <Input
+                    type="text"
+                    placeholder={t?.("configForm.addCustomLabel", {
+                      ns: "views/settings",
+                      defaultValue: "Add custom label...",
+                    })}
+                    value={customInput}
+                    onChange={(e) => setCustomInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        addCustomEntry();
+                      }
+                    }}
+                    onBlur={addCustomEntry}
+                  />
+                </div>
+              )}
             </>
           )}
         </CollapsibleContent>

--- a/web/src/components/config-form/theme/widgets/SwitchesWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/SwitchesWidget.tsx
@@ -45,6 +45,8 @@ export type SwitchesWidgetOptions = {
   enableSearch?: boolean;
   /** Allow users to add custom entries not in the predefined list */
   allowCustomEntries?: boolean;
+  /** i18n key for a hint shown when no entities are selected */
+  emptySelectionHintKey?: string;
 };
 
 function normalizeValue(value: unknown): string[] {
@@ -129,6 +131,11 @@ export function SwitchesWidget(props: WidgetProps) {
     [props.options],
   );
 
+  const emptySelectionHintKey = useMemo(
+    () => props.options?.emptySelectionHintKey as string | undefined,
+    [props.options],
+  );
+
   const selectedEntities = useMemo(() => normalizeValue(value), [value]);
   const [isOpen, setIsOpen] = useState(selectedEntities.length > 0);
   const [searchTerm, setSearchTerm] = useState("");
@@ -191,7 +198,7 @@ export function SwitchesWidget(props: WidgetProps) {
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <div className="space-y-3">
+      <div className="space-y-2">
         <CollapsibleTrigger asChild>
           <Button
             type="button"
@@ -207,6 +214,12 @@ export function SwitchesWidget(props: WidgetProps) {
             {summary}
           </Button>
         </CollapsibleTrigger>
+
+        {emptySelectionHintKey && selectedEntities.length === 0 && t && (
+          <div className="mt-0 pb-2 text-sm text-success">
+            {t(emptySelectionHintKey, { ns: namespace })}
+          </div>
+        )}
 
         <CollapsibleContent className="rounded-lg border border-input bg-secondary pb-1 pr-0 pt-2 md:max-w-md">
           {allEntities.length === 0 && !allowCustomEntries ? (

--- a/web/src/components/config-form/theme/widgets/SwitchesWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/SwitchesWidget.tsx
@@ -180,7 +180,7 @@ export function SwitchesWidget(props: WidgetProps) {
           </Button>
         </CollapsibleTrigger>
 
-        <CollapsibleContent className="rounded-lg bg-secondary p-2 pr-0 md:max-w-md">
+        <CollapsibleContent className="rounded-lg border border-input bg-secondary p-2 pr-0 md:max-w-md">
           {availableEntities.length === 0 ? (
             <div className="text-sm text-muted-foreground">{emptyMessage}</div>
           ) : (


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR adds label selection switches to the Review settings UI for both Alerts and Detections sections.
- `ReviewLabelSwitchesWidget` combines tracked object labels and audio listen labels, allowing users to configure `review.alerts.labels` and `review.detections.labels` directly from the UI.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
