### PR TITLE
Fix review page spinner not clearing when review item ends

### DIFF
--- a/web/src/pages/Events.tsx
+++ b/web/src/pages/Events.tsx
@@ -327,10 +327,11 @@ export default function Events() {
     };
   }, [reviews]);
 
-  // reload when a review item ends so in-progress spinners clear
   // update review items in place when a review segment ends
   const reviewUpdate = useFrigateReviews();
-  const [lastEndedReviewId, setLastEndedReviewId] = useState<string>();
+  const [endedReviews, setEndedReviews] = useState(
+    new Map<string, ReviewSegment>(),
+  );
 
   useEffect(() => {
     if (reviewUpdate?.type === "end") {
@@ -343,7 +344,9 @@ export default function Events() {
         },
         { revalidate: false, populateCache: true },
       );
-      setLastEndedReviewId(reviewUpdate.after.id);
+      setEndedReviews((prev) =>
+        new Map(prev).set(reviewUpdate.after.id, reviewUpdate.after),
+      );
     }
   }, [reviewUpdate, updateSegments]);
 
@@ -369,14 +372,16 @@ export default function Events() {
     } else {
       return current;
     }
+    // only refresh when severity or filter changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    severity,
-    reviewFilter,
-    showReviewed,
-    reviewItems?.all.length,
-    lastEndedReviewId,
-  ]);
+  }, [severity, reviewFilter, showReviewed, reviewItems?.all.length]);
+
+  // overlay end_time updates onto currentItems without re-running
+  // the has_been_reviewed filter, so hover-reviewed items stay visible
+  const displayItems = useMemo(() => {
+    if (!currentItems || endedReviews.size === 0) return currentItems;
+    return currentItems.map((seg) => endedReviews.get(seg.id) ?? seg);
+  }, [currentItems, endedReviews]);
 
   // review summary
 
@@ -629,7 +634,7 @@ export default function Events() {
     ) : (
       <EventView
         reviewItems={reviewItems}
-        currentReviewItems={currentItems}
+        currentReviewItems={displayItems}
         reviewSummary={reviewSummary}
         recordingsSummary={recordingsSummary}
         relevantPreviews={allPreviews}

--- a/web/src/pages/Events.tsx
+++ b/web/src/pages/Events.tsx
@@ -24,6 +24,7 @@ import {
 import EventView from "@/views/events/EventView";
 import MotionSearchView from "@/views/motion-search/MotionSearchView";
 import { RecordingView } from "@/views/recording/RecordingView";
+import { useFrigateReviews } from "@/api/ws";
 import axios from "axios";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -326,6 +327,26 @@ export default function Events() {
     };
   }, [reviews]);
 
+  // reload when a review item ends so in-progress spinners clear
+  // update review items in place when a review segment ends
+  const reviewUpdate = useFrigateReviews();
+  const [reviewEndCount, setReviewEndCount] = useState(0);
+
+  useEffect(() => {
+    if (reviewUpdate?.type === "end") {
+      updateSegments(
+        (data) => {
+          if (!data) return data;
+          return data.map((seg) =>
+            seg.id === reviewUpdate.after.id ? reviewUpdate.after : seg,
+          );
+        },
+        { revalidate: false, populateCache: true },
+      );
+      setReviewEndCount((c) => c + 1);
+    }
+  }, [reviewUpdate, updateSegments]);
+
   const currentItems = useMemo(() => {
     if (!reviewItems || !severity) {
       return null;
@@ -348,9 +369,14 @@ export default function Events() {
     } else {
       return current;
     }
-    // only refresh when severity or filter changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [severity, reviewFilter, showReviewed, reviewItems?.all.length]);
+  }, [
+    severity,
+    reviewFilter,
+    showReviewed,
+    reviewItems?.all.length,
+    reviewEndCount,
+  ]);
 
   // review summary
 

--- a/web/src/pages/Events.tsx
+++ b/web/src/pages/Events.tsx
@@ -330,7 +330,7 @@ export default function Events() {
   // reload when a review item ends so in-progress spinners clear
   // update review items in place when a review segment ends
   const reviewUpdate = useFrigateReviews();
-  const [reviewEndCount, setReviewEndCount] = useState(0);
+  const [lastEndedReviewId, setLastEndedReviewId] = useState<string>();
 
   useEffect(() => {
     if (reviewUpdate?.type === "end") {
@@ -343,7 +343,7 @@ export default function Events() {
         },
         { revalidate: false, populateCache: true },
       );
-      setReviewEndCount((c) => c + 1);
+      setLastEndedReviewId(reviewUpdate.after.id);
     }
   }, [reviewUpdate, updateSegments]);
 
@@ -375,7 +375,7 @@ export default function Events() {
     reviewFilter,
     showReviewed,
     reviewItems?.all.length,
-    reviewEndCount,
+    lastEndedReviewId,
   ]);
 
   // review summary


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
Subscribe to ws reviews topic and optimistically update the SWR cache when a review segment ends, so the in-progress spinner clears without a full page reload. 

When a type: "end" message arrives, the item is optimistically patched in the SWR cache and tracked in a separate `endedReviews` map. A `displayItems` memo overlays these end_time updates onto `currentItems` without re-running the `has_been_reviewed` filter, so in-progress spinners clear immediately while hover-reviewed items stay visible.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #22884
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
