### PR TITLE
Fix yolonas colab notebook

### DIFF
--- a/notebooks/YOLO_NAS_Pretrained_Export.ipynb
+++ b/notebooks/YOLO_NAS_Pretrained_Export.ipynb
@@ -1,88 +1,95 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "rmuF9iKWTbdk"
-      },
-      "outputs": [],
-      "source": [
-        "! pip install -q git+https://github.com/Deci-AI/super-gradients.git"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "NiRCt917KKcL"
-      },
-      "outputs": [],
-      "source": [
-        "! sed -i 's/sghub.deci.ai/sg-hub-nv.s3.amazonaws.com/' /usr/local/lib/python3.12/dist-packages/super_gradients/training/pretrained_models.py\n",
-        "! sed -i 's/sghub.deci.ai/sg-hub-nv.s3.amazonaws.com/' /usr/local/lib/python3.12/dist-packages/super_gradients/training/utils/checkpoint_utils.py"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "dTB0jy_NNSFz"
-      },
-      "outputs": [],
-      "source": [
-        "from super_gradients.common.object_names import Models\n",
-        "from super_gradients.conversion import DetectionOutputFormatMode\n",
-        "from super_gradients.training import models\n",
-        "\n",
-        "model = models.get(Models.YOLO_NAS_S, pretrained_weights=\"coco\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "GymUghyCNXem"
-      },
-      "outputs": [],
-      "source": [
-        "# export the model for compatibility with Frigate\n",
-        "\n",
-        "model.export(\"yolo_nas_s.onnx\",\n",
-        "             output_predictions_format=DetectionOutputFormatMode.FLAT_FORMAT,\n",
-        "             max_predictions_per_image=20,\n",
-        "             num_pre_nms_predictions=300,\n",
-        "             confidence_threshold=0.4,\n",
-        "             input_image_shape=(320,320),\n",
-        "            )"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "uBhXV5g4Nh42"
-      },
-      "outputs": [],
-      "source": [
-        "from google.colab import files\n",
-        "\n",
-        "files.download('yolo_nas_s.onnx')"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "runtime-notice"
+   },
+   "source": [
+    "**Before running:** go to **Runtime → Change runtime type → Fallback runtime version: 2025.07** (Python 3.11). The current Colab default (Python 3.12+) is incompatible with `super-gradients`."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rmuF9iKWTbdk"
+   },
+   "outputs": [],
+   "source": [
+    "! pip install -q \"jedi>=0.16\"\n",
+    "! pip install -q git+https://github.com/Deci-AI/super-gradients.git"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NiRCt917KKcL"
+   },
+   "outputs": [],
+   "source": "! sed -i 's/sghub\\.deci\\.ai/d2gjn4b69gu75n.cloudfront.net/g; s/sg-hub-nv\\.s3\\.amazonaws\\.com/d2gjn4b69gu75n.cloudfront.net/g' /usr/local/lib/python*/dist-packages/super_gradients/training/pretrained_models.py\n! sed -i 's/sghub\\.deci\\.ai/d2gjn4b69gu75n.cloudfront.net/g; s/sg-hub-nv\\.s3\\.amazonaws\\.com/d2gjn4b69gu75n.cloudfront.net/g' /usr/local/lib/python*/dist-packages/super_gradients/training/utils/checkpoint_utils.py"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "dTB0jy_NNSFz"
+   },
+   "outputs": [],
+   "source": [
+    "from super_gradients.common.object_names import Models\n",
+    "from super_gradients.conversion import DetectionOutputFormatMode\n",
+    "from super_gradients.training import models\n",
+    "\n",
+    "model = models.get(Models.YOLO_NAS_S, pretrained_weights=\"coco\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "GymUghyCNXem"
+   },
+   "outputs": [],
+   "source": [
+    "# export the model for compatibility with Frigate\n",
+    "\n",
+    "model.export(\"yolo_nas_s.onnx\",\n",
+    "             output_predictions_format=DetectionOutputFormatMode.FLAT_FORMAT,\n",
+    "             max_predictions_per_image=20,\n",
+    "             num_pre_nms_predictions=300,\n",
+    "             confidence_threshold=0.4,\n",
+    "             input_image_shape=(320,320),\n",
+    "            )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "uBhXV5g4Nh42"
+   },
+   "outputs": [],
+   "source": [
+    "from google.colab import files\n",
+    "\n",
+    "files.download('yolo_nas_s.onnx')"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
Colab's default Python 3.12 runtime no longer installs `super-gradients` cleanly, and the old `sg-hub-nv.s3.amazonaws.com` S3 mirror now returns `AccessDenied` (Deci/NVIDIA made the bucket private and fronted it with Cloudfront).

This PR updates the YOLO-NAS notebook to:
- Tell users to select the 2025.07 fallback runtime (Python 3.11), 
- Pre-install `jedi>=0.16`
- Glob the sed path across Python versions, and rewrite both stale hosts (`sghub.deci.ai` and `sg-hub-nv.s3.amazonaws.com`) to the canonical `d2gjn4b69gu75n.cloudfront.net` Cloudfront host used upstream (the latest `pretrained_models.py` from the `super-gradients` master branch model URLs now point at `https://d2gjn4b69gu75n.cloudfront.net/models/...`)

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #22933, fixes #21796
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
