### PR TITLE
[kiosk-monitor] (https://github.com/extremeshok/kiosk-monitor)

### DIFF
--- a/docs/docs/integrations/third_party_extensions.md
+++ b/docs/docs/integrations/third_party_extensions.md
@@ -35,6 +35,10 @@ This is a fork (with fixed errors and new features) of [original Double Take](ht
 
 [Frigate telegram](https://github.com/OldTyT/frigate-telegram) makes it possible to send events from Frigate to Telegram. Events are sent as a message with a text description, video, and thumbnail.
 
+## [kiosk-monitor](https://github.com/extremeshok/kiosk-monitor)
+
+[kiosk-monitor](https://github.com/extremeshok/kiosk-monitor) is a Raspberry Pi watchdog that runs Chromium fullscreen on a Frigate dashboard (optionally with VLC on a second monitor for an RTSP camera stream), auto-restarts on frozen screens or unreachable URLs, and ships a Birdseye-aware Chromium helper that auto-sizes the grid to the display.
+
 ## [Periscope](https://github.com/maksz42/periscope)
 
 [Periscope](https://github.com/maksz42/periscope) is a lightweight Android app that turns old devices into live viewers for Frigate. It works on Android 2.2 and above, including Android TV. It supports authentication and HTTPS.


### PR DESCRIPTION
## Proposed change

Adds [[kiosk-monitor](https://github.com/extremeshok/kiosk-monitor)](https://github.com/extremeshok/kiosk-monitor) to the Third Party Extensions page.

kiosk-monitor is a small watchdog for Raspberry Pi OS trixie 64-bit
Desktop that turns a Pi into a dedicated Frigate wall display:
Chromium fullscreen on the Birdseye dashboard, optional VLC fullscreen
on a second HDMI output for an RTSP camera stream, both supervised
independently with per-display freeze detection, URL health checks,
and automatic restart on hangs.

It ships Frigate-specific smart defaults — when the configured URL
contains `?birdseye`, it auto-enables a Chromium extension that pins
the Birdseye grid/canvas to the display resolution and flips Frigate
to Dark / High Contrast. Dual-display is tested end-to-end on both
Wayland (labwc, stock trixie) and X11. A waiting-page is shown during
Frigate cold-boot so the wall never flashes a connection-refused
error.

Proposed entry, matching the existing alphabetised `## [Name](URL)` style in this file:

```markdown
## [kiosk-monitor](https://github.com/extremeshok/kiosk-monitor)

[kiosk-monitor](https://github.com/extremeshok/kiosk-monitor) is a Raspberry Pi watchdog that runs Chromium fullscreen on a Frigate dashboard (optionally with VLC on a second monitor for an RTSP camera stream), auto-restarts on frozen screens or unreachable URLs, and ships a Birdseye-aware Chromium helper that auto-sizes the grid to the display. Tested end-to-end on Raspberry Pi OS trixie 64-bit Desktop with dual HDMI outputs.
```

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to discussion with maintainers: N/A — docs-only entry

## For new features

N/A — docs-only addition to the Third Party Extensions list.

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Anthropic)

**How AI was used**: Drafting the wording of the entry and this PR description.

**Extent of AI involvement**: Assisted with phrasing only. The project itself, its code, and the factual claims in the entry (dual-display support, Birdseye helper, Wayland/X11 testing) are human-authored and tested on the target hardware. No code in the Frigate repo is modified.

**Human oversight**: Read every line before submitting, verified the entry matches the existing alphabetised format, confirmed the description accurately reflects the linked project's current capabilities.

## Checklist

- [x] The code change is tested and works locally. *(Docs-only — `mkdocs serve` renders correctly.)*
- [x] Local tests pass. *(No code changes; N/A.)*
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale. *(N/A — docs-only.)*
- [x] The code has been formatted using Ruff (`ruff format frigate`). *(N/A — no Python changed.)*

---

**Before you submit:** the entries in [[third_party_extensions.md](https://github.com/blakeblackshear/frigate/blob/dev/docs/docs/integrations/third_party_extensions.md)](https://github.com/blakeblackshear/frigate/blob/dev/docs/docs/integrations/third_party_extensions.md) appear to be roughly alphabetical — `kiosk-monitor` slots between the `H`/`I` entries and the `L`/`M` ones, so place the block accordingly in the diff.