### PR TITLE
Miscellaneous fixes

### DIFF
--- a/docs/docs/configuration/face_recognition.md
+++ b/docs/docs/configuration/face_recognition.md
@@ -171,7 +171,7 @@ When choosing images to include in the face training set it is recommended to al
 - If it is difficult to make out details in a persons face it will not be helpful in training.
 - Avoid images with extreme under/over-exposure.
 - Avoid blurry / pixelated images.
-- Avoid training on infrared (gray-scale). The models are trained on color images and will be able to extract features from gray-scale images.
+- Avoid training on infrared (gray-scale). The models are trained on color images and will not be able to extract features from gray-scale images.
 - Using images of people wearing hats / sunglasses may confuse the model.
 - Do not upload too many similar images at the same time, it is recommended to train no more than 4-6 similar images for each person to avoid over-fitting.
 

--- a/frigate/embeddings/__init__.py
+++ b/frigate/embeddings/__init__.py
@@ -4,6 +4,7 @@ import base64
 import json
 import logging
 import os
+import sys
 import threading
 from json.decoder import JSONDecodeError
 from multiprocessing.synchronize import Event as MpEvent
@@ -52,6 +53,14 @@ class EmbeddingProcess(FrigateProcess):
             self.stop_event,
         )
         maintainer.start()
+        maintainer.join()
+
+        # If the maintainer thread exited but no shutdown was requested, it
+        # crashed. Surface as a non-zero exit so the watchdog restarts us
+        # instead of treating the silent thread death as a clean shutdown.
+        if not self.stop_event.is_set():
+            logger.error("Embeddings maintainer thread exited unexpectedly")
+            sys.exit(1)
 
 
 class EmbeddingsContext:

--- a/frigate/genai/gemini.py
+++ b/frigate/genai/gemini.py
@@ -143,15 +143,17 @@ class GeminiClient(GenAIClient):
                     )
                 elif role == "tool":
                     # Handle tool response
-                    function_response = {
-                        "name": msg.get("name", ""),
-                        "response": content,
-                    }
+                    response_payload = (
+                        content if isinstance(content, dict) else {"result": content}
+                    )
                     gemini_messages.append(
                         types.Content(
                             role="function",
                             parts=[
-                                types.Part.from_function_response(function_response)  # type: ignore[misc,call-arg,arg-type]
+                                types.Part.from_function_response(
+                                    name=msg.get("name", ""),
+                                    response=response_payload,
+                                )
                             ],
                         )
                     )
@@ -350,15 +352,17 @@ class GeminiClient(GenAIClient):
                     )
                 elif role == "tool":
                     # Handle tool response
-                    function_response = {
-                        "name": msg.get("name", ""),
-                        "response": content,
-                    }
+                    response_payload = (
+                        content if isinstance(content, dict) else {"result": content}
+                    )
                     gemini_messages.append(
                         types.Content(
                             role="function",
                             parts=[
-                                types.Part.from_function_response(function_response)  # type: ignore[misc,call-arg,arg-type]
+                                types.Part.from_function_response(
+                                    name=msg.get("name", ""),
+                                    response=response_payload,
+                                )
                             ],
                         )
                     )

--- a/frigate/genai/llama_cpp.py
+++ b/frigate/genai/llama_cpp.py
@@ -44,6 +44,7 @@ class LlamaCppClient(GenAIClient):
     _supports_tools: bool
     _image_token_cache: dict[tuple[int, int], int]
     _text_baseline_tokens: int | None
+    _media_marker: str
 
     def _init_provider(self) -> str | None:
         """Initialize the client and query model metadata from the server."""
@@ -56,6 +57,7 @@ class LlamaCppClient(GenAIClient):
         self._supports_tools = False
         self._image_token_cache = {}
         self._text_baseline_tokens = None
