### PR TITLE
fix(auth): wrap JWT secret in OctKey for joserfc 1.x compatibility

### DIFF
--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -16,6 +16,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, RedirectResponse
 from joserfc import jwt
+from joserfc.jwk import OctKey
 from peewee import DoesNotExist
 from slowapi import Limiter
 
@@ -401,10 +402,14 @@ def validate_password_strength(password: str) -> tuple[bool, Optional[str]]:
 
 
 def create_encoded_jwt(user, role, expiration, secret):
+    # joserfc 1.x requires an OctKey for symmetric algorithms instead of a
+    # raw string; passing the string raises joserfc.errors.MissingKeyError
+    # (surfaces as a 500 on POST /api/login). See requirements pin
+    # `joserfc == 1.2.*`.
     return jwt.encode(
         {"alg": "HS256"},
         {"sub": user, "role": role, "exp": expiration, "iat": int(time.time())},
-        secret,
+        OctKey.import_key(secret),
     )
 
 
@@ -677,7 +682,7 @@ def auth(request: Request):
         return fail_response
 
     try:
-        token = jwt.decode(encoded_token, request.app.jwt_token)
+        token = jwt.decode(encoded_token, OctKey.import_key(request.app.jwt_token))
         if "sub" not in token.claims:
             logger.debug("user not set in jwt token")
             return fail_response

--- a/frigate/test/test_jwt_roundtrip.py
+++ b/frigate/test/test_jwt_roundtrip.py
@@ -1,0 +1,31 @@
+"""Regression test for create_encoded_jwt + joserfc 1.x OctKey handling.
+
+joserfc 1.x requires an OctKey for symmetric algorithms; passing a raw
+string raises MissingKeyError / ValueError inside jwt.encode. This test
+pins the fix so a future refactor can't silently reintroduce the crash.
+"""
+
+import time
+import unittest
+
+from joserfc import jwt
+from joserfc.jwk import OctKey
+
+from frigate.api.auth import create_encoded_jwt
+
+
+class TestCreateEncodedJwtRoundTrip(unittest.TestCase):
+    def test_round_trip_with_string_secret(self):
+        secret = "unit-test-secret-string-abc123"
+        expiration = int(time.time()) + 60
+
+        token = create_encoded_jwt("alice", "admin", expiration, secret)
+
+        decoded = jwt.decode(token, OctKey.import_key(secret))
+        self.assertEqual(decoded.claims["sub"], "alice")
+        self.assertEqual(decoded.claims["role"], "admin")
+        self.assertEqual(decoded.claims["exp"], expiration)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

`joserfc == 1.2.*` (pinned in `docker/main/requirements-wheels.txt`) requires symmetric-algorithm keys to be `OctKey` instances rather than raw strings. Both `create_encoded_jwt()` and the symmetric-verify path in `is_logged_in_without_redirect()` pass the raw secret string into `jwt.encode` / `jwt.decode`, so every native-auth login attempt raises `joserfc.errors.MissingKeyError` and nginx surfaces it as a `500 Internal Server Error` on `POST /api/login`.

This PR wraps the secret with `OctKey.import_key(...)` at the two call sites and adds a regression test. `get_jwt_secret()` continues to return a string; the on-disk `.jwt_secret` format is unchanged. No new dependencies — `OctKey` ships with `joserfc` which is already pinned.

**Reproduction** (Frigate 0.17.1 / joserfc 1.2.2; `dev` at `cfb87f9` behaves identically):

```bash
docker exec <frigate> pip show joserfc       # Version: 1.2.2
curl -X POST -H 'Content-Type: application/json' \
  -d '{"user":"<valid>","password":"<valid>"}' \
  http://<frigate>:5000/api/login
# -> 500 Internal Server Error
# log: joserfc.errors.MissingKeyError: missing_key
#        at frigate/api/auth.py:404  (jwt.encode ... secret)
```

Library-level repro inside the container:

```python
>>> from joserfc import jwt
>>> jwt.encode({'alg':'HS256'}, {'sub':'t','exp':0}, 'some-secret')
ValueError: Invalid key
>>> from joserfc.jwk import OctKey
>>> jwt.encode({'alg':'HS256'}, {'sub':'t','exp':0}, OctKey.import_key('some-secret'))[:40]
'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...'
```

This is tripped by the Home Assistant Frigate integration on every setup attempt (it POSTs `/api/login` with the configured credentials), producing a "failed to connect" symptom rather than a usable auth error.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: _(no existing issue — I did not find a prior report in issues or discussions; happy to open a Discussion if the maintainers prefer that flow)_
- This PR is related to issue: _n/a_
- Link to discussion with maintainers (**required** for large/pinned features): _n/a — small bugfix_

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): Claude (Anthropic, Opus 4.7).

**How AI was used** (e.g., code generation, code review, debugging, documentation): Debugging (isolating the `500` on `POST /api/login` from the traceback, identifying the joserfc 1.x symmetric-key API change, and drafting the three-line fix); drafting this PR description.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): Suggested the specific `OctKey.import_key(...)` wrapper at the two call sites, wrote the regression test, and drafted the PR description. The code change is five additions and two removals in `auth.py` plus ~30 lines of new test.

**Human oversight**: I reproduced the failure end-to-end against a live Frigate 0.17.1 container (HA integration → `500 MissingKeyError` in the Frigate log). I then applied the patch in-container, restarted, and verified: (a) `POST /api/login` with bad credentials now returns a clean `401 {"message":"Login failed"}` instead of 500; (b) `POST /api/login` with valid credentials returns 200 + a signed JWT cookie and the Home Assistant integration completes setup and receives events; (c) the regression test `frigate/test/test_jwt_roundtrip.py` (encode via `create_encoded_jwt`, decode with `OctKey.import_key(secret)`, assert `sub`/`role`/`exp` claims) passes when run inside the Frigate container against the patched code; (d) `frigate/test/test_proxy_auth.py` still passes (11/11); (e) `ruff format frigate/api/auth.py frigate/test/test_jwt_roundtrip.py` reports no changes; `ruff check` on both clean. I read the relevant `joserfc.jwk.OctKey` source and the `joserfc.jwt.encode` signature before committing to confirm `OctKey.import_key(str)` is the intended entry point for symmetric keys.

## Checklist

- [x] The code change is tested and works locally. _(Reproduced the failure and verified the fix end-to-end against a live Frigate 0.17.1 container with joserfc 1.2.2: HA integration, `/api/login` with bad and good credentials, and the new regression test all exercised.)_
- [x] Local tests pass. _(`frigate.test.test_jwt_roundtrip` and `frigate.test.test_proxy_auth` both pass inside the Frigate container — 12/12. The full unittest suite can't be run outside the build image because many tests require native deps; CI will validate the rest.)_
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the \`en\` locale. _(n/a — backend-only.)_
- [x] The code has been formatted using Ruff (\`ruff format frigate\`). _(\`ruff format frigate/api/auth.py frigate/test/test_jwt_roundtrip.py\` reports no changes needed; \`ruff check\` clean.)_