### PR TITLE
fix(stats): report NVIDIA GPU stats for detector-only GPU setups

### DIFF
--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -205,11 +205,23 @@ async def set_bandwidth_stats(config: FrigateConfig, all_stats: dict[str, Any]) 
         all_stats["bandwidth_usages"] = bandwidth_stats
 
 
+def _detector_uses_nvidia_gpu(detector) -> bool:
+    """Check if a detector is configured to use an NVIDIA GPU."""
+    if detector.type == "tensorrt":
+        return True
+    if detector.type == "onnx":
+        device = str(getattr(detector, "device", "")).lower()
+        if device in ("tensorrt", "cuda"):
+            return True
+    return False
+
+
 async def set_gpu_stats(
     config: FrigateConfig, all_stats: dict[str, Any], hwaccel_errors: list[str]
 ) -> None:
     """Parse GPUs from hwaccel args and use for stats."""
     hwaccel_args = []
+    nvidia_stats_collected = False
 
     for camera in config.cameras.values():
         args = camera.ffmpeg.hwaccel_args
@@ -237,6 +249,7 @@ async def set_gpu_stats(
             stats["error-gpu"] = {"gpu": "", "mem": ""}
         elif "cuvid" in args or "nvidia" in args:
             # nvidia GPU
+            nvidia_stats_collected = True
             nvidia_usage = get_nvidia_gpu_stats()
 
             if nvidia_usage:
@@ -296,6 +309,29 @@ async def set_gpu_stats(
         elif "v4l2m2m" in args or "rpi" in args:
             # RPi v4l2m2m is currently not able to get usage stats
             stats["rpi-v4l2m2m"] = {"gpu": "", "mem": ""}
+
+    # Report NVIDIA GPU stats when an NVIDIA-backed detector (TensorRT or
+    # ONNX with CUDA/TensorRT EP) is configured but camera decode uses a
+    # different accelerator (e.g., Intel VAAPI). Without this, split-GPU
+    # setups never call get_nvidia_gpu_stats() because the hwaccel_args
+    # loop only sees the decode accelerator, not the detector device.
+    if not nvidia_stats_collected:
+        for detector in config.detectors.values():
+            if _detector_uses_nvidia_gpu(detector):
+                nvidia_usage = get_nvidia_gpu_stats()
+
+                if nvidia_usage:
+                    for i in range(len(nvidia_usage)):
+                        stats[nvidia_usage[i]["name"]] = {
+                            "gpu": str(round(float(nvidia_usage[i]["gpu"]), 2)) + "%",
+                            "mem": str(round(float(nvidia_usage[i]["mem"]), 2)) + "%",
+                            "enc": str(round(float(nvidia_usage[i]["enc"]), 2)) + "%",
+                            "dec": str(round(float(nvidia_usage[i]["dec"]), 2)) + "%",
+                            "temp": str(nvidia_usage[i]["temp"]),
+                        }
+                else:
+                    stats["nvidia-gpu"] = {"gpu": "", "mem": ""}
+                break
 
     if stats:
         all_stats["gpu_usages"] = stats


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

When using a split-GPU setup — e.g., Intel VAAPI for video decode + NVIDIA TensorRT for object detection — `set_gpu_stats()` never reports NVIDIA GPU metrics. This is because it only checks camera `hwaccel_args` to decide which GPU stats to collect, and those args only contain the decode accelerator (e.g., `vaapi`), not the detection device.

This PR adds a detector-aware fallback: after the existing hwaccel args loop, if no NVIDIA stats were collected, it checks whether any configured detector uses an NVIDIA GPU (type `tensorrt`, or type `onnx` with device `tensorrt`/`cuda`). If so, it calls `get_nvidia_gpu_stats()` via NVML so the GPU appears in System metrics.

Changes:
- Add `_detector_uses_nvidia_gpu()` helper to check detector config
- Track whether NVIDIA stats were already collected via hwaccel args
- After the hwaccel loop, fall back to detector config check if needed
- ~15 lines of new logic in `stats/util.py`

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/18694
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features): https://github.com/blakeblackshear/frigate/discussions/18694

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): Claude Code (Claude Opus)

**How AI was used** (e.g., code generation, code review, debugging, documentation): Assisted with drafting the patch and PR description. The fix approach was designed by the author based on reading the `set_gpu_stats()` source and understanding the split-GPU topology.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): Assisted with writing the implementation based on author's design. The logic mirrors the existing hwaccel pattern in `set_gpu_stats()` and the detector iteration pattern in `set_npu_usages()`.

**Human oversight**: Manually reviewed every line. Tested on a production Frigate 0.17.1 instance with 13 cameras (Intel VAAPI decode) and an NVIDIA T1000 running YOLOv8s via ONNX TensorRT. Verified NVIDIA GPU stats appear in the System metrics page. Confirmed no impact when NVIDIA stats are already collected via hwaccel args (the `nvidia_stats_collected` flag prevents duplicate calls).

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)