### PR TITLE
fix: guard against zero-dimension boxes crashing norfair distance()

### DIFF
--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -45,6 +45,15 @@ def distance(detection: np.ndarray, estimate: np.ndarray) -> float:
     estimate_dim = np.diff(estimate, axis=0).flatten()
     detection_dim = np.diff(detection, axis=0).flatten()
 
+    # Guard against zero-dimension estimates or detections (e.g. degenerate boxes
+    # produced by the Kalman filter on the first few frames).  Dividing by zero
+    # yields NaN which propagates into norfair and causes a hard crash with
+    # "Received nan values from distance function".
+    if estimate_dim[0] <= 0 or estimate_dim[1] <= 0:
+        return float("inf")
+    if detection_dim[0] <= 0 or detection_dim[1] <= 0:
+        return float("inf")
+
     # get bottom center positions
     detection_position = np.array(
         [np.average(detection[:, 0]), np.max(detection[:, 1])]


### PR DESCRIPTION
## Description

The `distance()` function in `norfair_tracker.py` divides by `estimate_dim[0]` and `estimate_dim[1]` (the estimated bounding box width and height) without first checking whether they are non-zero. When the Kalman filter produces a degenerate estimate — or when a model outputs a zero-area detection — the division yields NaN, which propagates into norfair's internal tracking state and causes a hard crash:

```
RuntimeWarning: divide by zero encountered in double_scalars
ValueError: Received nan values from distance function
```

This was reported in #9742 and closed as stale. A maintainer commented it was fixed by #9538, but that PR only tuned Kalman filter Q/R values — the division in `distance()` remained unguarded.

## Fix

Add an early-return guard before any division:

```python
if estimate_dim[0] <= 0 or estimate_dim[1] <= 0:
    return float("inf")
if detection_dim[0] <= 0 or detection_dim[1] <= 0:
    return float("inf")
```

Returning `float("inf")` tells norfair to treat the pairing as too distant to match rather than crashing.

## Reproduction

This crash is reliably triggered by custom YOLO models (e.g. YOLOv8s in OpenVINO IR format) where the first few model outputs can include near-zero-area predictions. It also occurs intermittently with the default model on fast-moving or partially occluded objects where the Kalman estimate temporarily collapses.

Closes #9742

🤖 Generated with [Claude Code](https://claude.com/claude-code)