### PR TITLE
fix: force H.264 for browser MSE streams to resolve H.265 camera live view stall

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -204,7 +204,12 @@ http {
             limit_except GET {
                 deny  all;
             }
-            proxy_pass http://go2rtc/api/ws;
+            # Request H.264 from go2rtc for browser MSE compatibility.
+            # H.265 cameras with non-standard PPS parameter sets cause Chrome's
+            # MSE decoder to receive the init segment but stall on media fragments,
+            # triggering a 6-second timeout and fallback to low-bandwidth JPEG mode.
+            set $args "${args}&video=h264&audio=aac";
+            proxy_pass http://go2rtc/api/ws?$args;
             include proxy.conf;
         }
 


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

When a camera streams H.265/HEVC natively, the browser MSE live view silently falls back to low-bandwidth JPEG mode on cameras whose streams have non-standard PPS (Picture Parameter Set) ordering - a common issue with many IP cameras.

**What happens:**
1. Browser connects to `/live/mse/api/ws?src=camera`
2. go2rtc detects Chrome advertises H.265 MSE support and serves the native H.265 stream
3. go2rtc sends the fMP4 init segment (built from the camera's SPS/PPS) successfully
4. go2rtc attempts to mux H.265 NALUs into fMP4 media fragments - but drops frames when the PPS ID in each frame doesn't match the init segment's PPS, producing zero media fragments
5. Chrome's MSE receives the init segment but no video data → stalls after 6 seconds → `MsePlayer` falls back to JPEG

This can be confirmed in browser DevTools:
```
MsePlayer - Browser negotiated codecs: video/mp4; codecs="hvc1.1.6.L153.B0,flac"
MsePlayer - MSE error 'stalled': Media playback has stalled after 6 seconds
```

**Fix:** Append `video=h264&audio=aac` to the go2rtc MSE WebSocket URL. This instructs go2rtc to transcode to H.264 when needed. H.264 fMP4 muxing does not have this PPS compatibility issue and is universally supported across all browsers.

Note: Requires go2rtc to have an H.264 source available (e.g. a secondary `ffmpeg:camera#video=h264` source in the go2rtc streams config).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Anthropic)

**How AI was used**: Debugging and root cause analysis. Used nginx access logs, browser DevTools console output, and go2rtc stream API inspection to trace the exact failure path from H.265 camera → go2rtc fMP4 muxer → browser MSE stall.

**Extent of AI involvement**: Identified the root cause and the nginx fix. The code change is two nginx directives.

**Human oversight**: Reproduced on a real system with a WIWA MW5 H.265 camera (RTSP, 2304×1296). Confirmed the `hvc1.1.6.L153.B0` codec being negotiated, the 1269-byte init-segment-only WebSocket response, and the 6-second stall in browser DevTools. After applying the fix with a go2rtc H.264 transcode source configured, live view worked correctly via MSE with no stall.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)

