### PR TITLE
Settings tweaks

### DIFF
--- a/web/src/components/config-form/section-configs/review.ts
+++ b/web/src/components/config-form/section-configs/review.ts
@@ -47,7 +47,7 @@ const review: SectionConfigOverrides = {
       "detections.labels": "/configuration/review/#alerts-and-detections",
     },
     restartRequired: [],
-    fieldOrder: ["alerts", "detections", "genai"],
+    fieldOrder: ["alerts", "detections", "genai", "genai.enabled"],
     fieldGroups: {},
     hiddenFields: [
       "enabled_in_config",

--- a/web/src/components/overlay/chip/GenAISummaryChip.tsx
+++ b/web/src/components/overlay/chip/GenAISummaryChip.tsx
@@ -108,7 +108,7 @@ export function GenAISummaryDialog({
   return (
     <Overlay open={open} onOpenChange={setOpen}>
       <Trigger asChild>
-        <div>{children}</div>
+        <div className="min-w-0">{children}</div>
       </Trigger>
       <Content
         className={cn(

--- a/web/src/components/timeline/DetailStream.tsx
+++ b/web/src/components/timeline/DetailStream.tsx
@@ -525,7 +525,7 @@ function ReviewGroup({
                       }
                     }}
                   >
-                    <span className="truncate hover:underline">
+                    <span className="block truncate hover:underline">
                       {review.data.metadata.title}
                     </span>
                   </GenAISummaryDialog>

--- a/web/src/lib/config-schema/transformer.ts
+++ b/web/src/lib/config-schema/transformer.ts
@@ -483,9 +483,20 @@ function generateUiSchema(
 
   const schemaObj = schema as Record<string, unknown>;
 
-  // Set field ordering
+  // Set field ordering — supports dot notation (e.g. "genai.enabled")
   if (fieldOrder && fieldOrder.length > 0) {
-    uiSchema["ui:order"] = [...fieldOrder, "*"];
+    const depth = currentPath.length;
+    const localOrder = fieldOrder
+      .map((f) => f.split("."))
+      .filter((segments) => {
+        if (segments.length !== depth + 1) return false;
+        return currentPath.every((p, i) => segments[i] === p);
+      })
+      .map((segments) => segments[depth]);
+
+    if (localOrder.length > 0) {
+      uiSchema["ui:order"] = [...localOrder, "*"];
+    }
   }
 
   if (!isSchemaObject(schemaObj.properties)) {


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
- Add ability to order subfields in the settings UI by using dot notation in the fieldOrder section config
- Move `review.genai.enabled` to the top of the GenAI section in Review so that it appears above alerts and detections
- Fix overflowing GenAI summary title in Detail Stream

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
