### PR TITLE
Add warm-up to onnx as some GPUs require kernel compilation

### DIFF
--- a/frigate/detectors/plugins/onnx.py
+++ b/frigate/detectors/plugins/onnx.py
@@ -8,6 +8,8 @@ from frigate.detectors.detection_api import DetectionApi
 from frigate.detectors.detection_runners import get_optimized_runner
 from frigate.detectors.detector_config import (
     BaseDetectorConfig,
+    InputDTypeEnum,
+    InputTensorEnum,
     ModelTypeEnum,
 )
 from frigate.util.model import (
@@ -59,7 +61,33 @@ class ONNXDetector(DetectionApi):
         if self.onnx_model_type == ModelTypeEnum.yolox:
             self.calculate_grids_strides()
 
+        self._warmup(detector_config)
         logger.info(f"ONNX: {path} loaded")
+
+    def _warmup(self, detector_config: ONNXDetectorConfig) -> None:
+        """Run a warmup inference to front-load one-time compilation costs.
+
+        Some GPU backends have a slow first inference: CUDA may need PTX JIT
+        compilation on newer architectures (e.g. NVIDIA 50-series / Blackwell),
+        and MIGraphX compiles the model graph on first run. Running it here
+        (during detector creation) keeps the watchdog start_time at 0.0 so the
+        process won't be killed.
+        """
+        if detector_config.model.input_tensor == InputTensorEnum.nchw:
+            shape = (1, 3, detector_config.model.height, detector_config.model.width)
+        else:
+            shape = (1, detector_config.model.height, detector_config.model.width, 3)
+
+        if detector_config.model.input_dtype in (
+            InputDTypeEnum.float,
+            InputDTypeEnum.float_denorm,
+        ):
+            dtype = np.float32
+        else:
+            dtype = np.uint8
+
+        logger.info("ONNX: warming up detector (may take a while on first run)...")
+        self.detect_raw(np.zeros(shape, dtype=dtype))
 
     def detect_raw(self, tensor_input: np.ndarray):
         if self.onnx_model_type == ModelTypeEnum.dfine:


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

RTX 50-series GPUs do not have pre-compiled kernels in ONNX runtime, this means that for their first inference they run JIT kernel compilation. This can take ~10 seconds which triggers the detection stuck logic. In some cases this is cached and finishes correctly on the second attempt, but in other cases it will loop forever. 

This is also a problem for AMD GPUs where the MiGraphX kernels are compiled JIT. This PR implements a warmup run for ONNX GPUs to ensure that the JIT compilation can complete without interfering with the detection timeout logic.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
