### PR TITLE
fix(face_recognition): feed BGR (not RGB) to FaceDetectorYN in manual detection branch

### DIFF
--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -229,10 +229,7 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
                 logger.debug(f"No person box available for {id}")
                 return
 
-            # YuNet (cv2.FaceDetectorYN) is trained on BGR; feeding RGB
-            # silently degrades detection confidence by ~10x on typical
-            # person crops, causing face_recognition to fail with no log
-            # signal. The else-branch below already does YUV2BGR correctly.
+            # YuNet (cv2.FaceDetectorYN) is trained on BGR
             bgr = cv2.cvtColor(frame, cv2.COLOR_YUV2BGR_I420)
             left, top, right, bottom = person_box
             person = bgr[top:bottom, left:right]

--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -229,9 +229,13 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
                 logger.debug(f"No person box available for {id}")
                 return
 
-            rgb = cv2.cvtColor(frame, cv2.COLOR_YUV2RGB_I420)
+            # YuNet (cv2.FaceDetectorYN) is trained on BGR; feeding RGB
+            # silently degrades detection confidence by ~10x on typical
+            # person crops, causing face_recognition to fail with no log
+            # signal. The else-branch below already does YUV2BGR correctly.
+            bgr = cv2.cvtColor(frame, cv2.COLOR_YUV2BGR_I420)
             left, top, right, bottom = person_box
-            person = rgb[top:bottom, left:right]
+            person = bgr[top:bottom, left:right]
             face_box = self.__detect_face(person, self.face_config.detection_threshold)
 
             if not face_box:
@@ -250,11 +254,6 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
                 )
                 return
 
-            try:
-                face_frame = cv2.cvtColor(face_frame, cv2.COLOR_RGB2BGR)
-            except Exception as e:
-                logger.debug(f"Failed to convert face frame color for {id}: {e}")
-                return
         else:
             # don't run for object without attributes
             if not obj_data.get("current_attributes"):


### PR DESCRIPTION
## Proposed change

`FaceRealTimeProcessor.process_frame` has two paths for sourcing the face image:

- **`requires_face_detection: True`** (face is *not* in `objects.track`): converts the YUV frame to **RGB**, crops the person, runs `cv2.FaceDetectorYN.detect(person)` to find faces.
- **`requires_face_detection: False`** (face *is* in `objects.track`): converts the YUV frame to **BGR**, slices the face from the existing object-detector face box.

`cv2.FaceDetectorYN` (YuNet) is trained on BGR. The first branch feeds it RGB, which silently degrades detection confidence enough that the detector's hard-coded `score_threshold=0.5` filters out the RGB-degraded faces before any user-facing log line. The else-branch already does this correctly (`COLOR_YUV2BGR_I420` on what was line 271 in 0.17.1, line 285 on current `dev`) — only the manual-detection branch was missed.

This bug is invisible from outside the container because:

- No exception is raised — the detector simply returns 0 faces.
- Logs at `info` show only `Detected no faces for person object.` for every person, identical to a "nobody is in frame" outcome.
- Recognized-face training samples in `/clips/faces/train/` simply stop accumulating.

### Reproduction (verified against running 0.17.1)

Identical person crop sliced from `/api/events/<id>/snapshot.jpg`, fed to a `cv2.FaceDetectorYN` instance built with the same params Frigate uses (`score_threshold=0.5, nms_threshold=0.3, input_size=(320,320)`):

| Color order | Top face confidence |
|---|---|
| BGR (`cv2.imread` default) | **0.744** ✓ passes 0.5 |
| RGB (this branch's path) | **0.047** ✗ filtered out |

5 of 5 person events tested produced the same pattern (BGR 0.74 / 0.77 / 0.13 / 0.13 / 0.05 vs RGB 0.05 / 0.14 / 0.08 / 0.05 / 0.04 across various crop sizes and cameras).

### Fix

Three changes in `frigate/data_processing/real_time/face.py`:

1. `cv2.COLOR_YUV2RGB_I420` → `cv2.COLOR_YUV2BGR_I420`
2. Variable rename `rgb` → `bgr` to match
3. Remove the now-redundant `cv2.cvtColor(face_frame, cv2.COLOR_RGB2BGR)` block — `face_frame` is already BGR after the upstream conversion change

Net diff: **+6 / -7**, pure Python, no new dependencies. Comment added explaining why BGR matters (and pointing at the else-branch that already does it right).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: _no existing issue found via search; happy to file one if you'd prefer to track separately_
- This PR is related to issue: _n/a_
- Link to discussion with maintainers: _n/a (small bugfix)_

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Anthropic)

**How AI was used**: Diagnostic assistance during a multi-hour investigation of a silent face-recognition outage on my production Frigate deployment, then code change identification and PR drafting.

**Extent of AI involvement**: Significant on the diagnostic phase. The AI agent walked through Frigate's source (`face.py`, `embeddings/__init__.py`, `data_processing/common/face/model.py`), identified that `classify()` was returning `None` because `__detect_face` was returning `None`, then proposed the BGR-vs-RGB hypothesis. I (the human) wrote and ran the reproduction script in-pod (`cv2.FaceDetectorYN` with both color orders on real snapshots) that produced the 0.744 / 0.047 numbers above. The patch itself is 3 changes I reviewed line-by-line.

**Human oversight**: 
- Independently verified the reproduction (BGR vs RGB confidence) in-pod against 0.17.1 before opening the PR.
- Read every line of the diff. Variable rename `rgb` → `bgr` verified to flow through correctly. Confirmed the removed `RGB2BGR` block is a no-op once input is BGR.
- Confirmed the same-file else-branch already uses `COLOR_YUV2BGR_I420` correctly — fix matches existing convention, not introducing a new pattern.

## Checklist

- [x] The code change is tested and works locally.
  - Verified reproduction (the bug, not the fix) in-pod against 0.17.1: identical input image gives confidence 0.744 BGR vs 0.047 RGB.
  - Full end-to-end test of the *patched* code (face detected → recognized → sub_label populated) is in progress via an internal patched-image deployment; I'll report results in this thread once that's verified. If you want me to wait for that confirmation before merging, totally understand.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
  - Being honest: I haven't run Frigate's full test suite locally on this fork. Happy to do so — point me at the canonical command and I'll run it and post results.
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
  - n/a — no UI changes
- [x] The code has been formatted using Ruff (`ruff format frigate`)
  - `ruff format --check` reports `1 file already formatted`
