### PR TITLE
Mask/zone editor fixes

### DIFF
--- a/docs/docs/configuration/profiles.md
+++ b/docs/docs/configuration/profiles.md
@@ -120,7 +120,7 @@ The following camera configuration sections can be overridden in a profile:
 
 :::note
 
-Only the fields you explicitly set in a profile override are applied. All other fields retain their base configuration values. For zones, profile zones are merged with the camera's base zones — any zone defined in the profile will override or add to the base zones.
+Only the fields you explicitly set in a profile override are applied. All other fields retain their base configuration values. For masks and zones, profile zones **override** the camera's base masks and zones. If configuring profiles via YAML, you should not define masks or zones in profiles that are not defined in the base config.
 
 :::
 

--- a/frigate/api/camera.py
+++ b/frigate/api/camera.py
@@ -1224,6 +1224,15 @@ def camera_set(
             status_code=400,
         )
 
+    if not sub_command and feature in _SUB_COMMAND_FEATURES:
+        return JSONResponse(
+            content={
+                "success": False,
+                "message": f"Feature '{feature}' requires a sub-command (e.g. mask or zone name)",
+            },
+            status_code=400,
+        )
+
     if camera_name == "*":
         cameras = list(frigate_config.cameras.keys())
     elif camera_name not in frigate_config.cameras:

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -118,9 +118,20 @@ class Dispatcher:
 
             try:
                 if command_type == "set":
+                    # Commands that require a sub-command (mask/zone name)
+                    sub_command_required = {
+                        "motion_mask",
+                        "object_mask",
+                        "zone",
+                    }
                     if sub_command:
                         self._camera_settings_handlers[command](
                             camera_name, sub_command, payload
+                        )
+                    elif command in sub_command_required:
+                        logger.error(
+                            "Command %s requires a sub-command (mask/zone name)",
+                            command,
                         )
                     else:
                         self._camera_settings_handlers[command](camera_name, payload)

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -614,6 +614,10 @@
           "desc": "Are you sure you want to delete the {{type}} <em>{{name}}</em>?",
           "success": "{{name}} has been deleted."
         },
+        "revertOverride": {
+          "title": "Revert to Base Config",
+          "desc": "This will remove the profile override for the {{type}} <em>{{name}}</em> and revert to the base configuration."
+        },
         "error": {
           "mustBeFinished": "Polygon drawing must be finished before saving."
         }

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -539,6 +539,7 @@
     },
     "restart_required": "Restart required (masks/zones changed)",
     "disabledInConfig": "Item is disabled in the config file",
+    "addDisabledProfile": "Add to the base config first, then override in the profile",
     "profileBase": "(base)",
     "profileOverride": "(override)",
     "toast": {

--- a/web/src/components/settings/MotionMaskEditPane.tsx
+++ b/web/src/components/settings/MotionMaskEditPane.tsx
@@ -74,9 +74,11 @@ export default function MotionMaskEditPane({
     }
   }, [polygons, activePolygonIndex]);
 
