### PR TITLE
fix: add H.264 hardware encoder codec variants to MSE player

### DIFF
--- a/web/src/components/player/MsePlayer.tsx
+++ b/web/src/components/player/MsePlayer.tsx
@@ -51,6 +51,12 @@ function MSEPlayer({
     "avc1.640029", // H.264 high 4.1 (Chromecast 1st and 2nd Gen)
     "avc1.64002A", // H.264 high 4.2 (Chromecast 3rd Gen)
     "avc1.640033", // H.264 high 5.1 (Chromecast with Google TV)
+    "avc1.640829", // H.264 progressive high 4.1 (Intel VAAPI/QSV)
+    "avc1.64082A", // H.264 progressive high 4.2 (Intel VAAPI/QSV)
+    "avc1.4D4029", // H.264 main 4.1
+    "avc1.4D402A", // H.264 main 4.2
+    "avc1.42C029", // H.264 constrained baseline 4.1 (libx264 ultrafast preset)
+    "avc1.42C02A", // H.264 constrained baseline 4.2 (libx264 ultrafast preset)
     "hvc1.1.6.L153.B0", // H.265 main 5.1 (Chromecast Ultra)
     "mp4a.40.2", // AAC LC
     "mp4a.40.5", // AAC HE


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

The MSE player has a hardcoded `CODECS` list used to advertise supported codecs to go2rtc. When go2rtc transcodes an H.265 camera stream to H.264 for browser MSE playback, the resulting codec string depends on the encoder used. The current list only covers three specific H.264 High Profile variants targeting Chromecast devices.

Hardware H.264 encoders commonly paired with go2rtc produce codec strings not in this list:
- **Intel VAAPI/QSV** sets `constraint_set4_flag`, producing `avc1.640829` / `avc1.64082A` (Progressive High Profile)
- **libx264 with `ultrafast` preset** produces `avc1.42C029` / `avc1.42C02A` (Constrained Baseline)
- **General H.264 Main Profile** encoders produce `avc1.4D4029` / `avc1.4D402A`

When go2rtc negotiates a codec not in the CODECS list, the MSE player cannot create a SourceBuffer for it and silently falls back to low-bandwidth JPEG mode — even though the browser fully supports playing that codec.

This PR adds the missing variants so hardware-transcoded H.264 streams work correctly in the MSE player.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Anthropic)

**How AI was used**: Debugging and root cause analysis. Used to identify that Intel VAAPI produces `avc1.640829` (constraint_set4_flag set) and libx264 ultrafast produces `avc1.42C029` (Constrained Baseline) by decoding the avcC box from the actual fMP4 stream on a real system.

**Extent of AI involvement**: Generated the list of codec strings to add based on analysis of actual encoder output. The fix itself is a straightforward addition to an existing list.

**Human oversight**: Tested on a real Proxmox LXC system with an Intel i5-11400 running go2rtc 1.9.14 and a WIWA MW5 H.265 camera. Confirmed that with an `ffmpeg:camera#video=h264` go2rtc source using libx264, the MSE player was falling back to JPEG due to the `avc1.42C029` codec not being in the list. After adding the codec variants, MSE playback worked correctly.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
