### PR TITLE
Fix CameraWatchdog out-of-order message and invalid segment processing

### DIFF
--- a/frigate/test/test_camera_watchdog.py
+++ b/frigate/test/test_camera_watchdog.py
@@ -1,0 +1,106 @@
+import logging
+import unittest
+from unittest.mock import MagicMock
+
+from frigate.comms.recordings_updater import RecordingsDataTypeEnum
+from frigate.video.ffmpeg import CameraWatchdog
+
+
+def _make_watchdog(camera_name: str = "front_door") -> CameraWatchdog:
+    """Create a CameraWatchdog with only the attributes needed by _process_segment_updates."""
+    watchdog = object.__new__(CameraWatchdog)
+    watchdog.config = MagicMock()
+    watchdog.config.name = camera_name
+    watchdog.logger = logging.getLogger("test.watchdog")
+    watchdog.latest_valid_segment_time = 0.0
+    watchdog.latest_invalid_segment_time = 0.0
+    watchdog.latest_cache_segment_time = 0.0
+    watchdog.segment_subscriber = MagicMock()
+    return watchdog
+
+
+def _topic(type_enum: RecordingsDataTypeEnum) -> str:
+    return f"recordings/{type_enum.value}"
+
+
+def _msg(topic: RecordingsDataTypeEnum, camera: str, t: float):
+    return (_topic(topic), (camera, t, None))
+
+
+class TestProcessSegmentUpdates(unittest.TestCase):
+    def test_in_order_valid_segments(self):
+        """Segments arriving in order advance latest_valid_segment_time to the last value."""
+        watchdog = _make_watchdog()
+        watchdog.segment_subscriber.check_for_update.side_effect = [
+            _msg(RecordingsDataTypeEnum.valid, "front_door", 10.0),
+            _msg(RecordingsDataTypeEnum.valid, "front_door", 20.0),
+            _msg(RecordingsDataTypeEnum.valid, "front_door", 30.0),
+            (None, None),
+        ]
+        watchdog._drain_segment_updates()
+        self.assertEqual(watchdog.latest_valid_segment_time, 30.0)
+
+    def test_out_of_order_valid_segments(self):
+        """Out-of-order valid segments still result in the maximum timestamp."""
+        watchdog = _make_watchdog()
+        watchdog.segment_subscriber.check_for_update.side_effect = [
+            _msg(RecordingsDataTypeEnum.valid, "front_door", 20.0),
+            _msg(RecordingsDataTypeEnum.valid, "front_door", 10.0),
+            _msg(RecordingsDataTypeEnum.valid, "front_door", 30.0),
+            (None, None),
+        ]
+        watchdog._drain_segment_updates()
+        self.assertEqual(watchdog.latest_valid_segment_time, 30.0)
+
+    def test_out_of_order_cache_segments(self):
+        """Out-of-order cache (latest) segments still result in the maximum timestamp."""
+        watchdog = _make_watchdog()
+        watchdog.segment_subscriber.check_for_update.side_effect = [
+            _msg(RecordingsDataTypeEnum.latest, "front_door", 100.0),
+            _msg(RecordingsDataTypeEnum.latest, "front_door", 50.0),
+            _msg(RecordingsDataTypeEnum.latest, "front_door", 200.0),
+            (None, None),
+        ]
+        watchdog._drain_segment_updates()
+        self.assertEqual(watchdog.latest_cache_segment_time, 200.0)
+
+    def test_cache_none_resets_to_zero(self):
+        """A None cache segment time resets latest_cache_segment_time to 0."""
+        watchdog = _make_watchdog()
+        watchdog.segment_subscriber.check_for_update.side_effect = [
+            _msg(RecordingsDataTypeEnum.latest, "front_door", 100.0),
+            (_topic(RecordingsDataTypeEnum.latest), ("front_door", None, None)),
+            (None, None),
+        ]
+        watchdog._drain_segment_updates()
+        self.assertEqual(watchdog.latest_cache_segment_time, 0.0)
+
+    def test_messages_for_other_camera_ignored(self):
+        """Segment messages for a different camera do not update timestamps."""
+        watchdog = _make_watchdog(camera_name="front_door")
+        watchdog.segment_subscriber.check_for_update.side_effect = [
+            _msg(RecordingsDataTypeEnum.valid, "back_yard", 999.0),
+            _msg(RecordingsDataTypeEnum.invalid, "back_yard", 999.0),
+            _msg(RecordingsDataTypeEnum.latest, "back_yard", 999.0),
+            (None, None),
+        ]
+        watchdog._drain_segment_updates()
+        self.assertEqual(watchdog.latest_valid_segment_time, 0.0)
+        self.assertEqual(watchdog.latest_invalid_segment_time, 0.0)
+        self.assertEqual(watchdog.latest_cache_segment_time, 0.0)
+
+    def test_mixed_types_tracked_independently(self):
+        """Valid and cache segment times are each tracked independently."""
+        watchdog = _make_watchdog()
+        watchdog.segment_subscriber.check_for_update.side_effect = [
+            _msg(RecordingsDataTypeEnum.valid, "front_door", 10.0),
+            _msg(RecordingsDataTypeEnum.latest, "front_door", 30.0),
+            (None, None),
+        ]
+        watchdog._drain_segment_updates()
+        self.assertEqual(watchdog.latest_valid_segment_time, 10.0)
+        self.assertEqual(watchdog.latest_cache_segment_time, 30.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frigate/test/test_camera_watchdog.py
+++ b/frigate/test/test_camera_watchdog.py
@@ -89,16 +89,30 @@ class TestProcessSegmentUpdates(unittest.TestCase):
         self.assertEqual(watchdog.latest_invalid_segment_time, 0.0)
         self.assertEqual(watchdog.latest_cache_segment_time, 0.0)
 
+    def test_out_of_order_invalid_segments(self):
+        """Out-of-order invalid segments still result in the maximum timestamp."""
+        watchdog = _make_watchdog()
+        watchdog.segment_subscriber.check_for_update.side_effect = [
+            _msg(RecordingsDataTypeEnum.invalid, "front_door", 5.0),
+            _msg(RecordingsDataTypeEnum.invalid, "front_door", 15.0),
+            _msg(RecordingsDataTypeEnum.invalid, "front_door", 8.0),
+            (None, None),
+        ]
+        watchdog._drain_segment_updates()
+        self.assertEqual(watchdog.latest_invalid_segment_time, 15.0)
+
     def test_mixed_types_tracked_independently(self):
-        """Valid and cache segment times are each tracked independently."""
+        """Valid, invalid, and cache segment times are each tracked independently."""
         watchdog = _make_watchdog()
         watchdog.segment_subscriber.check_for_update.side_effect = [
             _msg(RecordingsDataTypeEnum.valid, "front_door", 10.0),
+            _msg(RecordingsDataTypeEnum.invalid, "front_door", 20.0),
             _msg(RecordingsDataTypeEnum.latest, "front_door", 30.0),
             (None, None),
         ]
         watchdog._drain_segment_updates()
         self.assertEqual(watchdog.latest_valid_segment_time, 10.0)
+        self.assertEqual(watchdog.latest_invalid_segment_time, 20.0)
         self.assertEqual(watchdog.latest_cache_segment_time, 30.0)
 
 

--- a/frigate/video/ffmpeg.py
+++ b/frigate/video/ffmpeg.py
@@ -202,6 +202,44 @@ class CameraWatchdog(threading.Thread):
         self._check_config_updates()
         return self.config.enabled
 
+    def _drain_segment_updates(self) -> None:
+        """Drain the segment subscriber queue and update latest segment timestamps."""
+        while True:
+            update = self.segment_subscriber.check_for_update(timeout=0)
+
+            if update == (None, None):
+                break
+
+            raw_topic, payload = update
+            if raw_topic and payload:
+                topic = str(raw_topic)
+                camera, segment_time, _ = payload
+
+                if camera != self.config.name:
+                    continue
+
+                if topic.endswith(RecordingsDataTypeEnum.valid.value):
+                    self.logger.debug(
+                        f"Latest valid recording segment time on {camera}: {segment_time}"
+                    )
+                    self.latest_valid_segment_time = max(
+                        self.latest_valid_segment_time, segment_time
+                    )
+                elif topic.endswith(RecordingsDataTypeEnum.invalid.value):
+                    self.logger.warning(
+                        f"Invalid recording segment detected for {camera} at {segment_time}"
+                    )
+                    self.latest_invalid_segment_time = max(
+                        self.latest_invalid_segment_time, segment_time
+                    )
+                elif topic.endswith(RecordingsDataTypeEnum.latest.value):
+                    if segment_time is not None:
+                        self.latest_cache_segment_time = max(
+                            self.latest_cache_segment_time, segment_time
+                        )
+                    else:
+                        self.latest_cache_segment_time = 0
+
     def reset_capture_thread(
         self, terminate: bool = True, drain_output: bool = True
     ) -> None:
@@ -303,35 +341,7 @@ class CameraWatchdog(threading.Thread):
             if not enabled:
                 continue
 
-            while True:
-                update = self.segment_subscriber.check_for_update(timeout=0)
-
-                if update == (None, None):
-                    break
-
-                raw_topic, payload = update
-                if raw_topic and payload:
-                    topic = str(raw_topic)
-                    camera, segment_time, _ = payload
-
-                    if camera != self.config.name:
-                        continue
-
-                    if topic.endswith(RecordingsDataTypeEnum.valid.value):
-                        self.logger.debug(
-                            f"Latest valid recording segment time on {camera}: {segment_time}"
-                        )
-                        self.latest_valid_segment_time = segment_time
-                    elif topic.endswith(RecordingsDataTypeEnum.invalid.value):
-                        self.logger.warning(
-                            f"Invalid recording segment detected for {camera} at {segment_time}"
-                        )
-                        self.latest_invalid_segment_time = segment_time
-                    elif topic.endswith(RecordingsDataTypeEnum.latest.value):
-                        if segment_time is not None:
-                            self.latest_cache_segment_time = segment_time
-                        else:
-                            self.latest_cache_segment_time = 0
+            self._drain_segment_updates()
 
             now = datetime.now().timestamp()
 

--- a/frigate/video/ffmpeg.py
+++ b/frigate/video/ffmpeg.py
@@ -218,21 +218,21 @@ class CameraWatchdog(threading.Thread):
                 if camera != self.config.name:
                     continue
 
-                if topic.endswith(RecordingsDataTypeEnum.valid.value):
+                if topic.endswith(f"/{RecordingsDataTypeEnum.valid.value}"):
                     self.logger.debug(
                         f"Latest valid recording segment time on {camera}: {segment_time}"
                     )
                     self.latest_valid_segment_time = max(
                         self.latest_valid_segment_time, segment_time
                     )
-                elif topic.endswith(RecordingsDataTypeEnum.invalid.value):
+                elif topic.endswith(f"/{RecordingsDataTypeEnum.invalid.value}"):
                     self.logger.warning(
                         f"Invalid recording segment detected for {camera} at {segment_time}"
                     )
                     self.latest_invalid_segment_time = max(
                         self.latest_invalid_segment_time, segment_time
                     )
-                elif topic.endswith(RecordingsDataTypeEnum.latest.value):
+                elif topic.endswith(f"/{RecordingsDataTypeEnum.latest.value}"):
                     if segment_time is not None:
                         self.latest_cache_segment_time = max(
                             self.latest_cache_segment_time, segment_time


### PR DESCRIPTION
## Proposed change
Contains two fixes to the camera watchdog:

1. A bug whereby [processing out-of-order messages causes gaps in recordings (discussion #23012)](https://github.com/blakeblackshear/frigate/discussions/23021) due to a race condition.
2. A bug whereby invalid segment timestamps were never updated due to `topic.endswith("valid")` also matching `"recordings/invalid"`.

Adds tests for these two conditions.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes https://github.com/blakeblackshear/frigate/discussions/23021
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## AI disclosure


## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

Claude code helped me narrow down the root cause, made the code changes and wrote the tests under my supervision.

I have tested that the `No new valid recording segments were created for <camera> in the last 120s` no longer occurs with the fix applied. Previously, it occurred repeatedly over the course of the entire day.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