+  const maskCamera = polygon?.camera || "";
+  const maskName = polygon?.name || "";
   const { send: sendMotionMaskState } = useMotionMaskState(
-    polygon?.camera || "",
-    polygon?.name || "",
+    maskCamera,
+    maskName,
   );
 
   const cameraConfig = useMemo(() => {
@@ -250,8 +252,8 @@ export default function MotionMaskEditPane({
               },
             );
             updateConfig();
-            // Only publish WS state for base config
-            if (!editingProfile) {
+            // Only publish WS state for base config when mask has a name
+            if (!editingProfile && maskName) {
               sendMotionMaskState(enabled ? "ON" : "OFF");
             }
           } else {
@@ -291,6 +293,7 @@ export default function MotionMaskEditPane({
       cameraConfig,
       t,
       sendMotionMaskState,
+      maskName,
       editingProfile,
     ],
   );

--- a/web/src/components/settings/MotionMaskEditPane.tsx
+++ b/web/src/components/settings/MotionMaskEditPane.tsx
@@ -452,7 +452,7 @@ export default function MotionMaskEditPane({
                 <Button
                   variant="select"
                   aria-label={t("button.save", { ns: "common" })}
-                  disabled={isLoading}
+                  disabled={isLoading || !form.formState.isValid}
                   className="flex flex-1"
                   type="submit"
                 >

--- a/web/src/components/settings/MotionMaskEditPane.tsx
+++ b/web/src/components/settings/MotionMaskEditPane.tsx
@@ -156,7 +156,7 @@ export default function MotionMaskEditPane({
       message: t("masksAndZones.form.name.error.mustNotBeEmpty"),
     }),
     enabled: z.boolean(),
-    isFinished: z.boolean().refine(() => polygon?.isFinished === true, {
+    isFinished: z.boolean().refine((val) => val === true, {
       message: t("masksAndZones.form.polygonDrawing.error.mustBeFinished"),
     }),
   });
@@ -171,6 +171,12 @@ export default function MotionMaskEditPane({
       isFinished: polygon?.isFinished ?? false,
     },
   });
+
+  useEffect(() => {
+    if (polygon?.isFinished !== undefined) {
+      form.setValue("isFinished", polygon.isFinished, { shouldValidate: true });
+    }
+  }, [polygon?.isFinished, form]);
 
   const saveToConfig = useCallback(
     async ({

--- a/web/src/components/settings/ObjectMaskEditPane.tsx
+++ b/web/src/components/settings/ObjectMaskEditPane.tsx
@@ -456,7 +456,7 @@ export default function ObjectMaskEditPane({
                 </Button>
                 <Button
                   variant="select"
-                  disabled={isLoading}
+                  disabled={isLoading || !form.formState.isValid}
                   className="flex flex-1"
                   aria-label={t("button.save", { ns: "common" })}
                   type="submit"

--- a/web/src/components/settings/ObjectMaskEditPane.tsx
+++ b/web/src/components/settings/ObjectMaskEditPane.tsx
@@ -80,9 +80,10 @@ export default function ObjectMaskEditPane({
     }
   }, [polygons, activePolygonIndex]);
 
+  const maskName = polygon?.name || "";
   const { send: sendObjectMaskState } = useObjectMaskState(
     polygon?.camera || "",
-    polygon?.name || "",
+    maskName,
   );
 
   const cameraConfig = useMemo(() => {
@@ -256,8 +257,8 @@ export default function ObjectMaskEditPane({
               },
             );
             updateConfig();
-            // Only publish WS state for base config
-            if (!editingProfile) {
+            // Only publish WS state for base config when mask has a name
+            if (!editingProfile && maskName) {
               sendObjectMaskState(enabled ? "ON" : "OFF");
             }
           } else {
@@ -300,6 +301,7 @@ export default function ObjectMaskEditPane({
       cameraConfig,
       t,
       sendObjectMaskState,
+      maskName,
       editingProfile,
     ],
   );

--- a/web/src/components/settings/ObjectMaskEditPane.tsx
+++ b/web/src/components/settings/ObjectMaskEditPane.tsx
@@ -144,7 +144,7 @@ export default function ObjectMaskEditPane({
     }),
     enabled: z.boolean(),
     objects: z.string(),
-    isFinished: z.boolean().refine(() => polygon?.isFinished === true, {
+    isFinished: z.boolean().refine((val) => val === true, {
       message: t("masksAndZones.form.polygonDrawing.error.mustBeFinished"),
     }),
   });
@@ -160,6 +160,12 @@ export default function ObjectMaskEditPane({
       isFinished: polygon?.isFinished ?? false,
     },
   });
+
+  useEffect(() => {
+    if (polygon?.isFinished !== undefined) {
+      form.setValue("isFinished", polygon.isFinished, { shouldValidate: true });
+    }
+  }, [polygon?.isFinished, form]);
 
   const saveToConfig = useCallback(
     async ({

--- a/web/src/components/settings/PolygonItem.tsx
+++ b/web/src/components/settings/PolygonItem.tsx
@@ -30,7 +30,6 @@ import useSWR from "swr";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { reviewQueries } from "@/utils/zoneEdutUtil";
 import IconWrapper from "../ui/icon-wrapper";
-import { buttonVariants } from "../ui/button";
 import { Trans, useTranslation } from "react-i18next";
 import ActivityIndicator from "../indicators/activity-indicator";
 import { cn } from "@/lib/utils";
@@ -474,9 +473,7 @@ export default function PolygonItem({
             <AlertDialogHeader>
               <AlertDialogTitle>
                 {polygon.polygonSource === "override"
-                  ? t(
-                      "masksAndZones.form.polygonDrawing.revertOverride.title",
-                    )
+                  ? t("masksAndZones.form.polygonDrawing.revertOverride.title")
                   : t("masksAndZones.form.polygonDrawing.delete.title")}
               </AlertDialogTitle>
             </AlertDialogHeader>
@@ -514,10 +511,12 @@ export default function PolygonItem({
                 {t("button.cancel", { ns: "common" })}
               </AlertDialogCancel>
               <AlertDialogAction
-                className={buttonVariants({ variant: "destructive" })}
+                className="bg-destructive text-white hover:bg-destructive/90"
                 onClick={handleDelete}
               >
-                {t("button.delete", { ns: "common" })}
+                {polygon.polygonSource === "override"
+                  ? t("masksAndZones.form.polygonDrawing.revertOverride.title")
+                  : t("button.delete", { ns: "common" })}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
@@ -630,7 +629,9 @@ export default function PolygonItem({
                 />
               </TooltipTrigger>
               <TooltipContent>
-                {t("button.delete", { ns: "common" })}
+                {polygon.polygonSource === "override"
+                  ? t("masksAndZones.form.polygonDrawing.revertOverride.title")
+                  : t("button.delete", { ns: "common" })}
               </TooltipContent>
             </Tooltip>
           </div>

--- a/web/src/components/settings/PolygonItem.tsx
+++ b/web/src/components/settings/PolygonItem.tsx
@@ -154,7 +154,19 @@ export default function PolygonItem({
             cameraConfig?.review.alerts.required_zones || [],
             cameraConfig?.review.detections.required_zones || [],
           );
-          url = `cameras.${polygon.camera}.zones.${polygon.name}${alertQueries}${detectionQueries}`;
+          // Also delete from profiles that have overrides for this zone
+          let profileQueries = "";
+          if (allProfileNames && cameraConfig) {
+            for (const profileName of allProfileNames) {
+              if (
+                cameraConfig.profiles?.[profileName]?.zones?.[polygon.name] !==
+                undefined
+              ) {
+                profileQueries += `&cameras.${polygon.camera}.profiles.${profileName}.zones.${polygon.name}`;
+              }
+            }
+          }
+          url = `cameras.${polygon.camera}.zones.${polygon.name}${alertQueries}${detectionQueries}${profileQueries}`;
         }
 
         await axios
@@ -214,11 +226,41 @@ export default function PolygonItem({
                 },
               };
 
+      let cameraUpdate: Record<string, unknown>;
+      if (editingProfile) {
+        cameraUpdate = { profiles: { [editingProfile]: deleteSection } };
+      } else {
+        // Base mode: also delete from profiles that have overrides for this mask
+        const profileDeletes: Record<string, unknown> = {};
+        if (allProfileNames && cameraConfig) {
+          for (const profileName of allProfileNames) {
+            const profileData = cameraConfig.profiles?.[profileName];
+            if (!profileData) continue;
+
+            const hasMask =
+              polygon.type === "motion_mask"
+                ? profileData.motion?.mask?.[polygon.name] !== undefined
+                : polygon.type === "object_mask"
+                  ? profileData.objects?.mask?.[polygon.name] !== undefined ||
+                    Object.values(profileData.objects?.filters || {}).some(
+                      (f) => f?.mask?.[polygon.name] !== undefined,
+                    )
+                  : false;
+
+            if (hasMask) {
+              profileDeletes[profileName] = deleteSection;
+            }
+          }
+        }
+        cameraUpdate =
+          Object.keys(profileDeletes).length > 0
+            ? { ...deleteSection, profiles: profileDeletes }
+            : deleteSection;
+      }
+
       const configUpdate = {
         cameras: {
-          [polygon.camera]: editingProfile
-            ? { profiles: { [editingProfile]: deleteSection } }
-            : deleteSection,
+          [polygon.camera]: cameraUpdate,
         },
       };
 
@@ -271,6 +313,7 @@ export default function PolygonItem({
       index,
       setLoadingPolygonIndex,
       editingProfile,
+      allProfileNames,
       onDeleted,
     ],
   );
@@ -430,22 +473,41 @@ export default function PolygonItem({
           <AlertDialogContent>
             <AlertDialogHeader>
               <AlertDialogTitle>
-                {t("masksAndZones.form.polygonDrawing.delete.title")}
+                {polygon.polygonSource === "override"
+                  ? t(
+                      "masksAndZones.form.polygonDrawing.revertOverride.title",
+                    )
+                  : t("masksAndZones.form.polygonDrawing.delete.title")}
               </AlertDialogTitle>
             </AlertDialogHeader>
             <AlertDialogDescription>
-              <Trans
-                ns="views/settings"
-                values={{
-                  type: t(
-                    `masksAndZones.form.polygonDrawing.type.${polygon.type}`,
-                    { ns: "views/settings" },
-                  ),
-                  name: polygon.friendly_name ?? polygon.name,
-                }}
-              >
-                masksAndZones.form.polygonDrawing.delete.desc
-              </Trans>
+              {polygon.polygonSource === "override" ? (
+                <Trans
+                  ns="views/settings"
+                  values={{
+                    type: t(
+                      `masksAndZones.form.polygonDrawing.type.${polygon.type}`,
+                      { ns: "views/settings" },
+                    ),
+                    name: polygon.friendly_name ?? polygon.name,
+                  }}
+                >
+                  masksAndZones.form.polygonDrawing.revertOverride.desc
+                </Trans>
+              ) : (
+                <Trans
+                  ns="views/settings"
+                  values={{
+                    type: t(
+                      `masksAndZones.form.polygonDrawing.type.${polygon.type}`,
+                      { ns: "views/settings" },
+                    ),
+                    name: polygon.friendly_name ?? polygon.name,
+                  }}
+                >
+                  masksAndZones.form.polygonDrawing.delete.desc
+                </Trans>
+              )}
             </AlertDialogDescription>
             <AlertDialogFooter>
               <AlertDialogCancel>

--- a/web/src/components/settings/PolygonItem.tsx
+++ b/web/src/components/settings/PolygonItem.tsx
@@ -51,6 +51,7 @@ type PolygonItemProps = {
   setLoadingPolygonIndex: (index: number | undefined) => void;
   editingProfile?: string | null;
   allProfileNames?: string[];
+  onDeleted?: () => void;
 };
 
 export default function PolygonItem({
@@ -67,6 +68,7 @@ export default function PolygonItem({
   setLoadingPolygonIndex,
   editingProfile,
   allProfileNames,
+  onDeleted,
 }: PolygonItemProps) {
   const { t } = useTranslation("views/settings");
   const { data: config, mutate: updateConfig } =
@@ -169,6 +171,7 @@ export default function PolygonItem({
                 { position: "top-center" },
               );
               updateConfig();
+              onDeleted?.();
             } else {
               toast.error(
                 t("toast.save.error.title", {
@@ -234,6 +237,7 @@ export default function PolygonItem({
               { position: "top-center" },
             );
             updateConfig();
+            onDeleted?.();
           } else {
             toast.error(
               t("toast.save.error.title", {
@@ -267,6 +271,7 @@ export default function PolygonItem({
       index,
       setLoadingPolygonIndex,
       editingProfile,
+      onDeleted,
     ],
   );
 

--- a/web/src/components/settings/ZoneEditPane.tsx
+++ b/web/src/components/settings/ZoneEditPane.tsx
@@ -293,7 +293,7 @@ export default function ZoneEditPane({
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    mode: "onBlur",
+    mode: "onChange",
     defaultValues: {
       name: polygon?.name ?? "",
       friendly_name: polygon?.friendly_name ?? polygon?.name ?? "",
@@ -314,18 +314,25 @@ export default function ZoneEditPane({
     },
   });
 
+  const watchSpeedEstimation = form.watch("speedEstimation");
+  const watchLineA = form.watch("lineA");
+  const watchLineB = form.watch("lineB");
+  const watchLineC = form.watch("lineC");
+  const watchLineD = form.watch("lineD");
+
+  const canSave =
+    form.formState.isValid &&
+    (!watchSpeedEstimation ||
+      (!!watchLineA && !!watchLineB && !!watchLineC && !!watchLineD));
+
   useEffect(() => {
-    if (
-      form.watch("speedEstimation") &&
-      polygon &&
-      polygon.points.length !== 4
-    ) {
+    if (watchSpeedEstimation && polygon && polygon.points.length !== 4) {
       toast.error(
         t("masksAndZones.zones.speedThreshold.toast.error.pointLengthError"),
       );
       form.setValue("speedEstimation", false);
     }
-  }, [polygon, form, t]);
+  }, [polygon, form, t, watchSpeedEstimation]);
 
   const saveToConfig = useCallback(
     async (
@@ -966,7 +973,7 @@ export default function ZoneEditPane({
             </Button>
             <Button
               variant="select"
-              disabled={isLoading || !form.formState.isValid}
+              disabled={isLoading || !canSave}
               className="flex flex-1"
               aria-label={t("button.save", { ns: "common" })}
               type="submit"

--- a/web/src/components/settings/ZoneEditPane.tsx
+++ b/web/src/components/settings/ZoneEditPane.tsx
@@ -966,7 +966,7 @@ export default function ZoneEditPane({
             </Button>
             <Button
               variant="select"
-              disabled={isLoading}
+              disabled={isLoading || !form.formState.isValid}
               className="flex flex-1"
               aria-label={t("button.save", { ns: "common" })}
               type="submit"

--- a/web/src/components/settings/ZoneEditPane.tsx
+++ b/web/src/components/settings/ZoneEditPane.tsx
@@ -208,7 +208,7 @@ export default function ZoneEditPane({
         })
         .optional()
         .or(z.literal("")),
-      isFinished: z.boolean().refine(() => polygon?.isFinished === true, {
+      isFinished: z.boolean().refine((val) => val === true, {
         message: t("masksAndZones.form.polygonDrawing.error.mustBeFinished"),
       }),
       objects: z.array(z.string()).optional(),
@@ -333,6 +333,12 @@ export default function ZoneEditPane({
       form.setValue("speedEstimation", false);
     }
   }, [polygon, form, t, watchSpeedEstimation]);
+
+  useEffect(() => {
+    if (polygon?.isFinished !== undefined) {
+      form.setValue("isFinished", polygon.isFinished, { shouldValidate: true });
+    }
+  }, [polygon?.isFinished, form]);
 
   const saveToConfig = useCallback(
     async (

--- a/web/src/components/settings/ZoneEditPane.tsx
+++ b/web/src/components/settings/ZoneEditPane.tsx
@@ -91,10 +91,8 @@ export default function ZoneEditPane({
     }
   }, [polygons, activePolygonIndex]);
 
-  const { send: sendZoneState } = useZoneState(
-    polygon?.camera || "",
-    polygon?.name || "",
-  );
+  const zoneName = polygon?.name || "";
+  const { send: sendZoneState } = useZoneState(polygon?.camera || "", zoneName);
 
   const cameraConfig = useMemo(() => {
     if (polygon?.camera && config) {
@@ -303,8 +301,8 @@ export default function ZoneEditPane({
         resolvedZoneData?.enabled !== undefined
           ? resolvedZoneData.enabled
           : (polygon?.enabled ?? true),
-      inertia: resolvedZoneData?.inertia,
-      loitering_time: resolvedZoneData?.loitering_time,
+      inertia: resolvedZoneData?.inertia ?? 3,
+      loitering_time: resolvedZoneData?.loitering_time ?? 0,
       isFinished: polygon?.isFinished ?? false,
       objects: polygon?.objects ?? [],
       speedEstimation: !!(lineA || lineB || lineC || lineD),
@@ -516,8 +514,8 @@ export default function ZoneEditPane({
               },
             );
             updateConfig();
-            // Only publish WS state for base config (not profiles)
-            if (!editingProfile) {
+            // Only publish WS state for base config when zone has a name
+            if (!editingProfile && zoneName) {
               sendZoneState(enabled ? "ON" : "OFF");
             }
           } else {

--- a/web/src/views/settings/MasksAndZonesView.tsx
+++ b/web/src/views/settings/MasksAndZonesView.tsx
@@ -201,6 +201,16 @@ export default function MasksAndZonesView({
     setUnsavedChanges(false);
   }, [editingPolygons, setUnsavedChanges]);
 
+  const handlePolygonDeleted = useCallback(() => {
+    // Temporarily clear the edit pane guard so the useEffect that
+    // rebuilds editingPolygons from config will run when the fresh
+    // config arrives via updateConfig(). This handles all cases:
+    // base deletes, profile override deletes (which revert to base),
+    // and profile-only deletes.
+    setEditPane(undefined);
+    setActivePolygonIndex(undefined);
+  }, [setEditPane, setActivePolygonIndex]);
+
   useEffect(() => {
     if (isLoading) {
       return;
@@ -843,6 +853,7 @@ export default function MasksAndZonesView({
                             setLoadingPolygonIndex={setLoadingPolygonIndex}
                             editingProfile={currentEditingProfile}
                             allProfileNames={profileState?.allProfileNames}
+                            onDeleted={handlePolygonDeleted}
                           />
                         ))}
                     </div>
@@ -919,6 +930,7 @@ export default function MasksAndZonesView({
                             setLoadingPolygonIndex={setLoadingPolygonIndex}
                             editingProfile={currentEditingProfile}
                             allProfileNames={profileState?.allProfileNames}
+                            onDeleted={handlePolygonDeleted}
                           />
                         ))}
                     </div>
@@ -995,6 +1007,7 @@ export default function MasksAndZonesView({
                             setLoadingPolygonIndex={setLoadingPolygonIndex}
                             editingProfile={currentEditingProfile}
                             allProfileNames={profileState?.allProfileNames}
+                            onDeleted={handlePolygonDeleted}
                           />
                         ))}
                     </div>

--- a/web/src/views/settings/MasksAndZonesView.tsx
+++ b/web/src/views/settings/MasksAndZonesView.tsx
@@ -816,20 +816,25 @@ export default function MasksAndZonesView({
                         </HoverCard>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <Button
-                              variant="secondary"
-                              className="size-6 rounded-md bg-secondary-foreground p-1 text-background"
-                              aria-label={t("masksAndZones.zones.add")}
-                              onClick={() => {
-                                setEditPane("zone");
-                                handleNewPolygon("zone");
-                              }}
-                            >
-                              <LuPlus />
-                            </Button>
+                            <span className="inline-flex">
+                              <Button
+                                variant="secondary"
+                                className="size-6 rounded-md bg-secondary-foreground p-1 text-background"
+                                aria-label={t("masksAndZones.zones.add")}
+                                disabled={!!currentEditingProfile}
+                                onClick={() => {
+                                  setEditPane("zone");
+                                  handleNewPolygon("zone");
+                                }}
+                              >
+                                <LuPlus />
+                              </Button>
+                            </span>
                           </TooltipTrigger>
                           <TooltipContent>
-                            {t("masksAndZones.zones.add")}
+                            {currentEditingProfile
+                              ? t("masksAndZones.addDisabledProfile")
+                              : t("masksAndZones.zones.add")}
                           </TooltipContent>
                         </Tooltip>
                       </div>
@@ -891,20 +896,25 @@ export default function MasksAndZonesView({
                         </HoverCard>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <Button
-                              variant="secondary"
-                              className="size-6 rounded-md bg-secondary-foreground p-1 text-background"
-                              aria-label={t("masksAndZones.motionMasks.add")}
-                              onClick={() => {
-                                setEditPane("motion_mask");
-                                handleNewPolygon("motion_mask");
-                              }}
-                            >
-                              <LuPlus />
-                            </Button>
+                            <span className="inline-flex">
+                              <Button
+                                variant="secondary"
+                                className="size-6 rounded-md bg-secondary-foreground p-1 text-background"
+                                aria-label={t("masksAndZones.motionMasks.add")}
+                                disabled={!!currentEditingProfile}
+                                onClick={() => {
+                                  setEditPane("motion_mask");
+                                  handleNewPolygon("motion_mask");
+                                }}
+                              >
+                                <LuPlus />
+                              </Button>
+                            </span>
                           </TooltipTrigger>
                           <TooltipContent>
-                            {t("masksAndZones.motionMasks.add")}
+                            {currentEditingProfile
+                              ? t("masksAndZones.addDisabledProfile")
+                              : t("masksAndZones.motionMasks.add")}
                           </TooltipContent>
                         </Tooltip>
                       </div>
@@ -968,20 +978,25 @@ export default function MasksAndZonesView({
                         </HoverCard>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <Button
-                              variant="secondary"
-                              className="size-6 rounded-md bg-secondary-foreground p-1 text-background"
-                              aria-label={t("masksAndZones.objectMasks.add")}
-                              onClick={() => {
-                                setEditPane("object_mask");
-                                handleNewPolygon("object_mask");
-                              }}
-                            >
-                              <LuPlus />
-                            </Button>
+                            <span className="inline-flex">
+                              <Button
+                                variant="secondary"
+                                className="size-6 rounded-md bg-secondary-foreground p-1 text-background"
+                                aria-label={t("masksAndZones.objectMasks.add")}
+                                disabled={!!currentEditingProfile}
+                                onClick={() => {
+                                  setEditPane("object_mask");
+                                  handleNewPolygon("object_mask");
+                                }}
+                              >
+                                <LuPlus />
+                              </Button>
+                            </span>
                           </TooltipTrigger>
                           <TooltipContent>
-                            {t("masksAndZones.objectMasks.add")}
+                            {currentEditingProfile
+                              ? t("masksAndZones.addDisabledProfile")
+                              : t("masksAndZones.objectMasks.add")}
                           </TooltipContent>
                         </Tooltip>
                       </div>


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR fixes a few regressions to masks/zones due to the profiles implementation:
- Fix websocket crash when saving a new motion mask, object mask, or zone before a name is assigned. The empty name created a malformed topic (`cam/motion_mask//set`) that called the dispatcher handler with the wrong number of arguments.
- Add backend guards in the dispatcher and camera API to gracefully reject mask/zone commands missing a sub-command instead of crashing with TypeError
- Fix deleted masks/zones not disappearing from the list until navigating away. The edit pane guard that prevents layout shifts during editing also blocked delete updates from propagating to editingPolygons
- Fix deleting a profile override not reverting to the base mask in the list. On delete, the edit pane now closes and the polygon list rebuilds from fresh config, correctly showing the base version
- Fix the default inertia value in the zone editor causing a NaN on a save attempt
- Disable save button on all panes if form is invalid
- Remove polygon from all profiles when deleting from the base config
- Clarify confirmation message when removing a polygon override from a profile

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
