### PR TITLE
feat: native support for rootless container execution

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -287,6 +287,9 @@ RUN --mount=type=bind,source=docker/main/install_memryx.sh,target=/deps/install_
 
 COPY --from=deps-rootfs / /
 
+RUN mkdir -p /etc/letsencrypt/www /etc/letsencrypt/live/frigate /usr/local/nginx/logs /config /run /tmp/cache /media/frigate \
+    && chmod -R a+rwX /etc/letsencrypt /usr/local/nginx /config /run /tmp/cache /media/frigate
+
 RUN ldconfig
 
 EXPOSE 5000
@@ -297,6 +300,8 @@ EXPOSE 8555/tcp 8555/udp
 ENV S6_LOGGING_SCRIPT="T 1 n0 s10000000 T"
 # Do not fail on long-running download scripts
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
+# Set HOME to cache directory so rootless users can cache downloaded models
+ENV HOME=/tmp/cache
 
 ENTRYPOINT ["/init"]
 CMD []

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/certsync-log/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/certsync-log/run
@@ -1,4 +1,4 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
 
-exec logutil-service /dev/shm/logs/certsync
+exec /usr/local/bin/logutil /dev/shm/logs/certsync/

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate-log/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/frigate-log/run
@@ -1,4 +1,4 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
 
-exec logutil-service /dev/shm/logs/frigate
+exec /usr/local/bin/logutil /dev/shm/logs/frigate/

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc-log/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/go2rtc-log/run
@@ -1,4 +1,4 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
 
-exec logutil-service /dev/shm/logs/go2rtc
+exec /usr/local/bin/logutil /dev/shm/logs/go2rtc/

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/log-prepare/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/log-prepare/run
@@ -7,5 +7,7 @@ set -o errexit -o nounset -o pipefail
 dirs=(/dev/shm/logs/frigate /dev/shm/logs/go2rtc /dev/shm/logs/nginx /dev/shm/logs/certsync)
 
 mkdir -p "${dirs[@]}"
-chown nobody:nogroup "${dirs[@]}"
+if [ "$(id -u)" = "0" ]; then
+    chown nobody:nogroup "${dirs[@]}"
+fi
 chmod 02755 "${dirs[@]}"

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/nginx-log/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/nginx-log/run
@@ -1,4 +1,4 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
 
-exec logutil-service /dev/shm/logs/nginx
+exec /usr/local/bin/logutil /dev/shm/logs/nginx/

--- a/docker/main/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/docker/main/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -65,6 +65,11 @@ function set_worker_processes() {
 
 set_worker_processes
 
+# NGINX cannot switch users if running rootless; strip the directive
+if [ "$(id -u)" != "0" ]; then
+    sed -i '/^user root;/d' /usr/local/nginx/conf/nginx.conf || true
+fi
+
 # ensure the directory for ACME challenges exists
 mkdir -p /etc/letsencrypt/www
 

--- a/docker/main/rootfs/usr/local/bin/logutil
+++ b/docker/main/rootfs/usr/local/bin/logutil
@@ -1,0 +1,17 @@
+#!/command/with-contenv bash
+# shellcheck shell=bash
+
+LOG_DIR=$1
+
+if [ -z "$LOG_DIR" ]; then
+    echo "Usage: $0 <log-dir>"
+    exit 1
+fi
+
+CMD=(s6-log -b -- ${S6_LOGGING_SCRIPT:-n20 s1000000 T} "$LOG_DIR")
+
+if [ "$(id -u)" = "0" ]; then
+    exec /command/s6-envuidgid nobody /command/s6-applyuidgid -U -- "${CMD[@]}"
+else
+    exec "${CMD[@]}"
+fi


### PR DESCRIPTION
## Proposed change

Changes to allow running Frigate docker container as non-root user. This PR does a few things like ensuring directories are present and permissioned, plus skipping privilege changes is not running as root.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

I have not opened a new discussion about rootless as there are already a number of existing ones. Note that while this PR allows running the container as a non-root user, it does not attempt to:
 - Start as root and drop to non-root
 - Run rootless docker itself (although most likely this would now work, but not tested)

## For new features

There would be changes to the compose file to run rootless, outside the `user:<uid>` part. I'm not sure if we want to explicitly document these, but I can if required.

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

Antigravity / Gemini Pro.

**How AI was used** (e.g., code generation, code review, debugging, documentation):

3 steps:
 - Generate overlays onto the docker container to get everything working
 - Simplified were possible
 - Merge these overlays into the frigate source
 - Again simplified, as there was reuse opportunities

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

AI generated implementation, with human oversight and improvements at each step.

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

Reviewed code changes at each step. Ran tests + validated runtime with my own frigate setup.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
