### PR TITLE
Update restream.md docs and clarify output config

### DIFF
--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -208,7 +208,7 @@ Enabling arbitrary exec sources allows execution of arbitrary commands through g
 
 ## Advanced Restream Configurations
 
-The [exec](https://github.com/AlexxIT/go2rtc/tree/v1.9.10#source-exec) source in go2rtc can be used for custom ffmpeg commands. An example is below:
+The [exec](https://github.com/AlexxIT/go2rtc/tree/v1.9.10#source-exec) source in go2rtc can be used for custom ffmpeg commands and other applications. An example is below:
 
 :::warning
 
@@ -216,16 +216,11 @@ The `exec:`, `echo:`, and `expr:` sources are disabled by default for security. 
 
 :::
 
-:::warning
-
-The `exec:`, `echo:`, and `expr:` sources are disabled by default for security. You must set `GO2RTC_ALLOW_ARBITRARY_EXEC=true` to use them. See [Security: Restricted Stream Sources](#security-restricted-stream-sources) for more information.
-
-:::
-
-NOTE: The output will need to be passed with two curly braces `{{output}}`
+NOTE: RTSP output will need to be passed with two curly braces `{{output}}`, whereas pipe output must be passed without curly braces.
 
 ```yaml
 go2rtc:
   streams:
     stream1: exec:ffmpeg -hide_banner -re -stream_loop -1 -i /media/BigBuckBunny.mp4 -c copy -rtsp_transport tcp -f rtsp {{output}}
+    stream2: exec:rpicam-vid -t 0 --libav-format h264 -o - #raspberry pi 5b cam output via pipe
 ```

--- a/docs/docs/configuration/restream.md
+++ b/docs/docs/configuration/restream.md
@@ -222,5 +222,5 @@ NOTE: RTSP output will need to be passed with two curly braces `{{output}}`, whe
 go2rtc:
   streams:
     stream1: exec:ffmpeg -hide_banner -re -stream_loop -1 -i /media/BigBuckBunny.mp4 -c copy -rtsp_transport tcp -f rtsp {{output}}
-    stream2: exec:rpicam-vid -t 0 --libav-format h264 -o - #raspberry pi 5b cam output via pipe
+    stream2: exec:rpicam-vid -t 0 --libav-format h264 -o -
 ```


### PR DESCRIPTION
## Proposed change

1. Small change in restream docs: clarified that exec output must be put in curly braces ONLY in case of RTSP, not pipe, as per go2rtc docs. 
2. Added an additional example use-case in the form of Raspberry Pi cam config, which cannot be accessed without rpicam-vid and therefore requires the exec function. 
3. Deleted a double/duplicate warning.

Docs: https://github.com/AlexxIT/go2rtc/tree/v1.9.10#source-exec

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update

## Additional information

N/A

## AI disclosure

- [X] No AI tools were used in this PR.
- [ ] AI tools were used in this PR. Details below:

## Checklist
(not really applicable for a small docs change)
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
