### PR TITLE
fix MQTT snapshot race condition

### DIFF
--- a/frigate/camera/state.py
+++ b/frigate/camera/state.py
@@ -389,6 +389,18 @@ class CameraState:
                     c(self.name, updated_obj, frame_name)
                 updated_obj.last_published = frame_time
 
+            # send MQTT snapshot when object first enters a required zone,
+            # since the initial snapshot at creation time is blocked before
+            # zone evaluation has run
+            if updated_obj.new_zone_entered and not updated_obj.false_positive:
+                mqtt_required = self.camera_config.mqtt.required_zones
+                if mqtt_required and set(updated_obj.entered_zones) & set(
+                    mqtt_required
+                ):
+                    object_type = updated_obj.obj_data["label"]
+                    self.send_mqtt_snapshot(updated_obj, object_type)
+                updated_obj.new_zone_entered = False
+
         for id in removed_ids:
             # publish events to mqtt
             removed_obj = tracked_objects[id]

--- a/frigate/track/tracked_object.py
+++ b/frigate/track/tracked_object.py
@@ -61,6 +61,7 @@ class TrackedObject:
         self.zone_loitering: dict[str, int] = {}
         self.current_zones: list[str] = []
         self.entered_zones: list[str] = []
+        self.new_zone_entered: bool = False
         self.attributes: dict[str, float] = defaultdict(float)
         self.false_positive = True
         self.has_clip = False
@@ -278,6 +279,7 @@ class TrackedObject:
 
                             if name not in self.entered_zones:
                                 self.entered_zones.append(name)
+                                self.new_zone_entered = True
                         else:
                             self.zone_loitering[name] = loitering_score
 


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
When `mqtt.required_zones` is configured, the initial mqtt snapshot on object creation is always blocked because zone evaluation hasn't run yet (`entered_zones` is empty). Later, the snapshot is only re-sent if a better thumbnail is found, so if the first frame was already the best capture the snapshot is silently lost.

This PR adds a `new_zone_entered` flag to `TrackedObject` that triggers an mqtt snapshot publish as soon as zone entry is confirmed




## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: closes #21027
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
