### PR TITLE
fix: drop degenerate boxes from YOLO NMS post-processing

### DIFF
--- a/frigate/util/model.py
+++ b/frigate/util/model.py
@@ -205,6 +205,15 @@ def __post_process_nms_yolo(predictions: np.ndarray, width, height) -> np.ndarra
     boxes_xyxy[:, 3] = boxes[:, 1] + boxes[:, 3] / 2
     boxes = boxes_xyxy
 
+    # Drop degenerate boxes (zero or negative width/height).  These arise when
+    # a YOLO prediction has w=0 or h=0, which after cx±w/2 conversion gives
+    # x2<=x1 or y2<=y1.  They pass through NMS unchanged and then cause a
+    # divide-by-zero NaN in the norfair distance function (see norfair_tracker.py).
+    valid = (boxes[:, 2] > boxes[:, 0]) & (boxes[:, 3] > boxes[:, 1])
+    boxes = boxes[valid]
+    scores = scores[valid]
+    class_ids = class_ids[valid]
+
     # run NMS
     indices = cv2.dnn.NMSBoxes(boxes, scores, score_threshold=0.4, nms_threshold=0.4)
     detections = np.zeros((20, 6), np.float32)


### PR DESCRIPTION
## Description

`__post_process_nms_yolo` converts YOLO output from centre-format `(cx, cy, w, h)` to `(x1, y1, x2, y2)` by computing `x1 = cx - w/2` and `x2 = cx + w/2`. When a prediction has `w=0` or `h=0`, the result is a box where `x2 == x1` or `y2 == y1`. These degenerate boxes pass through `cv2.dnn.NMSBoxes` unchanged and enter the tracker.

Downstream, the norfair `distance()` function divides by box width and height. A zero-dimension box produces a divide-by-zero → NaN, which propagates into norfair and causes:

```
RuntimeWarning: divide by zero encountered in double_scalars
ValueError: Received nan values from distance function
```

This is also a contributing cause of the crash described in #9742.

## Fix

Add a vectorised validity mask immediately after the `xyxy` conversion to drop any prediction with non-positive width or height before NMS runs:

```python
valid = (boxes[:, 2] > boxes[:, 0]) & (boxes[:, 3] > boxes[:, 1])
boxes = boxes[valid]
scores = scores[valid]
class_ids = class_ids[valid]
```

This is a companion fix to the guard added in `norfair_tracker.py` — filtering at the source is cheaper than handling NaN later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)