### PR TITLE
bugfix(genai): add `api_key` auth support for Ollama Cloud

### DIFF
--- a/docs/docs/configuration/genai/config.md
+++ b/docs/docs/configuration/genai/config.md
@@ -201,7 +201,7 @@ Cloud Generative AI providers require an active internet connection to send imag
 
 ### Ollama Cloud
 
-Ollama also supports [cloud models](https://ollama.com/cloud), where your local Ollama instance handles requests from Frigate, but model inference is performed in the cloud. Set up Ollama locally, sign in with your Ollama account, and specify the cloud model name in your Frigate config. For more details, see the Ollama cloud model [docs](https://docs.ollama.com/cloud).
+Ollama also supports [cloud models](https://ollama.com/cloud), where model inference is performed in the cloud. You can connect directly to Ollama Cloud by setting `base_url` to `https://ollama.com` and providing an API key. Alternatively, you can run Ollama locally and use a cloud model name so your local instance forwards requests to the cloud. For more details, see the Ollama cloud model [docs](https://docs.ollama.com/cloud).
 
 #### Configuration
 
@@ -210,7 +210,8 @@ Ollama also supports [cloud models](https://ollama.com/cloud), where your local 
 
 1. Navigate to <NavPath path="Settings > Enrichments > Generative AI" />.
    - Set **Provider** to `ollama`
-   - Set **Base URL** to your local Ollama address (e.g., `http://localhost:11434`)
+   - Set **Base URL** to your local Ollama address (e.g., `http://localhost:11434`) or `https://ollama.com` for direct cloud inference
+   - Set **API key** if required by your endpoint (e.g., when using `https://ollama.com`)
    - Set **Model** to the cloud model name
 
 </TabItem>
@@ -221,6 +222,16 @@ genai:
   provider: ollama
   base_url: http://localhost:11434
   model: cloud-model-name
+```
+
+or when using Ollama Cloud directly
+
+```yaml
+genai:
+  provider: ollama
+  base_url: https://ollama.com
+  model: cloud-model-name
+  api_key: your-api-key
 ```
 
 </TabItem>

--- a/frigate/genai/ollama.py
+++ b/frigate/genai/ollama.py
@@ -31,6 +31,12 @@ class OllamaClient(GenAIClient):
     provider: ApiClient | None
     provider_options: dict[str, Any]
 
+    def _auth_headers(self) -> dict | None:
+        if self.genai_config.api_key:
+            return {"Authorization": "Bearer " + self.genai_config.api_key}
+
+        return None
+
     def _init_provider(self) -> ApiClient | None:
         """Initialize the client."""
         self.provider_options = {
@@ -39,7 +45,11 @@ class OllamaClient(GenAIClient):
         }
 
         try:
-            client = ApiClient(host=self.genai_config.base_url, timeout=self.timeout)
+            client = ApiClient(
+                host=self.genai_config.base_url,
+                timeout=self.timeout,
+                headers=self._auth_headers(),
+            )
             # ensure the model is available locally
             response = client.show(self.genai_config.model)
             if response.get("error"):
@@ -166,7 +176,9 @@ class OllamaClient(GenAIClient):
                 return []
             try:
                 client = ApiClient(
-                    host=self.genai_config.base_url, timeout=self.timeout
+                    host=self.genai_config.base_url,
+                    timeout=self.timeout,
+                    headers=self._auth_headers(),
                 )
             except Exception:
                 return []
@@ -344,6 +356,7 @@ class OllamaClient(GenAIClient):
                 async_client = OllamaAsyncClient(
                     host=self.genai_config.base_url,
                     timeout=self.timeout,
+                    headers=self._auth_headers(),
                 )
                 response = await async_client.chat(**request_params)
                 result = self._message_from_response(response)
@@ -359,6 +372,7 @@ class OllamaClient(GenAIClient):
             async_client = OllamaAsyncClient(
                 host=self.genai_config.base_url,
                 timeout=self.timeout,
+                headers=self._auth_headers(),
             )
             content_parts: list[str] = []
             final_message: dict[str, Any] | None = None


### PR DESCRIPTION
## Proposed change

This PR adds Bearer token authentication support for the Ollama GenAI provider, enabling users to connect directly to [Ollama Cloud](https://ollama.com/cloud) using an API key, as defined in [`ollama-python`'s docs](https://github.com/ollama/ollama-python#cloud-api-ollamacom)

Previously, Frigate's Ollama integration only supported unauthenticated local instances or local proxies that forwarded to the cloud. Now users can set base_url: https://ollama.com and provide api_key for direct cloud inference.

 ## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): Pi.dev

**How AI was used** (e.g., code generation, code review, debugging, documentation): Code and documentation review. Wrote the commit message.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): Code is my own. Reviewed by AI.

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

I validated this change on my own Frigate instance. No longer seeing "Auth" error logs.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)