### PR TITLE
Add config validators

### DIFF
--- a/frigate/config/camera/detect.py
+++ b/frigate/config/camera/detect.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from ..base import FrigateBaseModel
 
@@ -88,3 +88,11 @@ class DetectConfig(FrigateBaseModel):
         title="Annotation offset",
         description="Milliseconds to shift detect annotations to better align timeline bounding boxes with recordings; can be positive or negative.",
     )
+
+    @model_validator(mode="after")
+    def validate_dimensions(self) -> "DetectConfig":
+        if (self.width is None) != (self.height is None):
+            raise ValueError(
+                "detect -> both width and height must be specified together, or both omitted"
+            )
+        return self

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -188,6 +188,7 @@ class SemanticSearchConfig(FrigateBaseModel):
             except ValueError:
                 return v
         return v
+
     model_size: str = Field(
         default="small",
         title="Model size",

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Dict, List, Optional, Union
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, field_validator
 
 from .base import FrigateBaseModel
 
@@ -178,6 +178,16 @@ class SemanticSearchConfig(FrigateBaseModel):
         title="Semantic search model or GenAI provider name",
         description="The embeddings model to use for semantic search (for example 'jinav1'), or the name of a GenAI provider with the embeddings role.",
     )
+
+    @field_validator("model", mode="before")
+    @classmethod
+    def coerce_model_enum(cls, v):
+        if isinstance(v, str):
+            try:
+                return SemanticSearchModelEnum(v)
+            except ValueError:
+                return v
+        return v
     model_size: str = Field(
         default="small",
         title="Model size",

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -1188,7 +1188,7 @@ class TestConfig(unittest.TestCase):
     def test_global_detect_merge(self):
         config = {
             "mqtt": {"host": "mqtt"},
-            "detect": {"max_disappeared": 1, "height": 720},
+            "detect": {"max_disappeared": 1, "height": 720, "width": 1280},
             "cameras": {
                 "back": {
                     "ffmpeg": {


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR adds two new field validators:
- SemanticSearchConfig.model - explicitly try to coerce string values to `SemanticSearchModelEnum` before the model-level validation runs. Built-in model names (jinav1, jinav2) get converted to the enum, GenAI provider names that don't match stay as plain strings and follow the existing validation path.
- DetectConfig - raise a `ValueError` if only one of width/height is specified. Both must be provided together or both omitted (which triggers auto-detection from the stream).
- Fix test


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/22702
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
