### PR TITLE
Fix motion activity endpoint returning invalid timestamps after panda…

### DIFF
--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -40,6 +40,11 @@ from frigate.util.time import get_dst_transitions
 
 logger = logging.getLogger(__name__)
 
+# Pre-computed constants for resolution-independent datetime-to-epoch conversion
+# (pandas 3.0+ stores datetime64 as microseconds, not nanoseconds)
+_EPOCH = pd.Timestamp("1970-01-01")
+_ONE_SECOND = pd.Timedelta("1s")
+
 router = APIRouter(tags=[Tags.review])
 
 
@@ -659,7 +664,7 @@ def motion_activity(
             df.iloc[i : i + chunk, 0] = 0.0
 
     # change types for output
-    df.index = df.index.astype(int) // (10**9)
+    df.index = (df.index - _EPOCH) // _ONE_SECOND
     normalized = df.reset_index().to_dict("records")
     return JSONResponse(content=normalized)
 


### PR DESCRIPTION

pandas 3.0 changed DatetimeIndex internal storage from datetime64[ns] (nanoseconds) to datetime64[us] (microseconds). The motion activity endpoint in review.py converted DatetimeIndex to epoch seconds using:

    df.index = df.index.astype(int) // (10**9)

This assumed nanosecond resolution, dividing by 10^9 to get seconds. With microsecond resolution the division produces values ~1000x too small (e.g. 1774785 instead of 1774785600), causing every entry to have a start_time near zero. The frontend timeline could not match these timestamps to the visible range, so motion indicator bars disappeared entirely — despite the underlying recording data being correct.

Replace the resolution-dependent integer division with pandas Timedelta arithmetic:

    df.index = (df.index - _EPOCH) // _ONE_SECOND

This is resolution-independent (produces correct results on datetime64[s], [ms], [us], and [ns]), ~148x faster than the per-element .timestamp() alternative, produces native Python int types that serialize cleanly to JSON, and is backwards-compatible with older pandas versions.


## Proposed change

Changed a fixed `10**9` constant to a resolution independent conversion that will work on current and future builds of numpy/pandas. Removed duplicative `astype(int)` as `//` is all that is needed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

Discovered in build after numpy2 upgrade.

## AI disclosure

- [ ] No AI tools were used in this PR.
- [X] AI tools were used in this PR. Details below:

Claude Opus 4.6 for debugging, profiling, and some code generation ( with assistance ). All testing and PRs done by human.

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
