### PR TITLE
Miscellaneous fixes

### DIFF
--- a/docs/docs/troubleshooting/faqs.md
+++ b/docs/docs/troubleshooting/faqs.md
@@ -110,3 +110,27 @@ No. Frigate uses the TCP protocol to connect to your camera's RTSP URL. VLC auto
 TCP ensures that all data packets arrive in the correct order. This is crucial for video recording, decoding, and stream processing, which is why Frigate enforces a TCP connection. UDP is faster but less reliable, as it does not guarantee packet delivery or order, and VLC does not have the same requirements as Frigate.
 
 You can still configure Frigate to use UDP by using ffmpeg input args or the preset `preset-rtsp-udp`. See the [ffmpeg presets](/configuration/ffmpeg_presets) documentation.
+
+### Frigate hangs on startup with a "probing detect stream" message in the logs
+
+On startup, Frigate probes each camera's detect stream with OpenCV to auto-detect its resolution. OpenCV's FFmpeg backend may attempt RTSP over UDP during this probe regardless of the `-rtsp_transport tcp` in your `input_args` or preset. For cameras that do not respond to UDP (common on some Reolink models and others behind firewalls that block UDP), the probe can hang indefinitely and block Frigate from finishing startup, or it can return zeroed-out dimensions that show up as width `0` and height `0` in Camera Probe Info under System Metrics.
+
+There are two ways to avoid this:
+
+1. Set `detect.width` and `detect.height` explicitly in your camera config. When both are set, Frigate skips the auto-detect probe entirely:
+
+   ```yaml
+   cameras:
+     my_camera:
+       detect:
+         width: 1280
+         height: 720
+   ```
+
+2. Force OpenCV's FFmpeg backend to use TCP for RTSP by setting the environment variable on your Frigate container:
+
+   ```
+   OPENCV_FFMPEG_CAPTURE_OPTIONS=rtsp_transport;tcp
+   ```
+
+   This is a process-wide setting and applies to all cameras. If you have any cameras that require `preset-rtsp-udp`, use option 1 instead.

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -730,6 +730,9 @@ class FrigateConfig(FrigateBaseModel):
                 )
 
                 if need_detect_dimensions:
+                    logger.info(
+                        f"detect.width and detect.height not set for {camera_config.name}, probing detect stream to determine resolution."
+                    )
                     stream_info = {"width": 0, "height": 0, "fourcc": None}
                     try:
                         stream_info = stream_info_retriever.get_stream_info(

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -464,10 +464,12 @@ class RecordingMaintainer(threading.Thread):
                 self.drop_segment(cache_path)
                 return None
 
-        # if it doesn't overlap with an review item, go ahead and drop the segment
-        # if it ends more than the configured pre_capture for the camera
-        # BUT only if continuous/motion is NOT enabled (otherwise wait for processing)
-        elif highest is None:
+        # if it doesn't overlap with a review item, drop the segment once it
+        # ends more than event_pre_capture before the most recently processed
+        # frame. at this point we've already decided not to keep it for
+        # continuous/motion retention (either disabled or segment_stats said
+        # discard), so waiting longer just fills the cache.
+        else:
             camera_info = self.object_recordings_info[camera]
             most_recently_processed_frame_time = (
                 camera_info[-1][0] if len(camera_info) > 0 else 0

--- a/frigate/test/test_maintainer.py
+++ b/frigate/test/test_maintainer.py
@@ -1,3 +1,4 @@
+import datetime
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
@@ -73,6 +74,46 @@ class TestMaintainer(unittest.IsolatedAsyncioTestCase):
                             len(matching),
                             f"Expected a single warning for unexpected files, got {len(matching)}",
                         )
+
+    async def test_drops_quiet_segment_when_only_motion_retention(self):
+        # Regression: when motion retention is enabled but a segment has no
+        # motion and no review overlaps it, the segment must still be dropped.
+        # Otherwise it sits in cache forever, accumulates, and triggers the
+        # "Unable to keep up with recording segments in cache" warning every
+        # ~10s as the overflow trim in move_files discards the oldest one.
+        config = MagicMock(spec=FrigateConfig)
+
+        camera_config = MagicMock()
+        camera_config.record.enabled = True
+        camera_config.record.continuous.days = 0
+        camera_config.record.motion.days = 1
+        camera_config.record.event_pre_capture = 5
+        config.cameras = {"test_cam": camera_config}
+
+        stop_event = MagicMock()
+        maintainer = RecordingMaintainer(config, stop_event)
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        start_time = now - datetime.timedelta(seconds=20)
+        end_time = now - datetime.timedelta(seconds=10)
+        cache_path = "/tmp/cache/test_cam@20260417150000+0000.mp4"
+
+        maintainer.end_time_cache = {cache_path: (end_time, 10.0)}
+        # Single processed frame well past end_time with no motion/objects.
+        maintainer.object_recordings_info["test_cam"] = [(now.timestamp(), [], [], [])]
+        maintainer.audio_recordings_info["test_cam"] = []
+
+        maintainer.drop_segment = MagicMock()
+        maintainer.recordings_publisher = MagicMock()
+
+        result = await maintainer.validate_and_move_segment(
+            "test_cam",
+            reviews=[],
+            recording={"start_time": start_time, "cache_path": cache_path},
+        )
+
+        self.assertIsNone(result)
+        maintainer.drop_segment.assert_called_once_with(cache_path)
 
 
 if __name__ == "__main__":

--- a/web/src/hooks/use-camera-activity.ts
+++ b/web/src/hooks/use-camera-activity.ts
@@ -137,9 +137,11 @@ export function useCameraActivity(
           }
         }
 
-        newObjects[updatedEventIndex].label = label;
-        newObjects[updatedEventIndex].stationary =
-          updatedEvent.after.stationary;
+        newObjects[updatedEventIndex] = {
+          ...newObjects[updatedEventIndex],
+          label,
+          stationary: updatedEvent.after.stationary,
+        };
       }
     }
 


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
- Print log message on startup when probing detect stream
- Update FAQ in the docs to give options to work around failed resolution probing
- Fix stuck active ring when tracked object transitions to stationary
  - In `useCameraActivity`, the events effect mutates `newObjects[idx].stationary` in place. Because `newObjects = [...objects]` is a shallow copy, the mutation also modifies the same object reference held in objects. When `handleSetObjects` runs `isEqual(objects, newObjects)`, both arrays contain the same mutated object, so the comparison returns true, `setObjects` is never called, and the `hasActiveObjects` memo never recomputes. The camera's red active-tracking ring stays visible even after the last moving object becomes stationary. Replacing the in-place mutation with a new object spread fixes it.
- Fix issue introduced in https://github.com/blakeblackshear/frigate/pull/22887 where segments with motion-only retention that had no motion and no overlapping review were left in the cache instead of being dropped


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