+        self._media_marker = "<__media__>"
 
         base_url = (
             self.genai_config.base_url.rstrip("/")
@@ -140,6 +142,13 @@ class LlamaCppClient(GenAIClient):
             # Tool support from chat template capabilities
             chat_caps = props.get("chat_template_caps", {})
             self._supports_tools = chat_caps.get("supports_tools", False)
+
+            # Media marker for multimodal embeddings; the server randomizes this
+            # per startup unless LLAMA_MEDIA_MARKER is set, so we must read it
+            # from /props rather than hardcoding "<__media__>".
+            media_marker = props.get("media_marker")
+            if isinstance(media_marker, str) and media_marker:
+                self._media_marker = media_marker
 
             logger.info(
                 "llama.cpp model '%s' initialized — context: %s, vision: %s, audio: %s, tools: %s",
@@ -465,10 +474,11 @@ class LlamaCppClient(GenAIClient):
             jpeg_bytes = _to_jpeg(img)
             to_encode = jpeg_bytes if jpeg_bytes is not None else img
             encoded = base64.b64encode(to_encode).decode("utf-8")
-            # prompt_string must contain <__media__> placeholder for image tokenization
+            # prompt_string must contain the server's media marker placeholder.
+            # The marker is randomized per server startup (read from /props).
             content.append(
                 {
-                    "prompt_string": "<__media__>\n",
+                    "prompt_string": f"{self._media_marker}\n",
                     "multimodal_data": [encoded],  # type: ignore[dict-item]
                 }
             )

--- a/frigate/video/ffmpeg.py
+++ b/frigate/video/ffmpeg.py
@@ -24,7 +24,7 @@ from frigate.config.camera.updater import (
 )
 from frigate.const import PROCESS_PRIORITY_HIGH
 from frigate.log import LogPipe
-from frigate.util.builtin import EventsPerSecond
+from frigate.util.builtin import EventsPerSecond, get_ffmpeg_arg_list
 from frigate.util.ffmpeg import start_or_restart_ffmpeg, stop_ffmpeg
 from frigate.util.image import (
     FrameManager,
@@ -33,6 +33,23 @@ from frigate.util.image import (
 from frigate.util.process import FrigateProcess
 
 logger = logging.getLogger(__name__)
+
+# all built-in record presets use this segment_time
+DEFAULT_RECORD_SEGMENT_TIME = 10
+
+
+def _get_record_segment_time(config: CameraConfig) -> int:
+    """Extract -segment_time from the camera's record output args."""
+    record_args = get_ffmpeg_arg_list(config.ffmpeg.output_args.record)
+
+    if record_args and record_args[0].startswith("preset"):
+        return DEFAULT_RECORD_SEGMENT_TIME
+
+    try:
+        idx = record_args.index("-segment_time")
+        return int(record_args[idx + 1])
+    except (ValueError, IndexError):
+        return DEFAULT_RECORD_SEGMENT_TIME
 
 
 def capture_frames(
@@ -163,6 +180,12 @@ class CameraWatchdog(threading.Thread):
         self.latest_invalid_segment_time: float = 0
         self.latest_cache_segment_time: float = 0
         self.record_enable_time: datetime | None = None
+
+        # `valid` segments are published with the segment's start time, so the
+        # gap between consecutive publishes can reach 2 * segment_time. Pad the
+        # staleness threshold so it's never tighter than that worst case.
+        segment_time = _get_record_segment_time(self.config)
+        self.record_stale_threshold = max(120, 2 * segment_time + 30)
 
         # Stall tracking (based on last processed frame)
         self._stall_timestamps: deque[float] = deque()
@@ -413,16 +436,17 @@ class CameraWatchdog(threading.Thread):
 
                     # ensure segments are still being created and that they have valid video data
                     # Skip checks during grace period to allow segments to start being created
+                    stale_window = timedelta(seconds=self.record_stale_threshold)
                     cache_stale = not in_grace_period and now_utc > (
-                        latest_cache_dt + timedelta(seconds=120)
+                        latest_cache_dt + stale_window
                     )
                     valid_stale = not in_grace_period and now_utc > (
-                        latest_valid_dt + timedelta(seconds=120)
+                        latest_valid_dt + stale_window
                     )
                     invalid_stale_condition = (
                         self.latest_invalid_segment_time > 0
                         and not in_grace_period
-                        and now_utc > (latest_invalid_dt + timedelta(seconds=120))
+                        and now_utc > (latest_invalid_dt + stale_window)
                         and self.latest_valid_segment_time
                         <= self.latest_invalid_segment_time
                     )
@@ -439,7 +463,7 @@ class CameraWatchdog(threading.Thread):
                             )
 
                         self.logger.error(
-                            f"{reason} for {self.config.name} in the last 120s. Restarting the ffmpeg record process..."
+                            f"{reason} for {self.config.name} in the last {self.record_stale_threshold}s. Restarting the ffmpeg record process..."
                         )
                         p["process"] = start_or_restart_ffmpeg(
                             p["cmd"],

--- a/frigate/watchdog.py
+++ b/frigate/watchdog.py
@@ -28,6 +28,7 @@ class MonitoredProcess:
     restart_timestamps: deque[float] = field(
         default_factory=lambda: deque(maxlen=MAX_RESTARTS)
     )
+    clean_exit_logged: bool = False
 
     def is_restarting_too_fast(self, now: float) -> bool:
         while (
@@ -72,7 +73,9 @@ class FrigateWatchdog(threading.Thread):
 
         exitcode = entry.process.exitcode
         if exitcode == 0:
-            logger.info("Process %s exited cleanly, not restarting", entry.name)
+            if not entry.clean_exit_logged:
+                logger.info("Process %s exited cleanly, not restarting", entry.name)
+                entry.clean_exit_logged = True
             return
 
         logger.warning(

--- a/web/src/views/settings/MediaSyncSettingsView.tsx
+++ b/web/src/views/settings/MediaSyncSettingsView.tsx
@@ -10,13 +10,16 @@ import axios from "axios";
 import { toast } from "sonner";
 import { useJobStatus } from "@/api/ws";
 import { Switch } from "@/components/ui/switch";
-import { LuCheck, LuX } from "react-icons/lu";
+import { LuCheck, LuExternalLink, LuX } from "react-icons/lu";
 import { cn } from "@/lib/utils";
 import { formatUnixTimestampToDateTime } from "@/utils/dateUtil";
 import { MediaSyncResults, MediaSyncStats } from "@/types/ws";
+import { useDocDomain } from "@/hooks/use-doc-domain";
+import { Link } from "react-router-dom";
 
 export default function MediaSyncSettingsView() {
   const { t } = useTranslation("views/settings");
+  const { getLocaleDocUrl } = useDocDomain();
   const [selectedMediaTypes, setSelectedMediaTypes] = useState<string[]>([
     "all",
   ]);
@@ -109,13 +112,25 @@ export default function MediaSyncSettingsView() {
               <Heading as="h4" className="mb-2 hidden md:block">
                 {t("maintenance.sync.title")}
               </Heading>
-
               <div className="max-w-6xl">
-                <div className="mb-5 mt-2 flex max-w-5xl flex-col gap-2 text-sm text-muted-foreground">
+                <div className="mb-5 mt-2 flex max-w-5xl flex-col gap-2 text-sm text-primary-variant">
                   <p>{t("maintenance.sync.desc")}</p>
+
+                  <div className="flex items-center text-primary">
+                    <Link
+                      to={getLocaleDocUrl(
+                        "configuration/record#syncing-media-files-with-disk",
+                      )}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline"
+                    >
+                      {t("readTheDocumentation", { ns: "common" })}
+                      <LuExternalLink className="ml-2 inline-flex size-3" />
+                    </Link>
+                  </div>
                 </div>
               </div>
-
               <div className="space-y-6">
                 {/* Media Types Selection */}
                 <div>

--- a/web/src/views/settings/MediaSyncSettingsView.tsx
+++ b/web/src/views/settings/MediaSyncSettingsView.tsx
@@ -113,7 +113,7 @@ export default function MediaSyncSettingsView() {
                 {t("maintenance.sync.title")}
               </Heading>
               <div className="max-w-6xl">
-                <div className="mb-5 mt-2 flex max-w-5xl flex-col gap-2 text-sm text-primary-variant">
+                <div className="mb-5 mt-2 flex max-w-5xl flex-col gap-2 text-sm text-muted-foreground">
                   <p>{t("maintenance.sync.desc")}</p>
 
                   <div className="flex items-center text-primary">

--- a/web/src/views/settings/MediaSyncSettingsView.tsx
+++ b/web/src/views/settings/MediaSyncSettingsView.tsx
@@ -116,7 +116,7 @@ export default function MediaSyncSettingsView() {
                 <div className="mb-5 mt-2 flex max-w-5xl flex-col gap-2 text-sm text-muted-foreground">
                   <p>{t("maintenance.sync.desc")}</p>
 
-                  <div className="flex items-center text-primary">
+                  <div className="flex items-center text-primary-variant">
                     <Link
                       to={getLocaleDocUrl(
                         "configuration/record#syncing-media-files-with-disk",


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
- Ensure embeddings process restarts after maintainer thread crash
  - A crash in the thread left the process exiting with code 0, which the watchdog treated as a clean shutdown and refused to restart. The maintainer now joins the thread and exits non-zero on unexpected exit, and the watchdog dedupes the clean-exit log so it no longer repeats every 10s poll
- Add docs link to media sync header in Settings
- Ensure recording stateless check scales with segment_time
  - The watchdog's hardcoded 120s staleness threshold falsely fires when `segment_time` is close to 60, because `valid` messages carry the segment's start time and the gap between publishes can reach 2× `segment_time`. Threshold now scales as `max(120, 2 * segment_time + 30)` so default configs are unchanged and higher `segment_time` values get adequate headroom
- Docs update




## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for large/pinned features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [ ] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
