### PR TITLE
fix: bump OpenVINO to 2025.4.x to resolve LXC container detector crash

### DIFF
--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -42,8 +42,7 @@ opencv-python-headless == 4.11.0.*
 opencv-contrib-python == 4.11.0.*
 scipy == 1.16.*
 # OpenVino & ONNX
-openvino == 2025.4.*
-onnxruntime == 1.22.*
+onnxruntime-openvino == 1.24.*
 # Embeddings
 transformers == 4.45.*
 # Generative AI

--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -42,7 +42,7 @@ opencv-python-headless == 4.11.0.*
 opencv-contrib-python == 4.11.0.*
 scipy == 1.16.*
 # OpenVino & ONNX
-openvino == 2025.3.*
+openvino == 2025.4.*
 onnxruntime == 1.22.*
 # Embeddings
 transformers == 4.45.*

--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -42,7 +42,8 @@ opencv-python-headless == 4.11.0.*
 opencv-contrib-python == 4.11.0.*
 scipy == 1.16.*
 # OpenVino & ONNX
-onnxruntime-openvino == 1.24.*
+openvino == 2025.4.*
+onnxruntime == 1.22.*
 # Embeddings
 transformers == 4.45.*
 # Generative AI


### PR DESCRIPTION
## Proposed change

Bumps the pinned OpenVINO version from `2025.3.*` to `2025.4.*` in `docker/main/requirements-wheels.txt`.

OpenVINO 2025.3.x crashes on startup when Frigate runs natively in a Proxmox LXC container with partial CPU allocation. Any OpenVINO detector (CPU or GPU) fails with:

```
RuntimeError: Exception from src/plugins/intel_cpu/src/plugin.cpp:781: stoi
```

**Root cause:** In LXC containers, Proxmox allocates specific host CPU cores. The L3 cache sysfs file (`/sys/devices/system/cpu/cpuN/cache/index3/shared_cpu_list`) lists all CPUs in the physical socket (e.g. `"0-11"`) including offline ones. OpenVINO's `lin_system_conf.cpp` iterates all CPUs in the list and calls `std::stoi(system_info_table[offline_cpu][0])` where the string is empty for offline CPUs, throwing `std::invalid_argument`.

**Upstream fix:** OpenVINO 2025.4.0 added a null-check guard before the stoi call. Bumping to `2025.4.*` picks up this fix.

## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Anthropic)

**How AI was used**: Root cause analysis using GDB stack traces and OpenVINO source code diff between 2025.3.0 and 2025.4.0 to identify the exact crash and the upstream fix commit.

**Extent of AI involvement**: Identified the bug and the fix version. The change is a one-line version bump.

**Human oversight**: Reproduced on real hardware (Intel i5-11400, Proxmox 8.x, LXC with 4 vCPUs). Confirmed crash with 2025.3.0 and successful OpenVINO GPU detection after upgrading to 2025.4.1.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
