### PR TITLE
Export improvements

### DIFF
--- a/docs/static/frigate-api.yaml
+++ b/docs/static/frigate-api.yaml
@@ -2724,6 +2724,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
+  /exports/batch:
+    post:
+      tags:
+        - Export
+      summary: Start multi-camera recording export
+      description: >-
+        Starts recording exports for multiple cameras for the same time range and
+        assigns them to a single export case.
+      operationId: export_recordings_batch_exports_batch_post
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BatchExportBody"
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BatchExportResponse"
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPValidationError"
   /cases:
     get:
       tags:
@@ -6501,6 +6529,106 @@ components:
       required:
         - recognizedLicensePlate
       title: EventsLPRBody
+    BatchExportBody:
+      properties:
+        start_time:
+          type: number
+          title: Start time
+        end_time:
+          type: number
+          title: End time
+        camera_ids:
+          items:
+            type: string
+          type: array
+          minItems: 1
+          title: Camera IDs
+        name:
+          anyOf:
+            - type: string
+              maxLength: 256
+            - type: "null"
+          title: Friendly name template
+          description: Base export name. Each export is saved as '<name> - <camera>'
+        export_case_id:
+          anyOf:
+            - type: string
+              maxLength: 30
+            - type: "null"
+          title: Export case ID
+          description: Existing export case ID to assign all exports to
+        new_case_name:
+          anyOf:
+            - type: string
+              maxLength: 100
+            - type: "null"
+          title: New case name
+          description: Name of a new export case to create when export_case_id is omitted
+        new_case_description:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: New case description
+          description: Optional description for a newly created export case
+      type: object
+      required:
+        - start_time
+        - end_time
+        - camera_ids
+      title: BatchExportBody
+    BatchExportResponse:
+      properties:
+        export_case_id:
+          type: string
+          title: Export Case Id
+          description: Export case ID associated with the batch
+        export_ids:
+          items:
+            type: string
+          type: array
+          title: Export Ids
+          description: Export IDs successfully queued
+        results:
+          items:
+            $ref: "#/components/schemas/BatchExportResultModel"
+          type: array
+          title: Results
+          description: Per-camera batch export results
+      type: object
+      required:
+        - export_case_id
+        - export_ids
+        - results
+      title: BatchExportResponse
+      description: Response model for starting a multi-camera export batch.
+    BatchExportResultModel:
+      properties:
+        camera:
+          type: string
+          title: Camera
+          description: Camera name for this export attempt
+        export_id:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Export Id
+          description: The export ID when the export was successfully queued
+        success:
+          type: boolean
+          title: Success
+          description: Whether the export was successfully queued
+        error:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Error
+          description: Validation or queueing error for this camera, if any
+      type: object
+      required:
+        - camera
+        - success
+      title: BatchExportResultModel
+      description: Per-camera result for a batch export request.
     EventsSubLabelBody:
       properties:
         subLabel:

--- a/docs/static/frigate-api.yaml
+++ b/docs/static/frigate-api.yaml
@@ -2728,10 +2728,11 @@ paths:
     post:
       tags:
         - Export
-      summary: Start multi-camera recording export
+      summary: Start recording export batch
       description: >-
-        Starts recording exports for multiple cameras for the same time range and
-        assigns them to a single export case.
+        Starts recording exports for a batch of items, each with its own camera
+        and time range, and assigns them to a single export case. Attaching to
+        an existing case is temporarily admin-only until case-level ACLs exist.
       operationId: export_recordings_batch_exports_batch_post
       requestBody:
         required: true
@@ -2740,12 +2741,36 @@ paths:
             schema:
               $ref: "#/components/schemas/BatchExportBody"
       responses:
-        "200":
+        "202":
           description: Successful Response
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/BatchExportResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericResponse"
         "422":
           description: Validation Error
           content:
@@ -6531,32 +6556,21 @@ components:
       title: EventsLPRBody
     BatchExportBody:
       properties:
-        start_time:
-          type: number
-          title: Start time
-        end_time:
-          type: number
-          title: End time
-        camera_ids:
+        items:
           items:
-            type: string
+            $ref: "#/components/schemas/BatchExportItem"
           type: array
           minItems: 1
-          title: Camera IDs
-        name:
-          anyOf:
-            - type: string
-              maxLength: 256
-            - type: "null"
-          title: Friendly name template
-          description: Base export name. Each export is saved as '<name> - <camera>'
+          maxItems: 50
+          title: Items
+          description: List of export items. Each item has its own camera and time range.
         export_case_id:
           anyOf:
             - type: string
               maxLength: 30
             - type: "null"
           title: Export case ID
-          description: Existing export case ID to assign all exports to
+          description: Existing export case ID to assign all exports to. Attaching to an existing case is temporarily admin-only until case-level ACLs exist.
         new_case_name:
           anyOf:
             - type: string
@@ -6572,14 +6586,51 @@ components:
           description: Optional description for a newly created export case
       type: object
       required:
+        - items
+      title: BatchExportBody
+    BatchExportItem:
+      properties:
+        camera:
+          type: string
+          title: Camera name
+        start_time:
+          type: number
+          title: Start time
+        end_time:
+          type: number
+          title: End time
+        image_path:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Existing thumbnail path
+          description: Optional existing image to use as the export thumbnail
+        friendly_name:
+          anyOf:
+            - type: string
+              maxLength: 256
+            - type: "null"
+          title: Friendly name
+          description: Optional friendly name for this specific export item
+        client_item_id:
+          anyOf:
+            - type: string
+              maxLength: 128
+            - type: "null"
+          title: Client item ID
+          description: Optional opaque client identifier echoed back in results
+      type: object
+      required:
+        - camera
         - start_time
         - end_time
-        - camera_ids
-      title: BatchExportBody
+      title: BatchExportItem
     BatchExportResponse:
       properties:
         export_case_id:
-          type: string
+          anyOf:
+            - type: string
+            - type: "null"
           title: Export Case Id
           description: Export case ID associated with the batch
         export_ids:
@@ -6593,14 +6644,13 @@ components:
             $ref: "#/components/schemas/BatchExportResultModel"
           type: array
           title: Results
-          description: Per-camera batch export results
+          description: Per-item batch export results
       type: object
       required:
-        - export_case_id
         - export_ids
         - results
       title: BatchExportResponse
-      description: Response model for starting a multi-camera export batch.
+      description: Response model for starting an export batch.
     BatchExportResultModel:
       properties:
         camera:
@@ -6617,18 +6667,36 @@ components:
           type: boolean
           title: Success
           description: Whether the export was successfully queued
+        status:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Status
+          description: Queue status for this camera export
         error:
           anyOf:
             - type: string
             - type: "null"
           title: Error
-          description: Validation or queueing error for this camera, if any
+          description: Validation or queueing error for this item, if any
+        item_index:
+          anyOf:
+            - type: integer
+            - type: "null"
+          title: Item Index
+          description: Zero-based index of this result within the request items list
+        client_item_id:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Client Item Id
+          description: Opaque client-supplied item identifier echoed from the request
       type: object
       required:
         - camera
         - success
       title: BatchExportResultModel
-      description: Per-camera result for a batch export request.
+      description: Per-item result for a batch export request.
     EventsSubLabelBody:
       properties:
         subLabel:

--- a/docs/static/frigate-api.yaml
+++ b/docs/static/frigate-api.yaml
@@ -2731,8 +2731,9 @@ paths:
       summary: Start recording export batch
       description: >-
         Starts recording exports for a batch of items, each with its own camera
-        and time range, and assigns them to a single export case. Attaching to
-        an existing case is temporarily admin-only until case-level ACLs exist.
+        and time range. Optionally assigns them to a new or existing export case.
+        When neither export_case_id nor new_case_name is provided, exports are
+        added as uncategorized. Attaching to an existing case is admin-only.
       operationId: export_recordings_batch_exports_batch_post
       requestBody:
         required: true
@@ -2767,6 +2768,81 @@ paths:
                 $ref: "#/components/schemas/GenericResponse"
         "503":
           description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericResponse"
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPValidationError"
+  /exports/delete:
+    post:
+      tags:
+        - Export
+      summary: Bulk delete exports
+      description: >-
+        Deletes one or more exports by ID. All IDs must exist and none can be
+        in-progress. Admin-only.
+      operationId: bulk_delete_exports_exports_delete_post
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExportBulkDeleteBody"
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericResponse"
+        "400":
+          description: Bad Request - one or more exports are in-progress
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericResponse"
+        "404":
+          description: Not Found - one or more export IDs do not exist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericResponse"
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPValidationError"
+  /exports/reassign:
+    post:
+      tags:
+        - Export
+      summary: Bulk reassign exports to a case
+      description: >-
+        Assigns or unassigns one or more exports to/from a case. All IDs must
+        exist. Pass export_case_id as null to unassign (move to uncategorized).
+        Admin-only.
+      operationId: bulk_reassign_exports_exports_reassign_post
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExportBulkReassignBody"
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GenericResponse"
+        "404":
+          description: Not Found - one or more export IDs or the target case do not exist
           content:
             application/json:
               schema:
@@ -2906,39 +2982,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPValidationError"
-  "/export/{export_id}/case":
-    patch:
-      tags:
-        - Export
-      summary: Assign export to case
-      description: "Assigns an export to a case, or unassigns it if export_case_id is null."
-      operationId: assign_export_case_export__export_id__case_patch
-      parameters:
-        - name: export_id
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Export Id
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ExportCaseAssignBody"
-      responses:
-        "200":
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/GenericResponse"
-        "422":
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/HTTPValidationError"
   "/export/{camera_name}/start/{start_time}/end/{end_time}":
     post:
       tags:
@@ -3013,32 +3056,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/ExportRenameBody"
-      responses:
-        "200":
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/GenericResponse"
-        "422":
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/HTTPValidationError"
-  "/export/{event_id}":
-    delete:
-      tags:
-        - Export
-      summary: Delete export
-      operationId: export_delete_export__event_id__delete
-      parameters:
-        - name: event_id
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Event Id
       responses:
         "200":
           description: Successful Response
@@ -6719,18 +6736,41 @@ components:
       required:
         - subLabel
       title: EventsSubLabelBody
-    ExportCaseAssignBody:
+    ExportBulkDeleteBody:
       properties:
+        ids:
+          items:
+            type: string
+            minLength: 1
+          type: array
+          minItems: 1
+          title: Ids
+      type: object
+      required:
+        - ids
+      title: ExportBulkDeleteBody
+      description: Request body for bulk deleting exports.
+    ExportBulkReassignBody:
+      properties:
+        ids:
+          items:
+            type: string
+            minLength: 1
+          type: array
+          minItems: 1
+          title: Ids
         export_case_id:
           anyOf:
             - type: string
               maxLength: 30
             - type: "null"
           title: Export Case Id
-          description: "Case ID to assign to the export, or null to unassign"
+          description: "Case ID to assign to, or null to unassign from current case"
       type: object
-      title: ExportCaseAssignBody
-      description: Request body for assigning or unassigning an export to a case.
+      required:
+        - ids
+      title: ExportBulkReassignBody
+      description: Request body for bulk reassigning exports to a case.
     ExportCaseCreateBody:
       properties:
         name:

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -88,7 +88,9 @@ def require_admin_by_default():
         "/go2rtc/streams",
         "/event_ids",
         "/events",
+        "/cases",
         "/exports",
+        "/jobs/export",
     }
 
     # Path prefixes that should be exempt (for paths with parameters)
@@ -101,7 +103,9 @@ def require_admin_by_default():
         "/go2rtc/streams/",  # /go2rtc/streams/{camera}
         "/users/",  # /users/{username}/password (has own auth)
         "/preview/",  # /preview/{file}/thumbnail.jpg
+        "/cases/",  # /cases/{case_id}
         "/exports/",  # /exports/{export_id}
+        "/jobs/export/",  # /jobs/export/{export_id}
         "/vod/",  # /vod/{camera_name}/...
         "/notifications/",  # /notifications/pubkey, /notifications/register
     )

--- a/frigate/api/defs/request/batch_export_body.py
+++ b/frigate/api/defs/request/batch_export_body.py
@@ -62,7 +62,4 @@ class BatchExportBody(BaseModel):
             if item.end_time <= item.start_time:
                 raise ValueError("end_time must be after start_time")
 
-        if self.export_case_id is None and self.new_case_name is None:
-            raise ValueError("Either export_case_id or new_case_name must be provided")
-
         return self

--- a/frigate/api/defs/request/batch_export_body.py
+++ b/frigate/api/defs/request/batch_export_body.py
@@ -2,22 +2,47 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
+MAX_BATCH_EXPORT_ITEMS = 50
 
-class BatchExportBody(BaseModel):
+
+class BatchExportItem(BaseModel):
+    camera: str = Field(title="Camera name")
     start_time: float = Field(title="Start time")
     end_time: float = Field(title="End time")
-    camera_ids: List[str] = Field(title="Camera IDs", min_length=1)
-    name: Optional[str] = Field(
+    image_path: Optional[str] = Field(
         default=None,
-        title="Friendly name template",
+        title="Existing thumbnail path",
+        description="Optional existing image to use as the export thumbnail",
+    )
+    friendly_name: Optional[str] = Field(
+        default=None,
+        title="Friendly name",
         max_length=256,
-        description="Base export name. Each export is saved as '<name> - <camera>'",
+        description="Optional friendly name for this specific export item",
+    )
+    client_item_id: Optional[str] = Field(
+        default=None,
+        title="Client item ID",
+        max_length=128,
+        description="Optional opaque client identifier echoed back in results",
+    )
+
+
+class BatchExportBody(BaseModel):
+    items: List[BatchExportItem] = Field(
+        title="Items",
+        min_length=1,
+        max_length=MAX_BATCH_EXPORT_ITEMS,
+        description="List of export items. Each item has its own camera and time range.",
     )
     export_case_id: Optional[str] = Field(
         default=None,
         title="Export case ID",
         max_length=30,
-        description="Existing export case ID to assign all exports to",
+        description=(
+            "Existing export case ID to assign all exports to. Attaching to an "
+            "existing case is temporarily admin-only until case-level ACLs exist."
+        ),
     )
     new_case_name: Optional[str] = Field(
         default=None,
@@ -33,8 +58,9 @@ class BatchExportBody(BaseModel):
 
     @model_validator(mode="after")
     def validate_case_target(self) -> "BatchExportBody":
-        if self.end_time <= self.start_time:
-            raise ValueError("end_time must be after start_time")
+        for item in self.items:
+            if item.end_time <= item.start_time:
+                raise ValueError("end_time must be after start_time")
 
         if self.export_case_id is None and self.new_case_name is None:
             raise ValueError("Either export_case_id or new_case_name must be provided")

--- a/frigate/api/defs/request/batch_export_body.py
+++ b/frigate/api/defs/request/batch_export_body.py
@@ -1,0 +1,42 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class BatchExportBody(BaseModel):
+    start_time: float = Field(title="Start time")
+    end_time: float = Field(title="End time")
+    camera_ids: List[str] = Field(title="Camera IDs", min_length=1)
+    name: Optional[str] = Field(
+        default=None,
+        title="Friendly name template",
+        max_length=256,
+        description="Base export name. Each export is saved as '<name> - <camera>'",
+    )
+    export_case_id: Optional[str] = Field(
+        default=None,
+        title="Export case ID",
+        max_length=30,
+        description="Existing export case ID to assign all exports to",
+    )
+    new_case_name: Optional[str] = Field(
+        default=None,
+        title="New case name",
+        max_length=100,
+        description="Name of a new export case to create when export_case_id is omitted",
+    )
+    new_case_description: Optional[str] = Field(
+        default=None,
+        title="New case description",
+        description="Optional description for a newly created export case",
+    )
+
+    @model_validator(mode="after")
+    def validate_case_target(self) -> "BatchExportBody":
+        if self.end_time <= self.start_time:
+            raise ValueError("end_time must be after start_time")
+
+        if self.export_case_id is None and self.new_case_name is None:
+            raise ValueError("Either export_case_id or new_case_name must be provided")
+
+        return self

--- a/frigate/api/defs/request/export_bulk_body.py
+++ b/frigate/api/defs/request/export_bulk_body.py
@@ -1,0 +1,24 @@
+"""Request bodies for bulk export operations."""
+
+from typing import Optional
+
+from pydantic import BaseModel, Field, conlist, constr
+
+
+class ExportBulkDeleteBody(BaseModel):
+    """Request body for bulk deleting exports."""
+
+    # List of export IDs with at least one element and each element with at least one char
+    ids: conlist(constr(min_length=1), min_length=1)
+
+
+class ExportBulkReassignBody(BaseModel):
+    """Request body for bulk reassigning exports to a case."""
+
+    # List of export IDs with at least one element and each element with at least one char
+    ids: conlist(constr(min_length=1), min_length=1)
+    export_case_id: Optional[str] = Field(
+        default=None,
+        max_length=30,
+        description="Case ID to assign to, or null to unassign from current case",
+    )

--- a/frigate/api/defs/request/export_case_body.py
+++ b/frigate/api/defs/request/export_case_body.py
@@ -23,13 +23,3 @@ class ExportCaseUpdateBody(BaseModel):
     description: Optional[str] = Field(
         default=None, description="Updated description of the export case"
     )
-
-
-class ExportCaseAssignBody(BaseModel):
-    """Request body for assigning or unassigning an export to a case."""
-
-    export_case_id: Optional[str] = Field(
-        default=None,
-        max_length=30,
-        description="Case ID to assign to the export, or null to unassign",
-    )

--- a/frigate/api/defs/response/export_response.py
+++ b/frigate/api/defs/response/export_response.py
@@ -30,4 +30,29 @@ class StartExportResponse(BaseModel):
     )
 
 
+class BatchExportResultModel(BaseModel):
+    """Per-camera result for a batch export request."""
+
+    camera: str = Field(description="Camera name for this export attempt")
+    export_id: Optional[str] = Field(
+        default=None,
+        description="The export ID when the export was successfully queued",
+    )
+    success: bool = Field(description="Whether the export was successfully queued")
+    error: Optional[str] = Field(
+        default=None,
+        description="Validation or queueing error for this camera, if any",
+    )
+
+
+class BatchExportResponse(BaseModel):
+    """Response model for starting a multi-camera export batch."""
+
+    export_case_id: str = Field(description="Export case ID associated with the batch")
+    export_ids: List[str] = Field(description="Export IDs successfully queued")
+    results: List[BatchExportResultModel] = Field(
+        description="Per-camera batch export results"
+    )
+
+
 ExportsResponse = List[ExportModel]

--- a/frigate/api/defs/response/export_response.py
+++ b/frigate/api/defs/response/export_response.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -28,6 +28,10 @@ class StartExportResponse(BaseModel):
     export_id: Optional[str] = Field(
         default=None, description="The export ID if successfully started"
     )
+    status: Optional[str] = Field(
+        default=None,
+        description="Queue status for the export job",
+    )
 
 
 class BatchExportResultModel(BaseModel):
@@ -39,6 +43,10 @@ class BatchExportResultModel(BaseModel):
         description="The export ID when the export was successfully queued",
     )
     success: bool = Field(description="Whether the export was successfully queued")
+    status: Optional[str] = Field(
+        default=None,
+        description="Queue status for this camera export",
+    )
     error: Optional[str] = Field(
         default=None,
         description="Validation or queueing error for this camera, if any",
@@ -48,11 +56,52 @@ class BatchExportResultModel(BaseModel):
 class BatchExportResponse(BaseModel):
     """Response model for starting a multi-camera export batch."""
 
-    export_case_id: str = Field(description="Export case ID associated with the batch")
+    export_case_id: Optional[str] = Field(
+        default=None,
+        description="Export case ID associated with the batch",
+    )
     export_ids: List[str] = Field(description="Export IDs successfully queued")
     results: List[BatchExportResultModel] = Field(
         description="Per-camera batch export results"
     )
+
+
+class ExportJobModel(BaseModel):
+    """Model representing a queued or running export job."""
+
+    id: str = Field(description="Unique identifier for the export job")
+    job_type: str = Field(description="Job type")
+    status: str = Field(description="Current job status")
+    camera: str = Field(description="Camera associated with this export job")
+    name: Optional[str] = Field(
+        default=None,
+        description="Friendly name for the export",
+    )
+    export_case_id: Optional[str] = Field(
+        default=None,
+        description="ID of the export case this export belongs to",
+    )
+    request_start_time: float = Field(description="Requested export start time")
+    request_end_time: float = Field(description="Requested export end time")
+    start_time: Optional[float] = Field(
+        default=None,
+        description="Unix timestamp when execution started",
+    )
+    end_time: Optional[float] = Field(
+        default=None,
+        description="Unix timestamp when execution completed",
+    )
+    error_message: Optional[str] = Field(
+        default=None,
+        description="Error message for failed jobs",
+    )
+    results: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Result metadata for completed jobs",
+    )
+
+
+ExportJobsResponse = List[ExportJobModel]
 
 
 ExportsResponse = List[ExportModel]

--- a/frigate/api/defs/response/export_response.py
+++ b/frigate/api/defs/response/export_response.py
@@ -35,7 +35,7 @@ class StartExportResponse(BaseModel):
 
 
 class BatchExportResultModel(BaseModel):
-    """Per-camera result for a batch export request."""
+    """Per-item result for a batch export request."""
 
     camera: str = Field(description="Camera name for this export attempt")
     export_id: Optional[str] = Field(
@@ -49,12 +49,20 @@ class BatchExportResultModel(BaseModel):
     )
     error: Optional[str] = Field(
         default=None,
-        description="Validation or queueing error for this camera, if any",
+        description="Validation or queueing error for this item, if any",
+    )
+    item_index: Optional[int] = Field(
+        default=None,
+        description="Zero-based index of this result within the request items list",
+    )
+    client_item_id: Optional[str] = Field(
+        default=None,
+        description="Opaque client-supplied item identifier echoed from the request",
     )
 
 
 class BatchExportResponse(BaseModel):
-    """Response model for starting a multi-camera export batch."""
+    """Response model for starting an export batch."""
 
     export_case_id: Optional[str] = Field(
         default=None,
@@ -62,7 +70,7 @@ class BatchExportResponse(BaseModel):
     )
     export_ids: List[str] = Field(description="Export IDs successfully queued")
     results: List[BatchExportResultModel] = Field(
-        description="Per-camera batch export results"
+        description="Per-item batch export results"
     )
 
 

--- a/frigate/api/export.py
+++ b/frigate/api/export.py
@@ -18,10 +18,14 @@ from playhouse.shortcuts import model_to_dict
 from frigate.api.auth import (
     allow_any_authenticated,
     get_allowed_cameras_for_filter,
+    get_current_user,
     require_camera_access,
     require_role,
 )
-from frigate.api.defs.request.batch_export_body import BatchExportBody
+from frigate.api.defs.request.batch_export_body import (
+    BatchExportBody,
+    BatchExportItem,
+)
 from frigate.api.defs.request.export_case_body import (
     ExportCaseAssignBody,
     ExportCaseCreateBody,
@@ -172,45 +176,63 @@ def _validate_export_source(
     return None
 
 
-def _get_batch_recording_export_errors(
+def _get_item_recording_export_errors(
     request: Request,
-    camera_names: list[str],
-    start_time: float,
-    end_time: float,
-) -> dict[str, str]:
-    unique_camera_names = list(dict.fromkeys(camera_names))
+    items: list[BatchExportItem],
+) -> dict[int, str]:
+    """Return {item_index: error message} for items with invalid state.
+
+    Checks camera configuration and recording presence per item. Groups by
+    camera and issues one query per unique camera covering that camera's
+    full requested range, then checks each item's range against the returned
+    rows in Python. This avoids O(N) DB round-trips on large batches.
+    """
     configured_cameras = request.app.frigate_config.cameras
-    errors: dict[str, str] = {}
+    errors: dict[int, str] = {}
 
-    valid_camera_names = [
-        camera_name
-        for camera_name in unique_camera_names
-        if configured_cameras.get(camera_name)
-    ]
+    # Validate camera configuration first
+    item_ranges_by_camera: dict[str, list[tuple[int, float, float]]] = {}
+    for index, item in enumerate(items):
+        if not configured_cameras.get(item.camera):
+            errors[index] = f"{item.camera} is not a valid camera."
+            continue
+        item_ranges_by_camera.setdefault(item.camera, []).append(
+            (index, item.start_time, item.end_time)
+        )
 
-    for camera_name in unique_camera_names:
-        if camera_name not in valid_camera_names:
-            errors[camera_name] = f"{camera_name} is not a valid camera."
-
-    if not valid_camera_names:
+    if not item_ranges_by_camera:
         return errors
 
-    recordings = (
-        Recordings.select(Recordings.camera)
-        .distinct()
-        .where(
-            Recordings.camera << valid_camera_names,
-            Recordings.start_time.between(start_time, end_time)
-            | Recordings.end_time.between(start_time, end_time)
-            | ((start_time > Recordings.start_time) & (end_time < Recordings.end_time)),
-        )
-        .iterator()
-    )
-    cameras_with_recordings = {recording.camera for recording in recordings}
+    # For each camera, fetch recordings that cover the union of ranges
+    for camera_name, indexed_ranges in item_ranges_by_camera.items():
+        min_start = min(r[1] for r in indexed_ranges)
+        max_end = max(r[2] for r in indexed_ranges)
 
-    for camera_name in valid_camera_names:
-        if camera_name not in cameras_with_recordings:
-            errors[camera_name] = "No recordings found for time range"
+        recording_ranges = list(
+            Recordings.select(Recordings.start_time, Recordings.end_time)
+            .where(
+                Recordings.camera == camera_name,
+                Recordings.start_time.between(min_start, max_end)
+                | Recordings.end_time.between(min_start, max_end)
+                | (
+                    (min_start > Recordings.start_time)
+                    & (max_end < Recordings.end_time)
+                ),
+            )
+            .iterator()
+        )
+
+        for index, start_time, end_time in indexed_ranges:
+            has_recording = any(
+                (
+                    start_time <= rec.start_time <= end_time
+                    or start_time <= rec.end_time <= end_time
+                    or (start_time > rec.start_time and end_time < rec.end_time)
+                )
+                for rec in recording_ranges
+            )
+            if not has_recording:
+                errors[index] = "No recordings found for time range"
 
     return errors
 
@@ -473,39 +495,90 @@ async def get_export_job_status(export_id: str, request: Request):
 @router.post(
     "/exports/batch",
     response_model=BatchExportResponse,
-    dependencies=[Depends(require_role(["admin"]))],
-    summary="Start multi-camera recording export",
+    dependencies=[Depends(allow_any_authenticated())],
+    summary="Start recording export batch",
     description=(
-        "Starts recording exports for multiple cameras for the same time range and "
-        "assigns them to a single export case."
+        "Starts recording exports for a batch of items, each with its own camera "
+        "and time range, and assigns them to a single export case. Attaching to "
+        "an existing case is temporarily admin-only until case-level ACLs exist."
     ),
 )
-def export_recordings_batch(request: Request, body: BatchExportBody):
+def export_recordings_batch(
+    request: Request,
+    body: BatchExportBody,
+    allowed_cameras: List[str] = Depends(get_allowed_cameras_for_filter),
+    current_user: dict = Depends(get_current_user),
+):
+    if isinstance(current_user, JSONResponse):
+        return current_user
+
+    # Stopgap: attaching to an existing case remains admin-only until
+    # case-level ACLs exist. Non-admins can still create a fresh case
+    # as a side effect of queueing items they already have camera access to.
+    if body.export_case_id is not None and current_user["role"] != "admin":
+        return JSONResponse(
+            content={
+                "success": False,
+                "message": "Only admins can attach exports to an existing case.",
+            },
+            status_code=403,
+        )
+
     case_validation_error = _validate_export_case(body.export_case_id)
     if case_validation_error is not None:
         return case_validation_error
 
-    export_ids: list[str] = []
-    results: list[dict[str, Optional[str] | bool]] = []
-    camera_errors = _get_batch_recording_export_errors(
-        request,
-        body.camera_ids,
-        body.start_time,
-        body.end_time,
-    )
+    # Fail-closed camera access: any item referencing an inaccessible
+    # camera rejects the whole request. The UI's review list is already
+    # filtered by camera access, so reaching this branch implies a stale
+    # session or a crafted request — reject loudly rather than silently
+    # dropping items.
+    allowed_camera_set = set(allowed_cameras)
+    for item in body.items:
+        if item.camera not in allowed_camera_set:
+            return JSONResponse(
+                content={
+                    "success": False,
+                    "message": f"Cannot export from {item.camera}: access denied",
+                },
+                status_code=403,
+            )
 
-    cameras_to_queue = [
-        camera_name
-        for camera_name in dict.fromkeys(body.camera_ids)
-        if camera_errors.get(camera_name) is None
+    # Sanitize each item's image_path up front. A bad path in any item
+    # kills the whole request, consistent with single-export behavior.
+    sanitized_images: list[Optional[str]] = []
+    for item in body.items:
+        existing_image, image_validation_error = _sanitize_existing_image(
+            item.image_path
+        )
+        if image_validation_error is not None:
+            return image_validation_error
+        sanitized_images.append(existing_image)
+
+    item_errors = _get_item_recording_export_errors(request, body.items)
+
+    queueable_indexes = [
+        index for index in range(len(body.items)) if index not in item_errors
     ]
 
+    if not queueable_indexes:
+        return JSONResponse(
+            content={
+                "success": False,
+                "message": (
+                    "No exports could be queued: no recordings found for the "
+                    "requested ranges."
+                ),
+            },
+            status_code=400,
+        )
+
     # Preflight admission: reject the whole batch if we can't fit every
-    # queueable camera. Prevents creating a case we'd just roll back and
-    # avoids partial batches where the tail all fails with "queue full".
-    if cameras_to_queue and available_export_queue_slots(
-        request.app.frigate_config
-    ) < len(cameras_to_queue):
+    # queueable item. Prevents partial batches where the tail fails with
+    # "queue full" after we've already created a case.
+    if available_export_queue_slots(request.app.frigate_config) < len(
+        queueable_indexes
+    ):
         return JSONResponse(
             content={
                 "success": False,
@@ -516,33 +589,36 @@ def export_recordings_batch(request: Request, body: BatchExportBody):
 
     export_case = None
     export_case_id = body.export_case_id
-    if export_case_id is None and cameras_to_queue:
+    if export_case_id is None:
         export_case = _create_export_case_record(
-            body.new_case_name or body.name or "New Case",
+            body.new_case_name or "New Case",
             body.new_case_description,
         )
         export_case_id = export_case.id
 
-    for camera_name in dict.fromkeys(body.camera_ids):
-        camera_error = camera_errors.get(camera_name)
-        if camera_error is not None:
+    export_ids: list[str] = []
+    results: list[dict[str, Optional[str] | bool | int]] = []
+    for index, item in enumerate(body.items):
+        if index in item_errors:
             results.append(
                 {
-                    "camera": camera_name,
+                    "camera": item.camera,
                     "export_id": None,
                     "success": False,
                     "status": None,
-                    "error": camera_error,
+                    "error": item_errors[index],
+                    "item_index": index,
+                    "client_item_id": item.client_item_id,
                 }
             )
             continue
 
         export_job = _build_export_job(
-            camera_name,
-            body.start_time,
-            body.end_time,
-            f"{body.name} - {camera_name}" if body.name else None,
-            None,
+            item.camera,
+            item.start_time,
+            item.end_time,
+            item.friendly_name,
+            sanitized_images[index],
             PlaybackSourceEnum.recordings,
             export_case_id,
         )
@@ -552,11 +628,13 @@ def export_recordings_batch(request: Request, body: BatchExportBody):
             logger.exception("Failed to queue export job %s", export_job.id)
             results.append(
                 {
-                    "camera": camera_name,
+                    "camera": item.camera,
                     "export_id": None,
                     "success": False,
                     "status": None,
                     "error": str(err),
+                    "item_index": index,
+                    "client_item_id": item.client_item_id,
                 }
             )
             continue
@@ -564,11 +642,13 @@ def export_recordings_batch(request: Request, body: BatchExportBody):
         export_ids.append(export_job.id)
         results.append(
             {
-                "camera": camera_name,
+                "camera": item.camera,
                 "export_id": export_job.id,
                 "success": True,
                 "status": "queued",
                 "error": None,
+                "item_index": index,
+                "client_item_id": item.client_item_id,
             }
         )
 
@@ -602,7 +682,11 @@ def export_recording(
     start_time: float,
     end_time: float,
     body: ExportRecordingsBody,
+    current_user: dict = Depends(get_current_user),
 ):
+    if isinstance(current_user, JSONResponse):
+        return current_user
+
     camera_validation_error = _validate_camera_name(request, camera_name)
     if camera_validation_error is not None:
         return camera_validation_error
@@ -614,6 +698,19 @@ def export_recording(
         return image_validation_error
 
     export_case_id = body.export_case_id
+
+    # Attaching to an existing case requires admin. Single-export for
+    # cameras the user can access is otherwise non-admin; we only gate
+    # the case-attachment side effect.
+    if export_case_id is not None and current_user["role"] != "admin":
+        return JSONResponse(
+            content={
+                "success": False,
+                "message": "Only admins can attach exports to an existing case.",
+            },
+            status_code=403,
+        )
+
     case_validation_error = _validate_export_case(export_case_id)
     if case_validation_error is not None:
         return case_validation_error

--- a/frigate/api/export.py
+++ b/frigate/api/export.py
@@ -604,7 +604,7 @@ def export_recordings_batch(
                     "export_id": None,
                     "success": False,
                     "status": None,
-                    "error": str(err),
+                    "error": "Failed to queue export job",
                     "item_index": index,
                     "client_item_id": item.client_item_id,
                 }

--- a/frigate/api/export.py
+++ b/frigate/api/export.py
@@ -1,8 +1,11 @@
 """Export apis."""
 
+import datetime
 import logging
 import random
 import string
+import threading
+import time
 from pathlib import Path
 from typing import List, Optional
 
@@ -19,6 +22,7 @@ from frigate.api.auth import (
     require_camera_access,
     require_role,
 )
+from frigate.api.defs.request.batch_export_body import BatchExportBody
 from frigate.api.defs.request.export_case_body import (
     ExportCaseAssignBody,
     ExportCaseCreateBody,
@@ -34,6 +38,7 @@ from frigate.api.defs.response.export_case_response import (
     ExportCasesResponse,
 )
 from frigate.api.defs.response.export_response import (
+    BatchExportResponse,
     ExportModel,
     ExportsResponse,
     StartExportResponse,
@@ -53,6 +58,214 @@ from frigate.util.time import is_current_hour
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=[Tags.export])
+
+EXPORT_START_SEMAPHORE = threading.Semaphore(3)
+
+
+class ManagedRecordingExporter(RecordingExporter):
+    """Recording exporter that releases the shared concurrency slot on exit."""
+
+    def run(self) -> None:
+        try:
+            super().run()
+        finally:
+            EXPORT_START_SEMAPHORE.release()
+
+
+def _generate_id(length: int = 12) -> str:
+    return "".join(random.choices(string.ascii_lowercase + string.digits, k=length))
+
+
+def _generate_export_id(camera_name: str) -> str:
+    return f"{camera_name}_{_generate_id(6)}"
+
+
+def _create_export_case_record(
+    name: str,
+    description: Optional[str],
+) -> ExportCase:
+    now = datetime.datetime.fromtimestamp(time.time())
+    return ExportCase.create(
+        id=_generate_id(),
+        name=name,
+        description=description,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _validate_camera_name(request: Request, camera_name: str) -> Optional[JSONResponse]:
+    if camera_name and request.app.frigate_config.cameras.get(camera_name):
+        return None
+
+    return JSONResponse(
+        content={"success": False, "message": f"{camera_name} is not a valid camera."},
+        status_code=404,
+    )
+
+
+def _validate_export_case(export_case_id: Optional[str]) -> Optional[JSONResponse]:
+    if export_case_id is None:
+        return None
+
+    try:
+        ExportCase.get(ExportCase.id == export_case_id)
+    except DoesNotExist:
+        return JSONResponse(
+            content={"success": False, "message": "Export case not found"},
+            status_code=404,
+        )
+
+    return None
+
+
+def _sanitize_existing_image(
+    image_path: Optional[str],
+) -> tuple[Optional[str], Optional[JSONResponse]]:
+    existing_image = sanitize_filepath(image_path) if image_path else None
+
+    if existing_image and not existing_image.startswith(CLIPS_DIR):
+        return None, JSONResponse(
+            content={"success": False, "message": "Invalid image path"},
+            status_code=400,
+        )
+
+    return existing_image, None
+
+
+def _validate_export_source(
+    camera_name: str,
+    start_time: float,
+    end_time: float,
+    playback_source: PlaybackSourceEnum,
+) -> Optional[str]:
+    if playback_source == PlaybackSourceEnum.recordings:
+        recordings_count = (
+            Recordings.select()
+            .where(
+                Recordings.start_time.between(start_time, end_time)
+                | Recordings.end_time.between(start_time, end_time)
+                | (
+                    (start_time > Recordings.start_time)
+                    & (end_time < Recordings.end_time)
+                )
+            )
+            .where(Recordings.camera == camera_name)
+            .count()
+        )
+
+        if recordings_count <= 0:
+            return "No recordings found for time range"
+
+        return None
+
+    previews_count = (
+        Previews.select()
+        .where(
+            Previews.start_time.between(start_time, end_time)
+            | Previews.end_time.between(start_time, end_time)
+            | ((start_time > Previews.start_time) & (end_time < Previews.end_time))
+        )
+        .where(Previews.camera == camera_name)
+        .count()
+    )
+
+    if not is_current_hour(start_time) and previews_count <= 0:
+        return "No previews found for time range"
+
+    return None
+
+
+def _get_batch_recording_export_errors(
+    request: Request,
+    camera_names: list[str],
+    start_time: float,
+    end_time: float,
+) -> dict[str, str]:
+    unique_camera_names = list(dict.fromkeys(camera_names))
+    configured_cameras = request.app.frigate_config.cameras
+    errors: dict[str, str] = {}
+
+    valid_camera_names = [
+        camera_name
+        for camera_name in unique_camera_names
+        if configured_cameras.get(camera_name)
+    ]
+
+    for camera_name in unique_camera_names:
+        if camera_name not in valid_camera_names:
+            errors[camera_name] = f"{camera_name} is not a valid camera."
+
+    if not valid_camera_names:
+        return errors
+
+    recordings = (
+        Recordings.select(Recordings.camera)
+        .distinct()
+        .where(
+            Recordings.camera << valid_camera_names,
+            Recordings.start_time.between(start_time, end_time)
+            | Recordings.end_time.between(start_time, end_time)
+            | ((start_time > Recordings.start_time) & (end_time < Recordings.end_time)),
+        )
+        .iterator()
+    )
+    cameras_with_recordings = {recording.camera for recording in recordings}
+
+    for camera_name in valid_camera_names:
+        if camera_name not in cameras_with_recordings:
+            errors[camera_name] = "No recordings found for time range"
+
+    return errors
+
+
+def _build_exporter(
+    request: Request,
+    camera_name: str,
+    start_time: float,
+    end_time: float,
+    friendly_name: Optional[str],
+    existing_image: Optional[str],
+    playback_source: PlaybackSourceEnum,
+    export_case_id: Optional[str],
+    ffmpeg_input_args: Optional[str] = None,
+    ffmpeg_output_args: Optional[str] = None,
+    cpu_fallback: bool = False,
+) -> ManagedRecordingExporter:
+    return ManagedRecordingExporter(
+        request.app.frigate_config,
+        _generate_export_id(camera_name),
+        camera_name,
+        friendly_name,
+        existing_image,
+        int(start_time),
+        int(end_time),
+        playback_source,
+        export_case_id,
+        ffmpeg_input_args,
+        ffmpeg_output_args,
+        cpu_fallback,
+    )
+
+
+def _start_exporter(exporter: ManagedRecordingExporter) -> None:
+    EXPORT_START_SEMAPHORE.acquire()
+    try:
+        exporter.start()
+    except Exception:
+        EXPORT_START_SEMAPHORE.release()
+        raise
+
+
+def _export_case_to_dict(case: ExportCase) -> dict[str, object]:
+    case_dict = model_to_dict(case)
+
+    for field in ("created_at", "updated_at"):
+        value = case_dict.get(field)
+        if isinstance(value, datetime.datetime):
+            case_dict[field] = value.timestamp()
+
+    return case_dict
 
 
 @router.get(
@@ -103,10 +316,8 @@ def get_exports(
     description="Gets all export cases from the database.",
 )
 def get_export_cases():
-    cases = (
-        ExportCase.select().order_by(ExportCase.created_at.desc()).dicts().iterator()
-    )
-    return JSONResponse(content=[c for c in cases])
+    cases = ExportCase.select().order_by(ExportCase.created_at.desc()).iterator()
+    return JSONResponse(content=[_export_case_to_dict(case) for case in cases])
 
 
 @router.post(
@@ -117,14 +328,8 @@ def get_export_cases():
     description="Creates a new export case.",
 )
 def create_export_case(body: ExportCaseCreateBody):
-    case = ExportCase.create(
-        id="".join(random.choices(string.ascii_lowercase + string.digits, k=12)),
-        name=body.name,
-        description=body.description,
-        created_at=Path().stat().st_mtime,
-        updated_at=Path().stat().st_mtime,
-    )
-    return JSONResponse(content=model_to_dict(case))
+    case = _create_export_case_record(body.name, body.description)
+    return JSONResponse(content=_export_case_to_dict(case))
 
 
 @router.get(
@@ -137,7 +342,7 @@ def create_export_case(body: ExportCaseCreateBody):
 def get_export_case(case_id: str):
     try:
         case = ExportCase.get(ExportCase.id == case_id)
-        return JSONResponse(content=model_to_dict(case))
+        return JSONResponse(content=_export_case_to_dict(case))
     except DoesNotExist:
         return JSONResponse(
             content={"success": False, "message": "Export case not found"},
@@ -165,6 +370,8 @@ def update_export_case(case_id: str, body: ExportCaseUpdateBody):
         case.name = body.name
     if body.description is not None:
         case.description = body.description
+
+    case.updated_at = datetime.datetime.fromtimestamp(time.time())
 
     case.save()
 
@@ -242,6 +449,82 @@ async def assign_export_case(
 
 
 @router.post(
+    "/exports/batch",
+    response_model=BatchExportResponse,
+    dependencies=[Depends(require_role(["admin"]))],
+    summary="Start multi-camera recording export",
+    description=(
+        "Starts recording exports for multiple cameras for the same time range and "
+        "assigns them to a single export case."
+    ),
+)
+def export_recordings_batch(request: Request, body: BatchExportBody):
+    case_validation_error = _validate_export_case(body.export_case_id)
+    if case_validation_error is not None:
+        return case_validation_error
+
+    export_case_id = body.export_case_id
+    if export_case_id is None:
+        export_case = _create_export_case_record(
+            body.new_case_name or body.name or "New Case",
+            body.new_case_description,
+        )
+        export_case_id = export_case.id
+
+    export_ids: list[str] = []
+    results: list[dict[str, Optional[str] | bool]] = []
+    camera_errors = _get_batch_recording_export_errors(
+        request,
+        body.camera_ids,
+        body.start_time,
+        body.end_time,
+    )
+
+    for camera_name in dict.fromkeys(body.camera_ids):
+        camera_error = camera_errors.get(camera_name)
+        if camera_error is not None:
+            results.append(
+                {
+                    "camera": camera_name,
+                    "export_id": None,
+                    "success": False,
+                    "error": camera_error,
+                }
+            )
+            continue
+
+        exporter = _build_exporter(
+            request,
+            camera_name,
+            body.start_time,
+            body.end_time,
+            f"{body.name} - {camera_name}" if body.name else None,
+            None,
+            PlaybackSourceEnum.recordings,
+            export_case_id,
+        )
+        _start_exporter(exporter)
+
+        export_ids.append(exporter.export_id)
+        results.append(
+            {
+                "camera": camera_name,
+                "export_id": exporter.export_id,
+                "success": True,
+                "error": None,
+            }
+        )
+
+    return JSONResponse(
+        content={
+            "export_case_id": export_case_id,
+            "export_ids": export_ids,
+            "results": results,
+        }
+    )
+
+
+@router.post(
     "/export/{camera_name}/start/{start_time}/end/{end_time}",
     response_model=StartExportResponse,
     dependencies=[Depends(require_camera_access)],
@@ -258,100 +541,51 @@ def export_recording(
     end_time: float,
     body: ExportRecordingsBody,
 ):
-    if not camera_name or not request.app.frigate_config.cameras.get(camera_name):
-        return JSONResponse(
-            content=(
-                {"success": False, "message": f"{camera_name} is not a valid camera."}
-            ),
-            status_code=404,
-        )
+    camera_validation_error = _validate_camera_name(request, camera_name)
+    if camera_validation_error is not None:
+        return camera_validation_error
 
     playback_source = body.source
     friendly_name = body.name
-    existing_image = sanitize_filepath(body.image_path) if body.image_path else None
+    existing_image, image_validation_error = _sanitize_existing_image(body.image_path)
+    if image_validation_error is not None:
+        return image_validation_error
 
     export_case_id = body.export_case_id
-    if export_case_id is not None:
-        try:
-            ExportCase.get(ExportCase.id == export_case_id)
-        except DoesNotExist:
-            return JSONResponse(
-                content={"success": False, "message": "Export case not found"},
-                status_code=404,
-            )
+    case_validation_error = _validate_export_case(export_case_id)
+    if case_validation_error is not None:
+        return case_validation_error
 
-    # Ensure that existing_image is a valid path
-    if existing_image and not existing_image.startswith(CLIPS_DIR):
+    source_error = _validate_export_source(
+        camera_name,
+        start_time,
+        end_time,
+        playback_source,
+    )
+    if source_error is not None:
         return JSONResponse(
-            content=({"success": False, "message": "Invalid image path"}),
+            content={"success": False, "message": source_error},
             status_code=400,
         )
 
-    if playback_source == "recordings":
-        recordings_count = (
-            Recordings.select()
-            .where(
-                Recordings.start_time.between(start_time, end_time)
-                | Recordings.end_time.between(start_time, end_time)
-                | (
-                    (start_time > Recordings.start_time)
-                    & (end_time < Recordings.end_time)
-                )
-            )
-            .where(Recordings.camera == camera_name)
-            .count()
-        )
-
-        if recordings_count <= 0:
-            return JSONResponse(
-                content=(
-                    {"success": False, "message": "No recordings found for time range"}
-                ),
-                status_code=400,
-            )
-    else:
-        previews_count = (
-            Previews.select()
-            .where(
-                Previews.start_time.between(start_time, end_time)
-                | Previews.end_time.between(start_time, end_time)
-                | ((start_time > Previews.start_time) & (end_time < Previews.end_time))
-            )
-            .where(Previews.camera == camera_name)
-            .count()
-        )
-
-        if not is_current_hour(start_time) and previews_count <= 0:
-            return JSONResponse(
-                content=(
-                    {"success": False, "message": "No previews found for time range"}
-                ),
-                status_code=400,
-            )
-
-    export_id = f"{camera_name}_{''.join(random.choices(string.ascii_lowercase + string.digits, k=6))}"
-    exporter = RecordingExporter(
-        request.app.frigate_config,
-        export_id,
+    exporter = _build_exporter(
+        request,
         camera_name,
+        start_time,
+        end_time,
         friendly_name,
         existing_image,
-        int(start_time),
-        int(end_time),
-        (
-            PlaybackSourceEnum[playback_source]
-            if playback_source in PlaybackSourceEnum.__members__.values()
-            else PlaybackSourceEnum.recordings
-        ),
+        playback_source,
         export_case_id,
     )
-    exporter.start()
+    _start_exporter(exporter)
+
     return JSONResponse(
         content=(
             {
                 "success": True,
                 "message": "Starting export of recording.",
-                "export_id": export_id,
+                "export_id": exporter.export_id,
             }
         ),
         status_code=200,
@@ -472,81 +706,35 @@ def export_recording_custom(
     end_time: float,
     body: ExportRecordingsCustomBody,
 ):
-    if not camera_name or not request.app.frigate_config.cameras.get(camera_name):
-        return JSONResponse(
-            content=(
-                {"success": False, "message": f"{camera_name} is not a valid camera."}
-            ),
-            status_code=404,
-        )
+    camera_validation_error = _validate_camera_name(request, camera_name)
+    if camera_validation_error is not None:
+        return camera_validation_error
 
     playback_source = body.source
     friendly_name = body.name
-    existing_image = sanitize_filepath(body.image_path) if body.image_path else None
+    existing_image, image_validation_error = _sanitize_existing_image(body.image_path)
+    if image_validation_error is not None:
+        return image_validation_error
     ffmpeg_input_args = body.ffmpeg_input_args
     ffmpeg_output_args = body.ffmpeg_output_args
     cpu_fallback = body.cpu_fallback
 
     export_case_id = body.export_case_id
-    if export_case_id is not None:
-        try:
-            ExportCase.get(ExportCase.id == export_case_id)
-        except DoesNotExist:
-            return JSONResponse(
-                content={"success": False, "message": "Export case not found"},
-                status_code=404,
-            )
+    case_validation_error = _validate_export_case(export_case_id)
+    if case_validation_error is not None:
+        return case_validation_error
 
-    # Ensure that existing_image is a valid path
-    if existing_image and not existing_image.startswith(CLIPS_DIR):
+    source_error = _validate_export_source(
+        camera_name,
+        start_time,
+        end_time,
+        playback_source,
+    )
+    if source_error is not None:
         return JSONResponse(
-            content=({"success": False, "message": "Invalid image path"}),
+            content={"success": False, "message": source_error},
             status_code=400,
         )
-
-    if playback_source == "recordings":
-        recordings_count = (
-            Recordings.select()
-            .where(
-                Recordings.start_time.between(start_time, end_time)
-                | Recordings.end_time.between(start_time, end_time)
-                | (
-                    (start_time > Recordings.start_time)
-                    & (end_time < Recordings.end_time)
-                )
-            )
-            .where(Recordings.camera == camera_name)
-            .count()
-        )
-
-        if recordings_count <= 0:
-            return JSONResponse(
-                content=(
-                    {"success": False, "message": "No recordings found for time range"}
-                ),
-                status_code=400,
-            )
-    else:
-        previews_count = (
-            Previews.select()
-            .where(
-                Previews.start_time.between(start_time, end_time)
-                | Previews.end_time.between(start_time, end_time)
-                | ((start_time > Previews.start_time) & (end_time < Previews.end_time))
-            )
-            .where(Previews.camera == camera_name)
-            .count()
-        )
-
-        if not is_current_hour(start_time) and previews_count <= 0:
-            return JSONResponse(
-                content=(
-                    {"success": False, "message": "No previews found for time range"}
-                ),
-                status_code=400,
-            )
-
-    export_id = f"{camera_name}_{''.join(random.choices(string.ascii_lowercase + string.digits, k=6))}"
 
     # Validate user-provided ffmpeg args to prevent injection.
     # Admin users are trusted and skip validation.
@@ -577,31 +765,27 @@ def export_recording_custom(
     if ffmpeg_output_args is None:
         ffmpeg_output_args = DEFAULT_TIME_LAPSE_FFMPEG_ARGS
 
-    exporter = RecordingExporter(
-        request.app.frigate_config,
-        export_id,
+    exporter = _build_exporter(
+        request,
         camera_name,
+        start_time,
+        end_time,
         friendly_name,
         existing_image,
-        int(start_time),
-        int(end_time),
-        (
-            PlaybackSourceEnum[playback_source]
-            if playback_source in PlaybackSourceEnum.__members__.values()
-            else PlaybackSourceEnum.recordings
-        ),
+        playback_source,
         export_case_id,
         ffmpeg_input_args,
         ffmpeg_output_args,
         cpu_fallback,
     )
-    exporter.start()
+    _start_exporter(exporter)
+
     return JSONResponse(
         content=(
             {
                 "success": True,
                 "message": "Starting export of recording.",
-                "export_id": export_id,
+                "export_id": exporter.export_id,
             }
         ),
         status_code=200,

--- a/frigate/api/export.py
+++ b/frigate/api/export.py
@@ -596,7 +596,7 @@ def export_recordings_batch(
         )
         try:
             start_export_job(request.app.frigate_config, export_job)
-        except Exception as err:
+        except Exception:
             logger.exception("Failed to queue export job %s", export_job.id)
             results.append(
                 {

--- a/frigate/api/export.py
+++ b/frigate/api/export.py
@@ -26,8 +26,11 @@ from frigate.api.defs.request.batch_export_body import (
     BatchExportBody,
     BatchExportItem,
 )
+from frigate.api.defs.request.export_bulk_body import (
+    ExportBulkDeleteBody,
+    ExportBulkReassignBody,
+)
 from frigate.api.defs.request.export_case_body import (
-    ExportCaseAssignBody,
     ExportCaseCreateBody,
     ExportCaseUpdateBody,
 )
@@ -424,48 +427,6 @@ def delete_export_case(case_id: str, request: Request, delete_exports: bool = Fa
     )
 
 
-@router.patch(
-    "/export/{export_id}/case",
-    response_model=GenericResponse,
-    dependencies=[Depends(require_role(["admin"]))],
-    summary="Assign export to case",
-    description=(
-        "Assigns an export to a case, or unassigns it if export_case_id is null."
-    ),
-)
-async def assign_export_case(
-    export_id: str,
-    body: ExportCaseAssignBody,
-    request: Request,
-):
-    try:
-        export: Export = Export.get(Export.id == export_id)
-        await require_camera_access(export.camera, request=request)
-    except DoesNotExist:
-        return JSONResponse(
-            content={"success": False, "message": "Export not found."},
-            status_code=404,
-        )
-
-    if body.export_case_id is not None:
-        try:
-            ExportCase.get(ExportCase.id == body.export_case_id)
-        except DoesNotExist:
-            return JSONResponse(
-                content={"success": False, "message": "Export case not found."},
-                status_code=404,
-            )
-        export.export_case = body.export_case_id
-    else:
-        export.export_case = None
-
-    export.save()
-
-    return JSONResponse(
-        content={"success": True, "message": "Successfully updated export case."}
-    )
-
-
 @router.get(
     "/jobs/export",
     response_model=ExportJobsResponse,
@@ -600,9 +561,9 @@ def export_recordings_batch(
 
     export_case = None
     export_case_id = body.export_case_id
-    if export_case_id is None:
+    if export_case_id is None and body.new_case_name:
         export_case = _create_export_case_record(
-            body.new_case_name or "New Case",
+            body.new_case_name,
             body.new_case_description,
         )
         export_case_id = export_case.id
@@ -809,65 +770,6 @@ async def export_rename(event_id: str, body: ExportRenameBody, request: Request)
     )
 
 
-@router.delete(
-    "/export/{event_id}",
-    response_model=GenericResponse,
-    dependencies=[Depends(require_role(["admin"]))],
-    summary="Delete export",
-)
-async def export_delete(event_id: str, request: Request):
-    try:
-        export: Export = Export.get(Export.id == event_id)
-        await require_camera_access(export.camera, request=request)
-    except DoesNotExist:
-        return JSONResponse(
-            content=(
-                {
-                    "success": False,
-                    "message": "Export not found.",
-                }
-            ),
-            status_code=404,
-        )
-
-    files_in_use = []
-    for process in psutil.process_iter():
-        try:
-            if process.name() != "ffmpeg":
-                continue
-            file_list = process.open_files()
-            if file_list:
-                for nt in file_list:
-                    if nt.path.startswith(EXPORT_DIR):
-                        files_in_use.append(nt.path.split("/")[-1])
-        except psutil.Error:
-            continue
-
-    if export.video_path.split("/")[-1] in files_in_use:
-        return JSONResponse(
-            content=(
-                {"success": False, "message": "Can not delete in progress export."}
-            ),
-            status_code=400,
-        )
-
-    Path(export.video_path).unlink(missing_ok=True)
-
-    if export.thumb_path:
-        Path(export.thumb_path).unlink(missing_ok=True)
-
-    export.delete_instance()
-    return JSONResponse(
-        content=(
-            {
-                "success": True,
-                "message": "Successfully deleted export.",
-            }
-        ),
-        status_code=200,
-    )
-
-
 @router.post(
     "/export/custom/{camera_name}/start/{start_time}/end/{end_time}",
     response_model=StartExportResponse,
@@ -1000,3 +902,102 @@ async def get_export(export_id: str, request: Request):
             content={"success": False, "message": "Export not found"},
             status_code=404,
         )
+
+
+def _get_files_in_use() -> set[str]:
+    """Get set of export filenames currently in use by ffmpeg."""
+    files_in_use: set[str] = set()
+    for process in psutil.process_iter():
+        try:
+            if process.name() != "ffmpeg":
+                continue
+            file_list = process.open_files()
+            if file_list:
+                for nt in file_list:
+                    if nt.path.startswith(EXPORT_DIR):
+                        files_in_use.add(nt.path.split("/")[-1])
+        except psutil.Error:
+            continue
+    return files_in_use
+
+
+@router.post(
+    "/exports/delete",
+    response_model=GenericResponse,
+    dependencies=[Depends(require_role(["admin"]))],
+    summary="Bulk delete exports",
+    description="Deletes one or more exports by ID. All IDs must exist and none can be in-progress.",
+)
+def bulk_delete_exports(body: ExportBulkDeleteBody):
+    exports = list(Export.select().where(Export.id << body.ids))
+
+    if len(exports) != len(body.ids):
+        return JSONResponse(
+            content={"success": False, "message": "One or more exports not found."},
+            status_code=404,
+        )
+
+    files_in_use = _get_files_in_use()
+
+    for export in exports:
+        if export.video_path.split("/")[-1] in files_in_use:
+            return JSONResponse(
+                content={
+                    "success": False,
+                    "message": "Can not delete in-progress export.",
+                },
+                status_code=400,
+            )
+
+    for export in exports:
+        Path(export.video_path).unlink(missing_ok=True)
+        if export.thumb_path:
+            Path(export.thumb_path).unlink(missing_ok=True)
+
+    Export.delete().where(Export.id << body.ids).execute()
+
+    return JSONResponse(
+        content={
+            "success": True,
+            "message": f"Successfully deleted {len(exports)} export(s).",
+        },
+        status_code=200,
+    )
+
+
+@router.post(
+    "/exports/reassign",
+    response_model=GenericResponse,
+    dependencies=[Depends(require_role(["admin"]))],
+    summary="Bulk reassign exports to a case",
+    description="Assigns or unassigns one or more exports to/from a case. All IDs must exist.",
+)
+def bulk_reassign_exports(body: ExportBulkReassignBody):
+    exports = list(Export.select().where(Export.id << body.ids))
+
+    if len(exports) != len(body.ids):
+        return JSONResponse(
+            content={"success": False, "message": "One or more exports not found."},
+            status_code=404,
+        )
+
+    if body.export_case_id is not None:
+        try:
+            ExportCase.get(ExportCase.id == body.export_case_id)
+        except DoesNotExist:
+            return JSONResponse(
+                content={"success": False, "message": "Export case not found."},
+                status_code=404,
+            )
+
+    Export.update(export_case=body.export_case_id).where(
+        Export.id << body.ids
+    ).execute()
+
+    return JSONResponse(
+        content={
+            "success": True,
+            "message": f"Successfully updated {len(exports)} export(s).",
+        },
+        status_code=200,
+    )

--- a/frigate/api/export.py
+++ b/frigate/api/export.py
@@ -4,7 +4,6 @@ import datetime
 import logging
 import random
 import string
-import threading
 import time
 from pathlib import Path
 from typing import List, Optional
@@ -39,6 +38,8 @@ from frigate.api.defs.response.export_case_response import (
 )
 from frigate.api.defs.response.export_response import (
     BatchExportResponse,
+    ExportJobModel,
+    ExportJobsResponse,
     ExportModel,
     ExportsResponse,
     StartExportResponse,
@@ -46,11 +47,18 @@ from frigate.api.defs.response.export_response import (
 from frigate.api.defs.response.generic_response import GenericResponse
 from frigate.api.defs.tags import Tags
 from frigate.const import CLIPS_DIR, EXPORT_DIR
+from frigate.jobs.export import (
+    ExportJob,
+    ExportQueueFullError,
+    available_export_queue_slots,
+    get_export_job,
+    list_active_export_jobs,
+    start_export_job,
+)
 from frigate.models import Export, ExportCase, Previews, Recordings
 from frigate.record.export import (
     DEFAULT_TIME_LAPSE_FFMPEG_ARGS,
     PlaybackSourceEnum,
-    RecordingExporter,
     validate_ffmpeg_args,
 )
 from frigate.util.time import is_current_hour
@@ -58,18 +66,6 @@ from frigate.util.time import is_current_hour
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=[Tags.export])
-
-EXPORT_START_SEMAPHORE = threading.Semaphore(3)
-
-
-class ManagedRecordingExporter(RecordingExporter):
-    """Recording exporter that releases the shared concurrency slot on exit."""
-
-    def run(self) -> None:
-        try:
-            super().run()
-        finally:
-            EXPORT_START_SEMAPHORE.release()
 
 
 def _generate_id(length: int = 12) -> str:
@@ -219,8 +215,7 @@ def _get_batch_recording_export_errors(
     return errors
 
 
-def _build_exporter(
-    request: Request,
+def _build_export_job(
     camera_name: str,
     start_time: float,
     end_time: float,
@@ -231,30 +226,20 @@ def _build_exporter(
     ffmpeg_input_args: Optional[str] = None,
     ffmpeg_output_args: Optional[str] = None,
     cpu_fallback: bool = False,
-) -> ManagedRecordingExporter:
-    return ManagedRecordingExporter(
-        request.app.frigate_config,
-        _generate_export_id(camera_name),
-        camera_name,
-        friendly_name,
-        existing_image,
-        int(start_time),
-        int(end_time),
-        playback_source,
-        export_case_id,
-        ffmpeg_input_args,
-        ffmpeg_output_args,
-        cpu_fallback,
+) -> ExportJob:
+    return ExportJob(
+        id=_generate_export_id(camera_name),
+        camera=camera_name,
+        name=friendly_name,
+        image_path=existing_image,
+        export_case_id=export_case_id,
+        request_start_time=int(start_time),
+        request_end_time=int(end_time),
+        playback_source=playback_source.value,
+        ffmpeg_input_args=ffmpeg_input_args,
+        ffmpeg_output_args=ffmpeg_output_args,
+        cpu_fallback=cpu_fallback,
     )
-
-
-def _start_exporter(exporter: ManagedRecordingExporter) -> None:
-    EXPORT_START_SEMAPHORE.acquire()
-    try:
-        exporter.start()
-    except Exception:
-        EXPORT_START_SEMAPHORE.release()
-        raise
 
 
 def _export_case_to_dict(case: ExportCase) -> dict[str, object]:
@@ -448,6 +433,43 @@ async def assign_export_case(
     )
 
 
+@router.get(
+    "/jobs/export",
+    response_model=ExportJobsResponse,
+    dependencies=[Depends(allow_any_authenticated())],
+    summary="Get active export jobs",
+    description="Gets queued and running export jobs.",
+)
+def get_active_export_jobs(
+    request: Request,
+    allowed_cameras: List[str] = Depends(get_allowed_cameras_for_filter),
+):
+    jobs = list_active_export_jobs(request.app.frigate_config)
+    return JSONResponse(
+        content=[job.to_dict() for job in jobs if job.camera in allowed_cameras]
+    )
+
+
+@router.get(
+    "/jobs/export/{export_id}",
+    response_model=ExportJobModel,
+    dependencies=[Depends(allow_any_authenticated())],
+    summary="Get export job status",
+    description="Gets queued, running, or completed status for a specific export job.",
+)
+async def get_export_job_status(export_id: str, request: Request):
+    job = get_export_job(request.app.frigate_config, export_id)
+    if job is None:
+        return JSONResponse(
+            content={"success": False, "message": "Job not found"},
+            status_code=404,
+        )
+
+    await require_camera_access(job.camera, request=request)
+
+    return JSONResponse(content=job.to_dict())
+
+
 @router.post(
     "/exports/batch",
     response_model=BatchExportResponse,
@@ -463,14 +485,6 @@ def export_recordings_batch(request: Request, body: BatchExportBody):
     if case_validation_error is not None:
         return case_validation_error
 
-    export_case_id = body.export_case_id
-    if export_case_id is None:
-        export_case = _create_export_case_record(
-            body.new_case_name or body.name or "New Case",
-            body.new_case_description,
-        )
-        export_case_id = export_case.id
-
     export_ids: list[str] = []
     results: list[dict[str, Optional[str] | bool]] = []
     camera_errors = _get_batch_recording_export_errors(
@@ -480,6 +494,35 @@ def export_recordings_batch(request: Request, body: BatchExportBody):
         body.end_time,
     )
 
+    cameras_to_queue = [
+        camera_name
+        for camera_name in dict.fromkeys(body.camera_ids)
+        if camera_errors.get(camera_name) is None
+    ]
+
+    # Preflight admission: reject the whole batch if we can't fit every
+    # queueable camera. Prevents creating a case we'd just roll back and
+    # avoids partial batches where the tail all fails with "queue full".
+    if cameras_to_queue and available_export_queue_slots(
+        request.app.frigate_config
+    ) < len(cameras_to_queue):
+        return JSONResponse(
+            content={
+                "success": False,
+                "message": "Export queue is full. Try again once current exports finish.",
+            },
+            status_code=503,
+        )
+
+    export_case = None
+    export_case_id = body.export_case_id
+    if export_case_id is None and cameras_to_queue:
+        export_case = _create_export_case_record(
+            body.new_case_name or body.name or "New Case",
+            body.new_case_description,
+        )
+        export_case_id = export_case.id
+
     for camera_name in dict.fromkeys(body.camera_ids):
         camera_error = camera_errors.get(camera_name)
         if camera_error is not None:
@@ -488,13 +531,13 @@ def export_recordings_batch(request: Request, body: BatchExportBody):
                     "camera": camera_name,
                     "export_id": None,
                     "success": False,
+                    "status": None,
                     "error": camera_error,
                 }
             )
             continue
 
-        exporter = _build_exporter(
-            request,
+        export_job = _build_export_job(
             camera_name,
             body.start_time,
             body.end_time,
@@ -503,24 +546,43 @@ def export_recordings_batch(request: Request, body: BatchExportBody):
             PlaybackSourceEnum.recordings,
             export_case_id,
         )
-        _start_exporter(exporter)
+        try:
+            start_export_job(request.app.frigate_config, export_job)
+        except Exception as err:
+            logger.exception("Failed to queue export job %s", export_job.id)
+            results.append(
+                {
+                    "camera": camera_name,
+                    "export_id": None,
+                    "success": False,
+                    "status": None,
+                    "error": str(err),
+                }
+            )
+            continue
 
-        export_ids.append(exporter.export_id)
+        export_ids.append(export_job.id)
         results.append(
             {
                 "camera": camera_name,
-                "export_id": exporter.export_id,
+                "export_id": export_job.id,
                 "success": True,
+                "status": "queued",
                 "error": None,
             }
         )
+
+    if export_case is not None and not export_ids:
+        export_case.delete_instance()
+        export_case_id = None
 
     return JSONResponse(
         content={
             "export_case_id": export_case_id,
             "export_ids": export_ids,
             "results": results,
-        }
+        },
+        status_code=202,
     )
 
 
@@ -568,8 +630,7 @@ def export_recording(
             status_code=400,
         )
 
-    exporter = _build_exporter(
-        request,
+    export_job = _build_export_job(
         camera_name,
         start_time,
         end_time,
@@ -578,17 +639,28 @@ def export_recording(
         playback_source,
         export_case_id,
     )
-    _start_exporter(exporter)
+    try:
+        start_export_job(request.app.frigate_config, export_job)
+    except ExportQueueFullError:
+        logger.warning("Export queue is full; rejecting %s", export_job.id)
+        return JSONResponse(
+            content={
+                "success": False,
+                "message": "Export queue is full. Try again once current exports finish.",
+            },
+            status_code=503,
+        )
 
     return JSONResponse(
         content=(
             {
                 "success": True,
-                "message": "Starting export of recording.",
-                "export_id": exporter.export_id,
+                "message": "Export queued.",
+                "export_id": export_job.id,
+                "status": "queued",
             }
         ),
-        status_code=200,
+        status_code=202,
     )
 
 
@@ -765,8 +837,7 @@ def export_recording_custom(
     if ffmpeg_output_args is None:
         ffmpeg_output_args = DEFAULT_TIME_LAPSE_FFMPEG_ARGS
 
-    exporter = _build_exporter(
-        request,
+    export_job = _build_export_job(
         camera_name,
         start_time,
         end_time,
@@ -778,17 +849,28 @@ def export_recording_custom(
         ffmpeg_output_args,
         cpu_fallback,
     )
-    _start_exporter(exporter)
+    try:
+        start_export_job(request.app.frigate_config, export_job)
+    except ExportQueueFullError:
+        logger.warning("Export queue is full; rejecting %s", export_job.id)
+        return JSONResponse(
+            content={
+                "success": False,
+                "message": "Export queue is full. Try again once current exports finish.",
+            },
+            status_code=503,
+        )
 
     return JSONResponse(
         content=(
             {
                 "success": True,
-                "message": "Starting export of recording.",
-                "export_id": exporter.export_id,
+                "message": "Export queued.",
+                "export_id": export_job.id,
+                "status": "queued",
             }
         ),
-        status_code=200,
+        status_code=202,
     )
 
 

--- a/frigate/api/export.py
+++ b/frigate/api/export.py
@@ -55,6 +55,7 @@ from frigate.jobs.export import (
     ExportJob,
     ExportQueueFullError,
     available_export_queue_slots,
+    cancel_queued_export_jobs_for_case,
     get_export_job,
     list_active_export_jobs,
     start_export_job,
@@ -394,7 +395,7 @@ def update_export_case(case_id: str, body: ExportCaseUpdateBody):
     summary="Delete export case",
     description="""Deletes an export case.\n    Exports that reference this case will have their export_case set to null.\n    """,
 )
-def delete_export_case(case_id: str):
+def delete_export_case(case_id: str, request: Request, delete_exports: bool = False):
     try:
         case = ExportCase.get(ExportCase.id == case_id)
     except DoesNotExist:
@@ -403,8 +404,18 @@ def delete_export_case(case_id: str):
             status_code=404,
         )
 
-    # Unassign exports from this case but keep the exports themselves
-    Export.update(export_case=None).where(Export.export_case == case).execute()
+    if delete_exports:
+        cancel_queued_export_jobs_for_case(request.app.frigate_config, case_id)
+
+        exports = list(Export.select().where(Export.export_case == case_id))
+        for export in exports:
+            Path(export.video_path).unlink(missing_ok=True)
+            if export.thumb_path:
+                Path(export.thumb_path).unlink(missing_ok=True)
+            export.delete_instance()
+    else:
+        # Unassign exports from this case but keep the exports themselves
+        Export.update(export_case=None).where(Export.export_case == case_id).execute()
 
     case.delete_instance()
 

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -52,6 +52,7 @@ from frigate.embeddings import EmbeddingProcess, EmbeddingsContext
 from frigate.events.audio import AudioProcessor
 from frigate.events.cleanup import EventCleanup
 from frigate.events.maintainer import EventProcessor
+from frigate.jobs.export import reap_stale_exports
 from frigate.jobs.motion_search import stop_all_motion_search_jobs
 from frigate.log import _stop_logging
 from frigate.models import (
@@ -610,6 +611,11 @@ class FrigateApp:
 
         # Clean up any stale replay camera artifacts (filesystem + DB)
         cleanup_replay_cameras()
+
+        # Reap any Export rows still marked in_progress from a previous
+        # session (crash, kill, broken migration). Runs synchronously before
+        # uvicorn binds so no API request can observe a stale row.
+        reap_stale_exports()
 
         self.init_inter_process_communicator()
         self.start_detectors()

--- a/frigate/config/camera/record.py
+++ b/frigate/config/camera/record.py
@@ -92,6 +92,12 @@ class RecordExportConfig(FrigateBaseModel):
         title="Export hwaccel args",
         description="Hardware acceleration args to use for export/transcode operations.",
     )
+    max_concurrent: int = Field(
+        default=3,
+        ge=1,
+        title="Maximum concurrent exports",
+        description="Maximum number of export jobs to process at the same time.",
+    )
 
 
 class RecordConfig(FrigateBaseModel):

--- a/frigate/jobs/export.py
+++ b/frigate/jobs/export.py
@@ -1,9 +1,11 @@
 """Export job management with queued background execution."""
 
 import logging
+import os
 import threading
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from queue import Full, Queue
 from typing import Any, Optional
 
@@ -228,6 +230,88 @@ _job_manager_lock = threading.Lock()
 
 def _get_max_concurrent(config: FrigateConfig) -> int:
     return int(config.record.export.max_concurrent)
+
+
+def reap_stale_exports() -> None:
+    """Sweep Export rows stuck with in_progress=True from previous sessions.
+
+    On Frigate startup no export job is alive yet, so any in_progress=True
+    row must be a leftover from a previous session that crashed, was killed
+    mid-export, or returned early from RecordingExporter.run() without
+    flipping the flag. For each stale row we either:
+
+    - delete the row (and any thumb) if the video file is missing or empty,
+      since there is nothing worth recovering
+    - flip in_progress to False if the video file exists on disk and is
+      non-empty, treating it as a completed export the user can manage
+      through the normal UI
+
+    Must only be called when the export job manager is certain to have no
+    active jobs — i.e., at Frigate startup, before any worker runs.
+
+    All exceptions are caught and logged; the caller does not need to wrap
+    this in a try/except. A failure on a single row will not stop the rest
+    of the sweep, and a failure in the top-level query will log and return.
+    """
+    try:
+        stale_exports = list(Export.select().where(Export.in_progress == True))  # noqa: E712
+    except Exception:
+        logger.exception("Failed to query stale in-progress exports")
+        return
+
+    if not stale_exports:
+        logger.debug("No stale in-progress exports found on startup")
+        return
+
+    flipped = 0
+    deleted = 0
+    errored = 0
+
+    for export in stale_exports:
+        try:
+            video_path = export.video_path
+            has_usable_file = False
+
+            if video_path:
+                try:
+                    has_usable_file = os.path.getsize(video_path) > 0
+                except OSError:
+                    has_usable_file = False
+
+            if has_usable_file:
+                # Unassign from any case on recovery: the user should
+                # re-triage a recovered export rather than have it silently
+                # reappear inside a case they curated.
+                Export.update(
+                    {Export.in_progress: False, Export.export_case: None}
+                ).where(Export.id == export.id).execute()
+                flipped += 1
+                logger.info(
+                    "Recovered stale in-progress export %s (file intact on disk)",
+                    export.id,
+                )
+                continue
+
+            if export.thumb_path:
+                Path(export.thumb_path).unlink(missing_ok=True)
+            if video_path:
+                Path(video_path).unlink(missing_ok=True)
+            Export.delete().where(Export.id == export.id).execute()
+            deleted += 1
+            logger.info(
+                "Deleted stale in-progress export %s (no usable file on disk)",
+                export.id,
+            )
+        except Exception:
+            errored += 1
+            logger.exception("Failed to reap stale export %s", export.id)
+
+    logger.info(
+        "Stale export cleanup complete: %d recovered, %d deleted, %d errored",
+        flipped,
+        deleted,
+        errored,
+    )
 
 
 def get_export_job_manager(config: FrigateConfig) -> ExportJobManager:

--- a/frigate/jobs/export.py
+++ b/frigate/jobs/export.py
@@ -167,6 +167,41 @@ class ExportJobManager:
                 if job.status in (JobStatusTypesEnum.queued, JobStatusTypesEnum.running)
             ]
 
+    def cancel_queued_jobs_for_case(self, case_id: str) -> list[ExportJob]:
+        """Cancel queued export jobs assigned to a deleted case."""
+        cancelled_jobs: list[ExportJob] = []
+
+        with self.lock:
+            with self.queue.mutex:
+                retained_jobs: list[ExportJob] = []
+
+                while self.queue.queue:
+                    job = self.queue.queue.popleft()
+
+                    if (
+                        job.export_case_id == case_id
+                        and job.status == JobStatusTypesEnum.queued
+                    ):
+                        job.status = JobStatusTypesEnum.cancelled
+                        job.end_time = time.time()
+                        cancelled_jobs.append(job)
+                        continue
+
+                    retained_jobs.append(job)
+
+                self.queue.queue.extend(retained_jobs)
+
+                if cancelled_jobs:
+                    self.queue.unfinished_tasks = max(
+                        0,
+                        self.queue.unfinished_tasks - len(cancelled_jobs),
+                    )
+                    if self.queue.unfinished_tasks == 0:
+                        self.queue.all_tasks_done.notify_all()
+                    self.queue.not_full.notify_all()
+
+        return cancelled_jobs
+
     def available_slots(self) -> int:
         """Approximate number of additional jobs that could be queued right now.
 
@@ -338,6 +373,13 @@ def get_export_job(config: FrigateConfig, job_id: str) -> Optional[ExportJob]:
 def list_active_export_jobs(config: FrigateConfig) -> list[ExportJob]:
     """List queued and running export jobs."""
     return get_export_job_manager(config).list_active_jobs()
+
+
+def cancel_queued_export_jobs_for_case(
+    config: FrigateConfig, case_id: str
+) -> list[ExportJob]:
+    """Cancel queued export jobs that still point at a deleted case."""
+    return get_export_job_manager(config).cancel_queued_jobs_for_case(case_id)
 
 
 def available_export_queue_slots(config: FrigateConfig) -> int:

--- a/frigate/jobs/export.py
+++ b/frigate/jobs/export.py
@@ -1,0 +1,261 @@
+"""Export job management with queued background execution."""
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from queue import Full, Queue
+from typing import Any, Optional
+
+from peewee import DoesNotExist
+
+from frigate.config import FrigateConfig
+from frigate.jobs.job import Job
+from frigate.models import Export
+from frigate.record.export import PlaybackSourceEnum, RecordingExporter
+from frigate.types import JobStatusTypesEnum
+
+logger = logging.getLogger(__name__)
+
+# Maximum number of jobs that can sit in the queue waiting to run.
+# Prevents a runaway client from unbounded memory growth.
+MAX_QUEUED_EXPORT_JOBS = 100
+
+
+class ExportQueueFullError(RuntimeError):
+    """Raised when the export queue is at capacity."""
+
+
+@dataclass
+class ExportJob(Job):
+    """Job state for export operations."""
+
+    job_type: str = "export"
+    camera: str = ""
+    name: Optional[str] = None
+    image_path: Optional[str] = None
+    export_case_id: Optional[str] = None
+    request_start_time: float = 0.0
+    request_end_time: float = 0.0
+    playback_source: str = PlaybackSourceEnum.recordings.value
+    ffmpeg_input_args: Optional[str] = None
+    ffmpeg_output_args: Optional[str] = None
+    cpu_fallback: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for API responses.
+
+        Only exposes fields that are part of the public ExportJobModel schema.
+        Internal execution details (image_path, ffmpeg args, cpu_fallback) are
+        intentionally omitted so they don't leak through the API.
+        """
+        return {
+            "id": self.id,
+            "job_type": self.job_type,
+            "status": self.status,
+            "camera": self.camera,
+            "name": self.name,
+            "export_case_id": self.export_case_id,
+            "request_start_time": self.request_start_time,
+            "request_end_time": self.request_end_time,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "error_message": self.error_message,
+            "results": self.results,
+        }
+
+
+class ExportQueueWorker(threading.Thread):
+    """Worker that executes queued exports."""
+
+    def __init__(self, manager: "ExportJobManager", worker_index: int) -> None:
+        super().__init__(
+            daemon=True,
+            name=f"export_queue_worker_{worker_index}",
+        )
+        self.manager = manager
+
+    def run(self) -> None:
+        while True:
+            job = self.manager.queue.get()
+
+            try:
+                self.manager.run_job(job)
+            except Exception:
+                logger.exception(
+                    "Export queue worker failed while processing %s", job.id
+                )
+            finally:
+                self.manager.queue.task_done()
+
+
+class ExportJobManager:
+    """Concurrency-limited manager for queued export jobs."""
+
+    def __init__(
+        self,
+        config: FrigateConfig,
+        max_concurrent: int,
+        max_queued: int = MAX_QUEUED_EXPORT_JOBS,
+    ) -> None:
+        self.config = config
+        self.max_concurrent = max(1, max_concurrent)
+        self.queue: Queue[ExportJob] = Queue(maxsize=max(1, max_queued))
+        self.jobs: dict[str, ExportJob] = {}
+        self.lock = threading.Lock()
+        self.workers: list[ExportQueueWorker] = []
+        self.started = False
+
+    def ensure_started(self) -> None:
+        """Ensure worker threads are started exactly once."""
+        with self.lock:
+            if self.started:
+                self._restart_dead_workers_locked()
+                return
+
+            for index in range(self.max_concurrent):
+                worker = ExportQueueWorker(self, index)
+                worker.start()
+                self.workers.append(worker)
+
+            self.started = True
+
+    def _restart_dead_workers_locked(self) -> None:
+        for index, worker in enumerate(self.workers):
+            if worker.is_alive():
+                continue
+
+            logger.error(
+                "Export queue worker %s died unexpectedly, restarting", worker.name
+            )
+            replacement = ExportQueueWorker(self, index)
+            replacement.start()
+            self.workers[index] = replacement
+
+    def enqueue(self, job: ExportJob) -> str:
+        """Queue a job for background execution.
+
+        Raises ExportQueueFullError if the queue is at capacity.
+        """
+        self.ensure_started()
+
+        try:
+            self.queue.put_nowait(job)
+        except Full as err:
+            raise ExportQueueFullError(
+                "Export queue is full; try again once current exports finish"
+            ) from err
+
+        with self.lock:
+            self.jobs[job.id] = job
+
+        return job.id
+
+    def get_job(self, job_id: str) -> Optional[ExportJob]:
+        """Get a job by ID."""
+        with self.lock:
+            return self.jobs.get(job_id)
+
+    def list_active_jobs(self) -> list[ExportJob]:
+        """List queued and running jobs."""
+        with self.lock:
+            return [
+                job
+                for job in self.jobs.values()
+                if job.status in (JobStatusTypesEnum.queued, JobStatusTypesEnum.running)
+            ]
+
+    def available_slots(self) -> int:
+        """Approximate number of additional jobs that could be queued right now.
+
+        Uses Queue.qsize() which is best-effort; callers should treat the
+        result as advisory since another thread could enqueue between
+        checking and enqueueing.
+        """
+        return max(0, self.queue.maxsize - self.queue.qsize())
+
+    def run_job(self, job: ExportJob) -> None:
+        """Execute a queued export job."""
+        job.status = JobStatusTypesEnum.running
+        job.start_time = time.time()
+
+        exporter = RecordingExporter(
+            self.config,
+            job.id,
+            job.camera,
+            job.name,
+            job.image_path,
+            int(job.request_start_time),
+            int(job.request_end_time),
+            PlaybackSourceEnum(job.playback_source),
+            job.export_case_id,
+            job.ffmpeg_input_args,
+            job.ffmpeg_output_args,
+            job.cpu_fallback,
+        )
+
+        try:
+            exporter.run()
+            export = Export.get_or_none(Export.id == job.id)
+            if export is None:
+                job.status = JobStatusTypesEnum.failed
+                job.error_message = "Export failed"
+            elif export.in_progress:
+                job.status = JobStatusTypesEnum.failed
+                job.error_message = "Export did not complete"
+            else:
+                job.status = JobStatusTypesEnum.success
+                job.results = {
+                    "export_id": export.id,
+                    "export_case_id": export.export_case_id,
+                    "video_path": export.video_path,
+                    "thumb_path": export.thumb_path,
+                }
+        except DoesNotExist:
+            job.status = JobStatusTypesEnum.failed
+            job.error_message = "Export not found"
+        except Exception as err:
+            logger.exception("Export job %s failed: %s", job.id, err)
+            job.status = JobStatusTypesEnum.failed
+            job.error_message = str(err)
+        finally:
+            job.end_time = time.time()
+
+
+_job_manager: Optional[ExportJobManager] = None
+_job_manager_lock = threading.Lock()
+
+
+def _get_max_concurrent(config: FrigateConfig) -> int:
+    return int(config.record.export.max_concurrent)
+
+
+def get_export_job_manager(config: FrigateConfig) -> ExportJobManager:
+    """Get or create the singleton export job manager."""
+    global _job_manager
+
+    with _job_manager_lock:
+        if _job_manager is None:
+            _job_manager = ExportJobManager(config, _get_max_concurrent(config))
+        _job_manager.ensure_started()
+        return _job_manager
+
+
+def start_export_job(config: FrigateConfig, job: ExportJob) -> str:
+    """Queue an export job and return its ID."""
+    return get_export_job_manager(config).enqueue(job)
+
+
+def get_export_job(config: FrigateConfig, job_id: str) -> Optional[ExportJob]:
+    """Get a queued or completed export job by ID."""
+    return get_export_job_manager(config).get_job(job_id)
+
+
+def list_active_export_jobs(config: FrigateConfig) -> list[ExportJob]:
+    """List queued and running export jobs."""
+    return get_export_job_manager(config).list_active_jobs()
+
+
+def available_export_queue_slots(config: FrigateConfig) -> int:
+    """Approximate number of additional export jobs that could be queued now."""
+    return get_export_job_manager(config).available_slots()

--- a/frigate/test/http_api/test_http_export.py
+++ b/frigate/test/http_api/test_http_export.py
@@ -1,0 +1,146 @@
+from unittest.mock import patch
+
+from frigate.models import Export, ExportCase, Previews, Recordings
+from frigate.test.http_api.base_http_test import AuthTestClient, BaseTestHttp
+
+
+class TestHttpExport(BaseTestHttp):
+    def setUp(self):
+        super().setUp([Export, ExportCase, Previews, Recordings])
+        self.minimal_config["cameras"]["backyard"] = {
+            "ffmpeg": {
+                "inputs": [{"path": "rtsp://10.0.0.2:554/video", "roles": ["detect"]}]
+            },
+            "detect": {
+                "height": 1080,
+                "width": 1920,
+                "fps": 5,
+            },
+        }
+        self.app = super().create_app()
+
+    def tearDown(self):
+        self.app.dependency_overrides.clear()
+        super().tearDown()
+
+    def _insert_recording(
+        self,
+        recording_id: str,
+        camera: str,
+        start_time: float,
+        end_time: float,
+    ) -> None:
+        Recordings.create(
+            id=recording_id,
+            camera=camera,
+            path=f"/tmp/{recording_id}.mp4",
+            start_time=start_time,
+            end_time=end_time,
+            duration=end_time - start_time,
+            motion=0,
+            objects=0,
+            dBFS=0,
+            segment_size=1,
+            regions=0,
+            motion_heatmap=[],
+        )
+
+    def test_create_export_case_uses_wall_clock_time(self):
+        with patch("frigate.api.export.time.time", return_value=1234.5):
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/cases",
+                    json={
+                        "name": "Investigation",
+                        "description": "A test case",
+                    },
+                )
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert response_json["created_at"] == 1234.5
+        assert response_json["updated_at"] == 1234.5
+
+        case = ExportCase.get(ExportCase.id == response_json["id"])
+        assert case.created_at.timestamp() == 1234.5
+        assert case.updated_at.timestamp() == 1234.5
+
+    def test_update_export_case_refreshes_updated_at(self):
+        case = ExportCase.create(
+            id="case123",
+            name="Old name",
+            description="Old description",
+            created_at=10,
+            updated_at=10,
+        )
+
+        with patch("frigate.api.export.time.time", return_value=2222.0):
+            with AuthTestClient(self.app) as client:
+                response = client.patch(
+                    f"/cases/{case.id}",
+                    json={"name": "New name", "description": "Updated"},
+                )
+
+        assert response.status_code == 200
+
+        refreshed = ExportCase.get(ExportCase.id == case.id)
+        assert refreshed.name == "New name"
+        assert refreshed.description == "Updated"
+        assert refreshed.updated_at.timestamp() == 2222.0
+
+    def test_batch_export_creates_case_and_reports_partial_success(self):
+        self._insert_recording("rec-front", "front_door", 100, 200)
+
+        with patch("frigate.api.export._start_exporter") as start_exporter:
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    json={
+                        "start_time": 110,
+                        "end_time": 150,
+                        "camera_ids": ["front_door", "backyard"],
+                        "name": "Incident",
+                        "new_case_name": "Case Alpha",
+                        "new_case_description": "Batch export",
+                    },
+                )
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert len(response_json["export_ids"]) == 1
+        assert response_json["results"] == [
+            {
+                "camera": "front_door",
+                "export_id": response_json["export_ids"][0],
+                "success": True,
+                "error": None,
+            },
+            {
+                "camera": "backyard",
+                "export_id": None,
+                "success": False,
+                "error": "No recordings found for time range",
+            },
+        ]
+        start_exporter.assert_called_once()
+
+        case = ExportCase.get(ExportCase.id == response_json["export_case_id"])
+        assert case.name == "Case Alpha"
+        assert case.description == "Batch export"
+
+    def test_batch_export_requires_case_target(self):
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/batch",
+                json={
+                    "start_time": 110,
+                    "end_time": 150,
+                    "camera_ids": ["front_door"],
+                },
+            )
+
+        assert response.status_code == 422
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "Value error, Either export_case_id or new_case_name must be provided"
+        )

--- a/frigate/test/http_api/test_http_export.py
+++ b/frigate/test/http_api/test_http_export.py
@@ -504,26 +504,32 @@ class TestHttpExport(BaseTestHttp):
             assert row.in_progress is False
             assert os.path.exists(done_video)
 
-    def test_batch_export_requires_case_target(self):
-        with AuthTestClient(self.app) as client:
-            response = client.post(
-                "/exports/batch",
-                json={
-                    "items": [
-                        {
-                            "camera": "front_door",
-                            "start_time": 110,
-                            "end_time": 150,
-                        }
-                    ],
-                },
-            )
+    def test_batch_export_without_case_goes_to_uncategorized(self):
+        """Exports without a case target go to uncategorized."""
+        self._insert_recording("rec-front", "front_door", 100, 400)
 
-        assert response.status_code == 422
-        assert (
-            response.json()["detail"][0]["msg"]
-            == "Value error, Either export_case_id or new_case_name must be provided"
-        )
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ):
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                            }
+                        ],
+                    },
+                )
+
+        assert response.status_code == 202
+        response_json = response.json()
+        assert response_json["export_case_id"] is None
+        assert ExportCase.select().count() == 0
 
     # --- /exports/batch (item-shaped multi-export) ---------------------------
 
@@ -651,26 +657,33 @@ class TestHttpExport(BaseTestHttp):
             == "Value error, end_time must be after start_time"
         )
 
-    def test_batch_export_missing_case_target_rejected(self):
-        with AuthTestClient(self.app) as client:
-            response = client.post(
-                "/exports/batch",
-                json={
-                    "items": [
-                        {
-                            "camera": "front_door",
-                            "start_time": 100,
-                            "end_time": 150,
-                        }
-                    ],
-                },
-            )
+    def test_batch_export_non_admin_without_case_goes_to_uncategorized(self):
+        """Non-admin batch exports go to uncategorized."""
+        self._insert_recording("rec-front", "front_door", 100, 400)
 
-        assert response.status_code == 422
-        assert (
-            response.json()["detail"][0]["msg"]
-            == "Value error, Either export_case_id or new_case_name must be provided"
-        )
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ):
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    headers={"remote-user": "viewer", "remote-role": "viewer"},
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 100,
+                                "end_time": 150,
+                            }
+                        ],
+                    },
+                )
+
+        assert response.status_code == 202
+        response_json = response.json()
+        assert response_json["export_case_id"] is None
+        assert ExportCase.select().count() == 0
 
     def test_batch_export_camera_access_denied_fails_closed(self):
         from fastapi import Request
@@ -1108,3 +1121,313 @@ class TestHttpExport(BaseTestHttp):
 
         assert response.status_code == 202
         assert response.json()["success"] is True
+
+    # ── Bulk delete exports ────────────────────────────────────────
+
+    def test_bulk_delete_exports_success(self):
+        """All IDs exist, none in-progress → 200, all deleted."""
+        Export.create(
+            id="exp1",
+            camera="front_door",
+            name="export_1",
+            date=100,
+            video_path="/tmp/exp1.mp4",
+            thumb_path="/tmp/exp1.jpg",
+            in_progress=False,
+        )
+        Export.create(
+            id="exp2",
+            camera="front_door",
+            name="export_2",
+            date=200,
+            video_path="/tmp/exp2.mp4",
+            thumb_path="/tmp/exp2.jpg",
+            in_progress=False,
+        )
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/delete",
+                json={"ids": ["exp1", "exp2"]},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        assert Export.select().count() == 0
+
+    def test_bulk_delete_exports_single_item(self):
+        """Regression: single-item delete via batch endpoint."""
+        Export.create(
+            id="exp1",
+            camera="front_door",
+            name="export_1",
+            date=100,
+            video_path="/tmp/exp1.mp4",
+            thumb_path="/tmp/exp1.jpg",
+            in_progress=False,
+        )
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/delete",
+                json={"ids": ["exp1"]},
+            )
+
+        assert response.status_code == 200
+        assert Export.select().count() == 0
+
+    def test_bulk_delete_exports_some_missing(self):
+        """Some IDs don't exist → 404, nothing deleted."""
+        Export.create(
+            id="exp1",
+            camera="front_door",
+            name="export_1",
+            date=100,
+            video_path="/tmp/exp1.mp4",
+            thumb_path="/tmp/exp1.jpg",
+            in_progress=False,
+        )
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/delete",
+                json={"ids": ["exp1", "nonexistent"]},
+            )
+
+        assert response.status_code == 404
+        # Nothing deleted
+        assert Export.select().count() == 1
+
+    def test_bulk_delete_exports_all_missing(self):
+        """All IDs don't exist → 404."""
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/delete",
+                json={"ids": ["nope1", "nope2"]},
+            )
+
+        assert response.status_code == 404
+
+    def test_bulk_delete_exports_in_progress(self):
+        """Some exports in-progress → 400, nothing deleted."""
+        Export.create(
+            id="exp1",
+            camera="front_door",
+            name="export_1",
+            date=100,
+            video_path=f"{os.environ.get('EXPORT_DIR', '/media/frigate/exports')}/exp1.mp4",
+            thumb_path="/tmp/exp1.jpg",
+            in_progress=True,
+        )
+
+        with patch(
+            "frigate.api.export._get_files_in_use",
+            return_value={"exp1.mp4"},
+        ):
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/delete",
+                    json={"ids": ["exp1"]},
+                )
+
+        assert response.status_code == 400
+        assert Export.select().count() == 1
+
+    def test_bulk_delete_exports_non_admin_rejected(self):
+        """Non-admin users cannot bulk delete."""
+        Export.create(
+            id="exp1",
+            camera="front_door",
+            name="export_1",
+            date=100,
+            video_path="/tmp/exp1.mp4",
+            thumb_path="/tmp/exp1.jpg",
+            in_progress=False,
+        )
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/delete",
+                headers={"remote-user": "viewer", "remote-role": "viewer"},
+                json={"ids": ["exp1"]},
+            )
+
+        assert response.status_code == 403
+        assert Export.select().count() == 1
+
+    # ── Bulk reassign exports ──────────────────────────────────────
+
+    def test_bulk_reassign_exports_to_case(self):
+        """All IDs exist, case exists → 200, all reassigned."""
+        ExportCase.create(
+            id="case1",
+            name="Test Case",
+            description="",
+            created_at=10,
+            updated_at=10,
+        )
+        Export.create(
+            id="exp1",
+            camera="front_door",
+            name="export_1",
+            date=100,
+            video_path="/tmp/exp1.mp4",
+            thumb_path="/tmp/exp1.jpg",
+            in_progress=False,
+        )
+        Export.create(
+            id="exp2",
+            camera="front_door",
+            name="export_2",
+            date=200,
+            video_path="/tmp/exp2.mp4",
+            thumb_path="/tmp/exp2.jpg",
+            in_progress=False,
+        )
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/reassign",
+                json={"ids": ["exp1", "exp2"], "export_case_id": "case1"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        for exp_id in ["exp1", "exp2"]:
+            exp = Export.get(Export.id == exp_id)
+            assert exp.export_case_id == "case1"
+
+    def test_bulk_reassign_exports_to_null(self):
+        """Reassign to null (uncategorize) → 200."""
+        ExportCase.create(
+            id="case1",
+            name="Test Case",
+            description="",
+            created_at=10,
+            updated_at=10,
+        )
+        Export.create(
+            id="exp1",
+            camera="front_door",
+            name="export_1",
+            date=100,
+            video_path="/tmp/exp1.mp4",
+            thumb_path="/tmp/exp1.jpg",
+            in_progress=False,
+            export_case="case1",
+        )
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/reassign",
+                json={"ids": ["exp1"], "export_case_id": None},
+            )
+
+        assert response.status_code == 200
+        exp = Export.get(Export.id == "exp1")
+        assert exp.export_case_id is None
+
+    def test_bulk_reassign_exports_single_item(self):
+        """Regression: single-item reassign via batch endpoint."""
+        ExportCase.create(
+            id="case1",
+            name="Test Case",
+            description="",
+            created_at=10,
+            updated_at=10,
+        )
+        Export.create(
+            id="exp1",
+            camera="front_door",
+            name="export_1",
+            date=100,
+            video_path="/tmp/exp1.mp4",
+            thumb_path="/tmp/exp1.jpg",
+            in_progress=False,
+        )
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/reassign",
+                json={"ids": ["exp1"], "export_case_id": "case1"},
+            )
+
+        assert response.status_code == 200
+        exp = Export.get(Export.id == "exp1")
+        assert exp.export_case_id == "case1"
+
+    def test_bulk_reassign_exports_some_missing(self):
+        """Some IDs don't exist → 404, nothing reassigned."""
+        ExportCase.create(
+            id="case1",
+            name="Test Case",
+            description="",
+            created_at=10,
+            updated_at=10,
+        )
+        Export.create(
+            id="exp1",
+            camera="front_door",
+            name="export_1",
+            date=100,
+            video_path="/tmp/exp1.mp4",
+            thumb_path="/tmp/exp1.jpg",
+            in_progress=False,
+        )
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/reassign",
+                json={
+                    "ids": ["exp1", "nonexistent"],
+                    "export_case_id": "case1",
+                },
+            )
+
+        assert response.status_code == 404
+        # Nothing reassigned
+        exp = Export.get(Export.id == "exp1")
+        assert exp.export_case_id is None
+
+    def test_bulk_reassign_exports_case_not_found(self):
+        """Target case doesn't exist → 404."""
+        Export.create(
+            id="exp1",
+            camera="front_door",
+            name="export_1",
+            date=100,
+            video_path="/tmp/exp1.mp4",
+            thumb_path="/tmp/exp1.jpg",
+            in_progress=False,
+        )
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/reassign",
+                json={"ids": ["exp1"], "export_case_id": "nonexistent"},
+            )
+
+        assert response.status_code == 404
+        exp = Export.get(Export.id == "exp1")
+        assert exp.export_case_id is None
+
+    def test_bulk_reassign_exports_non_admin_rejected(self):
+        """Non-admin users cannot bulk reassign."""
+        Export.create(
+            id="exp1",
+            camera="front_door",
+            name="export_1",
+            date=100,
+            video_path="/tmp/exp1.mp4",
+            thumb_path="/tmp/exp1.jpg",
+            in_progress=False,
+        )
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/reassign",
+                headers={"remote-user": "viewer", "remote-role": "viewer"},
+                json={"ids": ["exp1"], "export_case_id": None},
+            )
+
+        assert response.status_code == 403

--- a/frigate/test/http_api/test_http_export.py
+++ b/frigate/test/http_api/test_http_export.py
@@ -1,6 +1,8 @@
+import os
+import tempfile
 from unittest.mock import patch
 
-from frigate.jobs.export import ExportJob
+from frigate.jobs.export import ExportJob, reap_stale_exports
 from frigate.models import Export, ExportCase, Previews, Recordings
 from frigate.test.http_api.base_http_test import AuthTestClient, BaseTestHttp
 
@@ -226,6 +228,144 @@ class TestHttpExport(BaseTestHttp):
 
         assert response.status_code == 200
         assert response.json() == [queued_job.to_dict()]
+
+    def test_reap_stale_exports_deletes_rows_with_no_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stale_video = os.path.join(tmpdir, "stale.mp4")
+            stale_thumb = os.path.join(tmpdir, "stale.webp")
+            # stale_video is intentionally NOT created
+            with open(stale_thumb, "w") as handle:
+                handle.write("thumb")
+
+            Export.create(
+                id="stale_no_file",
+                camera="front_door",
+                name="Stuck export",
+                date=100,
+                video_path=stale_video,
+                thumb_path=stale_thumb,
+                in_progress=True,
+            )
+
+            reap_stale_exports()
+
+            assert Export.get_or_none(Export.id == "stale_no_file") is None
+            assert not os.path.exists(stale_thumb)
+
+    def test_reap_stale_exports_recovers_rows_with_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            intact_video = os.path.join(tmpdir, "intact.mp4")
+            intact_thumb = os.path.join(tmpdir, "intact.webp")
+            with open(intact_video, "wb") as handle:
+                handle.write(b"not actually an mp4 but non-empty")
+            with open(intact_thumb, "wb") as handle:
+                handle.write(b"thumb")
+
+            case = ExportCase.create(
+                id="case_for_stale",
+                name="Curated case",
+                description="",
+                created_at=10,
+                updated_at=10,
+            )
+
+            Export.create(
+                id="stale_with_file",
+                camera="front_door",
+                name="Recoverable export",
+                date=200,
+                video_path=intact_video,
+                thumb_path=intact_thumb,
+                in_progress=True,
+                export_case=case,
+            )
+
+            reap_stale_exports()
+
+            recovered = Export.get(Export.id == "stale_with_file")
+            assert recovered.in_progress is False
+            # Case link must be cleared so the user re-triages the recovered row
+            assert recovered.export_case is None
+            # The case itself is untouched
+            assert ExportCase.get_or_none(ExportCase.id == "case_for_stale") is not None
+            # Recovered files must NOT be unlinked
+            assert os.path.exists(intact_video)
+            assert os.path.exists(intact_thumb)
+
+    def test_reap_stale_exports_delete_path_severs_case_link(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_video = os.path.join(tmpdir, "missing.mp4")
+            # file intentionally not created
+
+            case = ExportCase.create(
+                id="case_losing_member",
+                name="Case losing a member",
+                description="",
+                created_at=20,
+                updated_at=20,
+            )
+
+            Export.create(
+                id="stale_in_case_no_file",
+                camera="front_door",
+                name="Stuck and in a case",
+                date=250,
+                video_path=missing_video,
+                thumb_path="",
+                in_progress=True,
+                export_case=case,
+            )
+
+            reap_stale_exports()
+
+            # The export row is gone entirely
+            assert Export.get_or_none(Export.id == "stale_in_case_no_file") is None
+            # The case stays but has no exports pointing at it
+            remaining_case = ExportCase.get(ExportCase.id == "case_losing_member")
+            assert list(remaining_case.exports) == []
+
+    def test_reap_stale_exports_deletes_rows_with_empty_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            empty_video = os.path.join(tmpdir, "empty.mp4")
+            # Create a zero-byte file — partial ffmpeg output
+            open(empty_video, "w").close()
+
+            Export.create(
+                id="stale_empty_file",
+                camera="front_door",
+                name="Zero byte export",
+                date=300,
+                video_path=empty_video,
+                thumb_path="",
+                in_progress=True,
+            )
+
+            reap_stale_exports()
+
+            assert Export.get_or_none(Export.id == "stale_empty_file") is None
+            assert not os.path.exists(empty_video)
+
+    def test_reap_stale_exports_skips_completed_rows(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            done_video = os.path.join(tmpdir, "done.mp4")
+            with open(done_video, "wb") as handle:
+                handle.write(b"done")
+
+            Export.create(
+                id="already_done",
+                camera="front_door",
+                name="Completed export",
+                date=400,
+                video_path=done_video,
+                thumb_path="",
+                in_progress=False,
+            )
+
+            reap_stale_exports()
+
+            row = Export.get(Export.id == "already_done")
+            assert row.in_progress is False
+            assert os.path.exists(done_video)
 
     def test_batch_export_requires_case_target(self):
         with AuthTestClient(self.app) as client:

--- a/frigate/test/http_api/test_http_export.py
+++ b/frigate/test/http_api/test_http_export.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from frigate.jobs.export import ExportJob
 from frigate.models import Export, ExportCase, Previews, Recordings
 from frigate.test.http_api.base_http_test import AuthTestClient, BaseTestHttp
 
@@ -91,7 +92,10 @@ class TestHttpExport(BaseTestHttp):
     def test_batch_export_creates_case_and_reports_partial_success(self):
         self._insert_recording("rec-front", "front_door", 100, 200)
 
-        with patch("frigate.api.export._start_exporter") as start_exporter:
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ) as start_export_job:
             with AuthTestClient(self.app) as client:
                 response = client.post(
                     "/exports/batch",
@@ -105,7 +109,7 @@ class TestHttpExport(BaseTestHttp):
                     },
                 )
 
-        assert response.status_code == 200
+        assert response.status_code == 202
         response_json = response.json()
         assert len(response_json["export_ids"]) == 1
         assert response_json["results"] == [
@@ -113,20 +117,115 @@ class TestHttpExport(BaseTestHttp):
                 "camera": "front_door",
                 "export_id": response_json["export_ids"][0],
                 "success": True,
+                "status": "queued",
                 "error": None,
             },
             {
                 "camera": "backyard",
                 "export_id": None,
                 "success": False,
+                "status": None,
                 "error": "No recordings found for time range",
             },
         ]
-        start_exporter.assert_called_once()
+        start_export_job.assert_called_once()
 
         case = ExportCase.get(ExportCase.id == response_json["export_case_id"])
         assert case.name == "Case Alpha"
         assert case.description == "Batch export"
+
+    def test_single_export_is_queued_immediately(self):
+        self._insert_recording("rec-front", "front_door", 100, 200)
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ) as start_export_job:
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/export/front_door/start/110/end/150",
+                    json={
+                        "name": "Queued export",
+                    },
+                )
+
+        assert response.status_code == 202
+        response_json = response.json()
+        assert response_json["success"] is True
+        assert response_json["status"] == "queued"
+        assert response_json["export_id"].startswith("front_door_")
+        start_export_job.assert_called_once()
+
+    def test_single_export_returns_503_when_queue_full(self):
+        self._insert_recording("rec-front", "front_door", 100, 200)
+
+        from frigate.jobs.export import ExportQueueFullError
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=ExportQueueFullError("Export queue is full"),
+        ):
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/export/front_door/start/110/end/150",
+                    json={
+                        "name": "Rejected export",
+                    },
+                )
+
+        assert response.status_code == 503
+        response_json = response.json()
+        assert response_json["success"] is False
+        assert "queue is full" in response_json["message"].lower()
+
+    def test_batch_export_returns_503_when_queue_cannot_fit_batch(self):
+        self._insert_recording("rec-front", "front_door", 100, 200)
+        self._insert_recording("rec-back", "backyard", 100, 200)
+
+        with patch(
+            "frigate.api.export.available_export_queue_slots",
+            return_value=1,
+        ):
+            with patch(
+                "frigate.api.export.start_export_job",
+                side_effect=lambda _config, job: job.id,
+            ) as start_export_job:
+                with AuthTestClient(self.app) as client:
+                    response = client.post(
+                        "/exports/batch",
+                        json={
+                            "start_time": 110,
+                            "end_time": 150,
+                            "camera_ids": ["front_door", "backyard"],
+                            "new_case_name": "Overflow Case",
+                        },
+                    )
+
+        assert response.status_code == 503
+        assert response.json()["success"] is False
+        start_export_job.assert_not_called()
+
+        # Empty case should NOT have been created
+        assert ExportCase.select().count() == 0
+
+    def test_get_active_export_jobs_returns_queue_state(self):
+        queued_job = ExportJob(
+            id="front_door_queued",
+            camera="front_door",
+            status="queued",
+            request_start_time=100,
+            request_end_time=150,
+        )
+
+        with patch(
+            "frigate.api.export.list_active_export_jobs",
+            return_value=[queued_job],
+        ):
+            with AuthTestClient(self.app) as client:
+                response = client.get("/jobs/export")
+
+        assert response.status_code == 200
+        assert response.json() == [queued_job.to_dict()]
 
     def test_batch_export_requires_case_target(self):
         with AuthTestClient(self.app) as client:

--- a/frigate/test/http_api/test_http_export.py
+++ b/frigate/test/http_api/test_http_export.py
@@ -2,7 +2,12 @@ import os
 import tempfile
 from unittest.mock import patch
 
-from frigate.jobs.export import ExportJob, reap_stale_exports
+from frigate.jobs.export import (
+    ExportJob,
+    get_export_job_manager,
+    reap_stale_exports,
+    start_export_job,
+)
 from frigate.models import Export, ExportCase, Previews, Recordings
 from frigate.test.http_api.base_http_test import AuthTestClient, BaseTestHttp
 
@@ -90,6 +95,115 @@ class TestHttpExport(BaseTestHttp):
         assert refreshed.name == "New name"
         assert refreshed.description == "Updated"
         assert refreshed.updated_at.timestamp() == 2222.0
+
+    def test_delete_export_case_delete_exports_cancels_queued_jobs(self):
+        case = ExportCase.create(
+            id="case_delete_me",
+            name="Delete me",
+            description="",
+            created_at=10,
+            updated_at=10,
+        )
+        other_case = ExportCase.create(
+            id="case_keep_me",
+            name="Keep me",
+            description="",
+            created_at=20,
+            updated_at=20,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_path = os.path.join(tmpdir, "case_export.mp4")
+            thumb_path = os.path.join(tmpdir, "case_export.webp")
+            other_video_path = os.path.join(tmpdir, "other_export.mp4")
+            other_thumb_path = os.path.join(tmpdir, "other_export.webp")
+
+            with open(video_path, "wb") as handle:
+                handle.write(b"case")
+            with open(thumb_path, "wb") as handle:
+                handle.write(b"thumb")
+            with open(other_video_path, "wb") as handle:
+                handle.write(b"other")
+            with open(other_thumb_path, "wb") as handle:
+                handle.write(b"thumb")
+
+            Export.create(
+                id="export_in_case",
+                camera="front_door",
+                name="Case export",
+                date=100,
+                video_path=video_path,
+                thumb_path=thumb_path,
+                in_progress=False,
+                export_case=case,
+            )
+            Export.create(
+                id="export_other_case",
+                camera="front_door",
+                name="Other export",
+                date=110,
+                video_path=other_video_path,
+                thumb_path=other_thumb_path,
+                in_progress=False,
+                export_case=other_case,
+            )
+
+            with (
+                patch("frigate.jobs.export._job_manager", None),
+                patch(
+                    "frigate.jobs.export.ExportJobManager.ensure_started",
+                    autospec=True,
+                    return_value=None,
+                ),
+            ):
+                start_export_job(
+                    self.app.frigate_config,
+                    ExportJob(
+                        id="queued_case_job",
+                        camera="front_door",
+                        export_case_id=case.id,
+                        request_start_time=100,
+                        request_end_time=120,
+                    ),
+                )
+                start_export_job(
+                    self.app.frigate_config,
+                    ExportJob(
+                        id="queued_other_job",
+                        camera="front_door",
+                        export_case_id=other_case.id,
+                        request_start_time=130,
+                        request_end_time=150,
+                    ),
+                )
+
+                manager = get_export_job_manager(self.app.frigate_config)
+                assert {job.id for job in manager.list_active_jobs()} == {
+                    "queued_case_job",
+                    "queued_other_job",
+                }
+
+                with AuthTestClient(self.app) as client:
+                    response = client.delete(f"/cases/{case.id}?delete_exports=true")
+
+            assert response.status_code == 200
+            assert ExportCase.get_or_none(ExportCase.id == case.id) is None
+            assert ExportCase.get_or_none(ExportCase.id == other_case.id) is not None
+            assert Export.get_or_none(Export.id == "export_in_case") is None
+            assert Export.get_or_none(Export.id == "export_other_case") is not None
+            assert not os.path.exists(video_path)
+            assert not os.path.exists(thumb_path)
+
+            cancelled_job = manager.get_job("queued_case_job")
+            assert cancelled_job is not None
+            assert cancelled_job.status == "cancelled"
+
+            remaining_job = manager.get_job("queued_other_job")
+            assert remaining_job is not None
+            assert remaining_job.status == "queued"
+            assert [job.id for job in manager.list_active_jobs()] == [
+                "queued_other_job"
+            ]
 
     def test_batch_export_creates_case_and_reports_partial_success(self):
         self._insert_recording("rec-front", "front_door", 100, 200)

--- a/frigate/test/http_api/test_http_export.py
+++ b/frigate/test/http_api/test_http_export.py
@@ -102,10 +102,20 @@ class TestHttpExport(BaseTestHttp):
                 response = client.post(
                     "/exports/batch",
                     json={
-                        "start_time": 110,
-                        "end_time": 150,
-                        "camera_ids": ["front_door", "backyard"],
-                        "name": "Incident",
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                                "friendly_name": "Incident - Front Door",
+                            },
+                            {
+                                "camera": "backyard",
+                                "start_time": 110,
+                                "end_time": 150,
+                                "friendly_name": "Incident - Backyard",
+                            },
+                        ],
                         "new_case_name": "Case Alpha",
                         "new_case_description": "Batch export",
                     },
@@ -121,6 +131,8 @@ class TestHttpExport(BaseTestHttp):
                 "success": True,
                 "status": "queued",
                 "error": None,
+                "item_index": 0,
+                "client_item_id": None,
             },
             {
                 "camera": "backyard",
@@ -128,6 +140,8 @@ class TestHttpExport(BaseTestHttp):
                 "success": False,
                 "status": None,
                 "error": "No recordings found for time range",
+                "item_index": 1,
+                "client_item_id": None,
             },
         ]
         start_export_job.assert_called_once()
@@ -196,9 +210,18 @@ class TestHttpExport(BaseTestHttp):
                     response = client.post(
                         "/exports/batch",
                         json={
-                            "start_time": 110,
-                            "end_time": 150,
-                            "camera_ids": ["front_door", "backyard"],
+                            "items": [
+                                {
+                                    "camera": "front_door",
+                                    "start_time": 110,
+                                    "end_time": 150,
+                                },
+                                {
+                                    "camera": "backyard",
+                                    "start_time": 110,
+                                    "end_time": 150,
+                                },
+                            ],
                             "new_case_name": "Overflow Case",
                         },
                     )
@@ -372,9 +395,13 @@ class TestHttpExport(BaseTestHttp):
             response = client.post(
                 "/exports/batch",
                 json={
-                    "start_time": 110,
-                    "end_time": 150,
-                    "camera_ids": ["front_door"],
+                    "items": [
+                        {
+                            "camera": "front_door",
+                            "start_time": 110,
+                            "end_time": 150,
+                        }
+                    ],
                 },
             )
 
@@ -383,3 +410,587 @@ class TestHttpExport(BaseTestHttp):
             response.json()["detail"][0]["msg"]
             == "Value error, Either export_case_id or new_case_name must be provided"
         )
+
+    # --- /exports/batch (item-shaped multi-export) ---------------------------
+
+    def test_batch_export_happy_path_creates_case_and_queues_all(self):
+        self._insert_recording("rec-front", "front_door", 100, 400)
+        self._insert_recording("rec-back", "backyard", 100, 400)
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ) as start_export_job:
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                            },
+                            {
+                                "camera": "front_door",
+                                "start_time": 200,
+                                "end_time": 240,
+                            },
+                            {
+                                "camera": "backyard",
+                                "start_time": 300,
+                                "end_time": 340,
+                            },
+                        ],
+                        "new_case_name": "Incident Apr 11",
+                        "new_case_description": "Review items",
+                    },
+                )
+
+        assert response.status_code == 202
+        response_json = response.json()
+        assert len(response_json["export_ids"]) == 3
+        assert all(r["success"] for r in response_json["results"])
+        assert [r["item_index"] for r in response_json["results"]] == [0, 1, 2]
+        assert start_export_job.call_count == 3
+
+        case = ExportCase.get(ExportCase.id == response_json["export_case_id"])
+        assert case.name == "Incident Apr 11"
+        assert case.description == "Review items"
+
+    def test_batch_export_existing_case_does_not_create_new_case(self):
+        self._insert_recording("rec-front", "front_door", 100, 400)
+        ExportCase.create(
+            id="existing_case",
+            name="Existing",
+            description="",
+            created_at=10,
+            updated_at=10,
+        )
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ):
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                            }
+                        ],
+                        "export_case_id": "existing_case",
+                    },
+                )
+
+        assert response.status_code == 202
+        assert response.json()["export_case_id"] == "existing_case"
+        # No additional case was created
+        assert ExportCase.select().count() == 1
+
+    def test_batch_export_empty_items_rejected(self):
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/batch",
+                json={"items": [], "new_case_name": "Empty"},
+            )
+
+        assert response.status_code == 422
+
+    def test_batch_export_over_limit_rejected(self):
+        items = [
+            {"camera": "front_door", "start_time": 100 + i, "end_time": 100 + i + 5}
+            for i in range(51)
+        ]
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/batch",
+                json={"items": items, "new_case_name": "Too many"},
+            )
+
+        assert response.status_code == 422
+
+    def test_batch_export_end_before_start_rejected(self):
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/batch",
+                json={
+                    "items": [
+                        {
+                            "camera": "front_door",
+                            "start_time": 200,
+                            "end_time": 100,
+                        }
+                    ],
+                    "new_case_name": "Bad range",
+                },
+            )
+
+        assert response.status_code == 422
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "Value error, end_time must be after start_time"
+        )
+
+    def test_batch_export_missing_case_target_rejected(self):
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/batch",
+                json={
+                    "items": [
+                        {
+                            "camera": "front_door",
+                            "start_time": 100,
+                            "end_time": 150,
+                        }
+                    ],
+                },
+            )
+
+        assert response.status_code == 422
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "Value error, Either export_case_id or new_case_name must be provided"
+        )
+
+    def test_batch_export_camera_access_denied_fails_closed(self):
+        from fastapi import Request
+
+        from frigate.api.auth import get_allowed_cameras_for_filter
+
+        self._insert_recording("rec-front", "front_door", 100, 400)
+
+        async def restricted(request: Request):
+            return ["front_door"]
+
+        self.app.dependency_overrides[get_allowed_cameras_for_filter] = restricted
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ) as start_export_job:
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                            },
+                            {
+                                "camera": "backyard",  # not in allowed list
+                                "start_time": 110,
+                                "end_time": 150,
+                            },
+                        ],
+                        "new_case_name": "Nope",
+                    },
+                )
+
+        assert response.status_code == 403
+        start_export_job.assert_not_called()
+        # No case created
+        assert ExportCase.select().count() == 0
+
+    def test_batch_export_case_not_found(self):
+        self._insert_recording("rec-front", "front_door", 100, 400)
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/batch",
+                json={
+                    "items": [
+                        {
+                            "camera": "front_door",
+                            "start_time": 110,
+                            "end_time": 150,
+                        }
+                    ],
+                    "export_case_id": "does_not_exist",
+                },
+            )
+
+        assert response.status_code == 404
+
+    def test_batch_export_per_item_missing_recordings_partial_success(self):
+        self._insert_recording("rec-front", "front_door", 100, 200)
+        # backyard has no recordings at all
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ) as start_export_job:
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                            },
+                            {
+                                "camera": "backyard",
+                                "start_time": 110,
+                                "end_time": 150,
+                            },
+                        ],
+                        "new_case_name": "Partial",
+                    },
+                )
+
+        assert response.status_code == 202
+        response_json = response.json()
+        assert len(response_json["export_ids"]) == 1
+        results_by_camera = {r["camera"]: r for r in response_json["results"]}
+        assert results_by_camera["front_door"]["success"] is True
+        assert results_by_camera["backyard"]["success"] is False
+        assert (
+            results_by_camera["backyard"]["error"]
+            == "No recordings found for time range"
+        )
+        start_export_job.assert_called_once()
+
+        # Case is still created because at least one item succeeded
+        assert (
+            ExportCase.get(ExportCase.id == response_json["export_case_id"]) is not None
+        )
+
+    def test_batch_export_same_camera_different_ranges_one_missing(self):
+        # Recording covers 100-200 only. First item fits, second does not.
+        self._insert_recording("rec-front", "front_door", 100, 200)
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ) as start_export_job:
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                            },
+                            {
+                                "camera": "front_door",
+                                "start_time": 500,
+                                "end_time": 540,
+                            },
+                        ],
+                        "new_case_name": "Split recordings",
+                    },
+                )
+
+        assert response.status_code == 202
+        response_json = response.json()
+        assert len(response_json["export_ids"]) == 1
+        results = response_json["results"]
+        assert results[0]["success"] is True
+        assert results[0]["item_index"] == 0
+        assert results[1]["success"] is False
+        assert results[1]["item_index"] == 1
+        assert results[1]["error"] == "No recordings found for time range"
+        # Both results carry the same camera — item_index is the only way
+        # the client can tell them apart.
+        assert results[0]["camera"] == results[1]["camera"] == "front_door"
+        start_export_job.assert_called_once()
+
+    def test_batch_export_all_missing_recordings_rolls_back_case(self):
+        # No recordings inserted at all
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ) as start_export_job:
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                            }
+                        ],
+                        "new_case_name": "Should rollback",
+                    },
+                )
+
+        assert response.status_code == 400
+        start_export_job.assert_not_called()
+        assert ExportCase.select().count() == 0
+
+    def test_batch_export_preflight_queue_full(self):
+        self._insert_recording("rec-front", "front_door", 100, 400)
+        self._insert_recording("rec-back", "backyard", 100, 400)
+
+        with patch(
+            "frigate.api.export.available_export_queue_slots",
+            return_value=1,
+        ):
+            with patch(
+                "frigate.api.export.start_export_job",
+                side_effect=lambda _config, job: job.id,
+            ) as start_export_job:
+                with AuthTestClient(self.app) as client:
+                    response = client.post(
+                        "/exports/batch",
+                        json={
+                            "items": [
+                                {
+                                    "camera": "front_door",
+                                    "start_time": 110,
+                                    "end_time": 150,
+                                },
+                                {
+                                    "camera": "backyard",
+                                    "start_time": 110,
+                                    "end_time": 150,
+                                },
+                            ],
+                            "new_case_name": "Queue full",
+                        },
+                    )
+
+        assert response.status_code == 503
+        start_export_job.assert_not_called()
+        assert ExportCase.select().count() == 0
+
+    def test_batch_export_all_enqueue_calls_fail_rolls_back_case(self):
+        self._insert_recording("rec-front", "front_door", 100, 400)
+
+        def boom(_config, _job):
+            raise RuntimeError("simulated enqueue failure")
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=boom,
+        ):
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                            }
+                        ],
+                        "new_case_name": "Will fail",
+                    },
+                )
+
+        assert response.status_code == 202
+        response_json = response.json()
+        assert response_json["export_ids"] == []
+        assert response_json["export_case_id"] is None
+        assert ExportCase.select().count() == 0
+
+    def test_batch_export_rejects_invalid_image_path(self):
+        self._insert_recording("rec-front", "front_door", 100, 400)
+
+        with AuthTestClient(self.app) as client:
+            response = client.post(
+                "/exports/batch",
+                json={
+                    "items": [
+                        {
+                            "camera": "front_door",
+                            "start_time": 110,
+                            "end_time": 150,
+                            "image_path": "/etc/passwd",
+                        }
+                    ],
+                    "new_case_name": "Bad image",
+                },
+            )
+
+        assert response.status_code == 400
+        assert ExportCase.select().count() == 0
+
+    def test_batch_export_non_admin_can_queue(self):
+        self._insert_recording("rec-front", "front_door", 100, 400)
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ):
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    headers={"remote-user": "viewer", "remote-role": "viewer"},
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                            }
+                        ],
+                        "new_case_name": "Viewer export",
+                    },
+                )
+
+        assert response.status_code == 202
+        assert len(response.json()["export_ids"]) == 1
+
+    def test_batch_export_non_admin_cannot_attach_to_existing_case(self):
+        """Non-admins can create cases via new_case_name but cannot attach
+        to existing cases they did not create. Closes a write-path hole that
+        would otherwise be reachable through the unfiltered GET /cases list.
+        """
+        self._insert_recording("rec-front", "front_door", 100, 400)
+        ExportCase.create(
+            id="admins_only_case",
+            name="Admins only",
+            description="",
+            created_at=10,
+            updated_at=10,
+        )
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ) as start_export_job:
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    headers={"remote-user": "viewer", "remote-role": "viewer"},
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                            }
+                        ],
+                        "export_case_id": "admins_only_case",
+                    },
+                )
+
+        assert response.status_code == 403
+        start_export_job.assert_not_called()
+        # No exports should have been created in the target case
+        assert Export.select().count() == 0
+
+    def test_batch_export_admin_can_attach_to_existing_case(self):
+        self._insert_recording("rec-front", "front_door", 100, 400)
+        ExportCase.create(
+            id="shared_case",
+            name="Shared",
+            description="",
+            created_at=10,
+            updated_at=10,
+        )
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ):
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                            }
+                        ],
+                        "export_case_id": "shared_case",
+                    },
+                )
+
+        assert response.status_code == 202
+        assert response.json()["export_case_id"] == "shared_case"
+        # No additional case created
+        assert ExportCase.select().count() == 1
+
+    def test_batch_export_roundtrips_client_item_id(self):
+        self._insert_recording("rec-front", "front_door", 100, 400)
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ):
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/exports/batch",
+                    json={
+                        "items": [
+                            {
+                                "camera": "front_door",
+                                "start_time": 110,
+                                "end_time": 150,
+                                "client_item_id": "review-123",
+                            }
+                        ],
+                        "new_case_name": "Client id test",
+                    },
+                )
+
+        assert response.status_code == 202
+        assert response.json()["results"][0]["client_item_id"] == "review-123"
+
+    def test_single_export_non_admin_cannot_attach_to_existing_case(self):
+        """The single-export route has the same hole: non-admins should not
+        be able to smuggle exports into an existing case via export_case_id.
+        Admin-gating this matches /exports/batch.
+        """
+        self._insert_recording("rec-front", "front_door", 100, 400)
+        ExportCase.create(
+            id="admins_only_case",
+            name="Admins only",
+            description="",
+            created_at=10,
+            updated_at=10,
+        )
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ) as start_export_job:
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/export/front_door/start/110/end/150",
+                    headers={"remote-user": "viewer", "remote-role": "viewer"},
+                    json={"export_case_id": "admins_only_case"},
+                )
+
+        assert response.status_code == 403
+        start_export_job.assert_not_called()
+        assert Export.select().count() == 0
+
+    def test_single_export_non_admin_can_still_export_without_case(self):
+        """Regression guard: the admin gate only applies to export_case_id,
+        not to single exports in general. Non-admins should still be able
+        to start a single export for a camera they have access to.
+        """
+        self._insert_recording("rec-front", "front_door", 100, 400)
+
+        with patch(
+            "frigate.api.export.start_export_job",
+            side_effect=lambda _config, job: job.id,
+        ):
+            with AuthTestClient(self.app) as client:
+                response = client.post(
+                    "/export/front_door/start/110/end/150",
+                    headers={"remote-user": "viewer", "remote-role": "viewer"},
+                    json={},
+                )
+
+        assert response.status_code == 202
+        assert response.json()["success"] is True

--- a/web/e2e/helpers/api-mocker.ts
+++ b/web/e2e/helpers/api-mocker.ts
@@ -82,14 +82,26 @@ export class ApiMocker {
       route.fulfill({ json: stats }),
     );
 
-    // Reviews
-    await this.page.route("**/api/reviews**", (route) => {
-      const url = route.request().url();
-      if (url.includes("summary")) {
-        return route.fulfill({ json: reviewSummary });
-      }
-      return route.fulfill({ json: reviews });
-    });
+    // Reviews. The real backend exposes /review (singular) for the main
+    // list and /review/summary for the summary — the previous plural glob
+    // (**/api/reviews**) never matched either endpoint, so review-dependent
+    // tests silently ran without data. The POST mutations at /reviews/viewed
+    // and /reviews/delete (plural) still fall through to the generic
+    // mutation catch-all further down the file.
+    await this.page.route(/\/api\/review\/summary/, (route) =>
+      route.fulfill({ json: reviewSummary }),
+    );
+    await this.page.route(/\/api\/review(\?|$)/, (route) =>
+      route.fulfill({ json: reviews }),
+    );
+
+    // Export jobs. The Exports page polls this every 2s while any export
+    // is in_progress; without a mock route it falls through to the preview
+    // server which returns 500 and makes the page flap between loading and
+    // rendered state, breaking tests that navigate to /export.
+    await this.page.route("**/api/jobs/export", (route) =>
+      route.fulfill({ json: [] }),
+    );
 
     // Recordings summary
     await this.page.route("**/api/recordings/summary**", (route) =>

--- a/web/e2e/specs/export.spec.ts
+++ b/web/e2e/specs/export.spec.ts
@@ -460,10 +460,9 @@ test.describe("Multi-Review Export @high", () => {
       .filter({ hasText: /Export 2 reviews/i });
     await expect(dialog).toBeVisible({ timeout: 5_000 });
     // The dialog uses a Select trigger for case selection (admins). The
-    // default "Create new case" value is shown on the trigger and the
-    // New-case inputs render directly below.
+    // default "None" value is shown on the trigger.
     await expect(dialog.locator("button[role='combobox']")).toBeVisible();
-    await expect(dialog.getByText(/Create new case/i)).toBeVisible();
+    await expect(dialog.getByText(/None/)).toBeVisible();
   });
 
   test("starting an export posts the expected payload and navigates to the case", async ({
@@ -512,6 +511,12 @@ test.describe("Multi-Review Export @high", () => {
       .getByRole("dialog")
       .filter({ hasText: /Export 2 reviews/i });
     await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Select "Create new case" from the case dropdown (default is "None")
+    await dialog.locator("button[role='combobox']").click();
+    await frigateApp.page
+      .getByRole("option", { name: /Create new case/i })
+      .click();
 
     const nameInput = dialog.locator("input").first();
     await nameInput.fill("E2E Incident");

--- a/web/e2e/specs/export.spec.ts
+++ b/web/e2e/specs/export.spec.ts
@@ -137,6 +137,133 @@ test.describe("Export Page - Case Detail @high", () => {
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText(/Package Theft Investigation/)).toBeVisible();
   });
+
+  test("delete case can also delete its exports", async ({ frigateApp }) => {
+    let deleteRequestUrl: string | null = null;
+    let deleteCaseCompleted = false;
+
+    const initialCases = [
+      {
+        id: "case-001",
+        name: "Package Theft Investigation",
+        description: "Review of suspicious activity near the front porch",
+        created_at: 1775407931.3863528,
+        updated_at: 1775483531.3863528,
+      },
+    ];
+
+    const initialExports = [
+      {
+        id: "export-001",
+        camera: "front_door",
+        name: "Front Door - Person Alert",
+        date: 1775490731.3863528,
+        video_path: "/exports/export-001.mp4",
+        thumb_path: "/exports/export-001-thumb.jpg",
+        in_progress: false,
+        export_case_id: null,
+      },
+      {
+        id: "export-002",
+        camera: "backyard",
+        name: "Backyard - Car Detection",
+        date: 1775483531.3863528,
+        video_path: "/exports/export-002.mp4",
+        thumb_path: "/exports/export-002-thumb.jpg",
+        in_progress: false,
+        export_case_id: "case-001",
+      },
+      {
+        id: "export-003",
+        camera: "garage",
+        name: "Garage - In Progress",
+        date: 1775492531.3863528,
+        video_path: "/exports/export-003.mp4",
+        thumb_path: "/exports/export-003-thumb.jpg",
+        in_progress: true,
+        export_case_id: null,
+      },
+    ];
+
+    await frigateApp.page.route(/\/api\/cases(?:$|\?|\/)/, async (route) => {
+      const request = route.request();
+
+      if (request.method() === "DELETE") {
+        deleteRequestUrl = request.url();
+        deleteCaseCompleted = true;
+        return route.fulfill({ json: { success: true } });
+      }
+
+      if (request.method() === "GET") {
+        return route.fulfill({
+          json: deleteCaseCompleted ? [] : initialCases,
+        });
+      }
+
+      return route.fallback();
+    });
+
+    await frigateApp.page.route("**/api/exports**", async (route) => {
+      if (route.request().method() !== "GET") {
+        return route.fallback();
+      }
+
+      return route.fulfill({
+        json: deleteCaseCompleted
+          ? initialExports.filter((exp) => exp.export_case_id !== "case-001")
+          : initialExports,
+      });
+    });
+
+    await frigateApp.goto("/export");
+
+    await frigateApp.page
+      .getByText("Package Theft Investigation")
+      .first()
+      .click();
+    await frigateApp.page.getByRole("button", { name: "Delete Case" }).click();
+
+    const dialog = frigateApp.page
+      .getByRole("alertdialog")
+      .filter({ hasText: "Delete Case" });
+    await expect(dialog).toBeVisible();
+
+    const deleteExportsSwitch = dialog.getByRole("switch", {
+      name: "Also delete exports",
+    });
+    await expect(deleteExportsSwitch).toHaveAttribute("aria-checked", "false");
+    await expect(
+      dialog.getByText(
+        "Exports will remain available as uncategorized exports.",
+      ),
+    ).toBeVisible();
+
+    await deleteExportsSwitch.click();
+
+    await expect(deleteExportsSwitch).toHaveAttribute("aria-checked", "true");
+    await expect(
+      dialog.getByText("All exports in this case will be permanently deleted."),
+    ).toBeVisible();
+
+    await dialog.getByRole("button", { name: /^delete$/i }).click();
+
+    await expect
+      .poll(() => deleteRequestUrl)
+      .toContain("/api/cases/case-001?delete_exports=true");
+
+    await expect(dialog).toBeHidden();
+    await expect(
+      frigateApp.page.getByRole("heading", {
+        name: "Package Theft Investigation",
+      }),
+    ).toBeHidden();
+    await expect(
+      frigateApp.page.getByText("Backyard - Car Detection"),
+    ).toBeHidden();
+    await expect(
+      frigateApp.page.getByText("Front Door - Person Alert"),
+    ).toBeVisible();
+  });
 });
 
 test.describe("Export Page - Empty State @high", () => {

--- a/web/e2e/specs/export.spec.ts
+++ b/web/e2e/specs/export.spec.ts
@@ -1,74 +1,178 @@
-/**
- * Export page tests -- HIGH tier.
- *
- * Tests export card rendering with mock data, search filtering,
- * and delete confirmation dialog.
- */
-
 import { test, expect } from "../fixtures/frigate-test";
 
-test.describe("Export Page - Cards @high", () => {
-  test("export page renders export cards from mock data", async ({
+test.describe("Export Page - Overview @high", () => {
+  test("renders uncategorized exports and case cards from mock data", async ({
     frigateApp,
   }) => {
     await frigateApp.goto("/export");
-    await frigateApp.page.waitForTimeout(2000);
-    // Should show export names from our mock data
+
     await expect(
       frigateApp.page.getByText("Front Door - Person Alert"),
-    ).toBeVisible({ timeout: 10_000 });
+    ).toBeVisible();
     await expect(
-      frigateApp.page.getByText("Backyard - Car Detection"),
+      frigateApp.page.getByText("Garage - In Progress"),
+    ).toBeVisible();
+    await expect(
+      frigateApp.page.getByText("Package Theft Investigation"),
     ).toBeVisible();
   });
 
-  test("export page shows in-progress indicator", async ({ frigateApp }) => {
+  test("search filters uncategorized exports", async ({ frigateApp }) => {
     await frigateApp.goto("/export");
-    await frigateApp.page.waitForTimeout(2000);
-    // "Garage - In Progress" export should be visible
-    await expect(frigateApp.page.getByText("Garage - In Progress")).toBeVisible(
-      { timeout: 10_000 },
-    );
+
+    const searchInput = frigateApp.page.getByPlaceholder(/search/i).first();
+    await searchInput.fill("Front Door");
+
+    await expect(
+      frigateApp.page.getByText("Front Door - Person Alert"),
+    ).toBeVisible();
+    await expect(
+      frigateApp.page.getByText("Backyard - Car Detection"),
+    ).toBeHidden();
+    await expect(
+      frigateApp.page.getByText("Garage - In Progress"),
+    ).toBeHidden();
   });
 
-  test("export page shows case grouping", async ({ frigateApp }) => {
+  test("new case button opens the create case dialog", async ({
+    frigateApp,
+  }) => {
     await frigateApp.goto("/export");
-    await frigateApp.page.waitForTimeout(3000);
-    // Cases may render differently depending on API response shape
-    const pageText = await frigateApp.page.textContent("#pageRoot");
-    expect(pageText?.length).toBeGreaterThan(0);
-  });
-});
 
-test.describe("Export Page - Search @high", () => {
-  test("search input filters export list", async ({ frigateApp }) => {
-    await frigateApp.goto("/export");
-    await frigateApp.page.waitForTimeout(2000);
-    const searchInput = frigateApp.page.locator(
-      '#pageRoot input[type="text"], #pageRoot input',
-    );
-    if (
-      (await searchInput.count()) > 0 &&
-      (await searchInput.first().isVisible())
-    ) {
-      // Type a search term that matches one export
-      await searchInput.first().fill("Front Door");
-      await frigateApp.page.waitForTimeout(500);
-      // "Front Door - Person Alert" should still be visible
-      await expect(
-        frigateApp.page.getByText("Front Door - Person Alert"),
-      ).toBeVisible();
-    }
-    await expect(frigateApp.page.locator("#pageRoot")).toBeVisible();
+    await frigateApp.page.getByRole("button", { name: "New Case" }).click();
+
+    await expect(
+      frigateApp.page.getByRole("dialog").filter({ hasText: "Create Case" }),
+    ).toBeVisible();
+    await expect(frigateApp.page.getByPlaceholder("Case name")).toBeVisible();
   });
 });
 
-test.describe("Export Page - Controls @high", () => {
-  test("export page filter controls are present", async ({ frigateApp }) => {
+test.describe("Export Page - Case Detail @high", () => {
+  test("opening a case shows its detail view and associated export", async ({
+    frigateApp,
+  }) => {
     await frigateApp.goto("/export");
-    await frigateApp.page.waitForTimeout(1000);
-    const buttons = frigateApp.page.locator("#pageRoot button");
-    const count = await buttons.count();
-    expect(count).toBeGreaterThan(0);
+
+    await frigateApp.page
+      .getByText("Package Theft Investigation")
+      .first()
+      .click();
+
+    await expect(
+      frigateApp.page.getByRole("heading", {
+        name: "Package Theft Investigation",
+      }),
+    ).toBeVisible();
+    await expect(
+      frigateApp.page.getByText("Backyard - Car Detection"),
+    ).toBeVisible();
+    await expect(
+      frigateApp.page.getByRole("button", { name: "Add Export" }),
+    ).toBeVisible();
+    await expect(
+      frigateApp.page.getByRole("button", { name: "Edit Case" }),
+    ).toBeVisible();
+    await expect(
+      frigateApp.page.getByRole("button", { name: "Delete Case" }),
+    ).toBeVisible();
+  });
+
+  test("edit case opens a prefilled dialog", async ({ frigateApp }) => {
+    await frigateApp.goto("/export");
+
+    await frigateApp.page
+      .getByText("Package Theft Investigation")
+      .first()
+      .click();
+    await frigateApp.page.getByRole("button", { name: "Edit Case" }).click();
+
+    const dialog = frigateApp.page
+      .getByRole("dialog")
+      .filter({ hasText: "Edit Case" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.locator("input")).toHaveValue(
+      "Package Theft Investigation",
+    );
+    await expect(dialog.locator("textarea")).toHaveValue(
+      "Review of suspicious activity near the front porch",
+    );
+  });
+
+  test("add export shows uncategorized exports for assignment", async ({
+    frigateApp,
+  }) => {
+    await frigateApp.goto("/export");
+
+    await frigateApp.page
+      .getByText("Package Theft Investigation")
+      .first()
+      .click();
+    await frigateApp.page.getByRole("button", { name: "Add Export" }).click();
+
+    const dialog = frigateApp.page
+      .getByRole("dialog")
+      .filter({ hasText: "Add Export to Package Theft Investigation" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText("Front Door - Person Alert")).toBeVisible();
+    await expect(dialog.getByText("Garage - In Progress")).toBeVisible();
+  });
+
+  test("delete case opens a confirmation dialog", async ({ frigateApp }) => {
+    await frigateApp.goto("/export");
+
+    await frigateApp.page
+      .getByText("Package Theft Investigation")
+      .first()
+      .click();
+    await frigateApp.page.getByRole("button", { name: "Delete Case" }).click();
+
+    const dialog = frigateApp.page
+      .getByRole("alertdialog")
+      .filter({ hasText: "Delete Case" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(/Package Theft Investigation/)).toBeVisible();
+  });
+});
+
+test.describe("Export Page - Empty State @high", () => {
+  test("renders the empty state when there are no exports or cases", async ({
+    frigateApp,
+  }) => {
+    await frigateApp.page.route("**/api/export**", (route) =>
+      route.fulfill({ json: [] }),
+    );
+    await frigateApp.page.route("**/api/exports**", (route) =>
+      route.fulfill({ json: [] }),
+    );
+    await frigateApp.page.route("**/api/cases", (route) =>
+      route.fulfill({ json: [] }),
+    );
+    await frigateApp.page.route("**/api/cases**", (route) =>
+      route.fulfill({ json: [] }),
+    );
+
+    await frigateApp.goto("/export");
+
+    await expect(frigateApp.page.getByText("No exports found")).toBeVisible();
+  });
+});
+
+test.describe("Export Page - Mobile @high @mobile", () => {
+  test("mobile can open an export preview dialog", async ({ frigateApp }) => {
+    test.skip(!frigateApp.isMobile, "Mobile-only assertion");
+
+    await frigateApp.goto("/export");
+
+    await frigateApp.page
+      .getByText("Front Door - Person Alert")
+      .first()
+      .click();
+
+    const dialog = frigateApp.page
+      .getByRole("dialog")
+      .filter({ hasText: "Front Door - Person Alert" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.locator("video")).toBeVisible();
   });
 });

--- a/web/e2e/specs/export.spec.ts
+++ b/web/e2e/specs/export.spec.ts
@@ -99,7 +99,7 @@ test.describe("Export Page - Case Detail @high", () => {
     );
   });
 
-  test("add export shows uncategorized exports for assignment", async ({
+  test("add export shows completed uncategorized exports for assignment", async ({
     frigateApp,
   }) => {
     await frigateApp.goto("/export");
@@ -114,8 +114,12 @@ test.describe("Export Page - Case Detail @high", () => {
       .getByRole("dialog")
       .filter({ hasText: "Add Export to Package Theft Investigation" });
     await expect(dialog).toBeVisible();
+    // Completed, uncategorized exports are selectable
     await expect(dialog.getByText("Front Door - Person Alert")).toBeVisible();
-    await expect(dialog.getByText("Garage - In Progress")).toBeVisible();
+    // In-progress exports are intentionally hidden by AssignExportDialog
+    // (see Exports.tsx filteredExports) — they can't be assigned until
+    // they finish, so they should not show in the picker.
+    await expect(dialog.getByText("Garage - In Progress")).toBeHidden();
   });
 
   test("delete case opens a confirmation dialog", async ({ frigateApp }) => {
@@ -174,5 +178,425 @@ test.describe("Export Page - Mobile @high @mobile", () => {
       .filter({ hasText: "Front Door - Person Alert" });
     await expect(dialog).toBeVisible();
     await expect(dialog.locator("video")).toBeVisible();
+  });
+});
+
+test.describe("Multi-Review Export @high", () => {
+  // Two alert reviews close enough to "now" to fall within the
+  // default last-24-hours review window. Using numeric timestamps
+  // because the TS ReviewSegment type expects numbers even though
+  // the backend pydantic model serializes datetime as ISO strings —
+  // the app reads these as numbers for display math.
+  const now = Date.now() / 1000;
+  const mockReviews = [
+    {
+      id: "mex-review-001",
+      camera: "front_door",
+      start_time: now - 600,
+      end_time: now - 580,
+      has_been_reviewed: false,
+      severity: "alert",
+      thumb_path: "/clips/front_door/mex-review-001-thumb.jpg",
+      data: {
+        audio: [],
+        detections: ["person-001"],
+        objects: ["person"],
+        sub_labels: [],
+        significant_motion_areas: [],
+        zones: ["front_yard"],
+      },
+    },
+    {
+      id: "mex-review-002",
+      camera: "backyard",
+      start_time: now - 1200,
+      end_time: now - 1170,
+      has_been_reviewed: false,
+      severity: "alert",
+      thumb_path: "/clips/backyard/mex-review-002-thumb.jpg",
+      data: {
+        audio: [],
+        detections: ["car-002"],
+        objects: ["car"],
+        sub_labels: [],
+        significant_motion_areas: [],
+        zones: ["driveway"],
+      },
+    },
+  ];
+
+  // 51 alert reviews, all front_door, spaced 5 minutes apart. Used by the
+  // over-limit test to trigger Ctrl+A select-all and verify the Export
+  // button is hidden at 51 selected.
+  const oversizedReviews = Array.from({ length: 51 }, (_, i) => ({
+    id: `mex-oversized-${i.toString().padStart(3, "0")}`,
+    camera: "front_door",
+    start_time: now - 60 * 60 - i * 300,
+    end_time: now - 60 * 60 - i * 300 + 20,
+    has_been_reviewed: false,
+    severity: "alert",
+    thumb_path: `/clips/front_door/mex-oversized-${i}-thumb.jpg`,
+    data: {
+      audio: [],
+      detections: [`person-${i}`],
+      objects: ["person"],
+      sub_labels: [],
+      significant_motion_areas: [],
+      zones: ["front_yard"],
+    },
+  }));
+
+  const mockSummary = {
+    last24Hours: {
+      reviewed_alert: 0,
+      reviewed_detection: 0,
+      total_alert: 2,
+      total_detection: 0,
+    },
+  };
+
+  async function routeReviews(
+    page: import("@playwright/test").Page,
+    reviews: unknown[],
+  ) {
+    // Intercept the actual `/api/review` endpoint (singular — the
+    // default api-mocker only registers `/api/reviews**` (plural)
+    // which does not match the real request URL).
+    await page.route(/\/api\/review(\?|$)/, (route) =>
+      route.fulfill({ json: reviews }),
+    );
+    await page.route(/\/api\/review\/summary/, (route) =>
+      route.fulfill({ json: mockSummary }),
+    );
+  }
+
+  test.beforeEach(async ({ frigateApp }) => {
+    await routeReviews(frigateApp.page, mockReviews);
+    // Empty cases list by default so the dialog defaults to "new case".
+    // Individual tests override this to populate existing cases.
+    await frigateApp.page.route("**/api/cases", (route) =>
+      route.fulfill({ json: [] }),
+    );
+  });
+
+  async function selectTwoReviews(frigateApp: {
+    page: import("@playwright/test").Page;
+  }) {
+    // Every review card has className `review-item` on its wrapper
+    // (see EventView.tsx). Cards also have data-start attributes that
+    // we can key off if needed.
+    const reviewItems = frigateApp.page.locator(".review-item");
+    await reviewItems.first().waitFor({ state: "visible", timeout: 10_000 });
+
+    // Meta-click the first two items to enter multi-select mode.
+    // PreviewThumbnailPlayer reads e.metaKey to decide multi-select.
+    await reviewItems.nth(0).click({ modifiers: ["Meta"] });
+    await reviewItems.nth(1).click();
+  }
+
+  test("selecting two reviews reveals the export button", async ({
+    frigateApp,
+  }) => {
+    test.skip(frigateApp.isMobile, "Desktop multi-select flow");
+
+    await frigateApp.goto("/review");
+
+    await selectTwoReviews(frigateApp);
+
+    // Action group replaces the filter bar once items are selected
+    await expect(frigateApp.page.getByText(/2.*selected/i)).toBeVisible({
+      timeout: 5_000,
+    });
+
+    const exportButton = frigateApp.page.getByRole("button", {
+      name: /export/i,
+    });
+    await expect(exportButton).toBeVisible();
+  });
+
+  test("clicking export opens the multi-review dialog with correct title", async ({
+    frigateApp,
+  }) => {
+    test.skip(frigateApp.isMobile, "Desktop multi-select flow");
+
+    await frigateApp.goto("/review");
+
+    await selectTwoReviews(frigateApp);
+
+    await frigateApp.page
+      .getByRole("button", { name: /export/i })
+      .first()
+      .click();
+
+    const dialog = frigateApp.page
+      .getByRole("dialog")
+      .filter({ hasText: /Export 2 reviews/i });
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    // The dialog uses a Select trigger for case selection (admins). The
+    // default "Create new case" value is shown on the trigger and the
+    // New-case inputs render directly below.
+    await expect(dialog.locator("button[role='combobox']")).toBeVisible();
+    await expect(dialog.getByText(/Create new case/i)).toBeVisible();
+  });
+
+  test("starting an export posts the expected payload and navigates to the case", async ({
+    frigateApp,
+  }) => {
+    test.skip(frigateApp.isMobile, "Desktop multi-select flow");
+
+    let capturedPayload: unknown = null;
+    await frigateApp.page.route("**/api/exports/batch", async (route) => {
+      capturedPayload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 202,
+        json: {
+          export_case_id: "new-case-xyz",
+          export_ids: ["front_door_a", "backyard_b"],
+          results: [
+            {
+              camera: "front_door",
+              export_id: "front_door_a",
+              success: true,
+              status: "queued",
+              error: null,
+              item_index: 0,
+            },
+            {
+              camera: "backyard",
+              export_id: "backyard_b",
+              success: true,
+              status: "queued",
+              error: null,
+              item_index: 1,
+            },
+          ],
+        },
+      });
+    });
+
+    await frigateApp.goto("/review");
+    await selectTwoReviews(frigateApp);
+    await frigateApp.page
+      .getByRole("button", { name: /export/i })
+      .first()
+      .click();
+
+    const dialog = frigateApp.page
+      .getByRole("dialog")
+      .filter({ hasText: /Export 2 reviews/i });
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    const nameInput = dialog.locator("input").first();
+    await nameInput.fill("E2E Incident");
+
+    await dialog.getByRole("button", { name: /export 2 reviews/i }).click();
+
+    // Wait for the POST to fire
+    await expect.poll(() => capturedPayload, { timeout: 5_000 }).not.toBeNull();
+
+    const payload = capturedPayload as {
+      items: Array<{
+        camera: string;
+        start_time: number;
+        end_time: number;
+        image_path?: string;
+        client_item_id?: string;
+      }>;
+      new_case_name?: string;
+      export_case_id?: string;
+    };
+    expect(payload.items).toHaveLength(2);
+    expect(payload.new_case_name).toBe("E2E Incident");
+    // When creating a new case, we must NOT also send export_case_id —
+    // the two fields are mutually exclusive on the backend.
+    expect(payload.export_case_id).toBeUndefined();
+    expect(payload.items.map((i) => i.camera).sort()).toEqual([
+      "backyard",
+      "front_door",
+    ]);
+    // Each item must preserve REVIEW_PADDING (4s) on the edges —
+    // i.e. the padded window is 8s longer than the original review.
+    // The mock reviews above have 20s and 30s raw durations, so the
+    // expected padded durations are 28s and 38s.
+    const paddedDurations = payload.items
+      .map((i) => i.end_time - i.start_time)
+      .sort((a, b) => a - b);
+    expect(paddedDurations).toEqual([28, 38]);
+    // Thumbnails should be passed through per item
+    for (const item of payload.items) {
+      expect(item.image_path).toMatch(/mex-review-\d+-thumb\.jpg$/);
+    }
+    expect(payload.items.map((item) => item.client_item_id)).toEqual([
+      "mex-review-001",
+      "mex-review-002",
+    ]);
+
+    await expect(frigateApp.page).toHaveURL(/caseId=new-case-xyz/, {
+      timeout: 5_000,
+    });
+  });
+
+  test("mobile opens a drawer (not a dialog) for the multi-review export flow", async ({
+    frigateApp,
+  }) => {
+    test.skip(!frigateApp.isMobile, "Mobile-only Drawer assertion");
+
+    await frigateApp.goto("/review");
+    await selectTwoReviews(frigateApp);
+
+    await frigateApp.page
+      .getByRole("button", { name: /export/i })
+      .first()
+      .click();
+
+    // On mobile the component renders a shadcn Drawer, which uses
+    // role="dialog" but sets data-vaul-drawer. Desktop renders a
+    // shadcn Dialog with role="dialog" but no data-vaul-drawer.
+    // The title and submit button both contain "Export 2 reviews", so
+    // assert each element distinctly: the title is a heading and the
+    // submit button has role="button".
+    const drawer = frigateApp.page.locator("[data-vaul-drawer]");
+    await expect(drawer).toBeVisible({ timeout: 5_000 });
+    await expect(
+      drawer.getByRole("heading", { name: /Export 2 reviews/i }),
+    ).toBeVisible();
+    await expect(
+      drawer.getByRole("button", { name: /export 2 reviews/i }),
+    ).toBeVisible();
+  });
+
+  test("hides export button when more than 50 reviews are selected", async ({
+    frigateApp,
+  }) => {
+    test.skip(frigateApp.isMobile, "Desktop select-all keyboard flow");
+
+    // Override the default 2-review mock with 51 reviews before
+    // navigation. Playwright matches routes last-registered-first so
+    // this takes precedence over the beforeEach.
+    await routeReviews(frigateApp.page, oversizedReviews);
+
+    await frigateApp.goto("/review");
+
+    // Wait for any review item to render before firing the shortcut
+    await frigateApp.page
+      .locator(".review-item")
+      .first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    // Ctrl+A triggers onSelectAllReviews (see EventView.tsx useKeyboardListener)
+    await frigateApp.page.keyboard.press("Control+a");
+
+    // The action group should show "51 selected" but no Export button.
+    // Mark-as-reviewed is still there so the action bar is rendered.
+    // Scope the "Mark as reviewed" lookup to its exact aria-label because
+    // the page can render other "mark as reviewed" controls elsewhere
+    // (e.g. on individual cards) that would trip strict-mode matching.
+    await expect(frigateApp.page.getByText(/51.*selected/i)).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(
+      frigateApp.page.getByRole("button", { name: "Mark as reviewed" }),
+    ).toBeVisible();
+    await expect(
+      frigateApp.page.getByRole("button", { name: /^export$/i }),
+    ).toHaveCount(0);
+  });
+
+  test("attaching to an existing case sends export_case_id without new_case_name", async ({
+    frigateApp,
+  }) => {
+    test.skip(frigateApp.isMobile, "Desktop multi-select flow");
+
+    // Seed one existing case so the dialog can offer the "existing" branch.
+    // The fixture mocks the user as admin (adminProfile()), so useIsAdmin()
+    // is true and the dialog renders the "Existing case" radio.
+    await frigateApp.page.route("**/api/cases", (route) =>
+      route.fulfill({
+        json: [
+          {
+            id: "existing-case-abc",
+            name: "Incident #42",
+            description: "",
+            created_at: now - 3600,
+            updated_at: now - 3600,
+          },
+        ],
+      }),
+    );
+
+    let capturedPayload: unknown = null;
+    await frigateApp.page.route("**/api/exports/batch", async (route) => {
+      capturedPayload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 202,
+        json: {
+          export_case_id: "existing-case-abc",
+          export_ids: ["front_door_a", "backyard_b"],
+          results: [
+            {
+              camera: "front_door",
+              export_id: "front_door_a",
+              success: true,
+              status: "queued",
+              error: null,
+              item_index: 0,
+            },
+            {
+              camera: "backyard",
+              export_id: "backyard_b",
+              success: true,
+              status: "queued",
+              error: null,
+              item_index: 1,
+            },
+          ],
+        },
+      });
+    });
+
+    await frigateApp.goto("/review");
+    await selectTwoReviews(frigateApp);
+
+    await frigateApp.page
+      .getByRole("button", { name: /export/i })
+      .first()
+      .click();
+
+    const dialog = frigateApp.page
+      .getByRole("dialog")
+      .filter({ hasText: /Export 2 reviews/i });
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Open the Case Select dropdown and pick the seeded case directly.
+    // The dialog now uses a single Select listing existing cases above
+    // the "Create new case" option — no radio toggle needed.
+    const selectTrigger = dialog.locator("button[role='combobox']").first();
+    await selectTrigger.waitFor({ state: "visible", timeout: 5_000 });
+    await selectTrigger.click();
+
+    // The dropdown portal renders outside the dialog
+    await frigateApp.page.getByRole("option", { name: /Incident #42/ }).click();
+
+    await dialog.getByRole("button", { name: /export 2 reviews/i }).click();
+
+    await expect.poll(() => capturedPayload, { timeout: 5_000 }).not.toBeNull();
+
+    const payload = capturedPayload as {
+      items: unknown[];
+      new_case_name?: string;
+      new_case_description?: string;
+      export_case_id?: string;
+    };
+    expect(payload.export_case_id).toBe("existing-case-abc");
+    expect(payload.new_case_name).toBeUndefined();
+    expect(payload.new_case_description).toBeUndefined();
+    expect(payload.items).toHaveLength(2);
+
+    // Navigate should hit /export. useSearchEffect consumes the caseId
+    // query param and strips it once the case is found in the cases list,
+    // so we assert on the path, not the query string.
+    await expect(frigateApp.page).toHaveURL(/\/export(\?|$)/, {
+      timeout: 5_000,
+    });
   });
 });

--- a/web/public/locales/en/components/dialog.json
+++ b/web/public/locales/en/components/dialog.json
@@ -50,15 +50,40 @@
       "placeholder": "Name the Export"
     },
     "case": {
+      "newCaseOption": "Create new case",
+      "newCaseNamePlaceholder": "New case name",
+      "newCaseDescriptionPlaceholder": "Case description",
       "label": "Case",
       "placeholder": "Select a case"
     },
     "select": "Select",
     "export": "Export",
     "selectOrExport": "Select or Export",
+    "tabs": {
+      "export": "Single Camera",
+      "multiCamera": "Multi-Camera"
+    },
+    "multiCamera": {
+      "timeRange": "Time range",
+      "selectFromTimeline": "Select from Timeline",
+      "cameraSelection": "Cameras",
+      "selectedCount_one": "1 selected",
+      "selectedCount_other": "{{count}} selected",
+      "checkingActivity": "Checking camera activity...",
+      "noCameras": "No cameras available",
+      "detectionCount_one": "1 detection",
+      "detectionCount_other": "{{count}} detections",
+      "namePlaceholder": "Optional base name for these exports",
+      "exportButton_one": "Export 1 Camera",
+      "exportButton_other": "Export {{count}} Cameras"
+    },
     "toast": {
       "success": "Successfully started export. View the file in the exports page.",
       "view": "View",
+      "batchSuccess_one": "Started 1 export. Opening the case now.",
+      "batchSuccess_other": "Started {{count}} exports. Opening the case now.",
+      "batchPartial": "Started {{successful}} of {{total}} exports. Failed cameras: {{failedCameras}}",
+      "batchFailed": "Failed to start {{total}} exports. Failed cameras: {{failedCameras}}",
       "error": {
         "failed": "Failed to start export: {{error}}",
         "endTimeMustAfterStartTime": "End time must be after start time",
@@ -67,7 +92,8 @@
     },
     "fromTimeline": {
       "saveExport": "Save Export",
-      "previewExport": "Preview Export"
+      "previewExport": "Preview Export",
+      "useThisRange": "Use This Range"
     }
   },
   "streaming": {

--- a/web/public/locales/en/components/dialog.json
+++ b/web/public/locales/en/components/dialog.json
@@ -84,6 +84,7 @@
       "title_one": "Export 1 review",
       "title_other": "Export {{count}} reviews",
       "description": "Export each selected review. All exports will be grouped under a single case.",
+      "descriptionNoCase": "Export each selected review.",
       "caseNamePlaceholder": "Review export - {{date}}",
       "exportButton_one": "Export 1 review",
       "exportButton_other": "Export {{count}} reviews",
@@ -91,6 +92,8 @@
       "toast": {
         "started_one": "Started 1 export. Opening the case now.",
         "started_other": "Started {{count}} exports. Opening the case now.",
+        "startedNoCase_one": "Started 1 export.",
+        "startedNoCase_other": "Started {{count}} exports.",
         "partial": "Started {{successful}} of {{total}} exports. Failed: {{failedItems}}",
         "failed": "Failed to start {{total}} exports. Failed: {{failedItems}}"
       }

--- a/web/public/locales/en/components/dialog.json
+++ b/web/public/locales/en/components/dialog.json
@@ -58,6 +58,7 @@
     },
     "select": "Select",
     "export": "Export",
+    "queueing": "Queueing Export...",
     "selectOrExport": "Select or Export",
     "tabs": {
       "export": "Single Camera",
@@ -67,31 +68,38 @@
       "timeRange": "Time range",
       "selectFromTimeline": "Select from Timeline",
       "cameraSelection": "Cameras",
-      "selectedCount_one": "1 selected",
-      "selectedCount_other": "{{count}} selected",
+      "cameraSelectionHelp": "Cameras with tracked objects in this time range are pre-selected",
       "checkingActivity": "Checking camera activity...",
       "noCameras": "No cameras available",
-      "detectionCount_one": "1 detection",
-      "detectionCount_other": "{{count}} detections",
+      "detectionCount_one": "1 tracked object",
+      "detectionCount_other": "{{count}} tracked objects",
+      "nameLabel": "Export name",
       "namePlaceholder": "Optional base name for these exports",
+      "queueingButton": "Queueing Exports...",
       "exportButton_one": "Export 1 Camera",
       "exportButton_other": "Export {{count}} Cameras"
     },
     "toast": {
       "success": "Successfully started export. View the file in the exports page.",
+      "queued": "Export queued. View progress in the exports page.",
       "view": "View",
       "batchSuccess_one": "Started 1 export. Opening the case now.",
       "batchSuccess_other": "Started {{count}} exports. Opening the case now.",
       "batchPartial": "Started {{successful}} of {{total}} exports. Failed cameras: {{failedCameras}}",
       "batchFailed": "Failed to start {{total}} exports. Failed cameras: {{failedCameras}}",
+      "batchQueuedSuccess_one": "Queued 1 export. Opening the case now.",
+      "batchQueuedSuccess_other": "Queued {{count}} exports. Opening the case now.",
+      "batchQueuedPartial": "Queued {{successful}} of {{total}} exports. Failed cameras: {{failedCameras}}",
+      "batchQueueFailed": "Failed to queue {{total}} exports. Failed cameras: {{failedCameras}}",
       "error": {
-        "failed": "Failed to start export: {{error}}",
+        "failed": "Failed to queue export: {{error}}",
         "endTimeMustAfterStartTime": "End time must be after start time",
         "noVaildTimeSelected": "No valid time range selected"
       }
     },
     "fromTimeline": {
       "saveExport": "Save Export",
+      "queueingExport": "Queueing Export...",
       "previewExport": "Preview Export",
       "useThisRange": "Use This Range"
     }

--- a/web/public/locales/en/components/dialog.json
+++ b/web/public/locales/en/components/dialog.json
@@ -54,6 +54,7 @@
       "newCaseNamePlaceholder": "New case name",
       "newCaseDescriptionPlaceholder": "Case description",
       "label": "Case",
+      "nonAdminHelp": "A new case will be created for these exports.",
       "placeholder": "Select a case"
     },
     "select": "Select",
@@ -78,6 +79,21 @@
       "queueingButton": "Queueing Exports...",
       "exportButton_one": "Export 1 Camera",
       "exportButton_other": "Export {{count}} Cameras"
+    },
+    "multi": {
+      "title_one": "Export 1 review",
+      "title_other": "Export {{count}} reviews",
+      "description": "Export each selected review. All exports will be grouped under a single case.",
+      "caseNamePlaceholder": "Review export - {{date}}",
+      "exportButton_one": "Export 1 review",
+      "exportButton_other": "Export {{count}} reviews",
+      "exportingButton": "Exporting...",
+      "toast": {
+        "started_one": "Started 1 export. Opening the case now.",
+        "started_other": "Started {{count}} exports. Opening the case now.",
+        "partial": "Started {{successful}} of {{total}} exports. Failed: {{failedItems}}",
+        "failed": "Failed to start {{total}} exports. Failed: {{failedItems}}"
+      }
     },
     "toast": {
       "success": "Successfully started export. View the file in the exports page.",

--- a/web/public/locales/en/components/dialog.json
+++ b/web/public/locales/en/components/dialog.json
@@ -81,11 +81,13 @@
       "exportButton_other": "Export {{count}} Cameras"
     },
     "multi": {
+      "title": "Export {{count}} reviews",
       "title_one": "Export 1 review",
       "title_other": "Export {{count}} reviews",
       "description": "Export each selected review. All exports will be grouped under a single case.",
       "descriptionNoCase": "Export each selected review.",
       "caseNamePlaceholder": "Review export - {{date}}",
+      "exportButton": "Export {{count}} reviews",
       "exportButton_one": "Export 1 review",
       "exportButton_other": "Export {{count}} reviews",
       "exportingButton": "Exporting...",

--- a/web/public/locales/en/views/exports.json
+++ b/web/public/locales/en/views/exports.json
@@ -20,7 +20,8 @@
     "downloadVideo": "Download video",
     "editName": "Edit name",
     "deleteExport": "Delete export",
-    "assignToCase": "Add to case"
+    "assignToCase": "Add to case",
+    "removeFromCase": "Remove from case"
   },
   "toolbar": {
     "newCase": "New Case",
@@ -49,10 +50,6 @@
     "descriptionLabel": "Description"
   },
   "caseCard": {
-    "exportCount_one": "1 export",
-    "exportCount_other": "{{count}} exports",
-    "cameraCount_one": "1 camera",
-    "cameraCount_other": "{{count}} cameras",
     "emptyCase": "No exports yet"
   },
   "jobCard": {

--- a/web/public/locales/en/views/exports.json
+++ b/web/public/locales/en/views/exports.json
@@ -55,6 +55,11 @@
     "cameraCount_other": "{{count}} cameras",
     "emptyCase": "No exports yet"
   },
+  "jobCard": {
+    "defaultName": "{{camera}} export",
+    "queued": "Queued",
+    "running": "Running"
+  },
   "caseView": {
     "noDescription": "No description",
     "createdAt": "Created {{value}}",

--- a/web/public/locales/en/views/exports.json
+++ b/web/public/locales/en/views/exports.json
@@ -79,6 +79,9 @@
   "addExportDialog": {
     "title": "Add Export to {{caseName}}",
     "searchPlaceholder": "Search uncategorized exports",
-    "empty": "No uncategorized exports match this search."
+    "empty": "No uncategorized exports match this search.",
+    "addButton_one": "Add 1 Export",
+    "addButton_other": "Add {{count}} Exports",
+    "adding": "Adding..."
   }
 }

--- a/web/public/locales/en/views/exports.json
+++ b/web/public/locales/en/views/exports.json
@@ -22,11 +22,23 @@
     "deleteExport": "Delete export",
     "assignToCase": "Add to case"
   },
+  "toolbar": {
+    "newCase": "New Case",
+    "addExport": "Add Export",
+    "editCase": "Edit Case",
+    "deleteCase": "Delete Case"
+  },
   "toast": {
     "error": {
       "renameExportFailed": "Failed to rename export: {{errorMessage}}",
-      "assignCaseFailed": "Failed to update case assignment: {{errorMessage}}"
+      "assignCaseFailed": "Failed to update case assignment: {{errorMessage}}",
+      "caseSaveFailed": "Failed to save case: {{errorMessage}}",
+      "caseDeleteFailed": "Failed to delete case: {{errorMessage}}"
     }
+  },
+  "deleteCase": {
+    "label": "Delete Case",
+    "desc": "Are you sure you want to delete {{caseName}}? Exports will remain available as uncategorized exports."
   },
   "caseDialog": {
     "title": "Add to case",
@@ -35,5 +47,36 @@
     "newCaseOption": "Create new case",
     "nameLabel": "Case name",
     "descriptionLabel": "Description"
+  },
+  "caseCard": {
+    "exportCount_one": "1 export",
+    "exportCount_other": "{{count}} exports",
+    "cameraCount_one": "1 camera",
+    "cameraCount_other": "{{count}} cameras",
+    "emptyCase": "No exports yet"
+  },
+  "caseView": {
+    "noDescription": "No description",
+    "createdAt": "Created {{value}}",
+    "exportCount_one": "1 export",
+    "exportCount_other": "{{count}} exports",
+    "cameraCount_one": "1 camera",
+    "cameraCount_other": "{{count}} cameras",
+    "showMore": "Show more",
+    "showLess": "Show less",
+    "emptyTitle": "This case is empty",
+    "emptyDescription": "Add existing uncategorized exports to keep the case organized.",
+    "emptyDescriptionNoExports": "There are no uncategorized exports available to add yet."
+  },
+  "caseEditor": {
+    "createTitle": "Create Case",
+    "editTitle": "Edit Case",
+    "namePlaceholder": "Case name",
+    "descriptionPlaceholder": "Add notes or context for this case"
+  },
+  "addExportDialog": {
+    "title": "Add Export to {{caseName}}",
+    "searchPlaceholder": "Search uncategorized exports",
+    "empty": "No uncategorized exports match this search."
   }
 }

--- a/web/public/locales/en/views/exports.json
+++ b/web/public/locales/en/views/exports.json
@@ -86,5 +86,38 @@
     "addButton_one": "Add 1 Export",
     "addButton_other": "Add {{count}} Exports",
     "adding": "Adding..."
+  },
+  "selected_one": "{{count}} selected",
+  "selected_other": "{{count}} selected",
+  "bulkActions": {
+    "addToCase": "Add to Case",
+    "moveToCase": "Move to Case",
+    "removeFromCase": "Remove from Case",
+    "delete": "Delete",
+    "deleteNow": "Delete Now"
+  },
+  "bulkDelete": {
+    "title": "Delete Exports",
+    "desc_one": "Are you sure you want to delete {{count}} export?",
+    "desc_other": "Are you sure you want to delete {{count}} exports?"
+  },
+  "bulkRemoveFromCase": {
+    "title": "Remove from Case",
+    "desc_one": "Remove {{count}} export from this case?",
+    "desc_other": "Remove {{count}} exports from this case?",
+    "descKeepExports": "Exports will be moved to uncategorized.",
+    "descDeleteExports": "Exports will be permanently deleted.",
+    "deleteExports": "Delete exports instead"
+  },
+  "bulkToast": {
+    "success": {
+      "delete": "Successfully deleted exports",
+      "reassign": "Successfully updated case assignment",
+      "remove": "Successfully removed exports from case"
+    },
+    "error": {
+      "deleteFailed": "Failed to delete exports: {{errorMessage}}",
+      "reassignFailed": "Failed to update case assignment: {{errorMessage}}"
+    }
   }
 }

--- a/web/public/locales/en/views/exports.json
+++ b/web/public/locales/en/views/exports.json
@@ -39,7 +39,10 @@
   },
   "deleteCase": {
     "label": "Delete Case",
-    "desc": "Are you sure you want to delete {{caseName}}? Exports will remain available as uncategorized exports."
+    "desc": "Are you sure you want to delete {{caseName}}?",
+    "descKeepExports": "Exports will remain available as uncategorized exports.",
+    "descDeleteExports": "All exports in this case will be permanently deleted.",
+    "deleteExports": "Also delete exports"
   },
   "caseDialog": {
     "title": "Add to case",

--- a/web/src/components/card/ExportCard.tsx
+++ b/web/src/components/card/ExportCard.tsx
@@ -87,11 +87,11 @@ export function CaseCard({
           <FaFolder />
           <div className="truncate smart-capitalize">{exportCase.name}</div>
         </div>
-        <div className="mt-1 line-clamp-2 text-xs text-white/80">
-          {exports.length === 0
-            ? t("caseCard.emptyCase")
-            : exportCase.description}
-        </div>
+        {exports.length === 0 && (
+          <div className="mt-1 text-xs text-white/80">
+            {t("caseCard.emptyCase")}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -333,8 +333,8 @@ export function ExportCard({
           <Skeleton className="absolute inset-0 aspect-video rounded-lg md:rounded-2xl" />
         )}
         <ImageShadowOverlay />
-        <div className="absolute bottom-2 left-3 z-30 text-white">
-          <div className="flex items-end smart-capitalize">
+        <div className="absolute bottom-2 left-3 right-12 z-30 text-white">
+          <div className="truncate smart-capitalize">
             {exportedRecording.name.replaceAll("_", " ")}
           </div>
         </div>

--- a/web/src/components/card/ExportCard.tsx
+++ b/web/src/components/card/ExportCard.tsx
@@ -28,6 +28,10 @@ import {
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
 import { FaFolder } from "react-icons/fa";
+import { useCameraFriendlyName } from "@/hooks/use-camera-friendly-name";
+import { useFormattedTimestamp, useTimeFormat } from "@/hooks/use-date-utils";
+import useSWR from "swr";
+import { FrigateConfig } from "@/types/frigateConfig";
 
 type CaseCardProps = {
   className: string;
@@ -41,8 +45,13 @@ export function CaseCard({
   exports,
   onSelect,
 }: CaseCardProps) {
+  const { t } = useTranslation(["views/exports"]);
   const firstExport = useMemo(
     () => exports.find((exp) => exp.thumb_path && exp.thumb_path.length > 0),
+    [exports],
+  );
+  const cameraCount = useMemo(
+    () => new Set(exports.map((exp) => exp.camera)).size,
     [exports],
   );
 
@@ -61,10 +70,28 @@ export function CaseCard({
           alt=""
         />
       )}
+      {!firstExport && (
+        <div className="absolute inset-0 bg-gradient-to-br from-secondary via-secondary/80 to-muted" />
+      )}
       <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-16 bg-gradient-to-t from-black/60 to-transparent" />
-      <div className="absolute bottom-2 left-2 z-20 flex items-center justify-start gap-2 text-white">
-        <FaFolder />
-        <div className="capitalize">{exportCase.name}</div>
+      <div className="absolute left-2 top-2 z-20 flex flex-wrap gap-2 text-xs text-white">
+        <div className="rounded-full bg-black/55 px-2 py-1">
+          {t("caseCard.exportCount", { count: exports.length })}
+        </div>
+        <div className="rounded-full bg-black/55 px-2 py-1">
+          {t("caseCard.cameraCount", { count: cameraCount })}
+        </div>
+      </div>
+      <div className="absolute inset-x-2 bottom-2 z-20 text-white">
+        <div className="flex items-center justify-start gap-2">
+          <FaFolder />
+          <div className="truncate smart-capitalize">{exportCase.name}</div>
+        </div>
+        <div className="mt-1 line-clamp-2 text-xs text-white/80">
+          {exports.length === 0
+            ? t("caseCard.emptyCase")
+            : exportCase.description}
+        </div>
       </div>
     </div>
   );
@@ -88,6 +115,16 @@ export function ExportCard({
 }: ExportCardProps) {
   const { t } = useTranslation(["views/exports"]);
   const isAdmin = useIsAdmin();
+  const cameraName = useCameraFriendlyName(exportedRecording.camera);
+  const { data: config } = useSWR<FrigateConfig>("config");
+  const timeFormat = useTimeFormat(config);
+  const formattedDate = useFormattedTimestamp(
+    exportedRecording.date,
+    t(`time.formattedTimestampMonthDayYearHourMinute.${timeFormat}`, {
+      ns: "common",
+    }),
+    config?.ui.timezone,
+  );
   const [loading, setLoading] = useState(
     exportedRecording.thumb_path.length > 0,
   );
@@ -291,9 +328,15 @@ export function ExportCard({
         {loading && (
           <Skeleton className="absolute inset-0 aspect-video rounded-lg md:rounded-2xl" />
         )}
+        <div className="absolute left-3 top-3 z-30 rounded-full bg-black/55 px-2 py-1 text-xs text-white">
+          {cameraName}
+        </div>
         <ImageShadowOverlay />
-        <div className="absolute bottom-2 left-3 flex items-end text-white smart-capitalize">
-          {exportedRecording.name.replaceAll("_", " ")}
+        <div className="absolute bottom-2 left-3 z-30 text-white">
+          <div className="flex items-end smart-capitalize">
+            {exportedRecording.name.replaceAll("_", " ")}
+          </div>
+          <div className="mt-1 text-xs text-white/80">{formattedDate}</div>
         </div>
       </div>
     </>

--- a/web/src/components/card/ExportCard.tsx
+++ b/web/src/components/card/ExportCard.tsx
@@ -13,7 +13,7 @@ import {
 } from "../ui/dialog";
 import { Input } from "../ui/input";
 import useKeyboardListener from "@/hooks/use-keyboard-listener";
-import { DeleteClipType, Export, ExportCase } from "@/types/export";
+import { DeleteClipType, Export, ExportCase, ExportJob } from "@/types/export";
 import { baseUrl } from "@/api/baseUrl";
 import { cn } from "@/lib/utils";
 import { shareOrCopy } from "@/utils/browserUtil";
@@ -340,5 +340,59 @@ export function ExportCard({
         </div>
       </div>
     </>
+  );
+}
+
+type ActiveExportJobCardProps = {
+  className?: string;
+  job: ExportJob;
+};
+
+export function ActiveExportJobCard({
+  className = "",
+  job,
+}: ActiveExportJobCardProps) {
+  const { t } = useTranslation(["views/exports", "common"]);
+  const cameraName = useCameraFriendlyName(job.camera);
+  const { data: config } = useSWR<FrigateConfig>("config");
+  const timeFormat = useTimeFormat(config);
+  const formattedDate = useFormattedTimestamp(
+    job.request_start_time,
+    t(`time.formattedTimestampMonthDayYearHourMinute.${timeFormat}`, {
+      ns: "common",
+    }),
+    config?.ui.timezone,
+  );
+  const displayName = useMemo(() => {
+    if (job.name && job.name.length > 0) {
+      return job.name.replaceAll("_", " ");
+    }
+
+    return t("jobCard.defaultName", {
+      camera: cameraName,
+    });
+  }, [cameraName, job.name, t]);
+  const statusLabel =
+    job.status === "queued" ? t("jobCard.queued") : t("jobCard.running");
+
+  return (
+    <div
+      className={cn(
+        "relative flex aspect-video items-center justify-center overflow-hidden rounded-lg border border-dashed border-border bg-secondary/40 md:rounded-2xl",
+        className,
+      )}
+    >
+      <div className="absolute left-3 top-3 z-30 rounded-full bg-black/55 px-2 py-1 text-xs text-white">
+        {cameraName}
+      </div>
+      <div className="absolute right-3 top-3 z-30 rounded-full bg-selected/90 px-2 py-1 text-xs text-selected-foreground">
+        {statusLabel}
+      </div>
+      <div className="flex flex-col items-center gap-3 px-6 text-center">
+        <ActivityIndicator />
+        <div className="text-sm font-medium text-primary">{displayName}</div>
+        <div className="text-xs text-muted-foreground">{formattedDate}</div>
+      </div>
+    </div>
   );
 }

--- a/web/src/components/card/ExportCard.tsx
+++ b/web/src/components/card/ExportCard.tsx
@@ -27,11 +27,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
-import { FaFolder } from "react-icons/fa";
+import { FaFolder, FaVideo } from "react-icons/fa";
+import { HiSquare2Stack } from "react-icons/hi2";
 import { useCameraFriendlyName } from "@/hooks/use-camera-friendly-name";
-import { useFormattedTimestamp, useTimeFormat } from "@/hooks/use-date-utils";
-import useSWR from "swr";
-import { FrigateConfig } from "@/types/frigateConfig";
 
 type CaseCardProps = {
   className: string;
@@ -74,12 +72,14 @@ export function CaseCard({
         <div className="absolute inset-0 bg-gradient-to-br from-secondary via-secondary/80 to-muted" />
       )}
       <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-16 bg-gradient-to-t from-black/60 to-transparent" />
-      <div className="absolute left-2 top-2 z-20 flex flex-wrap gap-2 text-xs text-white">
-        <div className="rounded-full bg-black/55 px-2 py-1">
-          {t("caseCard.exportCount", { count: exports.length })}
+      <div className="absolute right-1 top-1 z-40 flex items-center gap-2 rounded-lg bg-black/50 px-2 py-1 text-xs text-white">
+        <div className="flex items-center gap-1">
+          <HiSquare2Stack className="size-3" />
+          <div>{exports.length}</div>
         </div>
-        <div className="rounded-full bg-black/55 px-2 py-1">
-          {t("caseCard.cameraCount", { count: cameraCount })}
+        <div className="flex items-center gap-1">
+          <FaVideo className="size-3" />
+          <div>{cameraCount}</div>
         </div>
       </div>
       <div className="absolute inset-x-2 bottom-2 z-20 text-white">
@@ -104,6 +104,7 @@ type ExportCardProps = {
   onRename: (original: string, update: string) => void;
   onDelete: ({ file, exportName }: DeleteClipType) => void;
   onAssignToCase?: (selected: Export) => void;
+  onRemoveFromCase?: (selected: Export) => void;
 };
 export function ExportCard({
   className,
@@ -112,19 +113,10 @@ export function ExportCard({
   onRename,
   onDelete,
   onAssignToCase,
+  onRemoveFromCase,
 }: ExportCardProps) {
   const { t } = useTranslation(["views/exports"]);
   const isAdmin = useIsAdmin();
-  const cameraName = useCameraFriendlyName(exportedRecording.camera);
-  const { data: config } = useSWR<FrigateConfig>("config");
-  const timeFormat = useTimeFormat(config);
-  const formattedDate = useFormattedTimestamp(
-    exportedRecording.date,
-    t(`time.formattedTimestampMonthDayYearHourMinute.${timeFormat}`, {
-      ns: "common",
-    }),
-    config?.ui.timezone,
-  );
   const [loading, setLoading] = useState(
     exportedRecording.thumb_path.length > 0,
   );
@@ -291,6 +283,18 @@ export function ExportCard({
                     {t("tooltip.assignToCase")}
                   </DropdownMenuItem>
                 )}
+                {isAdmin && onRemoveFromCase && (
+                  <DropdownMenuItem
+                    className="cursor-pointer"
+                    aria-label={t("tooltip.removeFromCase")}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRemoveFromCase(exportedRecording);
+                    }}
+                  >
+                    {t("tooltip.removeFromCase")}
+                  </DropdownMenuItem>
+                )}
                 {isAdmin && (
                   <DropdownMenuItem
                     className="cursor-pointer"
@@ -328,15 +332,11 @@ export function ExportCard({
         {loading && (
           <Skeleton className="absolute inset-0 aspect-video rounded-lg md:rounded-2xl" />
         )}
-        <div className="absolute left-3 top-3 z-30 rounded-full bg-black/55 px-2 py-1 text-xs text-white">
-          {cameraName}
-        </div>
         <ImageShadowOverlay />
         <div className="absolute bottom-2 left-3 z-30 text-white">
           <div className="flex items-end smart-capitalize">
             {exportedRecording.name.replaceAll("_", " ")}
           </div>
-          <div className="mt-1 text-xs text-white/80">{formattedDate}</div>
         </div>
       </div>
     </>
@@ -354,15 +354,6 @@ export function ActiveExportJobCard({
 }: ActiveExportJobCardProps) {
   const { t } = useTranslation(["views/exports", "common"]);
   const cameraName = useCameraFriendlyName(job.camera);
-  const { data: config } = useSWR<FrigateConfig>("config");
-  const timeFormat = useTimeFormat(config);
-  const formattedDate = useFormattedTimestamp(
-    job.request_start_time,
-    t(`time.formattedTimestampMonthDayYearHourMinute.${timeFormat}`, {
-      ns: "common",
-    }),
-    config?.ui.timezone,
-  );
   const displayName = useMemo(() => {
     if (job.name && job.name.length > 0) {
       return job.name.replaceAll("_", " ");
@@ -382,16 +373,12 @@ export function ActiveExportJobCard({
         className,
       )}
     >
-      <div className="absolute left-3 top-3 z-30 rounded-full bg-black/55 px-2 py-1 text-xs text-white">
-        {cameraName}
-      </div>
       <div className="absolute right-3 top-3 z-30 rounded-full bg-selected/90 px-2 py-1 text-xs text-selected-foreground">
         {statusLabel}
       </div>
       <div className="flex flex-col items-center gap-3 px-6 text-center">
         <ActivityIndicator />
         <div className="text-sm font-medium text-primary">{displayName}</div>
-        <div className="text-xs text-muted-foreground">{formattedDate}</div>
       </div>
     </div>
   );

--- a/web/src/components/card/ExportCard.tsx
+++ b/web/src/components/card/ExportCard.tsx
@@ -1,6 +1,6 @@
 import ActivityIndicator from "../indicators/activity-indicator";
 import { Button } from "../ui/button";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { isMobile } from "react-device-detect";
 import { FiMoreVertical } from "react-icons/fi";
 import { Skeleton } from "../ui/skeleton";
@@ -30,6 +30,7 @@ import {
 import { FaFolder, FaVideo } from "react-icons/fa";
 import { HiSquare2Stack } from "react-icons/hi2";
 import { useCameraFriendlyName } from "@/hooks/use-camera-friendly-name";
+import useContextMenu from "@/hooks/use-contextmenu";
 
 type CaseCardProps = {
   className: string;
@@ -100,7 +101,10 @@ export function CaseCard({
 type ExportCardProps = {
   className: string;
   exportedRecording: Export;
+  isSelected?: boolean;
+  selectionMode?: boolean;
   onSelect: (selected: Export) => void;
+  onContextSelect?: (selected: Export) => void;
   onRename: (original: string, update: string) => void;
   onDelete: ({ file, exportName }: DeleteClipType) => void;
   onAssignToCase?: (selected: Export) => void;
@@ -109,7 +113,10 @@ type ExportCardProps = {
 export function ExportCard({
   className,
   exportedRecording,
+  isSelected,
+  selectionMode,
   onSelect,
+  onContextSelect,
   onRename,
   onDelete,
   onAssignToCase,
@@ -120,6 +127,15 @@ export function ExportCard({
   const [loading, setLoading] = useState(
     exportedRecording.thumb_path.length > 0,
   );
+
+  // selection
+
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  useContextMenu(cardRef, () => {
+    if (!exportedRecording.in_progress && onContextSelect) {
+      onContextSelect(exportedRecording);
+    }
+  });
 
   // editing name
 
@@ -209,13 +225,18 @@ export function ExportCard({
       </Dialog>
 
       <div
+        ref={cardRef}
         className={cn(
           "relative flex aspect-video cursor-pointer items-center justify-center rounded-lg bg-black md:rounded-2xl",
           className,
         )}
-        onClick={() => {
+        onClick={(e) => {
           if (!exportedRecording.in_progress) {
-            onSelect(exportedRecording);
+            if ((selectionMode || e.ctrlKey || e.metaKey) && onContextSelect) {
+              onContextSelect(exportedRecording);
+            } else {
+              onSelect(exportedRecording);
+            }
           }
         }}
       >
@@ -234,7 +255,7 @@ export function ExportCard({
             )}
           </>
         )}
-        {!exportedRecording.in_progress && (
+        {!exportedRecording.in_progress && !selectionMode && (
           <div className="absolute bottom-2 right-3 z-40">
             <DropdownMenu modal={false}>
               <DropdownMenuTrigger>
@@ -333,6 +354,14 @@ export function ExportCard({
           <Skeleton className="absolute inset-0 aspect-video rounded-lg md:rounded-2xl" />
         )}
         <ImageShadowOverlay />
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-0 z-10 size-full rounded-lg outline outline-[3px] -outline-offset-[2.8px] md:rounded-2xl",
+            isSelected
+              ? "shadow-selected outline-selected"
+              : "outline-transparent duration-500",
+          )}
+        />
         <div className="absolute bottom-2 left-3 right-12 z-30 text-white">
           <div className="truncate smart-capitalize">
             {exportedRecording.name.replaceAll("_", " ")}

--- a/web/src/components/card/ReviewCard.tsx
+++ b/web/src/components/card/ReviewCard.tsx
@@ -81,7 +81,7 @@ export default function ReviewCard({
 
     axios
       .post(
-        `export/${event.camera}/start/${event.start_time + REVIEW_PADDING}/end/${endTime}`,
+        `export/${event.camera}/start/${event.start_time - REVIEW_PADDING}/end/${endTime}`,
         { playback: "realtime" },
       )
       .then((response) => {

--- a/web/src/components/config-form/section-configs/record.ts
+++ b/web/src/components/config-form/section-configs/record.ts
@@ -56,6 +56,11 @@ const record: SectionConfigOverrides = {
   },
   camera: {
     restartRequired: [],
+    hiddenFields: [
+      "enabled_in_config",
+      "sync_recordings",
+      "export.max_concurrent",
+    ],
   },
 };
 

--- a/web/src/components/filter/ExportActionGroup.tsx
+++ b/web/src/components/filter/ExportActionGroup.tsx
@@ -1,0 +1,384 @@
+import { useCallback, useMemo, useState } from "react";
+import axios from "axios";
+import { Button, buttonVariants } from "../ui/button";
+import { isDesktop } from "react-device-detect";
+import { HiTrash } from "react-icons/hi";
+import { LuFolderPlus, LuFolderX } from "react-icons/lu";
+import { Export, ExportCase } from "@/types/export";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../ui/alert-dialog";
+import { Label } from "../ui/label";
+import { Switch } from "../ui/switch";
+import useKeyboardListener from "@/hooks/use-keyboard-listener";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { useIsAdmin } from "@/hooks/use-is-admin";
+import OptionAndInputDialog from "../overlay/dialog/OptionAndInputDialog";
+
+type ExportActionGroupProps = {
+  selectedExports: Export[];
+  setSelectedExports: (exports: Export[]) => void;
+  context: "uncategorized" | "case";
+  cases?: ExportCase[];
+  currentCaseId?: string;
+  mutate: () => void;
+};
+export default function ExportActionGroup({
+  selectedExports,
+  setSelectedExports,
+  context,
+  cases,
+  currentCaseId,
+  mutate,
+}: ExportActionGroupProps) {
+  const { t } = useTranslation(["views/exports", "common"]);
+  const isAdmin = useIsAdmin();
+
+  const onClearSelected = useCallback(() => {
+    setSelectedExports([]);
+  }, [setSelectedExports]);
+
+  // ── Delete ──────────────────────────────────────────────────────
+
+  const onDelete = useCallback(() => {
+    const ids = selectedExports.map((e) => e.id);
+    axios
+      .post("exports/delete", { ids })
+      .then((resp) => {
+        if (resp.status === 200) {
+          toast.success(t("bulkToast.success.delete"), {
+            position: "top-center",
+          });
+          setSelectedExports([]);
+          mutate();
+        }
+      })
+      .catch((error) => {
+        const errorMessage =
+          error.response?.data?.message ||
+          error.response?.data?.detail ||
+          "Unknown error";
+        toast.error(t("bulkToast.error.deleteFailed", { errorMessage }), {
+          position: "top-center",
+        });
+      });
+  }, [selectedExports, setSelectedExports, mutate, t]);
+
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [bypassDialog, setBypassDialog] = useState(false);
+
+  useKeyboardListener(["Shift"], (_, modifiers) => {
+    setBypassDialog(modifiers.shift);
+    return false;
+  });
+
+  const handleDelete = useCallback(() => {
+    if (bypassDialog) {
+      onDelete();
+    } else {
+      setDeleteDialogOpen(true);
+    }
+  }, [bypassDialog, onDelete]);
+
+  // ── Remove from case ────────────────────────────────────────────
+
+  const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+  const [deleteExportsOnRemove, setDeleteExportsOnRemove] = useState(false);
+
+  const handleRemoveFromCase = useCallback(() => {
+    const ids = selectedExports.map((e) => e.id);
+
+    const request = deleteExportsOnRemove
+      ? axios.post("exports/delete", { ids })
+      : axios.post("exports/reassign", { ids, export_case_id: null });
+
+    request
+      .then((resp) => {
+        if (resp.status === 200) {
+          toast.success(t("bulkToast.success.remove"), {
+            position: "top-center",
+          });
+          setSelectedExports([]);
+          mutate();
+          setRemoveDialogOpen(false);
+          setDeleteExportsOnRemove(false);
+        }
+      })
+      .catch((error) => {
+        const errorMessage =
+          error.response?.data?.message ||
+          error.response?.data?.detail ||
+          "Unknown error";
+        toast.error(t("bulkToast.error.reassignFailed", { errorMessage }), {
+          position: "top-center",
+        });
+      });
+  }, [selectedExports, deleteExportsOnRemove, setSelectedExports, mutate, t]);
+
+  // ── Case picker ─────────────────────────────────────────────────
+
+  const [casePickerOpen, setCasePickerOpen] = useState(false);
+
+  const caseOptions = useMemo(
+    () => [
+      ...(cases ?? [])
+        .filter((c) => c.id !== currentCaseId)
+        .map((c) => ({
+          value: c.id,
+          label: c.name,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+      {
+        value: "new",
+        label: t("caseDialog.newCaseOption"),
+      },
+    ],
+    [cases, currentCaseId, t],
+  );
+
+  const handleAssignToCase = useCallback(
+    async (caseId: string) => {
+      const ids = selectedExports.map((e) => e.id);
+      try {
+        await axios.post("exports/reassign", {
+          ids,
+          export_case_id: caseId,
+        });
+        toast.success(t("bulkToast.success.reassign"), {
+          position: "top-center",
+        });
+        setSelectedExports([]);
+        mutate();
+      } catch (error) {
+        const apiError = error as {
+          response?: { data?: { message?: string; detail?: string } };
+        };
+        const errorMessage =
+          apiError.response?.data?.message ||
+          apiError.response?.data?.detail ||
+          "Unknown error";
+        toast.error(t("bulkToast.error.reassignFailed", { errorMessage }), {
+          position: "top-center",
+        });
+        throw error;
+      }
+    },
+    [selectedExports, setSelectedExports, mutate, t],
+  );
+
+  const handleCreateNewCase = useCallback(
+    async (name: string, description: string) => {
+      const ids = selectedExports.map((e) => e.id);
+      try {
+        const createResp = await axios.post("cases", { name, description });
+        const newCaseId: string | undefined = createResp.data?.id;
+
+        if (newCaseId) {
+          await axios.post("exports/reassign", {
+            ids,
+            export_case_id: newCaseId,
+          });
+        }
+
+        toast.success(t("bulkToast.success.reassign"), {
+          position: "top-center",
+        });
+        setSelectedExports([]);
+        mutate();
+      } catch (error) {
+        const apiError = error as {
+          response?: { data?: { message?: string; detail?: string } };
+        };
+        const errorMessage =
+          apiError.response?.data?.message ||
+          apiError.response?.data?.detail ||
+          "Unknown error";
+        toast.error(t("bulkToast.error.reassignFailed", { errorMessage }), {
+          position: "top-center",
+        });
+        throw error;
+      }
+    },
+    [selectedExports, setSelectedExports, mutate, t],
+  );
+
+  return (
+    <>
+      {/* Delete confirmation dialog */}
+      <AlertDialog
+        open={deleteDialogOpen}
+        onOpenChange={() => setDeleteDialogOpen(!deleteDialogOpen)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("bulkDelete.title")}</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogDescription>
+            {t("bulkDelete.desc", { count: selectedExports.length })}
+          </AlertDialogDescription>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              {t("button.cancel", { ns: "common" })}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              onClick={onDelete}
+            >
+              {t("button.delete", { ns: "common" })}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Remove from case dialog */}
+      {context === "case" && (
+        <AlertDialog
+          open={removeDialogOpen}
+          onOpenChange={(open) => {
+            if (!open) {
+              setRemoveDialogOpen(false);
+              setDeleteExportsOnRemove(false);
+            }
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                {t("bulkRemoveFromCase.title")}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {t("bulkRemoveFromCase.desc", {
+                  count: selectedExports.length,
+                })}{" "}
+                {deleteExportsOnRemove
+                  ? t("bulkRemoveFromCase.descDeleteExports")
+                  : t("bulkRemoveFromCase.descKeepExports")}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <div className="flex items-center justify-start gap-6">
+              <Label
+                htmlFor="bulk-delete-exports-switch"
+                className="cursor-pointer text-sm"
+              >
+                {t("bulkRemoveFromCase.deleteExports")}
+              </Label>
+              <Switch
+                id="bulk-delete-exports-switch"
+                checked={deleteExportsOnRemove}
+                onCheckedChange={setDeleteExportsOnRemove}
+              />
+            </div>
+            <AlertDialogFooter>
+              <AlertDialogCancel>
+                {t("button.cancel", { ns: "common" })}
+              </AlertDialogCancel>
+              <AlertDialogAction
+                className={buttonVariants({ variant: "destructive" })}
+                onClick={handleRemoveFromCase}
+              >
+                {t("button.delete", { ns: "common" })}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+
+      {/* Case picker dialog */}
+      <OptionAndInputDialog
+        open={casePickerOpen}
+        title={t("caseDialog.title")}
+        description={t("caseDialog.description")}
+        setOpen={setCasePickerOpen}
+        options={caseOptions}
+        nameLabel={t("caseDialog.nameLabel")}
+        descriptionLabel={t("caseDialog.descriptionLabel")}
+        initialValue={caseOptions[0]?.value}
+        newValueKey="new"
+        onSave={handleAssignToCase}
+        onCreateNew={handleCreateNewCase}
+      />
+
+      {/* Action bar */}
+      <div className="flex w-full items-center justify-end gap-2">
+        <div className="mx-1 flex items-center justify-center text-sm text-muted-foreground">
+          <div className="p-1">
+            {t("selected", { count: selectedExports.length })}
+          </div>
+          <div className="p-1">{"|"}</div>
+          <div
+            className="cursor-pointer p-2 text-primary hover:rounded-lg hover:bg-secondary"
+            onClick={onClearSelected}
+          >
+            {t("button.unselect", { ns: "common" })}
+          </div>
+        </div>
+        {isAdmin && (
+          <div className="flex items-center gap-1 md:gap-2">
+            {/* Add to Case / Move to Case */}
+            <Button
+              className="flex items-center gap-2 p-2"
+              aria-label={
+                context === "case"
+                  ? t("bulkActions.moveToCase")
+                  : t("bulkActions.addToCase")
+              }
+              size="sm"
+              onClick={() => setCasePickerOpen(true)}
+            >
+              <LuFolderPlus className="text-secondary-foreground" />
+              {isDesktop && (
+                <div className="text-primary">
+                  {context === "case"
+                    ? t("bulkActions.moveToCase")
+                    : t("bulkActions.addToCase")}
+                </div>
+              )}
+            </Button>
+
+            {/* Remove from Case (case context only) */}
+            {context === "case" && (
+              <Button
+                className="flex items-center gap-2 p-2"
+                aria-label={t("bulkActions.removeFromCase")}
+                size="sm"
+                onClick={() => setRemoveDialogOpen(true)}
+              >
+                <LuFolderX className="text-secondary-foreground" />
+                {isDesktop && (
+                  <div className="text-primary">
+                    {t("bulkActions.removeFromCase")}
+                  </div>
+                )}
+              </Button>
+            )}
+
+            {/* Delete */}
+            <Button
+              className="flex items-center gap-2 p-2"
+              aria-label={t("button.delete", { ns: "common" })}
+              size="sm"
+              onClick={handleDelete}
+            >
+              <HiTrash className="text-secondary-foreground" />
+              {isDesktop && (
+                <div className="text-primary">
+                  {bypassDialog
+                    ? t("bulkActions.deleteNow")
+                    : t("bulkActions.delete")}
+                </div>
+              )}
+            </Button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/web/src/components/filter/ReviewActionGroup.tsx
+++ b/web/src/components/filter/ReviewActionGroup.tsx
@@ -6,6 +6,7 @@ import { isDesktop } from "react-device-detect";
 import { FaCompactDisc } from "react-icons/fa";
 import { HiTrash } from "react-icons/hi";
 import { ReviewSegment } from "@/types/review";
+import { MAX_BATCH_EXPORT_ITEMS } from "@/types/export";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -20,6 +21,7 @@ import useKeyboardListener from "@/hooks/use-keyboard-listener";
 import { Trans, useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { useIsAdmin } from "@/hooks/use-is-admin";
+import MultiExportDialog from "../overlay/MultiExportDialog";
 
 type ReviewActionGroupProps = {
   selectedReviews: ReviewSegment[];
@@ -164,6 +166,29 @@ export default function ReviewActionGroup({
               )}
             </Button>
           )}
+          {selectedReviews.length >= 2 &&
+            selectedReviews.length <= MAX_BATCH_EXPORT_ITEMS && (
+              <MultiExportDialog
+                selectedReviews={selectedReviews}
+                onStarted={() => {
+                  onClearSelected();
+                  pullLatestData();
+                }}
+              >
+                <Button
+                  className="flex items-center gap-2 p-2"
+                  aria-label={t("recording.button.export")}
+                  size="sm"
+                >
+                  <FaCompactDisc className="text-secondary-foreground" />
+                  {isDesktop && (
+                    <div className="text-primary">
+                      {t("recording.button.export")}
+                    </div>
+                  )}
+                </Button>
+              </MultiExportDialog>
+            )}
           <Button
             className="flex items-center gap-2 p-2"
             aria-label={

--- a/web/src/components/overlay/ExportDialog.tsx
+++ b/web/src/components/overlay/ExportDialog.tsx
@@ -93,6 +93,8 @@ export default function ExportDialog({
   const { t } = useTranslation(["components/dialog"]);
   const [name, setName] = useState("");
   const [selectedCaseId, setSelectedCaseId] = useState<string | undefined>();
+  const [singleNewCaseName, setSingleNewCaseName] = useState("");
+  const [singleNewCaseDescription, setSingleNewCaseDescription] = useState("");
   const [activeTab, setActiveTab] = useState<ExportTab>("export");
   const [isStartingExport, setIsStartingExport] = useState(false);
   const previousModeRef = useRef<ExportMode>(mode);
@@ -137,12 +139,24 @@ export default function ExportDialog({
     setIsStartingExport(true);
 
     try {
+      let exportCaseId: string | undefined = selectedCaseId;
+
+      if (selectedCaseId === "new" && singleNewCaseName.trim().length > 0) {
+        const caseResp = await axios.post("cases", {
+          name: singleNewCaseName.trim(),
+          description: singleNewCaseDescription.trim() || undefined,
+        });
+        exportCaseId = caseResp.data?.id;
+      } else if (selectedCaseId === "new" || selectedCaseId === "none") {
+        exportCaseId = undefined;
+      }
+
       await axios.post<StartExportResponse>(
         `export/${camera}/start/${Math.round(range.after)}/end/${Math.round(range.before)}`,
         {
           source: "recordings",
           name,
-          export_case_id: selectedCaseId || undefined,
+          export_case_id: exportCaseId,
         },
       );
 
@@ -156,6 +170,8 @@ export default function ExportDialog({
       });
       setName("");
       setSelectedCaseId(undefined);
+      setSingleNewCaseName("");
+      setSingleNewCaseDescription("");
       setRange(undefined);
       setMode("none");
       return true;
@@ -183,6 +199,8 @@ export default function ExportDialog({
     name,
     range,
     selectedCaseId,
+    singleNewCaseDescription,
+    singleNewCaseName,
     setMode,
     setRange,
     t,
@@ -191,6 +209,8 @@ export default function ExportDialog({
   const handleCancel = useCallback(() => {
     setName("");
     setSelectedCaseId(undefined);
+    setSingleNewCaseName("");
+    setSingleNewCaseDescription("");
     setMode("none");
     setRange(undefined);
     setActiveTab("export");
@@ -272,12 +292,16 @@ export default function ExportDialog({
             range={range}
             name={name}
             selectedCaseId={selectedCaseId}
+            singleNewCaseName={singleNewCaseName}
+            singleNewCaseDescription={singleNewCaseDescription}
             activeTab={activeTab}
             isStartingExport={isStartingExport}
             onStartExport={onStartExport}
             setActiveTab={setActiveTab}
             setName={setName}
             setSelectedCaseId={setSelectedCaseId}
+            setSingleNewCaseName={setSingleNewCaseName}
+            setSingleNewCaseDescription={setSingleNewCaseDescription}
             setRange={setRange}
             setMode={setMode}
             onCancel={handleCancel}
@@ -294,12 +318,16 @@ type ExportContentProps = {
   range?: TimeRange;
   name: string;
   selectedCaseId?: string;
+  singleNewCaseName: string;
+  singleNewCaseDescription: string;
   activeTab: ExportTab;
   isStartingExport: boolean;
   onStartExport: () => Promise<boolean>;
   setActiveTab: (tab: ExportTab) => void;
   setName: (name: string) => void;
   setSelectedCaseId: (caseId: string | undefined) => void;
+  setSingleNewCaseName: (name: string) => void;
+  setSingleNewCaseDescription: (description: string) => void;
   setRange: (range: TimeRange | undefined) => void;
   setMode: (mode: ExportMode) => void;
   onCancel: () => void;
@@ -311,12 +339,16 @@ export function ExportContent({
   range,
   name,
   selectedCaseId,
+  singleNewCaseName,
+  singleNewCaseDescription,
   activeTab,
   isStartingExport,
   onStartExport,
   setActiveTab,
   setName,
   setSelectedCaseId,
+  setSingleNewCaseName,
+  setSingleNewCaseDescription,
   setRange,
   setMode,
   onCancel,
@@ -332,7 +364,7 @@ export function ExportContent({
   );
   const [selectedCameraIds, setSelectedCameraIds] = useState<string[]>([]);
   const [batchCaseSelection, setBatchCaseSelection] = useState<string>(
-    selectedCaseId || "new",
+    selectedCaseId || "none",
   );
   const [hasManualCameraSelection, setHasManualCameraSelection] =
     useState(false);
@@ -483,7 +515,8 @@ export function ExportContent({
     Boolean(range && range.before > range.after) &&
     selectedCameraCount > 0 &&
     !isStartingBatchExport &&
-    (batchCaseSelection !== "new" || newCaseName.trim().length > 0);
+    (batchCaseSelection !== "new" || newCaseName.trim().length > 0) &&
+    batchCaseSelection.length > 0;
 
   const onSelectTime = useCallback(
     (option: ExportOption) => {
@@ -567,7 +600,7 @@ export function ExportContent({
       })),
     };
 
-    if (isAdmin) {
+    if (isAdmin && batchCaseSelection !== "none") {
       if (batchCaseSelection === "new") {
         payload.new_case_name = newCaseName.trim();
         payload.new_case_description = newCaseDescription.trim() || undefined;
@@ -786,8 +819,30 @@ export function ExportContent({
                         {caseItem.name}
                       </SelectItem>
                     ))}
+                  <SelectSeparator />
+                  <SelectItem value="new">
+                    {t("export.case.newCaseOption")}
+                  </SelectItem>
                 </SelectContent>
               </Select>
+              {selectedCaseId === "new" && (
+                <div className="space-y-2 pt-1">
+                  <Input
+                    className="text-md"
+                    placeholder={t("export.case.newCaseNamePlaceholder")}
+                    value={singleNewCaseName}
+                    onChange={(e) => setSingleNewCaseName(e.target.value)}
+                  />
+                  <Textarea
+                    className="text-md"
+                    placeholder={t("export.case.newCaseDescriptionPlaceholder")}
+                    value={singleNewCaseDescription}
+                    onChange={(e) =>
+                      setSingleNewCaseDescription(e.target.value)
+                    }
+                  />
+                </div>
+              )}
             </div>
           )}
         </TabsContent>
@@ -947,6 +1002,9 @@ export function ExportContent({
                   <SelectValue placeholder={t("export.case.placeholder")} />
                 </SelectTrigger>
                 <SelectContent>
+                  <SelectItem value="none">
+                    {t("label.none", { ns: "common" })}
+                  </SelectItem>
                   {cases
                     ?.sort((a, b) => a.name.localeCompare(b.name))
                     .map((caseItem) => (

--- a/web/src/components/overlay/ExportDialog.tsx
+++ b/web/src/components/overlay/ExportDialog.tsx
@@ -53,6 +53,7 @@ import { resolveCameraName } from "@/hooks/use-camera-friendly-name";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { Textarea } from "../ui/textarea";
 import { useNavigate } from "react-router-dom";
+import { useIsAdmin } from "@/hooks/use-is-admin";
 
 const EXPORT_OPTIONS = [
   "1",
@@ -322,8 +323,9 @@ export function ExportContent({
 }: ExportContentProps) {
   const { t } = useTranslation(["components/dialog"]);
   const navigate = useNavigate();
+  const isAdmin = useIsAdmin();
   const [selectedOption, setSelectedOption] = useState<ExportOption>("1");
-  const { data: cases } = useSWR<ExportCase[]>("cases");
+  const { data: cases } = useSWR<ExportCase[]>(isAdmin ? "cases" : null);
   const { data: config } = useSWR<FrigateConfig>("config");
   const [debouncedRange, setDebouncedRange] = useState<TimeRange | undefined>(
     range,
@@ -555,16 +557,20 @@ export function ExportContent({
     }
 
     const payload: BatchExportBody = {
-      start_time: Math.round(range.after),
-      end_time: Math.round(range.before),
-      camera_ids: selectedCameraIds,
-      name: name || undefined,
+      items: selectedCameraIds.map((cameraId) => ({
+        camera: cameraId,
+        start_time: Math.round(range.after),
+        end_time: Math.round(range.before),
+        friendly_name: name
+          ? `${name} - ${resolveCameraName(config, cameraId)}`
+          : undefined,
+      })),
     };
 
     if (batchCaseSelection === "new") {
       payload.new_case_name = newCaseName.trim();
       payload.new_case_description = newCaseDescription.trim() || undefined;
-    } else if (batchCaseSelection !== "none") {
+    } else {
       payload.export_case_id = batchCaseSelection;
     }
 
@@ -752,33 +758,35 @@ export function ExportContent({
             onChange={(e) => setName(e.target.value)}
           />
 
-          <div className="space-y-2">
-            <Label className="text-sm text-secondary-foreground">
-              {t("export.case.label")}
-            </Label>
-            <Select
-              value={selectedCaseId || "none"}
-              onValueChange={(value) =>
-                setSelectedCaseId(value === "none" ? undefined : value)
-              }
-            >
-              <SelectTrigger>
-                <SelectValue placeholder={t("export.case.placeholder")} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">
-                  {t("label.none", { ns: "common" })}
-                </SelectItem>
-                {cases
-                  ?.sort((a, b) => a.name.localeCompare(b.name))
-                  .map((caseItem) => (
-                    <SelectItem key={caseItem.id} value={caseItem.id}>
-                      {caseItem.name}
-                    </SelectItem>
-                  ))}
-              </SelectContent>
-            </Select>
-          </div>
+          {isAdmin && (
+            <div className="space-y-2">
+              <Label className="text-sm text-secondary-foreground">
+                {t("export.case.label")}
+              </Label>
+              <Select
+                value={selectedCaseId || "none"}
+                onValueChange={(value) =>
+                  setSelectedCaseId(value === "none" ? undefined : value)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={t("export.case.placeholder")} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">
+                    {t("label.none", { ns: "common" })}
+                  </SelectItem>
+                  {cases
+                    ?.sort((a, b) => a.name.localeCompare(b.name))
+                    .map((caseItem) => (
+                      <SelectItem key={caseItem.id} value={caseItem.id}>
+                        {caseItem.name}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
         </TabsContent>
 
         <TabsContent
@@ -927,29 +935,55 @@ export function ExportContent({
             <Label className="text-sm text-secondary-foreground">
               {t("export.case.label")}
             </Label>
-            <Select
-              value={batchCaseSelection}
-              onValueChange={(value) => setBatchCaseSelection(value)}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder={t("export.case.placeholder")} />
-              </SelectTrigger>
-              <SelectContent>
-                {cases
-                  ?.sort((a, b) => a.name.localeCompare(b.name))
-                  .map((caseItem) => (
-                    <SelectItem key={caseItem.id} value={caseItem.id}>
-                      {caseItem.name}
+            {isAdmin ? (
+              <>
+                <Select
+                  value={batchCaseSelection}
+                  onValueChange={(value) => setBatchCaseSelection(value)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder={t("export.case.placeholder")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {cases
+                      ?.sort((a, b) => a.name.localeCompare(b.name))
+                      .map((caseItem) => (
+                        <SelectItem key={caseItem.id} value={caseItem.id}>
+                          {caseItem.name}
+                        </SelectItem>
+                      ))}
+                    <SelectSeparator />
+                    <SelectItem value="new">
+                      {t("export.case.newCaseOption")}
                     </SelectItem>
-                  ))}
-                <SelectSeparator />
-                <SelectItem value="new">
-                  {t("export.case.newCaseOption")}
-                </SelectItem>
-              </SelectContent>
-            </Select>
-            {batchCaseSelection === "new" && (
+                  </SelectContent>
+                </Select>
+                {batchCaseSelection === "new" && (
+                  <div className="space-y-2 pt-1">
+                    <Input
+                      className="text-md"
+                      placeholder={t("export.case.newCaseNamePlaceholder")}
+                      value={newCaseName}
+                      onChange={(event) => setNewCaseName(event.target.value)}
+                    />
+                    <Textarea
+                      className="text-md"
+                      placeholder={t(
+                        "export.case.newCaseDescriptionPlaceholder",
+                      )}
+                      value={newCaseDescription}
+                      onChange={(event) =>
+                        setNewCaseDescription(event.target.value)
+                      }
+                    />
+                  </div>
+                )}
+              </>
+            ) : (
               <div className="space-y-2 pt-1">
+                <div className="text-xs text-muted-foreground">
+                  {t("export.case.nonAdminHelp")}
+                </div>
                 <Input
                   className="text-md"
                   placeholder={t("export.case.newCaseNamePlaceholder")}

--- a/web/src/components/overlay/ExportDialog.tsx
+++ b/web/src/components/overlay/ExportDialog.tsx
@@ -567,11 +567,13 @@ export function ExportContent({
       })),
     };
 
-    if (batchCaseSelection === "new") {
-      payload.new_case_name = newCaseName.trim();
-      payload.new_case_description = newCaseDescription.trim() || undefined;
-    } else {
-      payload.export_case_id = batchCaseSelection;
+    if (isAdmin) {
+      if (batchCaseSelection === "new") {
+        payload.new_case_name = newCaseName.trim();
+        payload.new_case_description = newCaseDescription.trim() || undefined;
+      } else {
+        payload.export_case_id = batchCaseSelection;
+      }
     }
 
     setIsStartingBatchExport(true);
@@ -661,6 +663,7 @@ export function ExportContent({
   }, [
     batchCaseSelection,
     config,
+    isAdmin,
     isStartingBatchExport,
     name,
     newCaseDescription,
@@ -931,76 +934,52 @@ export function ExportContent({
             />
           </div>
 
-          <div className="space-y-2">
-            <Label className="text-sm text-secondary-foreground">
-              {t("export.case.label")}
-            </Label>
-            {isAdmin ? (
-              <>
-                <Select
-                  value={batchCaseSelection}
-                  onValueChange={(value) => setBatchCaseSelection(value)}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder={t("export.case.placeholder")} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {cases
-                      ?.sort((a, b) => a.name.localeCompare(b.name))
-                      .map((caseItem) => (
-                        <SelectItem key={caseItem.id} value={caseItem.id}>
-                          {caseItem.name}
-                        </SelectItem>
-                      ))}
-                    <SelectSeparator />
-                    <SelectItem value="new">
-                      {t("export.case.newCaseOption")}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                {batchCaseSelection === "new" && (
-                  <div className="space-y-2 pt-1">
-                    <Input
-                      className="text-md"
-                      placeholder={t("export.case.newCaseNamePlaceholder")}
-                      value={newCaseName}
-                      onChange={(event) => setNewCaseName(event.target.value)}
-                    />
-                    <Textarea
-                      className="text-md"
-                      placeholder={t(
-                        "export.case.newCaseDescriptionPlaceholder",
-                      )}
-                      value={newCaseDescription}
-                      onChange={(event) =>
-                        setNewCaseDescription(event.target.value)
-                      }
-                    />
-                  </div>
-                )}
-              </>
-            ) : (
-              <div className="space-y-2 pt-1">
-                <div className="text-xs text-muted-foreground">
-                  {t("export.case.nonAdminHelp")}
+          {isAdmin && (
+            <div className="space-y-2">
+              <Label className="text-sm text-secondary-foreground">
+                {t("export.case.label")}
+              </Label>
+              <Select
+                value={batchCaseSelection}
+                onValueChange={(value) => setBatchCaseSelection(value)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={t("export.case.placeholder")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {cases
+                    ?.sort((a, b) => a.name.localeCompare(b.name))
+                    .map((caseItem) => (
+                      <SelectItem key={caseItem.id} value={caseItem.id}>
+                        {caseItem.name}
+                      </SelectItem>
+                    ))}
+                  <SelectSeparator />
+                  <SelectItem value="new">
+                    {t("export.case.newCaseOption")}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              {batchCaseSelection === "new" && (
+                <div className="space-y-2 pt-1">
+                  <Input
+                    className="text-md"
+                    placeholder={t("export.case.newCaseNamePlaceholder")}
+                    value={newCaseName}
+                    onChange={(event) => setNewCaseName(event.target.value)}
+                  />
+                  <Textarea
+                    className="text-md"
+                    placeholder={t("export.case.newCaseDescriptionPlaceholder")}
+                    value={newCaseDescription}
+                    onChange={(event) =>
+                      setNewCaseDescription(event.target.value)
+                    }
+                  />
                 </div>
-                <Input
-                  className="text-md"
-                  placeholder={t("export.case.newCaseNamePlaceholder")}
-                  value={newCaseName}
-                  onChange={(event) => setNewCaseName(event.target.value)}
-                />
-                <Textarea
-                  className="text-md"
-                  placeholder={t("export.case.newCaseDescriptionPlaceholder")}
-                  value={newCaseDescription}
-                  onChange={(event) =>
-                    setNewCaseDescription(event.target.value)
-                  }
-                />
-              </div>
-            )}
-          </div>
+              )}
+            </div>
+          )}
         </TabsContent>
       </Tabs>
 

--- a/web/src/components/overlay/ExportDialog.tsx
+++ b/web/src/components/overlay/ExportDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -19,6 +19,12 @@ import { Input } from "../ui/input";
 import { TimeRange } from "@/types/timeline";
 import useSWR from "swr";
 import {
+  BatchExportBody,
+  BatchExportResponse,
+  CameraActivity,
+  ExportCase,
+} from "@/types/export";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -33,8 +39,14 @@ import { baseUrl } from "@/api/baseUrl";
 import { cn } from "@/lib/utils";
 import { GenericVideoPlayer } from "../player/GenericVideoPlayer";
 import { useTranslation } from "react-i18next";
-import { ExportCase } from "@/types/export";
 import { CustomTimeSelector } from "./CustomTimeSelector";
+import { Event } from "@/types/event";
+import { FrigateConfig } from "@/types/frigateConfig";
+import { resolveCameraName } from "@/hooks/use-camera-friendly-name";
+import { Checkbox } from "../ui/checkbox";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+import { Textarea } from "../ui/textarea";
+import { useNavigate } from "react-router-dom";
 
 const EXPORT_OPTIONS = [
   "1",
@@ -46,6 +58,7 @@ const EXPORT_OPTIONS = [
   "custom",
 ] as const;
 type ExportOption = (typeof EXPORT_OPTIONS)[number];
+export type ExportTab = "export" | "multi";
 
 type ExportDialogProps = {
   camera: string;
@@ -58,6 +71,7 @@ type ExportDialogProps = {
   setMode: (mode: ExportMode) => void;
   setShowPreview: (showPreview: boolean) => void;
 };
+
 export default function ExportDialog({
   camera,
   latestTime,
@@ -71,9 +85,27 @@ export default function ExportDialog({
 }: ExportDialogProps) {
   const { t } = useTranslation(["components/dialog"]);
   const [name, setName] = useState("");
-  const [selectedCaseId, setSelectedCaseId] = useState<string | undefined>(
-    undefined,
-  );
+  const [selectedCaseId, setSelectedCaseId] = useState<string | undefined>();
+  const [activeTab, setActiveTab] = useState<ExportTab>("export");
+  const previousModeRef = useRef<ExportMode>(mode);
+
+  useEffect(() => {
+    const previousMode = previousModeRef.current;
+
+    if (mode === "select" && previousMode === "none") {
+      setActiveTab("export");
+    }
+
+    if (mode === "select" && previousMode === "timeline_multi") {
+      setActiveTab("multi");
+    }
+
+    if (mode === "none") {
+      setActiveTab("export");
+    }
+
+    previousModeRef.current = mode;
+  }, [mode]);
 
   const onStartExport = useCallback(() => {
     if (!range) {
@@ -127,13 +159,14 @@ export default function ExportDialog({
           { position: "top-center" },
         );
       });
-  }, [camera, name, range, selectedCaseId, setRange, setName, setMode, t]);
+  }, [camera, name, range, selectedCaseId, setMode, setRange, t]);
 
   const handleCancel = useCallback(() => {
     setName("");
     setSelectedCaseId(undefined);
     setMode("none");
     setRange(undefined);
+    setActiveTab("export");
   }, [setMode, setRange]);
 
   const Overlay = isDesktop ? Dialog : Drawer;
@@ -150,16 +183,30 @@ export default function ExportDialog({
       />
       <SaveExportOverlay
         className="pointer-events-none absolute left-1/2 top-8 z-50 -translate-x-1/2"
-        show={mode == "timeline"}
+        show={mode == "timeline" || mode == "timeline_multi"}
+        hidePreview={mode == "timeline_multi"}
+        saveLabel={
+          mode == "timeline_multi"
+            ? t("export.fromTimeline.useThisRange")
+            : undefined
+        }
         onPreview={() => setShowPreview(true)}
-        onSave={() => onStartExport()}
+        onSave={() => {
+          if (mode == "timeline_multi") {
+            setActiveTab("multi");
+            setMode("select");
+            return;
+          }
+
+          onStartExport();
+        }}
         onCancel={handleCancel}
       />
       <Overlay
         open={mode == "select"}
         onOpenChange={(open) => {
           if (!open) {
-            setMode("none");
+            handleCancel();
           }
         }}
       >
@@ -171,22 +218,16 @@ export default function ExportDialog({
               size="sm"
               onClick={() => {
                 const now = new Date(latestTime * 1000);
-                let start = 0;
                 now.setHours(now.getHours() - 1);
-                start = now.getTime() / 1000;
+                setActiveTab("export");
                 setRange({
                   before: latestTime,
-                  after: start,
+                  after: now.getTime() / 1000,
                 });
                 setMode("select");
               }}
             >
               <FaArrowDown className="rounded-md bg-secondary-foreground fill-secondary p-1" />
-              {isDesktop && (
-                <div className="text-primary">
-                  {t("menu.export", { ns: "common" })}
-                </div>
-              )}
             </Button>
           </Trigger>
         )}
@@ -203,7 +244,9 @@ export default function ExportDialog({
             range={range}
             name={name}
             selectedCaseId={selectedCaseId}
+            activeTab={activeTab}
             onStartExport={onStartExport}
+            setActiveTab={setActiveTab}
             setName={setName}
             setSelectedCaseId={setSelectedCaseId}
             setRange={setRange}
@@ -222,20 +265,25 @@ type ExportContentProps = {
   range?: TimeRange;
   name: string;
   selectedCaseId?: string;
+  activeTab: ExportTab;
   onStartExport: () => void;
+  setActiveTab: (tab: ExportTab) => void;
   setName: (name: string) => void;
   setSelectedCaseId: (caseId: string | undefined) => void;
   setRange: (range: TimeRange | undefined) => void;
   setMode: (mode: ExportMode) => void;
   onCancel: () => void;
 };
+
 export function ExportContent({
   latestTime,
   currentTime,
   range,
   name,
   selectedCaseId,
+  activeTab,
   onStartExport,
+  setActiveTab,
   setName,
   setSelectedCaseId,
   setRange,
@@ -243,8 +291,143 @@ export function ExportContent({
   onCancel,
 }: ExportContentProps) {
   const { t } = useTranslation(["components/dialog"]);
+  const navigate = useNavigate();
   const [selectedOption, setSelectedOption] = useState<ExportOption>("1");
   const { data: cases } = useSWR<ExportCase[]>("cases");
+  const { data: config } = useSWR<FrigateConfig>("config");
+  const [debouncedRange, setDebouncedRange] = useState<TimeRange | undefined>(
+    range,
+  );
+  const [selectedCameraIds, setSelectedCameraIds] = useState<string[]>([]);
+  const [batchCaseSelection, setBatchCaseSelection] = useState<string>(
+    selectedCaseId || "none",
+  );
+  const [hasManualCameraSelection, setHasManualCameraSelection] =
+    useState(false);
+  const [newCaseName, setNewCaseName] = useState("");
+  const [newCaseDescription, setNewCaseDescription] = useState("");
+  const multiRangeKey = useMemo(() => {
+    if (activeTab !== "multi" || !range) {
+      return undefined;
+    }
+
+    return `${Math.round(range.after)}-${Math.round(range.before)}`;
+  }, [activeTab, range]);
+
+  useEffect(() => {
+    if (activeTab !== "multi") {
+      setDebouncedRange(undefined);
+      return;
+    }
+
+    if (!range) {
+      setDebouncedRange(undefined);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedRange(range);
+    }, 300);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [activeTab, range]);
+
+  useEffect(() => {
+    if (activeTab !== "multi") {
+      return;
+    }
+
+    if (selectedCaseId) {
+      setBatchCaseSelection(selectedCaseId);
+      return;
+    }
+
+    if ((cases?.length ?? 0) === 0) {
+      setBatchCaseSelection("new");
+      return;
+    }
+
+    setBatchCaseSelection("new");
+  }, [activeTab, cases?.length, selectedCaseId]);
+
+  useEffect(() => {
+    setHasManualCameraSelection(false);
+  }, [multiRangeKey]);
+
+  useEffect(() => {
+    if (activeTab !== "multi" || range) {
+      return;
+    }
+
+    setRange({
+      before: latestTime,
+      after: latestTime - 3600,
+    });
+  }, [activeTab, latestTime, range, setRange]);
+
+  const { data: events, isLoading: isEventsLoading } = useSWR<Event[]>(
+    activeTab === "multi" && debouncedRange
+      ? [
+          "events",
+          {
+            after: Math.round(debouncedRange.after),
+            before: Math.round(debouncedRange.before),
+            limit: 500,
+          },
+        ]
+      : null,
+  );
+
+  const cameraActivities = useMemo<CameraActivity[]>(() => {
+    const allCameraIds = Object.keys(config?.cameras ?? {});
+    const counts = new Map<string, number>();
+
+    events?.forEach((event) => {
+      counts.set(event.camera, (counts.get(event.camera) ?? 0) + 1);
+    });
+
+    const maxCount = Math.max(1, ...Array.from(counts.values()), 1);
+
+    return allCameraIds.map((cameraId) => {
+      const count = counts.get(cameraId) ?? 0;
+      return {
+        camera: cameraId,
+        count,
+        intensity: count / maxCount,
+        hasDetections: count > 0,
+      };
+    });
+  }, [config?.cameras, events]);
+
+  useEffect(() => {
+    if (
+      activeTab !== "multi" ||
+      !config ||
+      isEventsLoading ||
+      hasManualCameraSelection
+    ) {
+      return;
+    }
+
+    setSelectedCameraIds(
+      cameraActivities
+        .filter((activity) => activity.hasDetections)
+        .map((activity) => activity.camera),
+    );
+  }, [
+    activeTab,
+    cameraActivities,
+    config,
+    hasManualCameraSelection,
+    isEventsLoading,
+  ]);
+
+  const selectedCameraCount = selectedCameraIds.length;
+  const canStartBatchExport =
+    Boolean(range && range.before > range.after) &&
+    selectedCameraCount > 0 &&
+    ((batchCaseSelection !== "none" && batchCaseSelection !== "new") ||
+      (batchCaseSelection === "new" && newCaseName.trim().length > 0));
 
   const onSelectTime = useCallback(
     (option: ExportOption) => {
@@ -252,6 +435,7 @@ export function ExportContent({
 
       const now = new Date(latestTime * 1000);
       let start = 0;
+
       switch (option) {
         case "1":
           now.setHours(now.getHours() - 1);
@@ -276,6 +460,8 @@ export function ExportContent({
         case "custom":
           start = latestTime - 3600;
           break;
+        default:
+          start = latestTime - 3600;
       }
 
       setRange({
@@ -285,6 +471,139 @@ export function ExportContent({
     },
     [latestTime, setRange],
   );
+
+  const toggleCameraSelection = useCallback((cameraId: string) => {
+    setHasManualCameraSelection(true);
+    setSelectedCameraIds((previous) =>
+      previous.includes(cameraId)
+        ? previous.filter((selectedId) => selectedId !== cameraId)
+        : [...previous, cameraId],
+    );
+  }, []);
+
+  const startBatchExport = useCallback(async () => {
+    if (!range) {
+      toast.error(t("export.toast.error.noVaildTimeSelected"), {
+        position: "top-center",
+      });
+      return;
+    }
+
+    if (range.before <= range.after) {
+      toast.error(t("export.toast.error.endTimeMustAfterStartTime"), {
+        position: "top-center",
+      });
+      return;
+    }
+
+    const payload: BatchExportBody = {
+      start_time: Math.round(range.after),
+      end_time: Math.round(range.before),
+      camera_ids: selectedCameraIds,
+      name: name || undefined,
+    };
+
+    if (batchCaseSelection === "new") {
+      payload.new_case_name = newCaseName.trim();
+      payload.new_case_description = newCaseDescription.trim() || undefined;
+    } else if (batchCaseSelection !== "none") {
+      payload.export_case_id = batchCaseSelection;
+    }
+
+    try {
+      const response = await axios.post<BatchExportResponse>(
+        "exports/batch",
+        payload,
+      );
+      const results = response.data.results;
+      const successfulResults = results.filter((result) => result.success);
+      const failedResults = results.filter((result) => !result.success);
+      const failedSummary = failedResults
+        .map((result) => {
+          const cameraName = resolveCameraName(config, result.camera);
+          return result.error ? `${cameraName}: ${result.error}` : cameraName;
+        })
+        .join(", ");
+
+      if (failedResults.length > 0 && successfulResults.length > 0) {
+        toast.success(
+          t("export.toast.batchPartial", {
+            successful: successfulResults.length,
+            total: results.length,
+            failedCameras: failedResults
+              .map((result) => resolveCameraName(config, result.camera))
+              .join(", "),
+          }),
+          {
+            position: "top-center",
+            description: failedSummary,
+          },
+        );
+      } else if (failedResults.length > 0) {
+        toast.error(
+          t("export.toast.batchFailed", {
+            total: results.length,
+            failedCameras: failedResults
+              .map((result) => resolveCameraName(config, result.camera))
+              .join(", "),
+          }),
+          {
+            position: "top-center",
+            description: failedSummary,
+          },
+        );
+      } else {
+        toast.success(
+          t("export.toast.batchSuccess", {
+            count: successfulResults.length,
+          }),
+          { position: "top-center" },
+        );
+      }
+
+      if (successfulResults.length > 0) {
+        setName("");
+        setSelectedCaseId(undefined);
+        setBatchCaseSelection("none");
+        setNewCaseName("");
+        setNewCaseDescription("");
+        setRange(undefined);
+        setMode("none");
+        setActiveTab("export");
+        navigate(`/export?caseId=${response.data.export_case_id}`);
+      }
+    } catch (error) {
+      const apiError = error as {
+        response?: { data?: { message?: string; detail?: string } };
+      };
+      const errorMessage =
+        apiError.response?.data?.message ||
+        apiError.response?.data?.detail ||
+        "Unknown error";
+
+      toast.error(
+        t("export.toast.error.failed", {
+          error: errorMessage,
+        }),
+        { position: "top-center" },
+      );
+    }
+  }, [
+    batchCaseSelection,
+    config,
+    name,
+    newCaseDescription,
+    newCaseName,
+    range,
+    selectedCameraIds,
+    setActiveTab,
+    setMode,
+    setName,
+    setRange,
+    setSelectedCaseId,
+    t,
+    navigate,
+  ]);
 
   return (
     <div className="w-full">
@@ -296,89 +615,253 @@ export function ExportContent({
           <SelectSeparator className="my-4 bg-secondary" />
         </>
       )}
-      <RadioGroup
-        className={`flex flex-col gap-4 ${isDesktop ? "" : "mt-4"}`}
-        onValueChange={(value) => onSelectTime(value as ExportOption)}
+
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) => setActiveTab(value as ExportTab)}
+        className="w-full"
       >
-        {EXPORT_OPTIONS.map((opt) => {
-          return (
-            <div key={opt} className="flex items-center gap-2">
-              <RadioGroupItem
-                className={
-                  opt == selectedOption
-                    ? "bg-selected from-selected/50 to-selected/90 text-selected"
-                    : "bg-secondary from-secondary/50 to-secondary/90 text-secondary"
-                }
-                id={opt}
-                value={opt}
-              />
-              <Label className="cursor-pointer smart-capitalize" htmlFor={opt}>
-                {isNaN(parseInt(opt))
-                  ? opt == "timeline"
-                    ? t("export.time.fromTimeline")
-                    : t("export.time." + opt)
-                  : t("export.time.lastHour", {
-                      count: parseInt(opt),
-                    })}
-              </Label>
-            </div>
-          );
-        })}
-      </RadioGroup>
-      {selectedOption == "custom" && (
-        <CustomTimeSelector
-          latestTime={latestTime}
-          range={range}
-          setRange={setRange}
-          startLabel={t("export.time.start.title")}
-          endLabel={t("export.time.end.title")}
-        />
-      )}
-      <Input
-        className="text-md my-6"
-        type="search"
-        placeholder={t("export.name.placeholder")}
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-      />
-      <div className="my-4">
-        <Label className="text-sm text-secondary-foreground">
-          {t("export.case.label", { defaultValue: "Case (optional)" })}
-        </Label>
-        <Select
-          value={selectedCaseId || "none"}
-          onValueChange={(value) =>
-            setSelectedCaseId(value === "none" ? undefined : value)
-          }
-        >
-          <SelectTrigger className="mt-2">
-            <SelectValue
-              placeholder={t("export.case.placeholder", {
-                defaultValue: "Select a case (optional)",
-              })}
-            />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem
-              value="none"
-              className="cursor-pointer hover:bg-accent hover:text-accent-foreground"
-            >
-              {t("label.none", { ns: "common" })}
-            </SelectItem>
-            {cases
-              ?.sort((a, b) => a.name.localeCompare(b.name))
-              .map((caseItem) => (
-                <SelectItem
-                  key={caseItem.id}
-                  value={caseItem.id}
-                  className="cursor-pointer hover:bg-accent hover:text-accent-foreground"
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="export">{t("export.tabs.export")}</TabsTrigger>
+          <TabsTrigger value="multi">
+            {t("export.tabs.multiCamera")}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="export" className="mt-4 space-y-4">
+          <RadioGroup
+            className={`flex flex-col gap-4 ${isDesktop ? "" : "mt-1"}`}
+            onValueChange={(value) => onSelectTime(value as ExportOption)}
+            value={selectedOption}
+          >
+            {EXPORT_OPTIONS.map((opt) => (
+              <div key={opt} className="flex items-center gap-2">
+                <RadioGroupItem
+                  className={
+                    opt == selectedOption
+                      ? "bg-selected from-selected/50 to-selected/90 text-selected"
+                      : "bg-secondary from-secondary/50 to-secondary/90 text-secondary"
+                  }
+                  id={opt}
+                  value={opt}
+                />
+                <Label
+                  className="cursor-pointer smart-capitalize"
+                  htmlFor={opt}
                 >
-                  {caseItem.name}
+                  {isNaN(parseInt(opt))
+                    ? opt == "timeline"
+                      ? t("export.time.fromTimeline")
+                      : t(`export.time.${opt}`)
+                    : t("export.time.lastHour", {
+                        count: parseInt(opt),
+                      })}
+                </Label>
+              </div>
+            ))}
+          </RadioGroup>
+
+          {selectedOption == "custom" && (
+            <CustomTimeSelector
+              latestTime={latestTime}
+              range={range}
+              setRange={setRange}
+              startLabel={t("export.time.start.title")}
+              endLabel={t("export.time.end.title")}
+            />
+          )}
+
+          <Input
+            className="text-md"
+            type="search"
+            placeholder={t("export.name.placeholder")}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+
+          <div className="space-y-2">
+            <Label className="text-sm text-secondary-foreground">
+              {t("export.case.label")}
+            </Label>
+            <Select
+              value={selectedCaseId || "none"}
+              onValueChange={(value) =>
+                setSelectedCaseId(value === "none" ? undefined : value)
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder={t("export.case.placeholder")} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">
+                  {t("label.none", { ns: "common" })}
                 </SelectItem>
-              ))}
-          </SelectContent>
-        </Select>
-      </div>
+                {cases
+                  ?.sort((a, b) => a.name.localeCompare(b.name))
+                  .map((caseItem) => (
+                    <SelectItem key={caseItem.id} value={caseItem.id}>
+                      {caseItem.name}
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="multi" className="mt-4 space-y-4">
+          <div className="space-y-2">
+            <Label className="text-sm text-secondary-foreground">
+              {t("export.multiCamera.timeRange")}
+            </Label>
+            <CustomTimeSelector
+              latestTime={latestTime}
+              range={range}
+              setRange={setRange}
+              startLabel={t("export.time.start.title")}
+              endLabel={t("export.time.end.title")}
+            />
+            <Button
+              size="sm"
+              className="mt-2"
+              onClick={() => {
+                if (!range) {
+                  setRange({
+                    before: currentTime + 30,
+                    after: currentTime - 30,
+                  });
+                }
+
+                setActiveTab("multi");
+                setMode("timeline_multi");
+              }}
+            >
+              {t("export.multiCamera.selectFromTimeline")}
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label className="text-sm text-secondary-foreground">
+                {t("export.multiCamera.cameraSelection")}
+              </Label>
+              <div className="text-xs text-muted-foreground">
+                {t("export.multiCamera.selectedCount", {
+                  count: selectedCameraCount,
+                })}
+              </div>
+            </div>
+            <div className="max-h-64 space-y-2 overflow-y-auto rounded-lg border border-border bg-background/50 p-2">
+              {isEventsLoading && (
+                <div className="px-2 py-4 text-sm text-muted-foreground">
+                  {t("export.multiCamera.checkingActivity")}
+                </div>
+              )}
+              {!isEventsLoading && cameraActivities.length === 0 && (
+                <div className="px-2 py-4 text-sm text-muted-foreground">
+                  {t("export.multiCamera.noCameras")}
+                </div>
+              )}
+              {cameraActivities.map((activity) => {
+                const isSelected = selectedCameraIds.includes(activity.camera);
+
+                return (
+                  <button
+                    key={activity.camera}
+                    type="button"
+                    className={cn(
+                      "flex w-full items-center gap-3 rounded-md border border-border px-3 py-2 text-left transition-colors",
+                      activity.hasDetections
+                        ? "bg-secondary/40 hover:bg-secondary/70"
+                        : "bg-background text-muted-foreground",
+                    )}
+                    onClick={() => toggleCameraSelection(activity.camera)}
+                  >
+                    <Checkbox checked={isSelected} />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="truncate text-sm font-medium text-primary">
+                          {resolveCameraName(config, activity.camera)}
+                        </span>
+                        <span className="shrink-0 text-xs text-muted-foreground">
+                          {t("export.multiCamera.detectionCount", {
+                            count: activity.count,
+                          })}
+                        </span>
+                      </div>
+                      <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-secondary">
+                        <div
+                          className={cn(
+                            "h-full rounded-full",
+                            activity.hasDetections ? "bg-selected" : "bg-muted",
+                          )}
+                          style={{
+                            width: `${Math.max(activity.intensity * 100, activity.hasDetections ? 8 : 0)}%`,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <Input
+            className="text-md"
+            type="search"
+            placeholder={t("export.multiCamera.namePlaceholder")}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+
+          <div className="space-y-2">
+            <Label className="text-sm text-secondary-foreground">
+              {t("export.case.label")}
+            </Label>
+            <Select
+              value={batchCaseSelection}
+              onValueChange={(value) => setBatchCaseSelection(value)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder={t("export.case.placeholder")} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">
+                  {t("label.none", { ns: "common" })}
+                </SelectItem>
+                {cases
+                  ?.sort((a, b) => a.name.localeCompare(b.name))
+                  .map((caseItem) => (
+                    <SelectItem key={caseItem.id} value={caseItem.id}>
+                      {caseItem.name}
+                    </SelectItem>
+                  ))}
+                <SelectSeparator />
+                <SelectItem value="new">
+                  {t("export.case.newCaseOption")}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            {batchCaseSelection === "new" && (
+              <div className="space-y-2 rounded-lg border border-border bg-background/50 p-3">
+                <Input
+                  placeholder={t("export.case.newCaseNamePlaceholder")}
+                  value={newCaseName}
+                  onChange={(event) => setNewCaseName(event.target.value)}
+                />
+                <Textarea
+                  placeholder={t("export.case.newCaseDescriptionPlaceholder")}
+                  value={newCaseDescription}
+                  onChange={(event) =>
+                    setNewCaseDescription(event.target.value)
+                  }
+                />
+              </div>
+            )}
+          </div>
+        </TabsContent>
+      </Tabs>
+
       {isDesktop && <SelectSeparator className="my-4 bg-secondary" />}
       <DialogFooter
         className={isDesktop ? "" : "mt-3 flex flex-col-reverse gap-4"}
@@ -389,26 +872,43 @@ export function ExportContent({
         >
           {t("button.cancel", { ns: "common" })}
         </div>
-        <Button
-          className={isDesktop ? "" : "w-full"}
-          aria-label={t("export.selectOrExport")}
-          variant="select"
-          size="sm"
-          onClick={() => {
-            if (selectedOption == "timeline") {
-              setRange({ before: currentTime + 30, after: currentTime - 30 });
-              setMode("timeline");
-            } else {
-              onStartExport();
-              setSelectedOption("1");
-              setMode("none");
-            }
-          }}
-        >
-          {selectedOption == "timeline"
-            ? t("export.select")
-            : t("export.export")}
-        </Button>
+        {activeTab === "export" ? (
+          <Button
+            className={isDesktop ? "" : "w-full"}
+            aria-label={t("export.selectOrExport")}
+            variant="select"
+            size="sm"
+            onClick={() => {
+              if (selectedOption == "timeline") {
+                setRange({ before: currentTime + 30, after: currentTime - 30 });
+                setMode("timeline");
+              } else {
+                onStartExport();
+                setSelectedOption("1");
+                setMode("none");
+              }
+            }}
+          >
+            {selectedOption == "timeline"
+              ? t("export.select")
+              : t("export.export")}
+          </Button>
+        ) : (
+          <Button
+            className={isDesktop ? "" : "w-full"}
+            aria-label={t("export.multiCamera.exportButton", {
+              count: selectedCameraCount,
+            })}
+            variant="select"
+            size="sm"
+            disabled={!canStartBatchExport}
+            onClick={() => void startBatchExport()}
+          >
+            {t("export.multiCamera.exportButton", {
+              count: selectedCameraCount,
+            })}
+          </Button>
+        )}
       </DialogFooter>
     </div>
   );

--- a/web/src/components/overlay/ExportDialog.tsx
+++ b/web/src/components/overlay/ExportDialog.tsx
@@ -13,6 +13,7 @@ import { RadioGroup, RadioGroupItem } from "../ui/radio-group";
 import { Button } from "../ui/button";
 import { ExportMode } from "@/types/filter";
 import { FaArrowDown } from "react-icons/fa";
+import { LuAudioLines } from "react-icons/lu";
 import axios from "axios";
 import { toast } from "sonner";
 import { Input } from "../ui/input";
@@ -23,6 +24,7 @@ import {
   BatchExportResponse,
   CameraActivity,
   ExportCase,
+  StartExportResponse,
 } from "@/types/export";
 import {
   Select,
@@ -32,6 +34,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { isDesktop, isMobile } from "react-device-detect";
 import { Drawer, DrawerContent, DrawerTrigger } from "../ui/drawer";
 import SaveExportOverlay from "./SaveExportOverlay";
@@ -43,7 +50,6 @@ import { CustomTimeSelector } from "./CustomTimeSelector";
 import { Event } from "@/types/event";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { resolveCameraName } from "@/hooks/use-camera-friendly-name";
-import { Checkbox } from "../ui/checkbox";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { Textarea } from "../ui/textarea";
 import { useNavigate } from "react-router-dom";
@@ -87,6 +93,7 @@ export default function ExportDialog({
   const [name, setName] = useState("");
   const [selectedCaseId, setSelectedCaseId] = useState<string | undefined>();
   const [activeTab, setActiveTab] = useState<ExportTab>("export");
+  const [isStartingExport, setIsStartingExport] = useState(false);
   const previousModeRef = useRef<ExportMode>(mode);
 
   useEffect(() => {
@@ -107,59 +114,78 @@ export default function ExportDialog({
     previousModeRef.current = mode;
   }, [mode]);
 
-  const onStartExport = useCallback(() => {
+  const onStartExport = useCallback(async () => {
+    if (isStartingExport) {
+      return false;
+    }
+
     if (!range) {
       toast.error(t("export.toast.error.noVaildTimeSelected"), {
         position: "top-center",
       });
-      return;
+      return false;
     }
 
     if (range.before < range.after) {
       toast.error(t("export.toast.error.endTimeMustAfterStartTime"), {
         position: "top-center",
       });
-      return;
+      return false;
     }
 
-    axios
-      .post(
+    setIsStartingExport(true);
+
+    try {
+      await axios.post<StartExportResponse>(
         `export/${camera}/start/${Math.round(range.after)}/end/${Math.round(range.before)}`,
         {
-          playback: "realtime",
+          source: "recordings",
           name,
           export_case_id: selectedCaseId || undefined,
         },
-      )
-      .then((response) => {
-        if (response.status == 200) {
-          toast.success(t("export.toast.success"), {
-            position: "top-center",
-            action: (
-              <a href="/export" target="_blank" rel="noopener noreferrer">
-                <Button>{t("export.toast.view")}</Button>
-              </a>
-            ),
-          });
-          setName("");
-          setSelectedCaseId(undefined);
-          setRange(undefined);
-          setMode("none");
-        }
-      })
-      .catch((error) => {
-        const errorMessage =
-          error.response?.data?.message ||
-          error.response?.data?.detail ||
-          "Unknown error";
-        toast.error(
-          t("export.toast.error.failed", {
-            error: errorMessage,
-          }),
-          { position: "top-center" },
-        );
+      );
+
+      toast.success(t("export.toast.queued"), {
+        position: "top-center",
+        action: (
+          <a href="/export" target="_blank" rel="noopener noreferrer">
+            <Button>{t("export.toast.view")}</Button>
+          </a>
+        ),
       });
-  }, [camera, name, range, selectedCaseId, setMode, setRange, t]);
+      setName("");
+      setSelectedCaseId(undefined);
+      setRange(undefined);
+      setMode("none");
+      return true;
+    } catch (error) {
+      const apiError = error as {
+        response?: { data?: { message?: string; detail?: string } };
+      };
+      const errorMessage =
+        apiError.response?.data?.message ||
+        apiError.response?.data?.detail ||
+        "Unknown error";
+      toast.error(
+        t("export.toast.error.failed", {
+          error: errorMessage,
+        }),
+        { position: "top-center" },
+      );
+      return false;
+    } finally {
+      setIsStartingExport(false);
+    }
+  }, [
+    camera,
+    isStartingExport,
+    name,
+    range,
+    selectedCaseId,
+    setMode,
+    setRange,
+    t,
+  ]);
 
   const handleCancel = useCallback(() => {
     setName("");
@@ -185,6 +211,7 @@ export default function ExportDialog({
         className="pointer-events-none absolute left-1/2 top-8 z-50 -translate-x-1/2"
         show={mode == "timeline" || mode == "timeline_multi"}
         hidePreview={mode == "timeline_multi"}
+        isSaving={isStartingExport}
         saveLabel={
           mode == "timeline_multi"
             ? t("export.fromTimeline.useThisRange")
@@ -198,7 +225,7 @@ export default function ExportDialog({
             return;
           }
 
-          onStartExport();
+          void onStartExport();
         }}
         onCancel={handleCancel}
       />
@@ -245,6 +272,7 @@ export default function ExportDialog({
             name={name}
             selectedCaseId={selectedCaseId}
             activeTab={activeTab}
+            isStartingExport={isStartingExport}
             onStartExport={onStartExport}
             setActiveTab={setActiveTab}
             setName={setName}
@@ -266,7 +294,8 @@ type ExportContentProps = {
   name: string;
   selectedCaseId?: string;
   activeTab: ExportTab;
-  onStartExport: () => void;
+  isStartingExport: boolean;
+  onStartExport: () => Promise<boolean>;
   setActiveTab: (tab: ExportTab) => void;
   setName: (name: string) => void;
   setSelectedCaseId: (caseId: string | undefined) => void;
@@ -282,6 +311,7 @@ export function ExportContent({
   name,
   selectedCaseId,
   activeTab,
+  isStartingExport,
   onStartExport,
   setActiveTab,
   setName,
@@ -300,12 +330,13 @@ export function ExportContent({
   );
   const [selectedCameraIds, setSelectedCameraIds] = useState<string[]>([]);
   const [batchCaseSelection, setBatchCaseSelection] = useState<string>(
-    selectedCaseId || "none",
+    selectedCaseId || "new",
   );
   const [hasManualCameraSelection, setHasManualCameraSelection] =
     useState(false);
   const [newCaseName, setNewCaseName] = useState("");
   const [newCaseDescription, setNewCaseDescription] = useState("");
+  const [isStartingBatchExport, setIsStartingBatchExport] = useState(false);
   const multiRangeKey = useMemo(() => {
     if (activeTab !== "multi" || !range) {
       return undefined;
@@ -380,24 +411,47 @@ export function ExportContent({
 
   const cameraActivities = useMemo<CameraActivity[]>(() => {
     const allCameraIds = Object.keys(config?.cameras ?? {});
-    const counts = new Map<string, number>();
+    const byCamera = new Map<string, Event[]>();
 
     events?.forEach((event) => {
-      counts.set(event.camera, (counts.get(event.camera) ?? 0) + 1);
+      const bucket = byCamera.get(event.camera);
+      if (bucket) {
+        bucket.push(event);
+      } else {
+        byCamera.set(event.camera, [event]);
+      }
     });
 
-    const maxCount = Math.max(1, ...Array.from(counts.values()), 1);
+    const rangeStart = debouncedRange?.after ?? 0;
+    const rangeEnd = debouncedRange?.before ?? 0;
+    const rangeDuration = Math.max(1, rangeEnd - rangeStart);
 
     return allCameraIds.map((cameraId) => {
-      const count = counts.get(cameraId) ?? 0;
+      const cameraEvents = byCamera.get(cameraId) ?? [];
+      const segments = cameraEvents
+        .map((event) => {
+          // Event end_time is null for in-progress events; fall back to start.
+          const eventEnd = event.end_time ?? event.start_time;
+          const start = Math.max(
+            0,
+            Math.min(1, (event.start_time - rangeStart) / rangeDuration),
+          );
+          const end = Math.max(
+            0,
+            Math.min(1, (eventEnd - rangeStart) / rangeDuration),
+          );
+          return { start, end: Math.max(end, start) };
+        })
+        .sort((a, b) => a.start - b.start);
+
       return {
         camera: cameraId,
-        count,
-        intensity: count / maxCount,
-        hasDetections: count > 0,
+        count: cameraEvents.length,
+        hasDetections: cameraEvents.length > 0,
+        segments,
       };
     });
-  }, [config?.cameras, events]);
+  }, [config?.cameras, debouncedRange, events]);
 
   useEffect(() => {
     if (
@@ -426,8 +480,8 @@ export function ExportContent({
   const canStartBatchExport =
     Boolean(range && range.before > range.after) &&
     selectedCameraCount > 0 &&
-    ((batchCaseSelection !== "none" && batchCaseSelection !== "new") ||
-      (batchCaseSelection === "new" && newCaseName.trim().length > 0));
+    !isStartingBatchExport &&
+    (batchCaseSelection !== "new" || newCaseName.trim().length > 0);
 
   const onSelectTime = useCallback(
     (option: ExportOption) => {
@@ -482,6 +536,10 @@ export function ExportContent({
   }, []);
 
   const startBatchExport = useCallback(async () => {
+    if (isStartingBatchExport) {
+      return;
+    }
+
     if (!range) {
       toast.error(t("export.toast.error.noVaildTimeSelected"), {
         position: "top-center",
@@ -510,6 +568,8 @@ export function ExportContent({
       payload.export_case_id = batchCaseSelection;
     }
 
+    setIsStartingBatchExport(true);
+
     try {
       const response = await axios.post<BatchExportResponse>(
         "exports/batch",
@@ -527,7 +587,7 @@ export function ExportContent({
 
       if (failedResults.length > 0 && successfulResults.length > 0) {
         toast.success(
-          t("export.toast.batchPartial", {
+          t("export.toast.batchQueuedPartial", {
             successful: successfulResults.length,
             total: results.length,
             failedCameras: failedResults
@@ -541,7 +601,7 @@ export function ExportContent({
         );
       } else if (failedResults.length > 0) {
         toast.error(
-          t("export.toast.batchFailed", {
+          t("export.toast.batchQueueFailed", {
             total: results.length,
             failedCameras: failedResults
               .map((result) => resolveCameraName(config, result.camera))
@@ -554,7 +614,7 @@ export function ExportContent({
         );
       } else {
         toast.success(
-          t("export.toast.batchSuccess", {
+          t("export.toast.batchQueuedSuccess", {
             count: successfulResults.length,
           }),
           { position: "top-center" },
@@ -564,13 +624,15 @@ export function ExportContent({
       if (successfulResults.length > 0) {
         setName("");
         setSelectedCaseId(undefined);
-        setBatchCaseSelection("none");
+        setBatchCaseSelection("new");
         setNewCaseName("");
         setNewCaseDescription("");
         setRange(undefined);
         setMode("none");
         setActiveTab("export");
-        navigate(`/export?caseId=${response.data.export_case_id}`);
+        if (response.data.export_case_id) {
+          navigate(`/export?caseId=${response.data.export_case_id}`);
+        }
       }
     } catch (error) {
       const apiError = error as {
@@ -587,10 +649,13 @@ export function ExportContent({
         }),
         { position: "top-center" },
       );
+    } finally {
+      setIsStartingBatchExport(false);
     }
   }, [
     batchCaseSelection,
     config,
+    isStartingBatchExport,
     name,
     newCaseDescription,
     newCaseName,
@@ -606,20 +671,22 @@ export function ExportContent({
   ]);
 
   return (
-    <div className="w-full">
+    <div
+      className={cn(
+        "flex w-full flex-col",
+        !isDesktop && "max-h-[80dvh] min-h-0",
+      )}
+    >
       {isDesktop && (
-        <>
-          <DialogHeader>
-            <DialogTitle>{t("menu.export", { ns: "common" })}</DialogTitle>
-          </DialogHeader>
-          <SelectSeparator className="my-4 bg-secondary" />
-        </>
+        <DialogHeader className="mb-4">
+          <DialogTitle>{t("menu.export", { ns: "common" })}</DialogTitle>
+        </DialogHeader>
       )}
 
       <Tabs
         value={activeTab}
         onValueChange={(value) => setActiveTab(value as ExportTab)}
-        className="w-full"
+        className={cn("w-full", !isDesktop && "flex min-h-0 flex-1 flex-col")}
       >
         <TabsList className="grid w-full grid-cols-2">
           <TabsTrigger value="export">{t("export.tabs.export")}</TabsTrigger>
@@ -628,7 +695,13 @@ export function ExportContent({
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="export" className="mt-4 space-y-4">
+        <TabsContent
+          value="export"
+          className={cn(
+            "mt-4 space-y-4",
+            !isDesktop && "min-h-0 flex-1 overflow-y-auto pr-1",
+          )}
+        >
           <RadioGroup
             className={`flex flex-col gap-4 ${isDesktop ? "" : "mt-1"}`}
             onValueChange={(value) => onSelectTime(value as ExportOption)}
@@ -708,49 +781,69 @@ export function ExportContent({
           </div>
         </TabsContent>
 
-        <TabsContent value="multi" className="mt-4 space-y-4">
+        <TabsContent
+          value="multi"
+          className={cn(
+            "mt-4 space-y-4",
+            !isDesktop && "min-h-0 flex-1 overflow-y-auto pr-1",
+          )}
+        >
           <div className="space-y-2">
             <Label className="text-sm text-secondary-foreground">
               {t("export.multiCamera.timeRange")}
             </Label>
-            <CustomTimeSelector
-              latestTime={latestTime}
-              range={range}
-              setRange={setRange}
-              startLabel={t("export.time.start.title")}
-              endLabel={t("export.time.end.title")}
-            />
-            <Button
-              size="sm"
-              className="mt-2"
-              onClick={() => {
-                if (!range) {
-                  setRange({
-                    before: currentTime + 30,
-                    after: currentTime - 30,
-                  });
-                }
+            <div className="flex items-center gap-2">
+              <div className="min-w-0 flex-1 [&>div]:!mx-0 [&>div]:!mt-0">
+                <CustomTimeSelector
+                  latestTime={latestTime}
+                  range={range}
+                  setRange={setRange}
+                  startLabel={t("export.time.start.title")}
+                  endLabel={t("export.time.end.title")}
+                />
+              </div>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="size-9 shrink-0 p-0"
+                    aria-label={t("export.multiCamera.selectFromTimeline")}
+                    onClick={() => {
+                      if (!range) {
+                        setRange({
+                          before: currentTime + 30,
+                          after: currentTime - 30,
+                        });
+                      }
 
-                setActiveTab("multi");
-                setMode("timeline_multi");
-              }}
-            >
-              {t("export.multiCamera.selectFromTimeline")}
-            </Button>
+                      setActiveTab("multi");
+                      setMode("timeline_multi");
+                    }}
+                  >
+                    <LuAudioLines className="size-4 -rotate-90" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {t("export.multiCamera.selectFromTimeline")}
+                </TooltipContent>
+              </Tooltip>
+            </div>
           </div>
 
           <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <Label className="text-sm text-secondary-foreground">
-                {t("export.multiCamera.cameraSelection")}
-              </Label>
-              <div className="text-xs text-muted-foreground">
-                {t("export.multiCamera.selectedCount", {
-                  count: selectedCameraCount,
-                })}
-              </div>
+            <Label className="text-sm text-secondary-foreground">
+              {t("export.multiCamera.cameraSelection")}
+            </Label>
+            <div className="text-xs text-muted-foreground">
+              {t("export.multiCamera.cameraSelectionHelp")}
             </div>
-            <div className="max-h-64 space-y-2 overflow-y-auto rounded-lg border border-border bg-background/50 p-2">
+            <div
+              className={cn(
+                "scrollbar-container space-y-2",
+                isDesktop && "max-h-64 overflow-y-auto pr-1",
+              )}
+            >
               {isEventsLoading && (
                 <div className="px-2 py-4 text-sm text-muted-foreground">
                   {t("export.multiCamera.checkingActivity")}
@@ -768,15 +861,18 @@ export function ExportContent({
                   <button
                     key={activity.camera}
                     type="button"
+                    aria-pressed={isSelected}
                     className={cn(
-                      "flex w-full items-center gap-3 rounded-md border border-border px-3 py-2 text-left transition-colors",
-                      activity.hasDetections
-                        ? "bg-secondary/40 hover:bg-secondary/70"
-                        : "bg-background text-muted-foreground",
+                      "flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left transition-colors",
+                      isSelected
+                        ? "border-selected bg-selected/10 ring-1 ring-selected"
+                        : "border-transparent bg-secondary/40 hover:bg-secondary/70",
+                      !activity.hasDetections &&
+                        !isSelected &&
+                        "text-muted-foreground",
                     )}
                     onClick={() => toggleCameraSelection(activity.camera)}
                   >
-                    <Checkbox checked={isSelected} />
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center justify-between gap-2">
                         <span className="truncate text-sm font-medium text-primary">
@@ -788,16 +884,24 @@ export function ExportContent({
                           })}
                         </span>
                       </div>
-                      <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-secondary">
-                        <div
-                          className={cn(
-                            "h-full rounded-full",
-                            activity.hasDetections ? "bg-selected" : "bg-muted",
-                          )}
-                          style={{
-                            width: `${Math.max(activity.intensity * 100, activity.hasDetections ? 8 : 0)}%`,
-                          }}
-                        />
+                      <div className="relative mt-2 h-1.5 w-full overflow-hidden rounded-full bg-secondary">
+                        {activity.segments.map((segment, index) => {
+                          const leftPct = segment.start * 100;
+                          const widthPct = Math.max(
+                            (segment.end - segment.start) * 100,
+                            1,
+                          );
+                          return (
+                            <div
+                              key={index}
+                              className="absolute top-0 h-full rounded-full bg-selected"
+                              style={{
+                                left: `${leftPct}%`,
+                                width: `${widthPct}%`,
+                              }}
+                            />
+                          );
+                        })}
                       </div>
                     </div>
                   </button>
@@ -806,13 +910,18 @@ export function ExportContent({
             </div>
           </div>
 
-          <Input
-            className="text-md"
-            type="search"
-            placeholder={t("export.multiCamera.namePlaceholder")}
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
+          <div className="space-y-2">
+            <Label className="text-sm text-secondary-foreground">
+              {t("export.multiCamera.nameLabel")}
+            </Label>
+            <Input
+              className="text-md"
+              type="search"
+              placeholder={t("export.multiCamera.namePlaceholder")}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
 
           <div className="space-y-2">
             <Label className="text-sm text-secondary-foreground">
@@ -826,9 +935,6 @@ export function ExportContent({
                 <SelectValue placeholder={t("export.case.placeholder")} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="none">
-                  {t("label.none", { ns: "common" })}
-                </SelectItem>
                 {cases
                   ?.sort((a, b) => a.name.localeCompare(b.name))
                   .map((caseItem) => (
@@ -843,13 +949,15 @@ export function ExportContent({
               </SelectContent>
             </Select>
             {batchCaseSelection === "new" && (
-              <div className="space-y-2 rounded-lg border border-border bg-background/50 p-3">
+              <div className="space-y-2 pt-1">
                 <Input
+                  className="text-md"
                   placeholder={t("export.case.newCaseNamePlaceholder")}
                   value={newCaseName}
                   onChange={(event) => setNewCaseName(event.target.value)}
                 />
                 <Textarea
+                  className="text-md"
                   placeholder={t("export.case.newCaseDescriptionPlaceholder")}
                   value={newCaseDescription}
                   onChange={(event) =>
@@ -878,20 +986,24 @@ export function ExportContent({
             aria-label={t("export.selectOrExport")}
             variant="select"
             size="sm"
-            onClick={() => {
+            disabled={isStartingExport}
+            onClick={async () => {
               if (selectedOption == "timeline") {
                 setRange({ before: currentTime + 30, after: currentTime - 30 });
                 setMode("timeline");
               } else {
-                onStartExport();
-                setSelectedOption("1");
-                setMode("none");
+                const didQueue = await onStartExport();
+                if (didQueue) {
+                  setSelectedOption("1");
+                }
               }
             }}
           >
-            {selectedOption == "timeline"
-              ? t("export.select")
-              : t("export.export")}
+            {isStartingExport
+              ? t("export.queueing")
+              : selectedOption == "timeline"
+                ? t("export.select")
+                : t("export.export")}
           </Button>
         ) : (
           <Button
@@ -904,9 +1016,11 @@ export function ExportContent({
             disabled={!canStartBatchExport}
             onClick={() => void startBatchExport()}
           >
-            {t("export.multiCamera.exportButton", {
-              count: selectedCameraCount,
-            })}
+            {isStartingBatchExport
+              ? t("export.multiCamera.queueingButton")
+              : t("export.multiCamera.exportButton", {
+                  count: selectedCameraCount,
+                })}
           </Button>
         )}
       </DialogFooter>

--- a/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
+++ b/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
@@ -115,6 +115,8 @@ export default function MobileReviewSettingsDrawer({
   const [selectedCaseId, setSelectedCaseId] = useState<string | undefined>(
     undefined,
   );
+  const [singleNewCaseName, setSingleNewCaseName] = useState("");
+  const [singleNewCaseDescription, setSingleNewCaseDescription] = useState("");
   const [isStartingExport, setIsStartingExport] = useState(false);
   const onStartExport = useCallback(async () => {
     if (isStartingExport) {
@@ -148,12 +150,24 @@ export default function MobileReviewSettingsDrawer({
     setIsStartingExport(true);
 
     try {
+      let exportCaseId: string | undefined = selectedCaseId;
+
+      if (selectedCaseId === "new" && singleNewCaseName.trim().length > 0) {
+        const caseResp = await axios.post("cases", {
+          name: singleNewCaseName.trim(),
+          description: singleNewCaseDescription.trim() || undefined,
+        });
+        exportCaseId = caseResp.data?.id;
+      } else if (selectedCaseId === "new" || selectedCaseId === "none") {
+        exportCaseId = undefined;
+      }
+
       await axios.post<StartExportResponse>(
         `export/${camera}/start/${Math.round(range.after)}/end/${Math.round(range.before)}`,
         {
           source: "recordings",
           name,
-          export_case_id: selectedCaseId || undefined,
+          export_case_id: exportCaseId,
         },
       );
 
@@ -169,6 +183,8 @@ export default function MobileReviewSettingsDrawer({
       });
       setName("");
       setSelectedCaseId(undefined);
+      setSingleNewCaseName("");
+      setSingleNewCaseDescription("");
       setRange(undefined);
       setMode("none");
       return true;
@@ -199,6 +215,8 @@ export default function MobileReviewSettingsDrawer({
     name,
     range,
     selectedCaseId,
+    singleNewCaseDescription,
+    singleNewCaseName,
     setRange,
     setMode,
     t,
@@ -361,12 +379,16 @@ export default function MobileReviewSettingsDrawer({
         range={range}
         name={name}
         selectedCaseId={selectedCaseId}
+        singleNewCaseName={singleNewCaseName}
+        singleNewCaseDescription={singleNewCaseDescription}
         activeTab={exportTab}
         isStartingExport={isStartingExport}
         onStartExport={onStartExport}
         setActiveTab={setExportTab}
         setName={setName}
         setSelectedCaseId={setSelectedCaseId}
+        setSingleNewCaseName={setSingleNewCaseName}
+        setSingleNewCaseDescription={setSingleNewCaseDescription}
         setRange={setRange}
         setMode={(mode) => {
           setMode(mode);
@@ -379,6 +401,8 @@ export default function MobileReviewSettingsDrawer({
           setMode("none");
           setRange(undefined);
           setSelectedCaseId(undefined);
+          setSingleNewCaseName("");
+          setSingleNewCaseDescription("");
           setExportTab("export");
           setDrawerMode("select");
         }}

--- a/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
+++ b/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
@@ -4,7 +4,7 @@ import { Button } from "../ui/button";
 import { FaArrowDown, FaCalendarAlt, FaCog, FaFilter } from "react-icons/fa";
 import { LuBug } from "react-icons/lu";
 import { TimeRange } from "@/types/timeline";
-import { ExportContent, ExportPreviewDialog } from "./ExportDialog";
+import { ExportContent, ExportPreviewDialog, ExportTab } from "./ExportDialog";
 import {
   DebugReplayContent,
   SaveDebugReplayOverlay,
@@ -102,6 +102,7 @@ export default function MobileReviewSettingsDrawer({
   ]);
   const navigate = useNavigate();
   const [drawerMode, setDrawerMode] = useState<DrawerMode>("none");
+  const [exportTab, setExportTab] = useState<ExportTab>("export");
   const [selectedReplayOption, setSelectedReplayOption] = useState<
     "1" | "5" | "custom" | "timeline"
   >("1");
@@ -115,16 +116,26 @@ export default function MobileReviewSettingsDrawer({
   );
   const onStartExport = useCallback(() => {
     if (!range) {
-      toast.error(t("toast.error.noValidTimeSelected"), {
-        position: "top-center",
-      });
+      toast.error(
+        t("export.toast.error.noVaildTimeSelected", {
+          ns: "components/dialog",
+        }),
+        {
+          position: "top-center",
+        },
+      );
       return;
     }
 
     if (range.before < range.after) {
-      toast.error(t("toast.error.endTimeMustAfterStartTime"), {
-        position: "top-center",
-      });
+      toast.error(
+        t("export.toast.error.endTimeMustAfterStartTime", {
+          ns: "components/dialog",
+        }),
+        {
+          position: "top-center",
+        },
+      );
       return;
     }
 
@@ -166,7 +177,7 @@ export default function MobileReviewSettingsDrawer({
         toast.error(
           t("export.toast.error.failed", {
             ns: "components/dialog",
-            errorMessage,
+            error: errorMessage,
           }),
           {
             position: "top-center",
@@ -267,6 +278,7 @@ export default function MobileReviewSettingsDrawer({
             className="flex w-full items-center justify-center gap-2"
             aria-label={t("export")}
             onClick={() => {
+              setExportTab("export");
               setDrawerMode("export");
               setMode("select");
             }}
@@ -331,14 +343,16 @@ export default function MobileReviewSettingsDrawer({
         range={range}
         name={name}
         selectedCaseId={selectedCaseId}
+        activeTab={exportTab}
         onStartExport={onStartExport}
+        setActiveTab={setExportTab}
         setName={setName}
         setSelectedCaseId={setSelectedCaseId}
         setRange={setRange}
         setMode={(mode) => {
           setMode(mode);
 
-          if (mode == "timeline") {
+          if (mode == "timeline" || mode == "timeline_multi") {
             setDrawerMode("none");
           }
         }}
@@ -346,6 +360,7 @@ export default function MobileReviewSettingsDrawer({
           setMode("none");
           setRange(undefined);
           setSelectedCaseId(undefined);
+          setExportTab("export");
           setDrawerMode("select");
         }}
       />
@@ -483,9 +498,28 @@ export default function MobileReviewSettingsDrawer({
     <>
       <SaveExportOverlay
         className="pointer-events-none absolute left-1/2 top-8 z-50 -translate-x-1/2"
-        show={mode == "timeline"}
-        onSave={() => onStartExport()}
-        onCancel={() => setMode("none")}
+        show={mode == "timeline" || mode == "timeline_multi"}
+        hidePreview={mode == "timeline_multi"}
+        saveLabel={
+          mode == "timeline_multi"
+            ? t("export.fromTimeline.useThisRange", { ns: "components/dialog" })
+            : undefined
+        }
+        onSave={() => {
+          if (mode == "timeline_multi") {
+            setExportTab("multi");
+            setDrawerMode("export");
+            setMode("select");
+            return;
+          }
+
+          onStartExport();
+        }}
+        onCancel={() => {
+          setExportTab("export");
+          setRange(undefined);
+          setMode("none");
+        }}
         onPreview={() => setShowExportPreview(true)}
       />
       <SaveDebugReplayOverlay

--- a/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
+++ b/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
@@ -26,6 +26,7 @@ import SaveExportOverlay from "./SaveExportOverlay";
 import { isMobile } from "react-device-detect";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { StartExportResponse } from "@/types/export";
 
 type DrawerMode =
   | "none"
@@ -114,7 +115,12 @@ export default function MobileReviewSettingsDrawer({
   const [selectedCaseId, setSelectedCaseId] = useState<string | undefined>(
     undefined,
   );
-  const onStartExport = useCallback(() => {
+  const [isStartingExport, setIsStartingExport] = useState(false);
+  const onStartExport = useCallback(async () => {
+    if (isStartingExport) {
+      return false;
+    }
+
     if (!range) {
       toast.error(
         t("export.toast.error.noVaildTimeSelected", {
@@ -124,7 +130,7 @@ export default function MobileReviewSettingsDrawer({
           position: "top-center",
         },
       );
-      return;
+      return false;
     }
 
     if (range.before < range.after) {
@@ -136,55 +142,67 @@ export default function MobileReviewSettingsDrawer({
           position: "top-center",
         },
       );
-      return;
+      return false;
     }
 
-    axios
-      .post(
+    setIsStartingExport(true);
+
+    try {
+      await axios.post<StartExportResponse>(
         `export/${camera}/start/${Math.round(range.after)}/end/${Math.round(range.before)}`,
         {
-          playback: "realtime",
+          source: "recordings",
           name,
           export_case_id: selectedCaseId || undefined,
         },
-      )
-      .then((response) => {
-        if (response.status == 200) {
-          toast.success(
-            t("export.toast.success", { ns: "components/dialog" }),
-            {
-              position: "top-center",
-              action: (
-                <a href="/export" target="_blank" rel="noopener noreferrer">
-                  <Button>
-                    {t("export.toast.view", { ns: "components/dialog" })}
-                  </Button>
-                </a>
-              ),
-            },
-          );
-          setName("");
-          setSelectedCaseId(undefined);
-          setRange(undefined);
-          setMode("none");
-        }
-      })
-      .catch((error) => {
-        const errorMessage =
-          error.response?.data?.message ||
-          error.response?.data?.detail ||
-          "Unknown error";
-        toast.error(
-          t("export.toast.error.failed", {
-            ns: "components/dialog",
-            error: errorMessage,
-          }),
-          {
-            position: "top-center",
-          },
-        );
+      );
+
+      toast.success(t("export.toast.queued", { ns: "components/dialog" }), {
+        position: "top-center",
+        action: (
+          <a href="/export" target="_blank" rel="noopener noreferrer">
+            <Button>
+              {t("export.toast.view", { ns: "components/dialog" })}
+            </Button>
+          </a>
+        ),
       });
-  }, [camera, name, range, selectedCaseId, setRange, setName, setMode, t]);
+      setName("");
+      setSelectedCaseId(undefined);
+      setRange(undefined);
+      setMode("none");
+      return true;
+    } catch (error) {
+      const apiError = error as {
+        response?: { data?: { message?: string; detail?: string } };
+      };
+      const errorMessage =
+        apiError.response?.data?.message ||
+        apiError.response?.data?.detail ||
+        "Unknown error";
+      toast.error(
+        t("export.toast.error.failed", {
+          ns: "components/dialog",
+          error: errorMessage,
+        }),
+        {
+          position: "top-center",
+        },
+      );
+      return false;
+    } finally {
+      setIsStartingExport(false);
+    }
+  }, [
+    camera,
+    isStartingExport,
+    name,
+    range,
+    selectedCaseId,
+    setRange,
+    setMode,
+    t,
+  ]);
 
   const onStartDebugReplay = useCallback(async () => {
     if (
@@ -344,6 +362,7 @@ export default function MobileReviewSettingsDrawer({
         name={name}
         selectedCaseId={selectedCaseId}
         activeTab={exportTab}
+        isStartingExport={isStartingExport}
         onStartExport={onStartExport}
         setActiveTab={setExportTab}
         setName={setName}
@@ -500,6 +519,7 @@ export default function MobileReviewSettingsDrawer({
         className="pointer-events-none absolute left-1/2 top-8 z-50 -translate-x-1/2"
         show={mode == "timeline" || mode == "timeline_multi"}
         hidePreview={mode == "timeline_multi"}
+        isSaving={isStartingExport}
         saveLabel={
           mode == "timeline_multi"
             ? t("export.fromTimeline.useThisRange", { ns: "components/dialog" })
@@ -513,7 +533,7 @@ export default function MobileReviewSettingsDrawer({
             return;
           }
 
-          onStartExport();
+          void onStartExport();
         }}
         onCancel={() => {
           setExportTab("export");

--- a/web/src/components/overlay/MultiExportDialog.tsx
+++ b/web/src/components/overlay/MultiExportDialog.tsx
@@ -165,11 +165,12 @@ export default function MultiExportDialog({
   const canSubmit = useMemo(() => {
     if (isExporting) return false;
     if (count === 0) return false;
+    if (!isAdmin) return true;
     if (isNewCase) {
       return newCaseName.trim().length > 0;
     }
     return caseSelection.length > 0;
-  }, [caseSelection, count, isExporting, isNewCase, newCaseName]);
+  }, [caseSelection, count, isAdmin, isExporting, isNewCase, newCaseName]);
 
   const handleSubmit = useCallback(async () => {
     if (!canSubmit) return;
@@ -182,15 +183,16 @@ export default function MultiExportDialog({
       client_item_id: review.id,
     }));
 
-    const payload: BatchExportBody = {
-      items,
-      ...(isNewCase
-        ? {
-            new_case_name: newCaseName.trim(),
-            new_case_description: newCaseDescription.trim() || undefined,
-          }
-        : { export_case_id: caseSelection }),
-    };
+    const payload: BatchExportBody = { items };
+
+    if (isAdmin) {
+      if (isNewCase) {
+        payload.new_case_name = newCaseName.trim();
+        payload.new_case_description = newCaseDescription.trim() || undefined;
+      } else {
+        payload.export_case_id = caseSelection;
+      }
+    }
 
     setIsExporting(true);
     try {
@@ -205,10 +207,15 @@ export default function MultiExportDialog({
 
       if (successful.length > 0 && failed.length === 0) {
         toast.success(
-          t("export.multi.toast.started", {
-            ns: "components/dialog",
-            count: successful.length,
-          }),
+          t(
+            isAdmin
+              ? "export.multi.toast.started"
+              : "export.multi.toast.startedNoCase",
+            {
+              ns: "components/dialog",
+              count: successful.length,
+            },
+          ),
           { position: "top-center" },
         );
       } else if (successful.length > 0 && failed.length > 0) {
@@ -267,6 +274,7 @@ export default function MultiExportDialog({
     canSubmit,
     caseSelection,
     formatFailureLabel,
+    isAdmin,
     isNewCase,
     navigate,
     newCaseDescription,
@@ -302,7 +310,7 @@ export default function MultiExportDialog({
 
   const body = (
     <div className="flex flex-col gap-4">
-      {isAdmin ? (
+      {isAdmin && (
         <div className="space-y-2">
           <Label className="text-sm text-secondary-foreground">
             {t("export.case.label")}
@@ -327,16 +335,6 @@ export default function MultiExportDialog({
             </SelectContent>
           </Select>
           {isNewCase && newCaseInputs}
-        </div>
-      ) : (
-        <div className="space-y-2">
-          <Label className="text-sm text-secondary-foreground">
-            {t("export.case.label")}
-          </Label>
-          <div className="text-xs text-muted-foreground">
-            {t("export.case.nonAdminHelp")}
-          </div>
-          {newCaseInputs}
         </div>
       )}
     </div>
@@ -372,7 +370,9 @@ export default function MultiExportDialog({
           <DialogHeader>
             <DialogTitle>{t("export.multi.title", { count })}</DialogTitle>
             <DialogDescription>
-              {t("export.multi.description")}
+              {isAdmin
+                ? t("export.multi.description")
+                : t("export.multi.descriptionNoCase")}
             </DialogDescription>
           </DialogHeader>
           {body}
@@ -388,7 +388,11 @@ export default function MultiExportDialog({
       <DrawerContent className="px-4 pb-6">
         <DrawerHeader className="px-0">
           <DrawerTitle>{t("export.multi.title", { count })}</DrawerTitle>
-          <DrawerDescription>{t("export.multi.description")}</DrawerDescription>
+          <DrawerDescription>
+            {isAdmin
+              ? t("export.multi.description")
+              : t("export.multi.descriptionNoCase")}
+          </DrawerDescription>
         </DrawerHeader>
         {body}
         <div className="mt-4 flex flex-col-reverse gap-2">{footer}</div>

--- a/web/src/components/overlay/MultiExportDialog.tsx
+++ b/web/src/components/overlay/MultiExportDialog.tsx
@@ -55,6 +55,7 @@ type MultiExportDialogProps = {
   children: React.ReactNode;
 };
 
+const NONE_CASE_OPTION = "none";
 const NEW_CASE_OPTION = "new";
 
 export default function MultiExportDialog({
@@ -74,10 +75,7 @@ export default function MultiExportDialog({
   const { data: cases } = useSWR<ExportCase[]>(isAdmin ? "cases" : null);
 
   const [open, setOpen] = useState(false);
-  // Single unified state: either NEW_CASE_OPTION or an existing case id.
-  // Defaults to NEW_CASE_OPTION, which is also the only valid value for
-  // non-admins since they can't attach to existing cases.
-  const [caseSelection, setCaseSelection] = useState<string>(NEW_CASE_OPTION);
+  const [caseSelection, setCaseSelection] = useState<string>(NONE_CASE_OPTION);
   const [newCaseName, setNewCaseName] = useState("");
   const [newCaseDescription, setNewCaseDescription] = useState("");
   const [isExporting, setIsExporting] = useState(false);
@@ -134,7 +132,7 @@ export default function MultiExportDialog({
   }, [t, locale]);
 
   const resetState = useCallback(() => {
-    setCaseSelection(NEW_CASE_OPTION);
+    setCaseSelection(NONE_CASE_OPTION);
     setNewCaseName("");
     setNewCaseDescription("");
     setIsExporting(false);
@@ -146,7 +144,7 @@ export default function MultiExportDialog({
         resetState();
       } else {
         // Freshly reset each time so the default name reflects "now"
-        setCaseSelection(NEW_CASE_OPTION);
+        setCaseSelection(NONE_CASE_OPTION);
         setNewCaseName(defaultCaseName);
         setNewCaseDescription("");
         setIsExporting(false);
@@ -185,7 +183,7 @@ export default function MultiExportDialog({
 
     const payload: BatchExportBody = { items };
 
-    if (isAdmin) {
+    if (isAdmin && caseSelection !== NONE_CASE_OPTION) {
       if (isNewCase) {
         payload.new_case_name = newCaseName.trim();
         payload.new_case_description = newCaseDescription.trim() || undefined;
@@ -323,12 +321,15 @@ export default function MultiExportDialog({
               <SelectValue placeholder={t("export.case.placeholder")} />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value={NONE_CASE_OPTION}>
+                {t("label.none", { ns: "common" })}
+              </SelectItem>
               {existingCases.map((caseItem) => (
                 <SelectItem key={caseItem.id} value={caseItem.id}>
                   {caseItem.name}
                 </SelectItem>
               ))}
-              {existingCases.length > 0 && <SelectSeparator />}
+              <SelectSeparator />
               <SelectItem value={NEW_CASE_OPTION}>
                 {t("export.case.newCaseOption")}
               </SelectItem>

--- a/web/src/components/overlay/MultiExportDialog.tsx
+++ b/web/src/components/overlay/MultiExportDialog.tsx
@@ -1,0 +1,398 @@
+import { useCallback, useMemo, useState } from "react";
+import { isDesktop } from "react-device-detect";
+import axios from "axios";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import useSWR from "swr";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "../ui/drawer";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import { Textarea } from "../ui/textarea";
+
+import {
+  BatchExportBody,
+  BatchExportResponse,
+  BatchExportResult,
+  ExportCase,
+} from "@/types/export";
+import { FrigateConfig } from "@/types/frigateConfig";
+import { REVIEW_PADDING, ReviewSegment } from "@/types/review";
+import { resolveCameraName } from "@/hooks/use-camera-friendly-name";
+import { useDateLocale } from "@/hooks/use-date-locale";
+import { useIsAdmin } from "@/hooks/use-is-admin";
+import { formatUnixTimestampToDateTime } from "@/utils/dateUtil";
+
+type MultiExportDialogProps = {
+  selectedReviews: ReviewSegment[];
+  onStarted: () => void;
+  children: React.ReactNode;
+};
+
+const NEW_CASE_OPTION = "new";
+
+export default function MultiExportDialog({
+  selectedReviews,
+  onStarted,
+  children,
+}: MultiExportDialogProps) {
+  const { t } = useTranslation(["components/dialog", "common"]);
+  const locale = useDateLocale();
+  const navigate = useNavigate();
+  const isAdmin = useIsAdmin();
+
+  const { data: config } = useSWR<FrigateConfig>("config");
+  // Only admins can attach exports to an existing case (enforced server-side
+  // by POST /exports/batch). Skip fetching the case list entirely for
+  // non-admins — they can only ever use the "Create new case" branch.
+  const { data: cases } = useSWR<ExportCase[]>(isAdmin ? "cases" : null);
+
+  const [open, setOpen] = useState(false);
+  // Single unified state: either NEW_CASE_OPTION or an existing case id.
+  // Defaults to NEW_CASE_OPTION, which is also the only valid value for
+  // non-admins since they can't attach to existing cases.
+  const [caseSelection, setCaseSelection] = useState<string>(NEW_CASE_OPTION);
+  const [newCaseName, setNewCaseName] = useState("");
+  const [newCaseDescription, setNewCaseDescription] = useState("");
+  const [isExporting, setIsExporting] = useState(false);
+
+  const count = selectedReviews.length;
+
+  // Resolve a failed batch result back to a human-readable label via the
+  // client-provided review id when available. Falls back to item_index and
+  // finally camera name for defensive compatibility.
+  const formatFailureLabel = useCallback(
+    (result: BatchExportResult): string => {
+      const cameraName = resolveCameraName(config, result.camera);
+      if (result.client_item_id) {
+        const review = selectedReviews.find(
+          (item) => item.id === result.client_item_id,
+        );
+        if (review) {
+          const time = formatUnixTimestampToDateTime(review.start_time, {
+            date_style: "short",
+            time_style: "short",
+            locale,
+          });
+          return `${cameraName} • ${time}`;
+        }
+      }
+      if (
+        typeof result.item_index === "number" &&
+        result.item_index >= 0 &&
+        result.item_index < selectedReviews.length
+      ) {
+        const review = selectedReviews[result.item_index];
+        const time = formatUnixTimestampToDateTime(review.start_time, {
+          date_style: "short",
+          time_style: "short",
+          locale,
+        });
+        return `${cameraName} • ${time}`;
+      }
+      return cameraName;
+    },
+    [config, locale, selectedReviews],
+  );
+
+  const defaultCaseName = useMemo(() => {
+    const formattedDate = formatUnixTimestampToDateTime(Date.now() / 1000, {
+      date_style: "medium",
+      time_style: "short",
+      locale,
+    });
+    return t("export.multi.caseNamePlaceholder", {
+      ns: "components/dialog",
+      date: formattedDate,
+    });
+  }, [t, locale]);
+
+  const resetState = useCallback(() => {
+    setCaseSelection(NEW_CASE_OPTION);
+    setNewCaseName("");
+    setNewCaseDescription("");
+    setIsExporting(false);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) {
+        resetState();
+      } else {
+        // Freshly reset each time so the default name reflects "now"
+        setCaseSelection(NEW_CASE_OPTION);
+        setNewCaseName(defaultCaseName);
+        setNewCaseDescription("");
+        setIsExporting(false);
+      }
+      setOpen(next);
+    },
+    [defaultCaseName, resetState],
+  );
+
+  const existingCases = useMemo(() => {
+    return (cases ?? []).slice().sort((a, b) => a.name.localeCompare(b.name));
+  }, [cases]);
+
+  const isNewCase = caseSelection === NEW_CASE_OPTION;
+
+  const canSubmit = useMemo(() => {
+    if (isExporting) return false;
+    if (count === 0) return false;
+    if (isNewCase) {
+      return newCaseName.trim().length > 0;
+    }
+    return caseSelection.length > 0;
+  }, [caseSelection, count, isExporting, isNewCase, newCaseName]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+
+    const items = selectedReviews.map((review) => ({
+      camera: review.camera,
+      start_time: review.start_time - REVIEW_PADDING,
+      end_time: (review.end_time ?? Date.now() / 1000) + REVIEW_PADDING,
+      image_path: review.thumb_path || undefined,
+      client_item_id: review.id,
+    }));
+
+    const payload: BatchExportBody = {
+      items,
+      ...(isNewCase
+        ? {
+            new_case_name: newCaseName.trim(),
+            new_case_description: newCaseDescription.trim() || undefined,
+          }
+        : { export_case_id: caseSelection }),
+    };
+
+    setIsExporting(true);
+    try {
+      const response = await axios.post<BatchExportResponse>(
+        "exports/batch",
+        payload,
+      );
+
+      const results = response.data.results ?? [];
+      const successful = results.filter((r) => r.success);
+      const failed = results.filter((r) => !r.success);
+
+      if (successful.length > 0 && failed.length === 0) {
+        toast.success(
+          t("export.multi.toast.started", {
+            ns: "components/dialog",
+            count: successful.length,
+          }),
+          { position: "top-center" },
+        );
+      } else if (successful.length > 0 && failed.length > 0) {
+        // Resolve each failure to its review via item_index so same-camera
+        // items are disambiguated by time. Falls back to camera-only if the
+        // server didn't populate item_index.
+        const failedLabels = failed.map(formatFailureLabel).join(", ");
+        toast.success(
+          t("export.multi.toast.partial", {
+            ns: "components/dialog",
+            successful: successful.length,
+            total: results.length,
+            failedItems: failedLabels,
+          }),
+          { position: "top-center" },
+        );
+      } else {
+        const failedLabels = failed.map(formatFailureLabel).join(", ");
+        toast.error(
+          t("export.multi.toast.failed", {
+            ns: "components/dialog",
+            total: results.length,
+            failedItems: failedLabels,
+          }),
+          { position: "top-center" },
+        );
+      }
+
+      if (successful.length > 0) {
+        onStarted();
+        setOpen(false);
+        resetState();
+        if (response.data.export_case_id) {
+          navigate(`/export?caseId=${response.data.export_case_id}`);
+        }
+      }
+    } catch (error) {
+      const apiError = error as {
+        response?: { data?: { message?: string; detail?: string } };
+      };
+      const errorMessage =
+        apiError.response?.data?.message ||
+        apiError.response?.data?.detail ||
+        "Unknown error";
+      toast.error(
+        t("export.toast.error.failed", {
+          ns: "components/dialog",
+          error: errorMessage,
+        }),
+        { position: "top-center" },
+      );
+    } finally {
+      setIsExporting(false);
+    }
+  }, [
+    canSubmit,
+    caseSelection,
+    formatFailureLabel,
+    isNewCase,
+    navigate,
+    newCaseDescription,
+    newCaseName,
+    onStarted,
+    resetState,
+    selectedReviews,
+    t,
+  ]);
+
+  // New-case inputs: rendered below the Select when caseSelection === "new",
+  // or rendered standalone for non-admins (who never see the Select since
+  // they cannot attach to an existing case).
+  const newCaseInputs = (
+    <div className="space-y-2 pt-1">
+      <Input
+        className="text-md"
+        placeholder={t("export.case.newCaseNamePlaceholder")}
+        value={newCaseName}
+        onChange={(event) => setNewCaseName(event.target.value)}
+        maxLength={100}
+        autoFocus={isDesktop}
+      />
+      <Textarea
+        className="text-md"
+        placeholder={t("export.case.newCaseDescriptionPlaceholder")}
+        value={newCaseDescription}
+        onChange={(event) => setNewCaseDescription(event.target.value)}
+        rows={2}
+      />
+    </div>
+  );
+
+  const body = (
+    <div className="flex flex-col gap-4">
+      {isAdmin ? (
+        <div className="space-y-2">
+          <Label className="text-sm text-secondary-foreground">
+            {t("export.case.label")}
+          </Label>
+          <Select
+            value={caseSelection}
+            onValueChange={(value) => setCaseSelection(value)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder={t("export.case.placeholder")} />
+            </SelectTrigger>
+            <SelectContent>
+              {existingCases.map((caseItem) => (
+                <SelectItem key={caseItem.id} value={caseItem.id}>
+                  {caseItem.name}
+                </SelectItem>
+              ))}
+              {existingCases.length > 0 && <SelectSeparator />}
+              <SelectItem value={NEW_CASE_OPTION}>
+                {t("export.case.newCaseOption")}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          {isNewCase && newCaseInputs}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <Label className="text-sm text-secondary-foreground">
+            {t("export.case.label")}
+          </Label>
+          <div className="text-xs text-muted-foreground">
+            {t("export.case.nonAdminHelp")}
+          </div>
+          {newCaseInputs}
+        </div>
+      )}
+    </div>
+  );
+
+  const footer = (
+    <>
+      <Button
+        variant="outline"
+        onClick={() => handleOpenChange(false)}
+        disabled={isExporting}
+      >
+        {t("button.cancel", { ns: "common" })}
+      </Button>
+      <Button
+        variant="select"
+        onClick={handleSubmit}
+        disabled={!canSubmit}
+        aria-label={t("export.multi.exportButton", { count })}
+      >
+        {isExporting
+          ? t("export.multi.exportingButton")
+          : t("export.multi.exportButton", { count })}
+      </Button>
+    </>
+  );
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogTrigger asChild>{children}</DialogTrigger>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t("export.multi.title", { count })}</DialogTitle>
+            <DialogDescription>
+              {t("export.multi.description")}
+            </DialogDescription>
+          </DialogHeader>
+          {body}
+          <DialogFooter className="gap-2">{footer}</DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={handleOpenChange}>
+      <DrawerTrigger asChild>{children}</DrawerTrigger>
+      <DrawerContent className="px-4 pb-6">
+        <DrawerHeader className="px-0">
+          <DrawerTitle>{t("export.multi.title", { count })}</DrawerTitle>
+          <DrawerDescription>{t("export.multi.description")}</DrawerDescription>
+        </DrawerHeader>
+        {body}
+        <div className="mt-4 flex flex-col-reverse gap-2">{footer}</div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/web/src/components/overlay/SaveExportOverlay.tsx
+++ b/web/src/components/overlay/SaveExportOverlay.tsx
@@ -9,6 +9,7 @@ type SaveExportOverlayProps = {
   show: boolean;
   hidePreview?: boolean;
   saveLabel?: string;
+  isSaving?: boolean;
   onPreview: () => void;
   onSave: () => void;
   onCancel: () => void;
@@ -18,6 +19,7 @@ export default function SaveExportOverlay({
   show,
   hidePreview = false,
   saveLabel,
+  isSaving = false,
   onPreview,
   onSave,
   onCancel,
@@ -36,6 +38,7 @@ export default function SaveExportOverlay({
           className="flex items-center gap-1 text-primary"
           aria-label={t("button.cancel", { ns: "common" })}
           size="sm"
+          disabled={isSaving}
           onClick={onCancel}
         >
           <LuX />
@@ -46,6 +49,7 @@ export default function SaveExportOverlay({
             className="flex items-center gap-1"
             aria-label={t("export.fromTimeline.previewExport")}
             size="sm"
+            disabled={isSaving}
             onClick={onPreview}
           >
             <LuVideo />
@@ -57,10 +61,13 @@ export default function SaveExportOverlay({
           aria-label={saveLabel || t("export.fromTimeline.saveExport")}
           variant="select"
           size="sm"
+          disabled={isSaving}
           onClick={onSave}
         >
           <FaCompactDisc />
-          {saveLabel || t("export.fromTimeline.saveExport")}
+          {isSaving
+            ? t("export.fromTimeline.queueingExport")
+            : saveLabel || t("export.fromTimeline.saveExport")}
         </Button>
       </div>
     </div>

--- a/web/src/components/overlay/SaveExportOverlay.tsx
+++ b/web/src/components/overlay/SaveExportOverlay.tsx
@@ -7,6 +7,8 @@ import { useTranslation } from "react-i18next";
 type SaveExportOverlayProps = {
   className: string;
   show: boolean;
+  hidePreview?: boolean;
+  saveLabel?: string;
   onPreview: () => void;
   onSave: () => void;
   onCancel: () => void;
@@ -14,6 +16,8 @@ type SaveExportOverlayProps = {
 export default function SaveExportOverlay({
   className,
   show,
+  hidePreview = false,
+  saveLabel,
   onPreview,
   onSave,
   onCancel,
@@ -37,24 +41,26 @@ export default function SaveExportOverlay({
           <LuX />
           {t("button.cancel", { ns: "common" })}
         </Button>
+        {!hidePreview && (
+          <Button
+            className="flex items-center gap-1"
+            aria-label={t("export.fromTimeline.previewExport")}
+            size="sm"
+            onClick={onPreview}
+          >
+            <LuVideo />
+            {t("export.fromTimeline.previewExport")}
+          </Button>
+        )}
         <Button
           className="flex items-center gap-1"
-          aria-label={t("export.fromTimeline.previewExport")}
-          size="sm"
-          onClick={onPreview}
-        >
-          <LuVideo />
-          {t("export.fromTimeline.previewExport")}
-        </Button>
-        <Button
-          className="flex items-center gap-1"
-          aria-label={t("export.fromTimeline.saveExport")}
+          aria-label={saveLabel || t("export.fromTimeline.saveExport")}
           variant="select"
           size="sm"
           onClick={onSave}
         >
           <FaCompactDisc />
-          {t("export.fromTimeline.saveExport")}
+          {saveLabel || t("export.fromTimeline.saveExport")}
         </Button>
       </div>
     </div>

--- a/web/src/components/overlay/dialog/OptionAndInputDialog.tsx
+++ b/web/src/components/overlay/dialog/OptionAndInputDialog.tsx
@@ -16,9 +16,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import ActivityIndicator from "@/components/indicators/activity-indicator";
 import { cn } from "@/lib/utils";
 import { isMobile } from "react-device-detect";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 type Option = {
@@ -36,8 +37,8 @@ type OptionAndInputDialogProps = {
   nameLabel: string;
   descriptionLabel: string;
   setOpen: (open: boolean) => void;
-  onSave: (value: string) => void;
-  onCreateNew: (name: string, description: string) => void;
+  onSave: (value: string) => Promise<void>;
+  onCreateNew: (name: string, description: string) => Promise<void>;
 };
 
 export default function OptionAndInputDialog({
@@ -70,10 +71,12 @@ export default function OptionAndInputDialog({
     }
   }, [open, initialValue, firstOption]);
 
+  const [isLoading, setIsLoading] = useState(false);
   const isNew = selectedValue === newValueKey;
-  const disableSave = !selectedValue || (isNew && name.trim().length === 0);
+  const disableSave =
+    !selectedValue || (isNew && name.trim().length === 0) || isLoading;
 
-  const handleSave = () => {
+  const handleSave = useCallback(async () => {
     if (!selectedValue) {
       return;
     }
@@ -81,13 +84,26 @@ export default function OptionAndInputDialog({
     const trimmedName = name.trim();
     const trimmedDescription = descriptionValue.trim();
 
-    if (isNew) {
-      onCreateNew(trimmedName, trimmedDescription);
-    } else {
-      onSave(selectedValue);
+    setIsLoading(true);
+    try {
+      if (isNew) {
+        await onCreateNew(trimmedName, trimmedDescription);
+      } else {
+        await onSave(selectedValue);
+      }
+      setOpen(false);
+    } finally {
+      setIsLoading(false);
     }
-    setOpen(false);
-  };
+  }, [
+    selectedValue,
+    name,
+    descriptionValue,
+    isNew,
+    onCreateNew,
+    onSave,
+    setOpen,
+  ]);
 
   return (
     <Dialog open={open} defaultOpen={false} onOpenChange={setOpen}>
@@ -128,13 +144,18 @@ export default function OptionAndInputDialog({
               <label className="text-sm font-medium text-secondary-foreground">
                 {nameLabel}
               </label>
-              <Input value={name} onChange={(e) => setName(e.target.value)} />
+              <Input
+                className="text-md"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
             </div>
             <div className="space-y-1">
               <label className="text-sm font-medium text-secondary-foreground">
                 {descriptionLabel}
               </label>
               <Textarea
+                className="text-md"
                 value={descriptionValue}
                 onChange={(e) => setDescriptionValue(e.target.value)}
                 rows={2}
@@ -147,6 +168,7 @@ export default function OptionAndInputDialog({
           <Button
             type="button"
             variant="outline"
+            disabled={isLoading}
             onClick={() => {
               setOpen(false);
             }}
@@ -157,9 +179,13 @@ export default function OptionAndInputDialog({
             type="button"
             variant="select"
             disabled={disableSave}
-            onClick={handleSave}
+            onClick={() => void handleSave()}
           >
-            {t("button.save")}
+            {isLoading ? (
+              <ActivityIndicator className="size-4" />
+            ) : (
+              t("button.save")
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/web/src/components/overlay/dialog/OptionAndInputDialog.tsx
+++ b/web/src/components/overlay/dialog/OptionAndInputDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
   SelectContent,
@@ -133,9 +134,10 @@ export default function OptionAndInputDialog({
               <label className="text-sm font-medium text-secondary-foreground">
                 {descriptionLabel}
               </label>
-              <Input
+              <Textarea
                 value={descriptionValue}
                 onChange={(e) => setDescriptionValue(e.target.value)}
+                rows={2}
               />
             </div>
           </div>

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -19,7 +19,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           cancelButton:
             "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
           closeButton:
-            "group-[.toast]:bg-secondary border-primary border-[1px]",
+            "group-[.toast]:bg-secondary group-[.toast]:text-primary group-[.toast]:border-primary group-[.toast]:border-[1px]",
           success:
             "group toast group-[.toaster]:bg-success group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
           error:

--- a/web/src/pages/Exports.tsx
+++ b/web/src/pages/Exports.tsx
@@ -14,7 +14,12 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import Heading from "@/components/ui/heading";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -1024,9 +1029,14 @@ function CaseAddExportDialog({
 }: CaseAddExportDialogProps) {
   const { t } = useTranslation(["views/exports", "common"]);
   const [search, setSearch] = useState("");
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [isAdding, setIsAdding] = useState(false);
 
+  // Reset dialog state whenever the target case changes or the dialog reopens.
   useEffect(() => {
     setSearch("");
+    setSelectedIds([]);
+    setIsAdding(false);
   }, [exportCase?.id]);
 
   const filteredExports = useMemo(() => {
@@ -1043,51 +1053,73 @@ function CaseAddExportDialog({
     );
   }, [availableExports, search]);
 
+  const toggleSelection = useCallback((exportId: string) => {
+    setSelectedIds((previous) =>
+      previous.includes(exportId)
+        ? previous.filter((id) => id !== exportId)
+        : [...previous, exportId],
+    );
+  }, []);
+
+  const handleAdd = useCallback(async () => {
+    if (!exportCase || selectedIds.length === 0 || isAdding) {
+      return;
+    }
+
+    setIsAdding(true);
+    try {
+      await Promise.all(
+        selectedIds.map((id) => onAssign(id, exportCase.id)),
+      );
+      onClose();
+    } finally {
+      setIsAdding(false);
+    }
+  }, [exportCase, isAdding, onAssign, onClose, selectedIds]);
+
   return (
     <Dialog
       open={exportCase != undefined}
       onOpenChange={(open) => !open && onClose()}
     >
-      <DialogContent className="max-h-[80dvh] overflow-hidden">
+      <DialogContent className="flex max-h-[80dvh] flex-col overflow-hidden">
         <DialogTitle>
           {t("addExportDialog.title", { caseName: exportCase?.name })}
         </DialogTitle>
-        <div className="space-y-3 overflow-hidden">
+        <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
           <Input
             placeholder={t("addExportDialog.searchPlaceholder")}
             value={search}
             onChange={(event) => setSearch(event.target.value)}
           />
-          <div className="scrollbar-container max-h-[50dvh] space-y-2 overflow-y-auto">
+          <div className="scrollbar-container min-h-0 flex-1 space-y-2 overflow-y-auto py-1 pr-1">
             {filteredExports.length > 0 ? (
-              filteredExports.map((exportItem) => (
-                <div
-                  key={exportItem.id}
-                  className="flex items-center justify-between rounded-lg border border-border p-3"
-                >
-                  <div className="min-w-0 pr-4">
-                    <div className="truncate font-medium">
-                      {exportItem.name}
-                    </div>
-                    <div className="truncate text-xs text-muted-foreground">
-                      {exportItem.camera.replaceAll("_", " ")}
-                    </div>
-                  </div>
-                  <Button
-                    size="sm"
-                    variant="select"
-                    onClick={() => {
-                      if (!exportCase) {
-                        return;
-                      }
-
-                      void onAssign(exportItem.id, exportCase.id).then(onClose);
-                    }}
+              filteredExports.map((exportItem) => {
+                const isSelected = selectedIds.includes(exportItem.id);
+                return (
+                  <button
+                    key={exportItem.id}
+                    type="button"
+                    aria-pressed={isSelected}
+                    className={cn(
+                      "flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left transition-colors",
+                      isSelected
+                        ? "border-selected bg-selected/10 ring-1 ring-selected"
+                        : "border-transparent bg-secondary/40 hover:bg-secondary/70",
+                    )}
+                    onClick={() => toggleSelection(exportItem.id)}
                   >
-                    {t("button.add", { ns: "common" })}
-                  </Button>
-                </div>
-              ))
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium text-primary">
+                        {exportItem.name}
+                      </div>
+                      <div className="truncate text-xs text-muted-foreground">
+                        {exportItem.camera.replaceAll("_", " ")}
+                      </div>
+                    </div>
+                  </button>
+                );
+              })
             ) : (
               <div className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
                 {t("addExportDialog.empty")}
@@ -1095,6 +1127,23 @@ function CaseAddExportDialog({
             )}
           </div>
         </div>
+        <DialogFooter className="flex-row justify-end gap-2">
+          <Button variant="outline" size="sm" onClick={onClose}>
+            {t("button.cancel", { ns: "common" })}
+          </Button>
+          <Button
+            variant="select"
+            size="sm"
+            disabled={selectedIds.length === 0 || isAdding}
+            onClick={() => void handleAdd()}
+          >
+            {isAdding
+              ? t("addExportDialog.adding")
+              : t("addExportDialog.addButton", {
+                  count: selectedIds.length || 1,
+                })}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/web/src/pages/Exports.tsx
+++ b/web/src/pages/Exports.tsx
@@ -1,5 +1,9 @@
 import { baseUrl } from "@/api/baseUrl";
-import { CaseCard, ExportCard } from "@/components/card/ExportCard";
+import {
+  ActiveExportJobCard,
+  CaseCard,
+  ExportCard,
+} from "@/components/card/ExportCard";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -26,6 +30,7 @@ import {
   Export,
   ExportCase,
   ExportFilter,
+  ExportJob,
 } from "@/types/export";
 import OptionAndInputDialog from "@/components/overlay/dialog/OptionAndInputDialog";
 import axios from "axios";
@@ -66,11 +71,49 @@ function Exports() {
   // Data
 
   const { data: cases, mutate: updateCases } = useSWR<ExportCase[]>("cases");
+  const { data: activeExportJobs } = useSWR<ExportJob[]>("jobs/export", {
+    refreshInterval: 2000,
+  });
   const { data: rawExports, mutate: updateExports } = useSWR<Export[]>(
     exportSearchParams && Object.keys(exportSearchParams).length > 0
       ? ["exports", exportSearchParams]
       : "exports",
+    {
+      refreshInterval: (activeExportJobs?.length ?? 0) > 0 ? 2000 : 0,
+    },
   );
+
+  const visibleActiveJobs = useMemo<ExportJob[]>(() => {
+    const existingExportIds = new Set((rawExports ?? []).map((exp) => exp.id));
+    const filteredCameras = exportFilter?.cameras;
+
+    return (activeExportJobs ?? []).filter((job) => {
+      if (existingExportIds.has(job.id)) {
+        return false;
+      }
+
+      if (filteredCameras && filteredCameras.length > 0) {
+        return filteredCameras.includes(job.camera);
+      }
+
+      return true;
+    });
+  }, [activeExportJobs, exportFilter?.cameras, rawExports]);
+
+  const activeJobsByCase = useMemo<{ [caseId: string]: ExportJob[] }>(() => {
+    const grouped: { [caseId: string]: ExportJob[] } = {};
+
+    visibleActiveJobs.forEach((job) => {
+      const caseId = job.export_case_id ?? "none";
+      if (!grouped[caseId]) {
+        grouped[caseId] = [];
+      }
+
+      grouped[caseId].push(job);
+    });
+
+    return grouped;
+  }, [visibleActiveJobs]);
 
   const exportsByCase = useMemo<{ [caseId: string]: Export[] }>(() => {
     const grouped: { [caseId: string]: Export[] } = {};
@@ -515,6 +558,7 @@ function Exports() {
           selectedCase={selectedCase}
           exports={exportsByCase[selectedCase.id] || []}
           availableExports={uncategorizedExports}
+          activeJobs={activeJobsByCase[selectedCase.id] || []}
           search={search}
           setSelected={setSelected}
           renameClip={onHandleRename}
@@ -529,6 +573,7 @@ function Exports() {
           cases={filteredCases}
           exports={exports}
           exportsByCase={exportsByCase}
+          activeJobs={activeJobsByCase["none"] || []}
           setSelectedCaseId={setSelectedCaseId}
           setSelected={setSelected}
           renameClip={onHandleRename}
@@ -546,6 +591,7 @@ type AllExportsViewProps = {
   cases?: ExportCase[];
   exports: Export[];
   exportsByCase: { [caseId: string]: Export[] };
+  activeJobs: ExportJob[];
   setSelectedCaseId: (id: string) => void;
   setSelected: (e: Export) => void;
   renameClip: (id: string, update: string) => void;
@@ -558,6 +604,7 @@ function AllExportsView({
   cases,
   exports,
   exportsByCase,
+  activeJobs,
   setSelectedCaseId,
   setSelected,
   renameClip,
@@ -594,9 +641,24 @@ function AllExportsView({
     );
   }, [exports, search]);
 
+  const filteredActiveJobs = useMemo<ExportJob[]>(() => {
+    if (!search) {
+      return activeJobs;
+    }
+
+    return activeJobs.filter((job) =>
+      (job.name || job.camera)
+        .toLowerCase()
+        .replaceAll("_", " ")
+        .includes(search.toLowerCase()),
+    );
+  }, [activeJobs, search]);
+
   return (
     <div className="w-full overflow-hidden">
-      {filteredCases?.length || filteredExports.length ? (
+      {filteredCases?.length ||
+      filteredActiveJobs.length ||
+      filteredExports.length ? (
         <div
           ref={contentRef}
           className="scrollbar-container flex size-full flex-col gap-4 overflow-y-auto"
@@ -620,13 +682,16 @@ function AllExportsView({
             </div>
           )}
 
-          {filteredExports.length > 0 && (
+          {(filteredActiveJobs.length > 0 || filteredExports.length > 0) && (
             <div className="space-y-4">
               <Heading as="h4">{t("headings.uncategorizedExports")}</Heading>
               <div
                 ref={contentRef}
                 className="scrollbar-container grid gap-2 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
               >
+                {filteredActiveJobs.map((job) => (
+                  <ActiveExportJobCard key={job.id} job={job} />
+                ))}
                 {filteredExports.map((item) => (
                   <ExportCard
                     key={item.name}
@@ -659,6 +724,7 @@ type CaseViewProps = {
   selectedCase: ExportCase;
   exports?: Export[];
   availableExports: Export[];
+  activeJobs: ExportJob[];
   search: string;
   setSelected: (e: Export) => void;
   renameClip: (id: string, update: string) => void;
@@ -671,6 +737,7 @@ function CaseView({
   selectedCase,
   exports,
   availableExports,
+  activeJobs,
   search,
   setSelected,
   renameClip,
@@ -703,6 +770,23 @@ function CaseView({
         .includes(search.toLowerCase()),
     );
   }, [selectedCase, exports, search]);
+
+  const filteredActiveJobs = useMemo<ExportJob[]>(() => {
+    const caseJobs = activeJobs.filter(
+      (job) => job.export_case_id === selectedCase.id,
+    );
+
+    if (!search) {
+      return caseJobs;
+    }
+
+    return caseJobs.filter((job) =>
+      (job.name || job.camera)
+        .toLowerCase()
+        .replaceAll("_", " ")
+        .includes(search.toLowerCase()),
+    );
+  }, [activeJobs, search, selectedCase.id]);
 
   const cameraCount = useMemo(
     () => new Set(filteredExports.map((exp) => exp.camera)).size,
@@ -765,11 +849,14 @@ function CaseView({
           </div>
         )}
       </div>
-      {filteredExports.length > 0 ? (
+      {filteredExports.length > 0 || filteredActiveJobs.length > 0 ? (
         <div
           ref={contentRef}
           className="scrollbar-container grid min-h-0 flex-1 content-start gap-2 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
         >
+          {filteredActiveJobs.map((job) => (
+            <ActiveExportJobCard key={job.id} job={job} />
+          ))}
           {filteredExports.map((item) => (
             <ExportCard
               key={item.id}

--- a/web/src/pages/Exports.tsx
+++ b/web/src/pages/Exports.tsx
@@ -64,13 +64,16 @@ import {
 } from "react-icons/lu";
 import { toast } from "sonner";
 import useSWR from "swr";
+import ExportActionGroup from "@/components/filter/ExportActionGroup";
 import ExportFilterGroup from "@/components/filter/ExportFilterGroup";
+import { useIsAdmin } from "@/hooks/use-is-admin";
 
 // always parse these as string arrays
 const EXPORT_FILTER_ARRAY_KEYS = ["cameras"];
 
 function Exports() {
   const { t } = useTranslation(["views/exports"]);
+  const isAdmin = useIsAdmin();
 
   useEffect(() => {
     document.title = t("documentTitle");
@@ -224,6 +227,54 @@ function Exports() {
     return true;
   });
 
+  // Bulk selection
+
+  const [selectedExports, setSelectedExports] = useState<Export[]>([]);
+  const selectionMode = selectedExports.length > 0;
+
+  // Clear selection when switching views
+  useEffect(() => {
+    setSelectedExports([]);
+  }, [selectedCaseId]);
+
+  const onSelectExport = useCallback(
+    (exportItem: Export) => {
+      const index = selectedExports.findIndex((e) => e.id === exportItem.id);
+      if (index !== -1) {
+        if (selectedExports.length === 1) {
+          setSelectedExports([]);
+        } else {
+          setSelectedExports([
+            ...selectedExports.slice(0, index),
+            ...selectedExports.slice(index + 1),
+          ]);
+        }
+      } else {
+        setSelectedExports([...selectedExports, exportItem]);
+      }
+    },
+    [selectedExports],
+  );
+
+  const onSelectAllExports = useCallback(() => {
+    const currentExports = selectedCaseId
+      ? exportsByCase[selectedCaseId] || []
+      : exports;
+    const visibleExports = currentExports.filter((e) => {
+      if (e.in_progress) return false;
+      if (!search) return true;
+      return e.name
+        .toLowerCase()
+        .replaceAll("_", " ")
+        .includes(search.toLowerCase());
+    });
+    if (selectedExports.length < visibleExports.length) {
+      setSelectedExports(visibleExports);
+    } else {
+      setSelectedExports([]);
+    }
+  }, [selectedCaseId, exportsByCase, exports, search, selectedExports]);
+
   // Modifying
 
   const [deleteClip, setDeleteClip] = useState<DeleteClipType | undefined>();
@@ -242,12 +293,14 @@ function Exports() {
       return;
     }
 
-    axios.delete(`export/${deleteClip.file}`).then((response) => {
-      if (response.status == 200) {
-        setDeleteClip(undefined);
-        mutate();
-      }
-    });
+    axios
+      .post("exports/delete", { ids: [deleteClip.file] })
+      .then((response) => {
+        if (response.status == 200) {
+          setDeleteClip(undefined);
+          mutate();
+        }
+      });
   }, [deleteClip, mutate]);
 
   const onHandleRename = useCallback(
@@ -278,7 +331,27 @@ function Exports() {
   // Keyboard Listener
 
   const contentRef = useRef<HTMLDivElement | null>(null);
-  useKeyboardListener([], undefined, contentRef);
+  useKeyboardListener(
+    ["a", "Escape"],
+    (key, modifiers) => {
+      if (!modifiers.down) return true;
+
+      switch (key) {
+        case "a":
+          if (modifiers.ctrl && !modifiers.repeat) {
+            onSelectAllExports();
+            return true;
+          }
+          break;
+        case "Escape":
+          setSelectedExports([]);
+          return true;
+      }
+
+      return false;
+    },
+    contentRef,
+  );
 
   const selectedCase = useMemo(
     () => cases?.find((c) => c.id === selectedCaseId),
@@ -372,33 +445,11 @@ function Exports() {
     }
   }, [caseToDelete, deleteExportsWithCase, mutate, selectedCaseId, t]);
 
-  const handleAssignExportToCase = useCallback(
-    async (exportId: string, caseId: string) => {
-      try {
-        await axios.patch(`export/${exportId}/case`, {
-          export_case_id: caseId,
-        });
-        mutate();
-      } catch (error) {
-        const apiError = error as {
-          response?: { data?: { message?: string; detail?: string } };
-        };
-        const errorMessage =
-          apiError.response?.data?.message ||
-          apiError.response?.data?.detail ||
-          "Unknown error";
-        toast.error(t("toast.error.assignCaseFailed", { errorMessage }), {
-          position: "top-center",
-        });
-      }
-    },
-    [mutate, t],
-  );
-
   const handleRemoveExportFromCase = useCallback(
     async (exportedRecording: Export) => {
       try {
-        await axios.patch(`export/${exportedRecording.id}/case`, {
+        await axios.post("exports/reassign", {
+          ids: [exportedRecording.id],
           export_case_id: null,
         });
         mutate();
@@ -436,7 +487,7 @@ function Exports() {
         exportCase={caseForAddExport}
         availableExports={uncategorizedExports}
         onClose={() => setCaseForAddExport(undefined)}
-        onAssign={handleAssignExportToCase}
+        mutate={mutate}
       />
 
       <CaseAssignmentDialog
@@ -570,94 +621,120 @@ function Exports() {
           isMobileOnly && "mb-2 h-auto flex-wrap gap-2 space-y-0",
         )}
       >
-        <div className="flex w-full items-center gap-2">
-          {selectedCase && (
-            <Button
-              className="flex items-center gap-2.5 rounded-lg"
-              aria-label={t("label.back", { ns: "common" })}
-              size="sm"
-              onClick={() => setSelectedCaseId(undefined)}
-            >
-              <IoMdArrowRoundBack className="size-5 text-secondary-foreground" />
-              {!isMobileOnly && (
-                <div className="text-primary">
-                  {t("button.back", { ns: "common" })}
-                </div>
-              )}
-            </Button>
-          )}
-          <Input
-            className="text-md w-full bg-muted md:w-1/2"
-            placeholder={t("search")}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
+        {selectionMode ? (
+          <ExportActionGroup
+            selectedExports={selectedExports}
+            setSelectedExports={setSelectedExports}
+            context={selectedCase ? "case" : "uncategorized"}
+            cases={cases}
+            currentCaseId={selectedCaseId}
+            mutate={mutate}
           />
-        </div>
-        {!selectedCase && (
-          <div className="flex w-full items-center justify-between gap-2 md:justify-start lg:justify-end">
-            <ExportFilterGroup
-              className="justify-start"
-              filter={exportFilter}
-              filters={["cameras"]}
-              onUpdateFilter={setExportFilter}
-            />
-            <Button
-              className="flex items-center gap-2.5 rounded-lg"
-              variant="default"
-              size="sm"
-              onClick={() => setCaseDialog({ mode: "create" })}
-            >
-              <LuFolderPlus className="size-4 text-secondary-foreground" />
-              <div className="text-primary">{t("toolbar.newCase")}</div>
-            </Button>
-          </div>
-        )}
-        {selectedCase && (
-          <div className="flex w-full items-center justify-end gap-2">
-            <ExportFilterGroup
-              className="justify-start"
-              filter={exportFilter}
-              filters={["cameras"]}
-              onUpdateFilter={setExportFilter}
-            />
-            <div className="flex items-center gap-1 md:gap-2">
-              <Button
-                className="flex items-center gap-2 p-2"
-                size="sm"
-                aria-label={t("toolbar.addExport")}
-                onClick={() => setCaseForAddExport(selectedCase)}
-              >
-                <LuPlus className="size-4 text-secondary-foreground" />
-                {!isMobile && (
-                  <div className="text-primary">{t("toolbar.addExport")}</div>
-                )}
-              </Button>
-              <Button
-                className="flex items-center gap-2 p-2"
-                size="sm"
-                aria-label={t("toolbar.editCase")}
-                onClick={() =>
-                  setCaseDialog({ mode: "edit", exportCase: selectedCase })
-                }
-              >
-                <LuPencil className="size-4 text-secondary-foreground" />
-                {!isMobile && (
-                  <div className="text-primary">{t("toolbar.editCase")}</div>
-                )}
-              </Button>
-              <Button
-                className="flex items-center gap-2 p-2"
-                size="sm"
-                aria-label={t("toolbar.deleteCase")}
-                onClick={() => setCaseToDelete(selectedCase)}
-              >
-                <LuTrash2 className="size-4 text-secondary-foreground" />
-                {!isMobile && (
-                  <div className="text-primary">{t("toolbar.deleteCase")}</div>
-                )}
-              </Button>
+        ) : (
+          <>
+            <div className="flex w-full items-center gap-2">
+              {selectedCase && (
+                <Button
+                  className="flex items-center gap-2.5 rounded-lg"
+                  aria-label={t("label.back", { ns: "common" })}
+                  size="sm"
+                  onClick={() => setSelectedCaseId(undefined)}
+                >
+                  <IoMdArrowRoundBack className="size-5 text-secondary-foreground" />
+                  {!isMobileOnly && (
+                    <div className="text-primary">
+                      {t("button.back", { ns: "common" })}
+                    </div>
+                  )}
+                </Button>
+              )}
+              <Input
+                className="text-md w-full bg-muted md:w-1/2"
+                placeholder={t("search")}
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
             </div>
-          </div>
+            {!selectedCase && (
+              <div className="flex w-full items-center justify-end gap-2">
+                <ExportFilterGroup
+                  className="justify-start"
+                  filter={exportFilter}
+                  filters={["cameras"]}
+                  onUpdateFilter={setExportFilter}
+                />
+                {isAdmin && (
+                  <Button
+                    className="flex items-center gap-2.5 rounded-lg"
+                    variant="default"
+                    size="sm"
+                    onClick={() => setCaseDialog({ mode: "create" })}
+                  >
+                    <LuFolderPlus className="text-secondary-foreground" />
+                    <div className="text-primary">{t("toolbar.newCase")}</div>
+                  </Button>
+                )}
+              </div>
+            )}
+            {selectedCase && (
+              <div className="flex w-full items-center justify-end gap-2">
+                <ExportFilterGroup
+                  className="justify-start"
+                  filter={exportFilter}
+                  filters={["cameras"]}
+                  onUpdateFilter={setExportFilter}
+                />
+                {isAdmin && (
+                  <div className="flex items-center gap-1 md:gap-2">
+                    <Button
+                      className="flex items-center gap-2 p-2"
+                      size="sm"
+                      aria-label={t("toolbar.addExport")}
+                      onClick={() => setCaseForAddExport(selectedCase)}
+                    >
+                      <LuPlus className="text-secondary-foreground" />
+                      {!isMobile && (
+                        <div className="text-primary">
+                          {t("toolbar.addExport")}
+                        </div>
+                      )}
+                    </Button>
+                    <Button
+                      className="flex items-center gap-2 p-2"
+                      size="sm"
+                      aria-label={t("toolbar.editCase")}
+                      onClick={() =>
+                        setCaseDialog({
+                          mode: "edit",
+                          exportCase: selectedCase,
+                        })
+                      }
+                    >
+                      <LuPencil className="text-secondary-foreground" />
+                      {!isMobile && (
+                        <div className="text-primary">
+                          {t("toolbar.editCase")}
+                        </div>
+                      )}
+                    </Button>
+                    <Button
+                      className="flex items-center gap-2 p-2"
+                      size="sm"
+                      aria-label={t("toolbar.deleteCase")}
+                      onClick={() => setCaseToDelete(selectedCase)}
+                    >
+                      <LuTrash2 className="text-secondary-foreground" />
+                      {!isMobile && (
+                        <div className="text-primary">
+                          {t("toolbar.deleteCase")}
+                        </div>
+                      )}
+                    </Button>
+                  </div>
+                )}
+              </div>
+            )}
+          </>
         )}
       </div>
 
@@ -669,6 +746,9 @@ function Exports() {
           availableExports={uncategorizedExports}
           activeJobs={activeJobsByCase[selectedCase.id] || []}
           search={search}
+          selectedExports={selectedExports}
+          selectionMode={selectionMode}
+          onSelectExport={onSelectExport}
           setSelected={setSelected}
           renameClip={onHandleRename}
           setDeleteClip={setDeleteClip}
@@ -684,6 +764,9 @@ function Exports() {
           exports={exports}
           exportsByCase={exportsByCase}
           activeJobs={activeJobsByCase["none"] || []}
+          selectedExports={selectedExports}
+          selectionMode={selectionMode}
+          onSelectExport={onSelectExport}
           setSelectedCaseId={setSelectedCaseId}
           setSelected={setSelected}
           renameClip={onHandleRename}
@@ -702,6 +785,9 @@ type AllExportsViewProps = {
   exports: Export[];
   exportsByCase: { [caseId: string]: Export[] };
   activeJobs: ExportJob[];
+  selectedExports: Export[];
+  selectionMode: boolean;
+  onSelectExport: (e: Export) => void;
   setSelectedCaseId: (id: string) => void;
   setSelected: (e: Export) => void;
   renameClip: (id: string, update: string) => void;
@@ -715,6 +801,9 @@ function AllExportsView({
   exports,
   exportsByCase,
   activeJobs,
+  selectedExports,
+  selectionMode,
+  onSelectExport,
   setSelectedCaseId,
   setSelected,
   renameClip,
@@ -807,6 +896,9 @@ function AllExportsView({
                     key={item.name}
                     className=""
                     exportedRecording={item}
+                    isSelected={selectedExports.some((e) => e.id === item.id)}
+                    selectionMode={selectionMode}
+                    onContextSelect={onSelectExport}
                     onSelect={setSelected}
                     onRename={renameClip}
                     onDelete={({ file, exportName }) =>
@@ -836,6 +928,9 @@ type CaseViewProps = {
   availableExports: Export[];
   activeJobs: ExportJob[];
   search: string;
+  selectedExports: Export[];
+  selectionMode: boolean;
+  onSelectExport: (e: Export) => void;
   setSelected: (e: Export) => void;
   renameClip: (id: string, update: string) => void;
   setDeleteClip: (d: DeleteClipType | undefined) => void;
@@ -850,6 +945,9 @@ function CaseView({
   availableExports,
   activeJobs,
   search,
+  selectedExports,
+  selectionMode,
+  onSelectExport,
   setSelected,
   renameClip,
   setDeleteClip,
@@ -974,6 +1072,9 @@ function CaseView({
               key={item.id}
               className=""
               exportedRecording={item}
+              isSelected={selectedExports.some((e) => e.id === item.id)}
+              selectionMode={selectionMode}
+              onContextSelect={onSelectExport}
               onSelect={setSelected}
               onRename={renameClip}
               onDelete={({ file, exportName }) =>
@@ -1076,13 +1177,13 @@ type CaseAddExportDialogProps = {
   exportCase?: ExportCase;
   availableExports: Export[];
   onClose: () => void;
-  onAssign: (exportId: string, caseId: string) => Promise<void>;
+  mutate: () => void;
 };
 function CaseAddExportDialog({
   exportCase,
   availableExports,
   onClose,
-  onAssign,
+  mutate,
 }: CaseAddExportDialogProps) {
   const { t } = useTranslation(["views/exports", "common"]);
   const [search, setSearch] = useState("");
@@ -1125,12 +1226,27 @@ function CaseAddExportDialog({
 
     setIsAdding(true);
     try {
-      await Promise.all(selectedIds.map((id) => onAssign(id, exportCase.id)));
+      await axios.post("exports/reassign", {
+        ids: selectedIds,
+        export_case_id: exportCase.id,
+      });
+      mutate();
       onClose();
+    } catch (error) {
+      const apiError = error as {
+        response?: { data?: { message?: string; detail?: string } };
+      };
+      const errorMessage =
+        apiError.response?.data?.message ||
+        apiError.response?.data?.detail ||
+        "Unknown error";
+      toast.error(t("toast.error.assignCaseFailed", { errorMessage }), {
+        position: "top-center",
+      });
     } finally {
       setIsAdding(false);
     }
-  }, [exportCase, isAdding, onAssign, onClose, selectedIds]);
+  }, [exportCase, isAdding, mutate, onClose, selectedIds, t]);
 
   return (
     <Dialog
@@ -1240,7 +1356,8 @@ function CaseAssignmentDialog({
       if (!exportToAssign) return;
 
       try {
-        await axios.patch(`export/${exportToAssign.id}/case`, {
+        await axios.post("exports/reassign", {
+          ids: [exportToAssign.id],
           export_case_id: caseId,
         });
         mutate();
@@ -1256,6 +1373,7 @@ function CaseAssignmentDialog({
         toast.error(t("toast.error.assignCaseFailed", { errorMessage }), {
           position: "top-center",
         });
+        throw error;
       }
     },
     [exportToAssign, mutate, onClose, t],
@@ -1274,7 +1392,8 @@ function CaseAssignmentDialog({
         const newCaseId: string | undefined = createResp.data?.id;
 
         if (newCaseId) {
-          await axios.patch(`export/${exportToAssign.id}/case`, {
+          await axios.post("exports/reassign", {
+            ids: [exportToAssign.id],
             export_case_id: newCaseId,
           });
         }
@@ -1292,6 +1411,7 @@ function CaseAssignmentDialog({
         toast.error(t("toast.error.assignCaseFailed", { errorMessage }), {
           position: "top-center",
         });
+        throw error;
       }
     },
     [exportToAssign, mutate, onClose, t],

--- a/web/src/pages/Exports.tsx
+++ b/web/src/pages/Exports.tsx
@@ -13,12 +13,14 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import Heading from "@/components/ui/heading";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Toaster } from "@/components/ui/sonner";
 import useKeyboardListener from "@/hooks/use-keyboard-listener";
 import { useSearchEffect } from "@/hooks/use-overlay-state";
 import { useHistoryBack } from "@/hooks/use-history-back";
 import { useApiFilterArgs } from "@/hooks/use-api-filter";
 import { cn } from "@/lib/utils";
+import { useFormattedTimestamp, useTimeFormat } from "@/hooks/use-date-utils";
 import {
   DeleteClipType,
   Export,
@@ -27,6 +29,7 @@ import {
 } from "@/types/export";
 import OptionAndInputDialog from "@/components/overlay/dialog/OptionAndInputDialog";
 import axios from "axios";
+import { FrigateConfig } from "@/types/frigateConfig";
 
 import {
   MutableRefObject,
@@ -39,6 +42,7 @@ import {
 import { isMobile, isMobileOnly } from "react-device-detect";
 import { useTranslation } from "react-i18next";
 
+import { IoMdArrowRoundBack } from "react-icons/io";
 import { LuFolderX } from "react-icons/lu";
 import { toast } from "sonner";
 import useSWR from "swr";
@@ -71,7 +75,7 @@ function Exports() {
   const exportsByCase = useMemo<{ [caseId: string]: Export[] }>(() => {
     const grouped: { [caseId: string]: Export[] } = {};
     (rawExports ?? []).forEach((exp) => {
-      const caseId = exp.export_case || "none";
+      const caseId = exp.export_case ?? exp.export_case_id ?? "none";
       if (!grouped[caseId]) {
         grouped[caseId] = [];
       }
@@ -82,15 +86,8 @@ function Exports() {
   }, [rawExports]);
 
   const filteredCases = useMemo<ExportCase[]>(() => {
-    if (!cases) {
-      return [];
-    }
-
-    return cases.filter((caseItem) => {
-      const caseExports = exportsByCase[caseItem.id];
-      return caseExports?.length;
-    });
-  }, [cases, exportsByCase]);
+    return cases || [];
+  }, [cases]);
 
   const exports = useMemo<Export[]>(
     () => exportsByCase["none"] || [],
@@ -149,6 +146,13 @@ function Exports() {
 
   const [deleteClip, setDeleteClip] = useState<DeleteClipType | undefined>();
   const [exportToAssign, setExportToAssign] = useState<Export | undefined>();
+  const [caseDialog, setCaseDialog] = useState<
+    { mode: "create" | "edit"; exportCase?: ExportCase } | undefined
+  >();
+  const [caseToDelete, setCaseToDelete] = useState<ExportCase | undefined>();
+  const [caseForAddExport, setCaseForAddExport] = useState<
+    ExportCase | undefined
+  >();
 
   const onHandleDelete = useCallback(() => {
     if (!deleteClip) {
@@ -194,8 +198,115 @@ function Exports() {
   useKeyboardListener([], undefined, contentRef);
 
   const selectedCase = useMemo(
-    () => filteredCases?.find((c) => c.id === selectedCaseId),
-    [filteredCases, selectedCaseId],
+    () => cases?.find((c) => c.id === selectedCaseId),
+    [cases, selectedCaseId],
+  );
+
+  const uncategorizedExports = useMemo(
+    () => exportsByCase["none"] || [],
+    [exportsByCase],
+  );
+
+  const saveCase = useCallback(
+    async (
+      payload: { name: string; description: string },
+      exportCaseId?: string,
+    ) => {
+      try {
+        let savedCaseId = exportCaseId;
+
+        if (exportCaseId) {
+          await axios.patch(`cases/${exportCaseId}`, payload);
+        } else {
+          const response = await axios.post("cases", payload);
+          savedCaseId = response.data.id;
+        }
+
+        if (savedCaseId) {
+          setSelectedCaseId(savedCaseId);
+        }
+
+        mutate();
+        return true;
+      } catch (error) {
+        const apiError = error as {
+          response?: { data?: { message?: string; detail?: string } };
+        };
+        const errorMessage =
+          apiError.response?.data?.message ||
+          apiError.response?.data?.detail ||
+          "Unknown error";
+        toast.error(t("toast.error.caseSaveFailed", { errorMessage }), {
+          position: "top-center",
+        });
+
+        return false;
+      }
+    },
+    [mutate, t],
+  );
+
+  const handleSaveCase = useCallback(
+    async (payload: { name: string; description: string }) => {
+      const didSave = await saveCase(
+        payload,
+        caseDialog?.mode === "edit" ? caseDialog.exportCase?.id : undefined,
+      );
+
+      if (didSave) {
+        setCaseDialog(undefined);
+      }
+    },
+    [caseDialog, saveCase],
+  );
+
+  const handleDeleteCase = useCallback(async () => {
+    if (!caseToDelete) {
+      return;
+    }
+
+    try {
+      await axios.delete(`cases/${caseToDelete.id}`);
+      if (selectedCaseId === caseToDelete.id) {
+        setSelectedCaseId(undefined);
+      }
+      setCaseToDelete(undefined);
+      mutate();
+    } catch (error) {
+      const apiError = error as {
+        response?: { data?: { message?: string; detail?: string } };
+      };
+      const errorMessage =
+        apiError.response?.data?.message ||
+        apiError.response?.data?.detail ||
+        "Unknown error";
+      toast.error(t("toast.error.caseDeleteFailed", { errorMessage }), {
+        position: "top-center",
+      });
+    }
+  }, [caseToDelete, mutate, selectedCaseId, t]);
+
+  const handleAssignExportToCase = useCallback(
+    async (exportId: string, caseId: string) => {
+      try {
+        await axios.patch(`export/${exportId}/case`, {
+          export_case_id: caseId,
+        });
+        mutate();
+      } catch (error) {
+        const apiError = error as {
+          response?: { data?: { message?: string; detail?: string } };
+        };
+        const errorMessage =
+          apiError.response?.data?.message ||
+          apiError.response?.data?.detail ||
+          "Unknown error";
+        toast.error(t("toast.error.assignCaseFailed", { errorMessage }), {
+          position: "top-center",
+        });
+      }
+    },
+    [mutate, t],
   );
 
   const resetCaseDialog = useCallback(() => {
@@ -205,6 +316,19 @@ function Exports() {
   return (
     <div className="flex size-full flex-col gap-2 overflow-hidden px-1 pt-2 md:p-2">
       <Toaster closeButton={true} />
+
+      <CaseEditorDialog
+        caseDialog={caseDialog}
+        onClose={() => setCaseDialog(undefined)}
+        onSave={handleSaveCase}
+      />
+
+      <CaseAddExportDialog
+        exportCase={caseForAddExport}
+        availableExports={uncategorizedExports}
+        onClose={() => setCaseForAddExport(undefined)}
+        onAssign={handleAssignExportToCase}
+      />
 
       <CaseAssignmentDialog
         exportToAssign={exportToAssign}
@@ -234,6 +358,34 @@ function Exports() {
               aria-label="Delete Export"
               variant="destructive"
               onClick={() => onHandleDelete()}
+            >
+              {t("button.delete", { ns: "common" })}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={caseToDelete != undefined}
+        onOpenChange={() => setCaseToDelete(undefined)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("deleteCase.label")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("deleteCase.desc", {
+                caseName: caseToDelete?.name,
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              {t("button.cancel", { ns: "common" })}
+            </AlertDialogCancel>
+            <Button
+              className="text-white"
+              variant="destructive"
+              onClick={() => void handleDeleteCase()}
             >
               {t("button.delete", { ns: "common" })}
             </Button>
@@ -288,7 +440,22 @@ function Exports() {
           isMobileOnly && "mb-2 h-auto flex-wrap gap-2 space-y-0",
         )}
       >
-        <div className="w-full">
+        <div className="flex w-full items-center gap-2">
+          {selectedCase && (
+            <Button
+              className="flex items-center gap-2.5 rounded-lg"
+              aria-label={t("label.back", { ns: "common" })}
+              size="sm"
+              onClick={() => setSelectedCaseId(undefined)}
+            >
+              <IoMdArrowRoundBack className="size-5 text-secondary-foreground" />
+              {!isMobileOnly && (
+                <div className="text-primary">
+                  {t("button.back", { ns: "common" })}
+                </div>
+              )}
+            </Button>
+          )}
           <Input
             className="text-md w-full bg-muted md:w-1/2"
             placeholder={t("search")}
@@ -296,12 +463,50 @@ function Exports() {
             onChange={(e) => setSearch(e.target.value)}
           />
         </div>
-        <ExportFilterGroup
-          className="w-full justify-between md:justify-start lg:justify-end"
-          filter={exportFilter}
-          filters={["cameras"]}
-          onUpdateFilter={setExportFilter}
-        />
+        {!selectedCase && (
+          <div className="flex w-full items-center justify-between gap-2 md:justify-start lg:justify-end">
+            <ExportFilterGroup
+              className="justify-start"
+              filter={exportFilter}
+              filters={["cameras"]}
+              onUpdateFilter={setExportFilter}
+            />
+            <Button
+              variant="default"
+              size="sm"
+              onClick={() => setCaseDialog({ mode: "create" })}
+            >
+              {t("toolbar.newCase")}
+            </Button>
+          </div>
+        )}
+        {selectedCase && (
+          <div className="flex w-full items-center justify-end gap-2">
+            <Button
+              className="flex items-center gap-2.5 rounded-lg"
+              size="sm"
+              onClick={() => setCaseForAddExport(selectedCase)}
+            >
+              <div className="text-primary">{t("toolbar.addExport")}</div>
+            </Button>
+            <Button
+              className="flex items-center gap-2.5 rounded-lg"
+              size="sm"
+              onClick={() =>
+                setCaseDialog({ mode: "edit", exportCase: selectedCase })
+              }
+            >
+              <div className="text-primary">{t("toolbar.editCase")}</div>
+            </Button>
+            <Button
+              className="flex items-center gap-2.5 rounded-lg"
+              size="sm"
+              onClick={() => setCaseToDelete(selectedCase)}
+            >
+              <div className="text-primary">{t("toolbar.deleteCase")}</div>
+            </Button>
+          </div>
+        )}
       </div>
 
       {selectedCase ? (
@@ -309,11 +514,13 @@ function Exports() {
           contentRef={contentRef}
           selectedCase={selectedCase}
           exports={exportsByCase[selectedCase.id] || []}
+          availableExports={uncategorizedExports}
           search={search}
           setSelected={setSelected}
           renameClip={onHandleRename}
           setDeleteClip={setDeleteClip}
           onAssignToCase={setExportToAssign}
+          onAddExport={() => setCaseForAddExport(selectedCase)}
         />
       ) : (
         <AllExportsView
@@ -398,14 +605,10 @@ function AllExportsView({
             <div className="space-y-2">
               <Heading as="h4">{t("headings.cases")}</Heading>
               <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                {cases?.map((item) => (
+                {filteredCases.map((item) => (
                   <CaseCard
                     key={item.id}
-                    className={
-                      search == "" || filteredCases?.includes(item)
-                        ? ""
-                        : "hidden"
-                    }
+                    className=""
                     exportCase={item}
                     exports={exportsByCase[item.id] || []}
                     onSelect={() => {
@@ -424,14 +627,10 @@ function AllExportsView({
                 ref={contentRef}
                 className="scrollbar-container grid gap-2 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
               >
-                {exports.map((item) => (
+                {filteredExports.map((item) => (
                   <ExportCard
                     key={item.name}
-                    className={
-                      search == "" || filteredExports.includes(item)
-                        ? ""
-                        : "hidden"
-                    }
+                    className=""
                     exportedRecording={item}
                     onSelect={setSelected}
                     onRename={renameClip}
@@ -459,25 +658,38 @@ type CaseViewProps = {
   contentRef: MutableRefObject<HTMLDivElement | null>;
   selectedCase: ExportCase;
   exports?: Export[];
+  availableExports: Export[];
   search: string;
   setSelected: (e: Export) => void;
   renameClip: (id: string, update: string) => void;
   setDeleteClip: (d: DeleteClipType | undefined) => void;
   onAssignToCase: (e: Export) => void;
+  onAddExport: () => void;
 };
 function CaseView({
   contentRef,
   selectedCase,
   exports,
+  availableExports,
   search,
   setSelected,
   renameClip,
   setDeleteClip,
   onAssignToCase,
+  onAddExport,
 }: CaseViewProps) {
+  const { t } = useTranslation(["views/exports", "common"]);
+  const { data: config } = useSWR<FrigateConfig>("config");
+  const timeFormat = useTimeFormat(config);
+  const createdAt = useFormattedTimestamp(
+    selectedCase.created_at,
+    t(`time.formattedTimestampMonthDayYear.${timeFormat}`, { ns: "common" }),
+    config?.ui.timezone,
+  );
+
   const filteredExports = useMemo<Export[]>(() => {
     const caseExports = (exports || []).filter(
-      (e) => e.export_case == selectedCase.id,
+      (e) => (e.export_case ?? e.export_case_id) == selectedCase.id,
     );
 
     if (!search) {
@@ -492,35 +704,257 @@ function CaseView({
     );
   }, [selectedCase, exports, search]);
 
+  const cameraCount = useMemo(
+    () => new Set(filteredExports.map((exp) => exp.camera)).size,
+    [filteredExports],
+  );
+
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
+  const descriptionRef = useRef<HTMLDivElement | null>(null);
+  const [descriptionIsClamped, setDescriptionIsClamped] = useState(false);
+
+  useEffect(() => {
+    setDescriptionExpanded(false);
+  }, [selectedCase.id]);
+
+  useEffect(() => {
+    const element = descriptionRef.current;
+    if (!element) {
+      setDescriptionIsClamped(false);
+      return;
+    }
+
+    setDescriptionIsClamped(element.scrollHeight > element.clientHeight + 1);
+  }, [selectedCase.description, descriptionExpanded]);
+
   return (
-    <div className="flex size-full flex-col gap-8 overflow-hidden">
-      <div className="flex shrink-0 flex-col gap-1">
-        <Heading className="capitalize" as="h2">
+    <div className="flex size-full flex-col gap-4 overflow-hidden">
+      <div className="flex shrink-0 flex-col gap-2">
+        <Heading className="mb-0" as="h2">
           {selectedCase.name}
         </Heading>
-        <div className="text-secondary-foreground">
-          {selectedCase.description}
+        <div className="mb-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+          <span>{t("caseView.createdAt", { value: createdAt })}</span>
+          <span>
+            {t("caseView.exportCount", { count: filteredExports.length })}
+          </span>
+          <span>{t("caseView.cameraCount", { count: cameraCount })}</span>
         </div>
+        {selectedCase.description && (
+          <div className="mb-2 flex max-w-5xl flex-col items-start gap-1">
+            <div
+              ref={descriptionRef}
+              className={cn(
+                "whitespace-pre-wrap text-sm text-secondary-foreground",
+                !descriptionExpanded && "line-clamp-3",
+              )}
+            >
+              {selectedCase.description}
+            </div>
+            {(descriptionIsClamped || descriptionExpanded) && (
+              <button
+                type="button"
+                className="text-xs text-primary-variant underline-offset-2 hover:underline"
+                onClick={() => setDescriptionExpanded((prev) => !prev)}
+              >
+                {descriptionExpanded
+                  ? t("caseView.showLess")
+                  : t("caseView.showMore")}
+              </button>
+            )}
+          </div>
+        )}
       </div>
-      <div
-        ref={contentRef}
-        className="scrollbar-container grid min-h-0 flex-1 content-start gap-2 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-      >
-        {exports?.map((item) => (
-          <ExportCard
-            key={item.name}
-            className={filteredExports.includes(item) ? "" : "hidden"}
-            exportedRecording={item}
-            onSelect={setSelected}
-            onRename={renameClip}
-            onDelete={({ file, exportName }) =>
-              setDeleteClip({ file, exportName })
-            }
-            onAssignToCase={onAssignToCase}
-          />
-        ))}
-      </div>
+      {filteredExports.length > 0 ? (
+        <div
+          ref={contentRef}
+          className="scrollbar-container grid min-h-0 flex-1 content-start gap-2 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+        >
+          {filteredExports.map((item) => (
+            <ExportCard
+              key={item.id}
+              className=""
+              exportedRecording={item}
+              onSelect={setSelected}
+              onRename={renameClip}
+              onDelete={({ file, exportName }) =>
+                setDeleteClip({ file, exportName })
+              }
+              onAssignToCase={onAssignToCase}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="flex min-h-[16rem] flex-col items-center justify-center rounded-2xl border border-dashed border-border bg-background/40 p-6 text-center">
+          <LuFolderX className="size-12" />
+          <div className="mt-3 text-lg font-medium">
+            {t("caseView.emptyTitle")}
+          </div>
+          <div className="mt-2 max-w-md text-sm text-muted-foreground">
+            {availableExports.length > 0
+              ? t("caseView.emptyDescription")
+              : t("caseView.emptyDescriptionNoExports")}
+          </div>
+          {availableExports.length > 0 && (
+            <Button className="mt-4" variant="default" onClick={onAddExport}>
+              {t("toolbar.addExport")}
+            </Button>
+          )}
+        </div>
+      )}
     </div>
+  );
+}
+
+type CaseEditorDialogProps = {
+  caseDialog?: { mode: "create" | "edit"; exportCase?: ExportCase };
+  onClose: () => void;
+  onSave: (payload: { name: string; description: string }) => Promise<void>;
+};
+function CaseEditorDialog({
+  caseDialog,
+  onClose,
+  onSave,
+}: CaseEditorDialogProps) {
+  const { t } = useTranslation(["views/exports", "common"]);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    setName(caseDialog?.exportCase?.name || "");
+    setDescription(caseDialog?.exportCase?.description || "");
+  }, [caseDialog?.exportCase?.description, caseDialog?.exportCase?.name]);
+
+  return (
+    <Dialog
+      open={caseDialog != undefined}
+      onOpenChange={(open) => !open && onClose()}
+    >
+      <DialogContent>
+        <DialogTitle>
+          {caseDialog?.mode === "edit"
+            ? t("caseEditor.editTitle")
+            : t("caseEditor.createTitle")}
+        </DialogTitle>
+        <div className="space-y-3">
+          <Input
+            placeholder={t("caseEditor.namePlaceholder")}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+          <Textarea
+            placeholder={t("caseEditor.descriptionPlaceholder")}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+          />
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={onClose}>
+              {t("button.cancel", { ns: "common" })}
+            </Button>
+            <Button
+              variant="default"
+              disabled={name.trim().length === 0}
+              onClick={() =>
+                void onSave({
+                  name: name.trim(),
+                  description: description.trim(),
+                })
+              }
+            >
+              {caseDialog?.mode === "edit"
+                ? t("button.save", { ns: "common" })
+                : t("toolbar.newCase")}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+type CaseAddExportDialogProps = {
+  exportCase?: ExportCase;
+  availableExports: Export[];
+  onClose: () => void;
+  onAssign: (exportId: string, caseId: string) => Promise<void>;
+};
+function CaseAddExportDialog({
+  exportCase,
+  availableExports,
+  onClose,
+  onAssign,
+}: CaseAddExportDialogProps) {
+  const { t } = useTranslation(["views/exports", "common"]);
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    setSearch("");
+  }, [exportCase?.id]);
+
+  const filteredExports = useMemo(() => {
+    if (!search) {
+      return availableExports;
+    }
+
+    return availableExports.filter((exportItem) =>
+      exportItem.name.toLowerCase().includes(search.toLowerCase()),
+    );
+  }, [availableExports, search]);
+
+  return (
+    <Dialog
+      open={exportCase != undefined}
+      onOpenChange={(open) => !open && onClose()}
+    >
+      <DialogContent className="max-h-[80dvh] overflow-hidden">
+        <DialogTitle>
+          {t("addExportDialog.title", { caseName: exportCase?.name })}
+        </DialogTitle>
+        <div className="space-y-3 overflow-hidden">
+          <Input
+            placeholder={t("addExportDialog.searchPlaceholder")}
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+          <div className="scrollbar-container max-h-[50dvh] space-y-2 overflow-y-auto">
+            {filteredExports.length > 0 ? (
+              filteredExports.map((exportItem) => (
+                <div
+                  key={exportItem.id}
+                  className="flex items-center justify-between rounded-lg border border-border p-3"
+                >
+                  <div className="min-w-0 pr-4">
+                    <div className="truncate font-medium">
+                      {exportItem.name}
+                    </div>
+                    <div className="truncate text-xs text-muted-foreground">
+                      {exportItem.camera.replaceAll("_", " ")}
+                    </div>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="select"
+                    onClick={() => {
+                      if (!exportCase) {
+                        return;
+                      }
+
+                      void onAssign(exportItem.id, exportCase.id).then(onClose);
+                    }}
+                  >
+                    {t("button.add", { ns: "common" })}
+                  </Button>
+                </div>
+              ))
+            ) : (
+              <div className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+                {t("addExportDialog.empty")}
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/web/src/pages/Exports.tsx
+++ b/web/src/pages/Exports.tsx
@@ -48,7 +48,13 @@ import { isMobile, isMobileOnly } from "react-device-detect";
 import { useTranslation } from "react-i18next";
 
 import { IoMdArrowRoundBack } from "react-icons/io";
-import { LuFolderX } from "react-icons/lu";
+import {
+  LuFolderPlus,
+  LuFolderX,
+  LuPencil,
+  LuPlus,
+  LuTrash2,
+} from "react-icons/lu";
 import { toast } from "sonner";
 import useSWR from "swr";
 import ExportFilterGroup from "@/components/filter/ExportFilterGroup";
@@ -74,12 +80,25 @@ function Exports() {
   const { data: activeExportJobs } = useSWR<ExportJob[]>("jobs/export", {
     refreshInterval: 2000,
   });
+  // Keep polling exports while there are queued/running jobs OR while any
+  // existing export is still marked in_progress. Without the second clause,
+  // a stale in_progress=true snapshot can stick if the activeExportJobs poll
+  // clears before the rawExports poll fires — SWR cancels the pending
+  // rawExports refresh and the UI freezes on spinners until a manual reload.
   const { data: rawExports, mutate: updateExports } = useSWR<Export[]>(
     exportSearchParams && Object.keys(exportSearchParams).length > 0
       ? ["exports", exportSearchParams]
       : "exports",
     {
-      refreshInterval: (activeExportJobs?.length ?? 0) > 0 ? 2000 : 0,
+      refreshInterval: (latestExports) => {
+        if ((activeExportJobs?.length ?? 0) > 0) {
+          return 2000;
+        }
+        if ((latestExports ?? []).some((exp) => exp.in_progress)) {
+          return 2000;
+        }
+        return 0;
+      },
     },
   );
 
@@ -352,6 +371,29 @@ function Exports() {
     [mutate, t],
   );
 
+  const handleRemoveExportFromCase = useCallback(
+    async (exportedRecording: Export) => {
+      try {
+        await axios.patch(`export/${exportedRecording.id}/case`, {
+          export_case_id: null,
+        });
+        mutate();
+      } catch (error) {
+        const apiError = error as {
+          response?: { data?: { message?: string; detail?: string } };
+        };
+        const errorMessage =
+          apiError.response?.data?.message ||
+          apiError.response?.data?.detail ||
+          "Unknown error";
+        toast.error(t("toast.error.assignCaseFailed", { errorMessage }), {
+          position: "top-center",
+        });
+      }
+    },
+    [mutate, t],
+  );
+
   const resetCaseDialog = useCallback(() => {
     setExportToAssign(undefined);
   }, []);
@@ -515,11 +557,13 @@ function Exports() {
               onUpdateFilter={setExportFilter}
             />
             <Button
+              className="flex items-center gap-2.5 rounded-lg"
               variant="default"
               size="sm"
               onClick={() => setCaseDialog({ mode: "create" })}
             >
-              {t("toolbar.newCase")}
+              <LuFolderPlus className="size-4 text-secondary-foreground" />
+              <div className="text-primary">{t("toolbar.newCase")}</div>
             </Button>
           </div>
         )}
@@ -530,6 +574,7 @@ function Exports() {
               size="sm"
               onClick={() => setCaseForAddExport(selectedCase)}
             >
+              <LuPlus className="size-4 text-secondary-foreground" />
               <div className="text-primary">{t("toolbar.addExport")}</div>
             </Button>
             <Button
@@ -539,6 +584,7 @@ function Exports() {
                 setCaseDialog({ mode: "edit", exportCase: selectedCase })
               }
             >
+              <LuPencil className="size-4 text-secondary-foreground" />
               <div className="text-primary">{t("toolbar.editCase")}</div>
             </Button>
             <Button
@@ -546,6 +592,7 @@ function Exports() {
               size="sm"
               onClick={() => setCaseToDelete(selectedCase)}
             >
+              <LuTrash2 className="size-4 text-secondary-foreground" />
               <div className="text-primary">{t("toolbar.deleteCase")}</div>
             </Button>
           </div>
@@ -564,6 +611,7 @@ function Exports() {
           renameClip={onHandleRename}
           setDeleteClip={setDeleteClip}
           onAssignToCase={setExportToAssign}
+          onRemoveFromCase={handleRemoveExportFromCase}
           onAddExport={() => setCaseForAddExport(selectedCase)}
         />
       ) : (
@@ -730,6 +778,7 @@ type CaseViewProps = {
   renameClip: (id: string, update: string) => void;
   setDeleteClip: (d: DeleteClipType | undefined) => void;
   onAssignToCase: (e: Export) => void;
+  onRemoveFromCase: (e: Export) => void;
   onAddExport: () => void;
 };
 function CaseView({
@@ -743,6 +792,7 @@ function CaseView({
   renameClip,
   setDeleteClip,
   onAssignToCase,
+  onRemoveFromCase,
   onAddExport,
 }: CaseViewProps) {
   const { t } = useTranslation(["views/exports", "common"]);
@@ -868,6 +918,7 @@ function CaseView({
                 setDeleteClip({ file, exportName })
               }
               onAssignToCase={onAssignToCase}
+              onRemoveFromCase={onRemoveFromCase}
             />
           ))}
         </div>
@@ -939,7 +990,7 @@ function CaseEditorDialog({
               {t("button.cancel", { ns: "common" })}
             </Button>
             <Button
-              variant="default"
+              variant="select"
               disabled={name.trim().length === 0}
               onClick={() =>
                 void onSave({
@@ -979,11 +1030,15 @@ function CaseAddExportDialog({
   }, [exportCase?.id]);
 
   const filteredExports = useMemo(() => {
+    const completedExports = availableExports.filter(
+      (exportItem) => !exportItem.in_progress,
+    );
+
     if (!search) {
-      return availableExports;
+      return completedExports;
     }
 
-    return availableExports.filter((exportItem) =>
+    return completedExports.filter((exportItem) =>
       exportItem.name.toLowerCase().includes(search.toLowerCase()),
     );
   }, [availableExports, search]);

--- a/web/src/pages/Exports.tsx
+++ b/web/src/pages/Exports.tsx
@@ -928,7 +928,7 @@ function CaseView({
           ))}
         </div>
       ) : (
-        <div className="flex min-h-[16rem] flex-col items-center justify-center rounded-2xl border border-dashed border-border bg-background/40 p-6 text-center">
+        <div className="flex min-h-[16rem] flex-col items-center justify-center p-6 text-center">
           <LuFolderX className="size-12" />
           <div className="mt-3 text-lg font-medium">
             {t("caseView.emptyTitle")}

--- a/web/src/pages/Exports.tsx
+++ b/web/src/pages/Exports.tsx
@@ -23,6 +23,8 @@ import {
 import Heading from "@/components/ui/heading";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Toaster } from "@/components/ui/sonner";
 import useKeyboardListener from "@/hooks/use-keyboard-listener";
 import { useSearchEffect } from "@/hooks/use-overlay-state";
@@ -83,7 +85,7 @@ function Exports() {
 
   const { data: cases, mutate: updateCases } = useSWR<ExportCase[]>("cases");
   const { data: activeExportJobs } = useSWR<ExportJob[]>("jobs/export", {
-    refreshInterval: 2000,
+    refreshInterval: (latestJobs) => ((latestJobs ?? []).length > 0 ? 2000 : 0),
   });
   // Keep polling exports while there are queued/running jobs OR while any
   // existing export is still marked in_progress. Without the second clause,
@@ -153,8 +155,21 @@ function Exports() {
   }, [rawExports]);
 
   const filteredCases = useMemo<ExportCase[]>(() => {
-    return cases || [];
-  }, [cases]);
+    if (!cases) return [];
+
+    const hasCameraFilter =
+      exportFilter?.cameras && exportFilter.cameras.length > 0;
+
+    if (!hasCameraFilter) return cases;
+
+    // When a camera filter is active, hide cases that have zero exports
+    // and zero active jobs matching the filter — they're just noise.
+    return cases.filter(
+      (c) =>
+        (exportsByCase[c.id]?.length ?? 0) > 0 ||
+        (activeJobsByCase[c.id]?.length ?? 0) > 0,
+    );
+  }, [activeJobsByCase, cases, exportFilter?.cameras, exportsByCase]);
 
   const exports = useMemo<Export[]>(
     () => exportsByCase["none"] || [],
@@ -217,6 +232,7 @@ function Exports() {
     { mode: "create" | "edit"; exportCase?: ExportCase } | undefined
   >();
   const [caseToDelete, setCaseToDelete] = useState<ExportCase | undefined>();
+  const [deleteExportsWithCase, setDeleteExportsWithCase] = useState(false);
   const [caseForAddExport, setCaseForAddExport] = useState<
     ExportCase | undefined
   >();
@@ -333,11 +349,14 @@ function Exports() {
     }
 
     try {
-      await axios.delete(`cases/${caseToDelete.id}`);
+      await axios.delete(`cases/${caseToDelete.id}`, {
+        params: deleteExportsWithCase ? { delete_exports: true } : undefined,
+      });
       if (selectedCaseId === caseToDelete.id) {
         setSelectedCaseId(undefined);
       }
       setCaseToDelete(undefined);
+      setDeleteExportsWithCase(false);
       mutate();
     } catch (error) {
       const apiError = error as {
@@ -351,7 +370,7 @@ function Exports() {
         position: "top-center",
       });
     }
-  }, [caseToDelete, mutate, selectedCaseId, t]);
+  }, [caseToDelete, deleteExportsWithCase, mutate, selectedCaseId, t]);
 
   const handleAssignExportToCase = useCallback(
     async (exportId: string, caseId: string) => {
@@ -457,7 +476,12 @@ function Exports() {
 
       <AlertDialog
         open={caseToDelete != undefined}
-        onOpenChange={() => setCaseToDelete(undefined)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setCaseToDelete(undefined);
+            setDeleteExportsWithCase(false);
+          }
+        }}
       >
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -465,9 +489,25 @@ function Exports() {
             <AlertDialogDescription>
               {t("deleteCase.desc", {
                 caseName: caseToDelete?.name,
-              })}
+              })}{" "}
+              {deleteExportsWithCase
+                ? t("deleteCase.descDeleteExports")
+                : t("deleteCase.descKeepExports")}
             </AlertDialogDescription>
           </AlertDialogHeader>
+          <div className="flex items-center justify-start gap-6">
+            <Label
+              htmlFor="delete-exports-switch"
+              className="cursor-pointer text-sm"
+            >
+              {t("deleteCase.deleteExports")}
+            </Label>
+            <Switch
+              id="delete-exports-switch"
+              checked={deleteExportsWithCase}
+              onCheckedChange={setDeleteExportsWithCase}
+            />
+          </div>
           <AlertDialogFooter>
             <AlertDialogCancel>
               {t("button.cancel", { ns: "common" })}
@@ -526,7 +566,7 @@ function Exports() {
 
       <div
         className={cn(
-          "flex w-full flex-col items-start space-y-2 pr-2 md:mb-2 lg:relative lg:h-10 lg:flex-row lg:items-center lg:space-y-0",
+          "flex w-full flex-col items-start space-y-2 md:mb-2 lg:relative lg:h-10 lg:flex-row lg:items-center lg:space-y-0",
           isMobileOnly && "mb-2 h-auto flex-wrap gap-2 space-y-0",
         )}
       >
@@ -574,32 +614,49 @@ function Exports() {
         )}
         {selectedCase && (
           <div className="flex w-full items-center justify-end gap-2">
-            <Button
-              className="flex items-center gap-2.5 rounded-lg"
-              size="sm"
-              onClick={() => setCaseForAddExport(selectedCase)}
-            >
-              <LuPlus className="size-4 text-secondary-foreground" />
-              <div className="text-primary">{t("toolbar.addExport")}</div>
-            </Button>
-            <Button
-              className="flex items-center gap-2.5 rounded-lg"
-              size="sm"
-              onClick={() =>
-                setCaseDialog({ mode: "edit", exportCase: selectedCase })
-              }
-            >
-              <LuPencil className="size-4 text-secondary-foreground" />
-              <div className="text-primary">{t("toolbar.editCase")}</div>
-            </Button>
-            <Button
-              className="flex items-center gap-2.5 rounded-lg"
-              size="sm"
-              onClick={() => setCaseToDelete(selectedCase)}
-            >
-              <LuTrash2 className="size-4 text-secondary-foreground" />
-              <div className="text-primary">{t("toolbar.deleteCase")}</div>
-            </Button>
+            <ExportFilterGroup
+              className="justify-start"
+              filter={exportFilter}
+              filters={["cameras"]}
+              onUpdateFilter={setExportFilter}
+            />
+            <div className="flex items-center gap-1 md:gap-2">
+              <Button
+                className="flex items-center gap-2 p-2"
+                size="sm"
+                aria-label={t("toolbar.addExport")}
+                onClick={() => setCaseForAddExport(selectedCase)}
+              >
+                <LuPlus className="size-4 text-secondary-foreground" />
+                {!isMobile && (
+                  <div className="text-primary">{t("toolbar.addExport")}</div>
+                )}
+              </Button>
+              <Button
+                className="flex items-center gap-2 p-2"
+                size="sm"
+                aria-label={t("toolbar.editCase")}
+                onClick={() =>
+                  setCaseDialog({ mode: "edit", exportCase: selectedCase })
+                }
+              >
+                <LuPencil className="size-4 text-secondary-foreground" />
+                {!isMobile && (
+                  <div className="text-primary">{t("toolbar.editCase")}</div>
+                )}
+              </Button>
+              <Button
+                className="flex items-center gap-2 p-2"
+                size="sm"
+                aria-label={t("toolbar.deleteCase")}
+                onClick={() => setCaseToDelete(selectedCase)}
+              >
+                <LuTrash2 className="size-4 text-secondary-foreground" />
+                {!isMobile && (
+                  <div className="text-primary">{t("toolbar.deleteCase")}</div>
+                )}
+              </Button>
+            </div>
           </div>
         )}
       </div>

--- a/web/src/pages/Exports.tsx
+++ b/web/src/pages/Exports.tsx
@@ -1068,9 +1068,7 @@ function CaseAddExportDialog({
 
     setIsAdding(true);
     try {
-      await Promise.all(
-        selectedIds.map((id) => onAssign(id, exportCase.id)),
-      );
+      await Promise.all(selectedIds.map((id) => onAssign(id, exportCase.id)));
       onClose();
     } finally {
       setIsAdding(false);

--- a/web/src/types/export.ts
+++ b/web/src/types/export.ts
@@ -32,20 +32,55 @@ export type BatchExportResult = {
   camera: string;
   export_id?: string | null;
   success: boolean;
+  status?: string | null;
   error?: string | null;
 };
 
 export type BatchExportResponse = {
-  export_case_id: string;
+  export_case_id?: string | null;
   export_ids: string[];
   results: BatchExportResult[];
+};
+
+export type StartExportResponse = {
+  success: boolean;
+  message: string;
+  export_id?: string | null;
+  status?: string | null;
+};
+
+export type ExportJob = {
+  id: string;
+  job_type: string;
+  status: string;
+  camera: string;
+  name?: string | null;
+  export_case_id?: string | null;
+  request_start_time: number;
+  request_end_time: number;
+  start_time?: number | null;
+  end_time?: number | null;
+  error_message?: string | null;
+  results?: {
+    export_id?: string;
+    export_case_id?: string | null;
+    video_path?: string;
+    thumb_path?: string;
+  } | null;
+};
+
+export type CameraActivitySegment = {
+  /** Fractional start position within the time range, 0-1 inclusive. */
+  start: number;
+  /** Fractional end position within the time range, 0-1 inclusive. */
+  end: number;
 };
 
 export type CameraActivity = {
   camera: string;
   count: number;
-  intensity: number;
   hasDetections: boolean;
+  segments: CameraActivitySegment[];
 };
 
 export type DeleteClipType = {

--- a/web/src/types/export.ts
+++ b/web/src/types/export.ts
@@ -6,7 +6,8 @@ export type Export = {
   video_path: string;
   thumb_path: string;
   in_progress: boolean;
-  export_case?: string;
+  export_case?: string | null;
+  export_case_id?: string | null;
 };
 
 export type ExportCase = {
@@ -15,6 +16,36 @@ export type ExportCase = {
   description: string;
   created_at: number;
   updated_at: number;
+};
+
+export type BatchExportBody = {
+  start_time: number;
+  end_time: number;
+  camera_ids: string[];
+  name?: string;
+  export_case_id?: string;
+  new_case_name?: string;
+  new_case_description?: string;
+};
+
+export type BatchExportResult = {
+  camera: string;
+  export_id?: string | null;
+  success: boolean;
+  error?: string | null;
+};
+
+export type BatchExportResponse = {
+  export_case_id: string;
+  export_ids: string[];
+  results: BatchExportResult[];
+};
+
+export type CameraActivity = {
+  camera: string;
+  count: number;
+  intensity: number;
+  hasDetections: boolean;
 };
 
 export type DeleteClipType = {

--- a/web/src/types/export.ts
+++ b/web/src/types/export.ts
@@ -19,13 +19,21 @@ export type ExportCase = {
 };
 
 export type BatchExportBody = {
-  start_time: number;
-  end_time: number;
-  camera_ids: string[];
-  name?: string;
+  items: BatchExportItem[];
   export_case_id?: string;
   new_case_name?: string;
   new_case_description?: string;
+};
+
+export const MAX_BATCH_EXPORT_ITEMS = 50;
+
+export type BatchExportItem = {
+  camera: string;
+  start_time: number;
+  end_time: number;
+  image_path?: string;
+  friendly_name?: string;
+  client_item_id?: string;
 };
 
 export type BatchExportResult = {
@@ -34,6 +42,8 @@ export type BatchExportResult = {
   success: boolean;
   status?: string | null;
   error?: string | null;
+  item_index?: number | null;
+  client_item_id?: string | null;
 };
 
 export type BatchExportResponse = {

--- a/web/src/types/filter.ts
+++ b/web/src/types/filter.ts
@@ -2,7 +2,7 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FilterType = { [searchKey: string]: any };
 
-export type ExportMode = "select" | "timeline" | "none";
+export type ExportMode = "select" | "timeline" | "timeline_multi" | "none";
 
 export type FilterList = {
   labels?: string[];

--- a/web/src/views/motion-search/MotionSearchView.tsx
+++ b/web/src/views/motion-search/MotionSearchView.tsx
@@ -270,7 +270,10 @@ export default function MotionSearchView({
   );
 
   useEffect(() => {
-    if (exportMode !== "timeline" || exportRange) {
+    if (
+      (exportMode !== "timeline" && exportMode !== "timeline_multi") ||
+      exportRange
+    ) {
       return;
     }
 
@@ -955,9 +958,25 @@ export default function MotionSearchView({
 
       <SaveExportOverlay
         className="pointer-events-none absolute inset-x-0 top-0 z-30"
-        show={exportMode === "timeline" && Boolean(exportRange)}
+        show={
+          (exportMode === "timeline" || exportMode === "timeline_multi") &&
+          Boolean(exportRange)
+        }
+        hidePreview={exportMode === "timeline_multi"}
+        saveLabel={
+          exportMode === "timeline_multi"
+            ? t("export.fromTimeline.useThisRange", { ns: "components/dialog" })
+            : undefined
+        }
         onPreview={handleExportPreview}
-        onSave={handleExportSave}
+        onSave={() => {
+          if (exportMode === "timeline_multi") {
+            setExportMode("select");
+            return;
+          }
+
+          handleExportSave();
+        }}
         onCancel={handleExportCancel}
       />
 
@@ -976,7 +995,10 @@ export default function MotionSearchView({
           noRecordingRanges={noRecordings ?? []}
           contentRef={contentRef}
           onHandlebarDraggingChange={(dragging) => setScrubbing(dragging)}
-          showExportHandles={exportMode === "timeline" && Boolean(exportRange)}
+          showExportHandles={
+            (exportMode === "timeline" || exportMode === "timeline_multi") &&
+            Boolean(exportRange)
+          }
           exportStartTime={exportRange?.after}
           exportEndTime={exportRange?.before}
           setExportStartTime={setExportStartTime}
@@ -1408,7 +1430,11 @@ export default function MotionSearchView({
                 onControllerReady={(controller) => {
                   mainControllerRef.current = controller;
                 }}
-                isScrubbing={scrubbing || exportMode == "timeline"}
+                isScrubbing={
+                  scrubbing ||
+                  exportMode == "timeline" ||
+                  exportMode == "timeline_multi"
+                }
                 supportsFullscreen={supportsFullScreen}
                 setFullResolution={setFullResolution}
                 toggleFullscreen={toggleFullscreen}

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -833,6 +833,7 @@ export function RecordingView({
                   isScrubbing={
                     scrubbing ||
                     exportMode == "timeline" ||
+                    exportMode == "timeline_multi" ||
                     debugReplayMode == "timeline"
                   }
                   supportsFullscreen={supportsFullScreen}
@@ -911,7 +912,7 @@ export function RecordingView({
             activeReviewItem={activeReviewItem}
             currentTime={currentTime}
             exportRange={
-              exportMode == "timeline"
+              exportMode == "timeline" || exportMode == "timeline_multi"
                 ? exportRange
                 : debugReplayMode == "timeline"
                   ? debugReplayRange


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR builds on the existing export cases foundation to add multi-camera batch exports from review (both in alerts/detections view and recording view), bulk selection and actions on the exports page, integration with the Job infrastructure, and proper admin-only gating for all case management operations. Non-admin users can still export but always to uncategorized. Case add/edit/delete elements are hidden entirely for non-admin users.

Backend

- Add export `Job` queue infrastructure (`frigate/jobs/export.py`) with concurrent job management, `GET /jobs/export` and `GET /jobs/export/{id}` status endpoints
- Add `POST /exports/batch` for multi-camera batch exports with optional case assignment
- Add `POST /exports/delete` for bulk deleting exports (all-or-nothing with 404/400 semantics)
- Add `POST /exports/reassign` for bulk reassigning exports to a case or uncategorized
- Replace single-item `DELETE /export/{id}` and `PATCH /export/{id}/case` with the bulk endpoints above
- Extend `DELETE /cases/{id}` with `delete_exports` param and queued job cancellation
- Batch exports no longer require a case target — omitting case fields sends exports to uncategorized
- Add auth route exceptions for export paths with explicit admin-only guards on mutation endpoints
- Add stale export reaping on startup
- Add `max_concurrent` to record export config to limit the number of `Job`s that are running simultaneously (default 3)

Frontend

- Add multi-camera export tab to `ExportDialog` with camera selection from review timeline
- Add `MultiExportDialog` for bulk exporting selected review items from `ReviewActionGroup`
- Add bulk selection on exports page: right-click/long-press, Ctrl/Cmd+click, Ctrl+A, Escape
- Add `ExportActionGroup` toolbar with context-aware actions (add to case, move to case, remove from case, delete)
- Add selection ring overlay on `ExportCard`, hide kebab menu in selection mode
- Expand exports page with case detail view metadata, add-export-to-case dialog, case assignment dialog, and delete-case-with-exports dialog
- Refactor `OptionAndInputDialog` to support async handlers with loading state
- Hide all case management UI (create, edit, delete, assign) for non-admin users across exports page and export dialogs
- Migrate all frontend export delete/reassign callers to use batch endpoints

Tests

- Add backend tests for bulk delete/reassign (auth, 404, 400, single-item regression), batch export without case target, case deletion with exports, stale export reaping
- Add e2e tests for case deletion with export cleanup

Breaking Changes

- `DELETE /export/{id}` removed — use `POST /exports/delete` with `{ ids: [id] }`


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: closes https://github.com/blakeblackshear/frigate/issues/12603
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
