### PR TITLE
Add camera wizard improvements

### DIFF
--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -807,10 +807,15 @@ async def get_video_properties(
 ) -> dict[str, Any]:
     async def probe_with_ffprobe(
         url: str,
+        rtsp_transport: Optional[str] = None,
     ) -> tuple[bool, int, int, Optional[str], float]:
         """Fallback using ffprobe: returns (valid, width, height, codec, duration)."""
-        cmd = [
-            ffmpeg.ffprobe_path,
+        cmd = [ffmpeg.ffprobe_path]
+        if rtsp_transport:
+            cmd += ["-rtsp_transport", rtsp_transport]
+        cmd += [
+            "-rw_timeout",
+            "5000000",
             "-v",
             "quiet",
             "-print_format",
@@ -878,6 +883,12 @@ async def get_video_properties(
     # fallback to ffprobe if needed
     if not has_video or (get_duration and duration < 0):
         has_video, width, height, fourcc, duration = await probe_with_ffprobe(url)
+
+    # last resort for RTSP: try TCP transport, since default UDP may be blocked
+    if (not has_video or (get_duration and duration < 0)) and url.startswith("rtsp://"):
+        has_video, width, height, fourcc, duration = await probe_with_ffprobe(
+            url, rtsp_transport="tcp"
+        )
 
     result: dict[str, Any] = {"has_valid_video": has_video}
     if has_video:

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -415,6 +415,7 @@
         "audioCodecGood": "Audio codec is {{codec}}.",
         "resolutionHigh": "A resolution of {{resolution}} may cause increased resource usage.",
         "resolutionLow": "A resolution of {{resolution}} may be too low for reliable detection of small objects.",
+        "resolutionUnknown": "The resolution of this stream could not be probed. This will cause issues on startup. You should manually set the detect resolution in Settings or your config.",
         "noAudioWarning": "No audio detected for this stream, recordings will not have audio.",
         "audioCodecRecordError": "The AAC audio codec is required to support audio in recordings.",
         "audioCodecRequired": "An audio stream is required to support audio detection.",

--- a/web/src/components/settings/wizard/Step4Validation.tsx
+++ b/web/src/components/settings/wizard/Step4Validation.tsx
@@ -607,23 +607,38 @@ function StreamIssues({
       }
     }
 
-    if (stream.roles.includes("detect") && stream.resolution) {
-      const [width, height] = stream.resolution.split("x").map(Number);
-      if (!isNaN(width) && !isNaN(height) && width > 0 && height > 0) {
-        const minDimension = Math.min(width, height);
-        const maxDimension = Math.max(width, height);
+    if (stream.roles.includes("detect") && stream.testResult) {
+      const probedResolution = stream.testResult.resolution;
+      let probedWidth = 0;
+      let probedHeight = 0;
+      if (probedResolution) {
+        const [w, h] = probedResolution.split("x").map(Number);
+        if (!isNaN(w) && !isNaN(h)) {
+          probedWidth = w;
+          probedHeight = h;
+        }
+      }
+
+      if (probedWidth <= 0 || probedHeight <= 0) {
+        result.push({
+          type: "error",
+          message: t("cameraWizard.step4.issues.resolutionUnknown"),
+        });
+      } else {
+        const minDimension = Math.min(probedWidth, probedHeight);
+        const maxDimension = Math.max(probedWidth, probedHeight);
         if (minDimension > 1080) {
           result.push({
             type: "warning",
             message: t("cameraWizard.step4.issues.resolutionHigh", {
-              resolution: stream.resolution,
+              resolution: probedResolution,
             }),
           });
         } else if (maxDimension < 640) {
           result.push({
             type: "error",
             message: t("cameraWizard.step4.issues.resolutionLow", {
-              resolution: stream.resolution,
+              resolution: probedResolution,
             }),
           });
         }


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
The camera wizard silently omits `detect.width`/`height` when the Step 4 probe returns no resolution, which lets the backend's save-time probe hang on cameras that don't respond over UDP. This PR causes an error message to be displayed in the per-stream issues pane when the detect stream's probed resolution is missing or unparseable so the user knows to set dimensions manually.

Also, this adds a TCP fallback and 5s network timeout to `get_video_properties()` for RTSP streams only.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/blakeblackshear/frigate/discussions/22961
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
