### PR TITLE
fix: save face crops as unknown when no model is trained yet

### DIFF
--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -295,7 +295,15 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
         res = self.recognizer.classify(face_frame)
 
         if not res:
-            logger.debug(f"Face recognizer returned no result for {id}")
+            # classify() returns None when no faces have been trained yet (empty
+            # embeddings).  Save the crop as "unknown" so the user can assign it
+            # from the UI and bootstrap face recognition after a fresh start or
+            # after deleting all known faces — otherwise the train queue stays
+            # empty forever and there is no way to add new training data.
+            self.write_face_attempt(
+                face_frame, id, datetime.datetime.now().timestamp(), "unknown", 0.0
+            )
+            logger.debug(f"Face recognizer returned no result for {id}, saved crop as unknown")
             self.__update_metrics(datetime.datetime.now().timestamp() - start)
             return
 


### PR DESCRIPTION
## Description

`classify()` returns `None` when no faces have been trained (the recognizer's `mean_embs` is empty). The code path for this case was:

```python
if not res:
    logger.debug(f"Face recognizer returned no result for {id}")
    self.__update_metrics(...)
    return   # ← write_face_attempt() never called
```

Because `write_face_attempt()` was never called, the `train/` directory stays empty. This creates a bootstrap deadlock:

1. User deletes all known faces (or starts fresh)
2. `classify()` always returns `None`  
3. No crops ever appear in the train queue
4. The UI has nothing to label
5. Face recognition can never be trained again without manually calling the register API or restarting Frigate

## Fix

Call `write_face_attempt()` with `sub_label="unknown"` and `score=0.0` before returning when `classify()` yields no result. `write_face_attempt` already checks the `save_attempts` config flag, so this path is a no-op when saving is disabled:

```python
if not res:
    self.write_face_attempt(
        face_frame, id, datetime.datetime.now().timestamp(), "unknown", 0.0
    )
    ...
    return
```

The saved crops appear in the Frigate UI's face training view where they can be assigned to a person, exactly like crops that came from a model with low confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)