### PR TITLE
Miscellaneous fixes

### DIFF
--- a/web/src/components/config-form/theme/fields/DictAsYamlField.tsx
+++ b/web/src/components/config-form/theme/fields/DictAsYamlField.tsx
@@ -2,7 +2,7 @@ import type { FieldPathList, FieldProps } from "@rjsf/utils";
 import yaml from "js-yaml";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 function formatYaml(value: unknown): string {
   if (
@@ -54,10 +54,14 @@ export function DictAsYamlField(props: FieldProps) {
 
   const [text, setText] = useState(() => formatYaml(formData));
   const [error, setError] = useState<string>();
+  const focusedRef = useRef(false);
 
   useEffect(() => {
-    setText(formatYaml(formData));
-    setError(undefined);
+    // Only sync from external formData changes, not our own onChange
+    if (!focusedRef.current) {
+      setText(formatYaml(formData));
+      setError(undefined);
+    }
   }, [formData]);
 
   const handleChange = useCallback(
@@ -73,8 +77,13 @@ export function DictAsYamlField(props: FieldProps) {
     [onChange, fieldPath],
   );
 
+  const handleFocus = useCallback(() => {
+    focusedRef.current = true;
+  }, []);
+
   const handleBlur = useCallback(
     (_e: React.FocusEvent<HTMLTextAreaElement>) => {
+      focusedRef.current = false;
       // Reformat on blur if valid
       const { value } = parseYaml(text);
       if (value !== undefined) {
@@ -101,6 +110,7 @@ export function DictAsYamlField(props: FieldProps) {
         placeholder={"key: value"}
         rows={Math.max(3, text.split("\n").length + 1)}
         onChange={handleChange}
+        onFocus={handleFocus}
         onBlur={handleBlur}
       />
       {error && <p className="text-xs text-destructive">{error}</p>}

--- a/web/src/components/player/LivePlayer.tsx
+++ b/web/src/components/player/LivePlayer.tsx
@@ -195,6 +195,7 @@ export default function LivePlayer({
   }, [preferredLiveMode]);
 
   const [key, setKey] = useState(0);
+  const prevStreamNameRef = useRef(streamName);
 
   const resetPlayer = () => {
     setLiveReady(false);
@@ -202,8 +203,11 @@ export default function LivePlayer({
   };
 
   useEffect(() => {
-    if (streamName) {
-      resetPlayer();
+    if (prevStreamNameRef.current !== streamName) {
+      prevStreamNameRef.current = streamName;
+      if (streamName) {
+        resetPlayer();
+      }
     }
   }, [streamName]);
 

--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -81,6 +81,7 @@ function MSEPlayer({
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTIDRef = useRef<number | null>(null);
   const intentionalDisconnectRef = useRef<boolean>(false);
+  const onCloseRef = useRef<(() => void) | null>(null);
   const ondataRef = useRef<((data: ArrayBufferLike) => void) | null>(null);
   const onmessageRef = useRef<{
     [key: string]: (msg: { value: string; type: string }) => void;
@@ -167,6 +168,8 @@ function MSEPlayer({
     wsRef.current = new WebSocket(wsURL);
     wsRef.current.binaryType = "arraybuffer";
     wsRef.current.addEventListener("open", onOpen);
+    // Capture current onClose identity so removeEventListener can find it later
+    onCloseRef.current = onClose;
     wsRef.current.addEventListener("close", onClose);
     // we know that these deps are correct
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -200,20 +203,23 @@ function MSEPlayer({
       intentionalDisconnectRef.current = true;
       setWsState(WebSocket.CLOSED);
 
-      // Remove event listeners to prevent them firing during close
+      // Remove event listeners to prevent them firing during close.
+      // Use onCloseRef to remove the exact function that was attached in onConnect,
+      // since onClose may have been recreated by React since then.
       try {
         ws.removeEventListener("open", onOpen);
-        ws.removeEventListener("close", onClose);
+        if (onCloseRef.current) {
+          ws.removeEventListener("close", onCloseRef.current);
+          onCloseRef.current = null;
+        }
       } catch {
         // Ignore errors removing listeners
       }
 
-      // Only call close() if the socket is OPEN or CLOSING
-      // For CONNECTING or CLOSED sockets, just let it die
-      if (
-        currentReadyState === WebSocket.OPEN ||
-        currentReadyState === WebSocket.CLOSING
-      ) {
+      // Close the socket in any non-CLOSED state, including CONNECTING.
+      // A CONNECTING socket that is not closed will complete its handshake
+      // and remain open, leaking a browser connection.
+      if (currentReadyState !== WebSocket.CLOSED) {
         try {
           ws.close();
         } catch {


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
- Fix MSE WebSocket leak: close sockets in `CONNECTING` state during disconnect instead of abandoning them (introduced in https://github.com/blakeblackshear/frigate/pull/21558, fixes https://github.com/blakeblackshear/frigate/discussions/22761)
- Fix `onClose` handler identity: store the attached listener reference so `removeEventListener` removes the correct function after callback recreation
- Skip unnecessary `MSEPlayer` remount on initial render: use a previous-value ref for the `streamName` effect in `LivePlayer` to avoid a wasted websocket connect/disconnect cycle
- Fix DictAsYamlField feedback loop where `formData` sync overwrites user input by skipping external sync while the field is focused.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
