### PR TITLE
UI fixes

### DIFF
--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -72,7 +72,7 @@ This does not affect using hardware for accelerating other tasks such as [semant
 
 # Officially Supported Detectors
 
-Frigate provides a number of builtin detector types. By default, Frigate will use a single CPU detector. Other detectors may require additional configuration as described below. When using multiple detectors they will run in dedicated processes, but pull from a common queue of detection requests from across all cameras.
+Frigate provides a number of builtin detector types. By default, Frigate will use a single OpenVINO detector running on the CPU. Other detectors may require additional configuration as described below. When using multiple detectors they will run in dedicated processes, but pull from a common queue of detection requests from across all cameras.
 
 ## Edge TPU Detector
 

--- a/docs/docs/guides/getting_started.md
+++ b/docs/docs/guides/getting_started.md
@@ -192,7 +192,7 @@ cameras:
 
 ### Step 4: Configure detectors
 
-By default, Frigate will use a single CPU detector.
+By default, Frigate will use a single OpenVINO detector running on the CPU.
 
 In many cases, the integrated graphics on Intel CPUs provides sufficient performance for typical Frigate setups. If you have an Intel processor, you can follow the configuration below.
 

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -499,9 +499,7 @@ def config_save(save_option: str, body: Any = Body(media_type="text/plain")):
         )
 
 
-def _restore_masked_camera_paths(
-    config_data: dict, config: FrigateConfig
-) -> None:
+def _restore_masked_camera_paths(config_data: dict, config: FrigateConfig) -> None:
     """Substitute incoming `*:*` masked credentials with the in-memory ones.
 
     The /config response masks ffmpeg input credentials, so the settings UI
@@ -545,9 +543,7 @@ def _config_set_in_memory(request: Request, body: AppConfigSetBody) -> JSONRespo
     try:
         updates = {}
         if body.config_data:
-            _restore_masked_camera_paths(
-                body.config_data, request.app.frigate_config
-            )
+            _restore_masked_camera_paths(body.config_data, request.app.frigate_config)
             updates = flatten_config_data(body.config_data)
             updates = {k: ("" if v is None else v) for k, v in updates.items()}
 

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -499,6 +499,42 @@ def config_save(save_option: str, body: Any = Body(media_type="text/plain")):
         )
 
 
+def _restore_masked_camera_paths(
+    config_data: dict, config: FrigateConfig
+) -> None:
+    """Substitute incoming `*:*` masked credentials with the in-memory ones.
+
+    The /config response masks ffmpeg input credentials, so the settings UI
+    sends the masked path back when sibling fields (e.g. hwaccel_args) are
+    edited.  Without this we'd write `rtsp://*:*@host` into YAML and lose
+    the real credentials.  Mutates `config_data` in place.
+    """
+    cameras = config_data.get("cameras")
+    if not isinstance(cameras, dict):
+        return
+
+    for camera_name, camera_data in cameras.items():
+        if not isinstance(camera_data, dict):
+            continue
+        inputs = camera_data.get("ffmpeg", {}).get("inputs")
+        if not isinstance(inputs, list):
+            continue
+        existing = config.cameras.get(camera_name)
+        if existing is None:
+            continue
+        existing_paths = [inp.path for inp in existing.ffmpeg.inputs]
+        for index, input_obj in enumerate(inputs):
+            if not isinstance(input_obj, dict):
+                continue
+            path = input_obj.get("path")
+            if not isinstance(path, str):
+                continue
+            if ("://*:*@" in path or "user=*&password=*" in path) and index < len(
+                existing_paths
+            ):
+                input_obj["path"] = existing_paths[index]
+
+
 def _config_set_in_memory(request: Request, body: AppConfigSetBody) -> JSONResponse:
     """Apply config changes in-memory only, without writing to YAML.
 
@@ -509,6 +545,9 @@ def _config_set_in_memory(request: Request, body: AppConfigSetBody) -> JSONRespo
     try:
         updates = {}
         if body.config_data:
+            _restore_masked_camera_paths(
+                body.config_data, request.app.frigate_config
+            )
             updates = flatten_config_data(body.config_data)
             updates = {k: ("" if v is None else v) for k, v in updates.items()}
 
@@ -615,6 +654,9 @@ def config_set(request: Request, body: AppConfigSetBody):
                 if query_string:
                     updates = process_config_query_string(query_string)
                 elif body.config_data:
+                    _restore_masked_camera_paths(
+                        body.config_data, request.app.frigate_config
+                    )
                     updates = flatten_config_data(body.config_data)
                     # Convert None values to empty strings for deletion (e.g., when deleting masks)
                     updates = {k: ("" if v is None else v) for k, v in updates.items()}

--- a/frigate/config/camera/genai.py
+++ b/frigate/config/camera/genai.py
@@ -41,8 +41,7 @@ class GenAIConfig(FrigateBaseModel):
         title="Model",
         description="The model to use from the provider for generating descriptions or summaries.",
     )
-    provider: GenAIProviderEnum | None = Field(
-        default=None,
+    provider: GenAIProviderEnum = Field(
         title="Provider",
         description="The GenAI provider to use (for example: ollama, gemini, openai).",
     )

--- a/frigate/config/camera/updater.py
+++ b/frigate/config/camera/updater.py
@@ -121,7 +121,10 @@ class CameraConfigUpdateSubscriber:
         elif update_type == CameraConfigUpdateEnum.objects:
             config.objects = updated_config
         elif update_type == CameraConfigUpdateEnum.record:
+            old_enabled_in_config = config.record.enabled_in_config
             config.record = updated_config
+            if old_enabled_in_config != updated_config.enabled_in_config:
+                config.recreate_ffmpeg_cmds()
         elif update_type == CameraConfigUpdateEnum.review:
             config.review = updated_config
         elif update_type == CameraConfigUpdateEnum.review_genai:

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -26,6 +26,11 @@ class EnrichmentsDeviceEnum(str, Enum):
     CPU = "CPU"
 
 
+class ModelSizeEnum(str, Enum):
+    small = "small"
+    large = "large"
+
+
 class TriggerType(str, Enum):
     THUMBNAIL = "thumbnail"
     DESCRIPTION = "description"
@@ -53,13 +58,13 @@ class AudioTranscriptionConfig(FrigateBaseModel):
         title="Transcription language",
         description="Language code used for transcription/translation (for example 'en' for English). See https://whisper-api.com/docs/languages/ for supported language codes.",
     )
-    device: Optional[EnrichmentsDeviceEnum] = Field(
+    device: EnrichmentsDeviceEnum = Field(
         default=EnrichmentsDeviceEnum.CPU,
         title="Transcription device",
         description="Device key (CPU/GPU) to run the transcription model on. Only NVIDIA CUDA GPUs are currently supported for transcription.",
     )
-    model_size: str = Field(
-        default="small",
+    model_size: ModelSizeEnum = Field(
+        default=ModelSizeEnum.small,
         title="Model size",
         description="Model size to use for offline audio event transcription.",
     )
@@ -189,8 +194,8 @@ class SemanticSearchConfig(FrigateBaseModel):
                 return v
         return v
 
-    model_size: str = Field(
-        default="small",
+    model_size: ModelSizeEnum = Field(
+        default=ModelSizeEnum.small,
         title="Model size",
         description="Select model size; 'small' runs on CPU and 'large' typically requires GPU.",
     )
@@ -253,8 +258,8 @@ class FaceRecognitionConfig(FrigateBaseModel):
         title="Enable face recognition",
         description="Enable or disable face recognition for all cameras; can be overridden per-camera.",
     )
-    model_size: str = Field(
-        default="small",
+    model_size: ModelSizeEnum = Field(
+        default=ModelSizeEnum.small,
         title="Model size",
         description="Model size to use for face embeddings (small/large); larger may require GPU.",
     )
@@ -335,8 +340,8 @@ class LicensePlateRecognitionConfig(FrigateBaseModel):
         title="Enable LPR",
         description="Enable or disable license plate recognition for all cameras; can be overridden per-camera.",
     )
-    model_size: str = Field(
-        default="small",
+    model_size: ModelSizeEnum = Field(
+        default=ModelSizeEnum.small,
         title="Model size",
         description="Model size used for text detection/recognition. Most users should use 'small'.",
     )

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import logging
 import os
@@ -80,16 +81,39 @@ logger = logging.getLogger(__name__)
 
 yaml = YAML()
 
+DEFAULT_DETECTORS = {
+    "ov": {
+        "type": "openvino",
+        "device": "CPU",
+    }
+}
+DEFAULT_MODEL = {
+    "width": 300,
+    "height": 300,
+    "input_tensor": "nhwc",
+    "input_pixel_format": "bgr",
+    "path": "/openvino-model/ssdlite_mobilenet_v2.xml",
+    "labelmap_path": "/openvino-model/coco_91cl_bkgr.txt",
+}
+DEFAULT_DETECT_DIMENSIONS = {"width": 1280, "height": 720}
+
+
+def _render_default_yaml(data: dict) -> str:
+    buf = io.StringIO()
+    _yaml_writer = YAML()
+    _yaml_writer.indent(mapping=2, sequence=4, offset=2)
+    _yaml_writer.dump(data, buf)
+    return buf.getvalue()
+
+
 DEFAULT_CONFIG = f"""
 mqtt:
   enabled: False
 
+{_render_default_yaml({"detectors": DEFAULT_DETECTORS, "model": DEFAULT_MODEL})}
 cameras: {{}}  # No cameras defined, UI wizard should be used
 version: {CURRENT_CONFIG_VERSION}
 """
-
-DEFAULT_DETECTORS = {"cpu": {"type": "cpu"}}
-DEFAULT_DETECT_DIMENSIONS = {"width": 1280, "height": 720}
 
 # stream info handler
 stream_info_retriever = StreamInfoRetriever()
@@ -679,6 +703,9 @@ class FrigateConfig(FrigateBaseModel):
                     model_config["path"] = "/cpu_model.tflite"
                 elif detector_config.type == "edgetpu":
                     model_config["path"] = "/edgetpu_model.tflite"
+                elif detector_config.type == "openvino":
+                    for default_key, default_value in DEFAULT_MODEL.items():
+                        model_config.setdefault(default_key, default_value)
 
             model = ModelConfig.model_validate(model_config)
             model.check_and_load_plus_model(self.plus_api, detector_config.type)

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -64,9 +64,9 @@ class TestConfig(unittest.TestCase):
 
     def test_config_class(self):
         frigate_config = FrigateConfig(**self.minimal)
-        assert "cpu" in frigate_config.detectors.keys()
-        assert frigate_config.detectors["cpu"].type == DetectorTypeEnum.cpu
-        assert frigate_config.detectors["cpu"].model.width == 320
+        assert "ov" in frigate_config.detectors.keys()
+        assert frigate_config.detectors["ov"].type == DetectorTypeEnum.openvino
+        assert frigate_config.detectors["ov"].model.width == 300
 
     @patch("frigate.detectors.detector_config.load_labels")
     def test_detector_custom_model_path(self, mock_labels):
@@ -1005,6 +1005,7 @@ class TestConfig(unittest.TestCase):
 
         config = {
             "mqtt": {"host": "mqtt"},
+            "detectors": {"cpu": {"type": "cpu"}},
             "model": {"path": "plus://test"},
             "cameras": {
                 "back": {

--- a/frigate/video/ffmpeg.py
+++ b/frigate/video/ffmpeg.py
@@ -174,6 +174,7 @@ class CameraWatchdog(threading.Thread):
         )
         self.requestor = InterProcessRequestor()
         self.was_enabled = self.config.enabled
+        self.was_record_enabled_in_config = self.config.record.enabled_in_config
 
         self.segment_subscriber = RecordingsDataSubscriber(RecordingsDataTypeEnum.all)
         self.latest_valid_segment_time: float = 0
@@ -321,6 +322,22 @@ class CameraWatchdog(threading.Thread):
                     self._send_detect_status("disabled", now)
                     self._send_record_status("disabled", now)
                 self.was_enabled = enabled
+                continue
+
+            record_enabled_in_config = self.config.record.enabled_in_config
+            if record_enabled_in_config != self.was_record_enabled_in_config:
+                if record_enabled_in_config and enabled:
+                    self.logger.debug(
+                        f"Record enabled in config for {self.config.name}, restarting ffmpeg"
+                    )
+                    self.stop_all_ffmpeg()
+                    self.start_all_ffmpeg()
+                    self.latest_valid_segment_time = 0
+                    self.latest_invalid_segment_time = 0
+                    self.latest_cache_segment_time = 0
+                    self.record_enable_time = datetime.now().astimezone(timezone.utc)
+                    last_restart_time = datetime.now().timestamp()
+                self.was_record_enabled_in_config = record_enabled_in_config
                 continue
 
             if not enabled:

--- a/web/public/locales/en/views/live.json
+++ b/web/public/locales/en/views/live.json
@@ -70,7 +70,8 @@
   },
   "recording": {
     "enable": "Enable Recording",
-    "disable": "Disable Recording"
+    "disable": "Disable Recording",
+    "disabledInConfig": "Recording must first be enabled in Settings for this camera."
   },
   "snapshots": {
     "enable": "Enable Snapshots",

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -1663,12 +1663,12 @@
       "fpsGreaterThanFive": "Setting the detect FPS higher than 5 is not recommended. Higher values may cause performance issues and will not provide any benefit."
     },
     "faceRecognition": {
-      "globalDisabled": "Face recognition is not enabled at the global level. Enable it in Enrichments for camera-level face recognition to function.",
-      "personNotTracked": "Face recognition requires the 'person' object to be tracked. Ensure 'person' is in the object tracking list."
+      "globalDisabled": "The face recognition enrichment must be enabled for face recognition features to function on this camera.",
+      "personNotTracked": "Face recognition requires the 'person' object to be tracked. Enable 'person' in Objects for this camera."
     },
     "lpr": {
-      "globalDisabled": "License plate recognition is not enabled at the global level. Enable it in Enrichments for camera-level LPR to function.",
-      "vehicleNotTracked": "License plate recognition requires 'car' or 'motorcycle' to be tracked."
+      "globalDisabled": "The license plate recognition enrichment must be enabled for LPR features to function on this camera.",
+      "vehicleNotTracked": "License plate recognition requires 'car' or 'motorcycle' to be tracked. Enable 'car' or 'motorcycle' in Objects for this camera."
     },
     "record": {
       "noRecordRole": "No streams have the record role defined. Recording will not function."

--- a/web/public/locales/en/views/system.json
+++ b/web/public/locales/en/views/system.json
@@ -177,6 +177,9 @@
       }
     },
     "framesAndDetections": "Frames / Detections",
+    "noCameras": {
+      "title": "No Cameras Found"
+    },
     "label": {
       "camera": "camera",
       "detect": "detect",

--- a/web/src/components/config-form/section-configs/audio_transcription.ts
+++ b/web/src/components/config-form/section-configs/audio_transcription.ts
@@ -10,7 +10,11 @@ const audioTranscription: SectionConfigOverrides = {
         severity: "warning",
         condition: (ctx) => {
           if (ctx.level === "camera" && ctx.fullCameraConfig) {
-            return ctx.fullCameraConfig.audio.enabled === false;
+            return (
+              !ctx.fullCameraConfig.ffmpeg?.inputs?.some((input) =>
+                input.roles?.includes("audio"),
+              ) || ctx.fullCameraConfig.audio.enabled === false
+            );
           }
           return false;
         },

--- a/web/src/components/config-form/section-configs/face_recognition.ts
+++ b/web/src/components/config-form/section-configs/face_recognition.ts
@@ -53,6 +53,11 @@ const faceRecognition: SectionConfigOverrides = {
       "device",
     ],
     restartRequired: ["enabled", "model_size", "device"],
+    uiSchema: {
+      model_size: {
+        "ui:options": { size: "xs" },
+      },
+    },
   },
 };
 

--- a/web/src/components/config-form/section-configs/lpr.ts
+++ b/web/src/components/config-form/section-configs/lpr.ts
@@ -83,6 +83,9 @@ const lpr: SectionConfigOverrides = {
           suppressDescription: true,
         },
       },
+      model_size: {
+        "ui:options": { size: "xs" },
+      },
     },
   },
 };

--- a/web/src/components/config-form/section-configs/objects.ts
+++ b/web/src/components/config-form/section-configs/objects.ts
@@ -1,4 +1,12 @@
+import type { FrigateConfig } from "@/types/frigateConfig";
 import type { SectionConfigOverrides } from "./types";
+
+// Attribute labels (face, license_plate, Frigate+ couriers like DHL/Amazon,
+// etc.) are populated into objects.filters by the backend even when the
+// model can't actually detect them. They aren't user-settable, so hide any
+// `filters.<attr>` patterns from forms and override comparisons.
+const hideAttributeFilters = (config: FrigateConfig): string[] =>
+  (config.model?.all_attributes ?? []).map((attr) => `filters.${attr}`);
 
 const objects: SectionConfigOverrides = {
   base: {
@@ -26,6 +34,7 @@ const objects: SectionConfigOverrides = {
       "filters.*.raw_mask",
       "filters.mask",
       "filters.raw_mask",
+      hideAttributeFilters,
     ],
     advancedFields: ["genai"],
     uiSchema: {
@@ -99,6 +108,7 @@ const objects: SectionConfigOverrides = {
       "filters.mask",
       "filters.raw_mask",
       "genai.required_zones",
+      hideAttributeFilters,
     ],
   },
   camera: {
@@ -123,6 +133,7 @@ const objects: SectionConfigOverrides = {
       "filters.*.raw_mask",
       "filters.mask",
       "filters.raw_mask",
+      hideAttributeFilters,
     ],
     advancedFields: [],
   },

--- a/web/src/components/config-form/sections/BaseSection.tsx
+++ b/web/src/components/config-form/sections/BaseSection.tsx
@@ -22,6 +22,7 @@ import {
   modifySchemaForSection,
   getEffectiveDefaultsForSection,
   sanitizeOverridesForSection,
+  synthesizeMissingObjectFilters,
 } from "./section-special-cases";
 import { getSectionValidation } from "../section-validations";
 import { useConfigOverride } from "@/hooks/use-config-override";
@@ -357,15 +358,19 @@ export function ConfigSection({
     return get(config, sectionPath);
   }, [config, cameraName, sectionPath, effectiveLevel, profileName]);
 
-  const rawFormData = useMemo(() => {
+  const rawFormData = useMemo<ConfigSectionData>(() => {
     if (!config) return {};
 
     if (rawSectionValue === undefined || rawSectionValue === null) {
       return {};
     }
 
-    return rawSectionValue;
-  }, [config, rawSectionValue]);
+    return synthesizeMissingObjectFilters(
+      sectionPath,
+      rawSectionValue,
+      modifiedSchema ?? undefined,
+    ) as ConfigSectionData;
+  }, [config, rawSectionValue, sectionPath, modifiedSchema]);
 
   // When editing a profile, hide fields that require a restart since they
   // cannot take effect via profile switching alone.
@@ -387,7 +392,7 @@ export function ConfigSection({
     const baseData = modifiedSchema
       ? applySchemaDefaults(modifiedSchema, rawFormData)
       : rawFormData;
-    return sanitizeSectionData(baseData);
+    return sanitizeSectionData(baseData as ConfigSectionData);
   }, [rawFormData, modifiedSchema, sanitizeSectionData]);
 
   const baselineSnapshot = useMemo(() => {
@@ -506,7 +511,11 @@ export function ConfigSection({
         setPendingOverrides(undefined);
         return;
       }
-      const sanitizedData = sanitizeSectionData(data as ConfigSectionData);
+      const sanitizedData = synthesizeMissingObjectFilters(
+        sectionPath,
+        sanitizeSectionData(data as ConfigSectionData),
+        modifiedSchema ?? undefined,
+      ) as ConfigSectionData;
       const nextBaselineFormData = baselineSnapshot;
       const overrides = buildOverrides(
         sanitizedData,
@@ -546,6 +555,8 @@ export function ConfigSection({
       setPendingOverrides,
       setDirtyOverrides,
       baselineSnapshot,
+      sectionPath,
+      modifiedSchema,
     ],
   );
 

--- a/web/src/components/config-form/sections/BaseSection.tsx
+++ b/web/src/components/config-form/sections/BaseSection.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useContext,
 } from "react";
-import useSWR from "swr";
+import useSWR, { mutate as swrMutate } from "swr";
 import axios from "axios";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
@@ -754,6 +754,7 @@ export function ConfigSection({
       }
 
       await refreshConfig();
+      swrMutate("config/raw_paths");
       setPendingData(null);
       onSave?.();
     } catch (error) {

--- a/web/src/components/config-form/sections/BaseSection.tsx
+++ b/web/src/components/config-form/sections/BaseSection.tsx
@@ -521,11 +521,7 @@ export function ConfigSection({
         setPendingOverrides(undefined);
         return;
       }
-      const sanitizedData = synthesizeMissingObjectFilters(
-        sectionPath,
-        sanitizeSectionData(data as ConfigSectionData),
-        modifiedSchema ?? undefined,
-      ) as ConfigSectionData;
+      const sanitizedData = sanitizeSectionData(data as ConfigSectionData);
       const nextBaselineFormData = baselineSnapshot;
       const overrides = buildOverrides(
         sanitizedData,
@@ -565,8 +561,6 @@ export function ConfigSection({
       setPendingOverrides,
       setDirtyOverrides,
       baselineSnapshot,
-      sectionPath,
-      modifiedSchema,
     ],
   );
 

--- a/web/src/components/config-form/sections/BaseSection.tsx
+++ b/web/src/components/config-form/sections/BaseSection.tsx
@@ -59,7 +59,11 @@ import {
 } from "@/components/ui/alert-dialog";
 import { applySchemaDefaults } from "@/lib/config-schema";
 import { cn } from "@/lib/utils";
-import { ConfigSectionData, JsonValue } from "@/types/configForm";
+import {
+  ConfigSectionData,
+  HiddenFieldEntry,
+  JsonValue,
+} from "@/types/configForm";
 import ActivityIndicator from "@/components/indicators/activity-indicator";
 import { StatusBarMessagesContext } from "@/context/statusbar-provider";
 import {
@@ -69,6 +73,7 @@ import {
   buildConfigDataForPath,
   flattenOverrides,
   getBaseCameraSectionValue,
+  resolveHiddenFieldEntries,
   sanitizeSectionData as sharedSanitizeSectionData,
   requiresRestartForOverrides as sharedRequiresRestartForOverrides,
 } from "@/utils/configUtil";
@@ -91,7 +96,7 @@ export interface SectionConfig {
   /** Fields to group together */
   fieldGroups?: Record<string, string[]>;
   /** Fields to hide from UI */
-  hiddenFields?: string[];
+  hiddenFields?: HiddenFieldEntry[];
   /** Fields to show in advanced section */
   advancedFields?: string[];
   /** Fields to compare for override detection */
@@ -375,12 +380,17 @@ export function ConfigSection({
   // When editing a profile, hide fields that require a restart since they
   // cannot take effect via profile switching alone.
   const effectiveHiddenFields = useMemo(() => {
+    const base = resolveHiddenFieldEntries(sectionConfig.hiddenFields, config);
     if (!profileName || !sectionConfig.restartRequired?.length) {
-      return sectionConfig.hiddenFields;
+      return base;
     }
-    const base = sectionConfig.hiddenFields ?? [];
     return [...new Set([...base, ...sectionConfig.restartRequired])];
-  }, [profileName, sectionConfig.hiddenFields, sectionConfig.restartRequired]);
+  }, [
+    profileName,
+    sectionConfig.hiddenFields,
+    sectionConfig.restartRequired,
+    config,
+  ]);
 
   const sanitizeSectionData = useCallback(
     (data: ConfigSectionData) =>

--- a/web/src/components/config-form/sections/CameraOverridesBadge.tsx
+++ b/web/src/components/config-form/sections/CameraOverridesBadge.tsx
@@ -43,17 +43,33 @@ const CAMERA_PAGE_BY_SECTION: Record<string, string> = {
 const MAX_FIELDS_PER_CAMERA = 5;
 
 /**
- * Enrichment sections where the cross-camera override badge should be
- * suppressed because they're effectively global-only (or per-camera
- * configuration there isn't a useful affordance to surface here).
- * Face recognition and LPR are intentionally omitted so the badge does show
- * on those enrichment pages.
+ * Sections where the cross-camera override badge should be suppressed.
+ * Includes enrichment sections that aren't meaningfully per-camera
+ * (face recognition and LPR are intentionally omitted so the badge does show
+ * there) and every System sub-page (detector hardware, database, networking,
+ * etc.) which configures Frigate as a whole, not per-camera state.
  */
 const SECTIONS_WITHOUT_OVERRIDE_BADGE = new Set([
+  // Enrichments (face_recognition and lpr remain enabled)
   "semantic_search",
   "genai",
   "classification",
   "audio_transcription",
+  // System
+  "go2rtc_streams",
+  "database",
+  "mqtt",
+  "tls",
+  "auth",
+  "networking",
+  "proxy",
+  "ui",
+  "logger",
+  "environment_vars",
+  "telemetry",
+  "birdseye",
+  "detectors",
+  "model",
 ]);
 
 /**

--- a/web/src/components/config-form/sections/CameraOverridesBadge.tsx
+++ b/web/src/components/config-form/sections/CameraOverridesBadge.tsx
@@ -20,7 +20,7 @@ import type { ProfilesApiResponse } from "@/types/profile";
 import { humanizeKey } from "@/components/config-form/theme/utils/i18n";
 import { useCameraFriendlyName } from "@/hooks/use-camera-friendly-name";
 import { formatList } from "@/utils/stringUtil";
-import { getSectionConfig } from "@/utils/configUtil";
+import { getEffectiveHiddenFields } from "@/utils/configUtil";
 
 const CAMERA_PAGE_BY_SECTION: Record<string, string> = {
   detect: "cameraDetect",
@@ -247,8 +247,11 @@ export function CameraOverridesBadge({ sectionPath, className }: Props) {
   const rawEntries = useCamerasOverridingSection(config, sectionPath);
 
   const entries = useMemo(() => {
-    const hiddenFields =
-      getSectionConfig(sectionPath, "global").hiddenFields ?? [];
+    const hiddenFields = getEffectiveHiddenFields(
+      sectionPath,
+      "global",
+      config,
+    );
     if (hiddenFields.length === 0) return rawEntries;
     return rawEntries
       .map((entry) => ({
@@ -261,7 +264,7 @@ export function CameraOverridesBadge({ sectionPath, className }: Props) {
         ),
       }))
       .filter((entry) => entry.fieldDeltas.length > 0);
-  }, [rawEntries, sectionPath]);
+  }, [rawEntries, sectionPath, config]);
 
   if (SECTIONS_WITHOUT_OVERRIDE_BADGE.has(sectionPath)) {
     return null;

--- a/web/src/components/config-form/sections/section-special-cases.ts
+++ b/web/src/components/config-form/sections/section-special-cases.ts
@@ -106,6 +106,51 @@ export function getEffectiveDefaultsForSection(
 }
 
 /**
+ * Add default filter entries for any label in `objects.track` that isn't
+ * already in `objects.filters`, so each tracked label gets a collapsible.
+ * The backend only auto-populates filters at config init, not after profile
+ * merges or live track edits.
+ */
+export function synthesizeMissingObjectFilters(
+  sectionPath: string,
+  data: unknown,
+  sectionSchema: RJSFSchema | undefined,
+): unknown {
+  if (sectionPath !== "objects") return data;
+  if (!isJsonObject(data)) return data;
+
+  const trackValue = (data as JsonObject).track;
+  if (!Array.isArray(trackValue) || trackValue.length === 0) return data;
+
+  const properties = (sectionSchema as { properties?: Record<string, unknown> })
+    ?.properties;
+  const filtersSchema = isJsonObject(properties)
+    ? (properties.filters as { additionalProperties?: unknown } | undefined)
+    : undefined;
+  const filterEntrySchema = isJsonObject(filtersSchema?.additionalProperties)
+    ? (filtersSchema.additionalProperties as RJSFSchema)
+    : undefined;
+
+  const existingFilters = isJsonObject((data as JsonObject).filters)
+    ? ((data as JsonObject).filters as JsonObject)
+    : {};
+
+  const newFilters: JsonObject = { ...existingFilters };
+  let added = false;
+  for (const label of trackValue) {
+    if (typeof label !== "string") continue;
+    if (Object.prototype.hasOwnProperty.call(newFilters, label)) continue;
+    newFilters[label] = (
+      filterEntrySchema ? applySchemaDefaults(filterEntrySchema, {}) : {}
+    ) as JsonValue;
+    added = true;
+  }
+
+  if (!added) return data;
+  return { ...(data as JsonObject), filters: newFilters };
+}
+
+/**
  * Sanitize overrides payloads for section-specific quirks.
  */
 export function sanitizeOverridesForSection(

--- a/web/src/components/config-form/sections/section-special-cases.ts
+++ b/web/src/components/config-form/sections/section-special-cases.ts
@@ -15,7 +15,7 @@ import { JsonObject, JsonValue } from "@/types/configForm";
  * Sections that require special handling at the global level.
  * Add new section paths here as needed.
  */
-const SPECIAL_CASE_SECTIONS = ["motion", "detectors"] as const;
+const SPECIAL_CASE_SECTIONS = ["motion", "detectors", "genai"] as const;
 
 /**
  * Check if a section requires special case handling.
@@ -51,6 +51,29 @@ export function modifySchemaForSection(
   if (sectionPath === "detectors" && "default" in schema) {
     const { default: _, ...schemaWithoutDefault } = schema;
     return schemaWithoutDefault;
+  }
+
+  if (sectionPath === "genai") {
+    const additional = schema.additionalProperties;
+    if (
+      additional &&
+      typeof additional === "object" &&
+      !Array.isArray(additional)
+    ) {
+      const props = (additional as RJSFSchema).properties;
+      if (props && typeof props.provider === "object") {
+        return {
+          ...schema,
+          additionalProperties: {
+            ...additional,
+            properties: {
+              ...props,
+              provider: { ...(props.provider as object), default: "openai" },
+            },
+          },
+        };
+      }
+    }
   }
 
   return schema;

--- a/web/src/components/config-form/sections/section-special-cases.ts
+++ b/web/src/components/config-form/sections/section-special-cases.ts
@@ -109,7 +109,7 @@ export function getEffectiveDefaultsForSection(
  * Add default filter entries for any label in `objects.track` that isn't
  * already in `objects.filters`, so each tracked label gets a collapsible.
  * The backend only auto-populates filters at config init, not after profile
- * merges or live track edits.
+ * merges.
  */
 export function synthesizeMissingObjectFilters(
   sectionPath: string,

--- a/web/src/hooks/use-config-override.ts
+++ b/web/src/hooks/use-config-override.ts
@@ -1,12 +1,16 @@
 // Hook to detect when camera config overrides global defaults
 import { useMemo } from "react";
+import useSWR from "swr";
 import isEqual from "lodash/isEqual";
 import get from "lodash/get";
 import set from "lodash/set";
+import type { RJSFSchema } from "@rjsf/utils";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { JsonObject, JsonValue } from "@/types/configForm";
 import { isJsonObject } from "@/lib/utils";
 import { getBaseCameraSectionValue } from "@/utils/configUtil";
+import { extractSectionSchema } from "@/hooks/use-config-schema";
+import { applySchemaDefaults } from "@/lib/config-schema";
 
 const INTERNAL_FIELD_SUFFIXES = ["enabled_in_config", "raw_mask"];
 
@@ -32,6 +36,36 @@ function stripInternalFields(value: JsonValue): JsonValue {
 
 export function normalizeConfigValue(value: unknown): JsonValue {
   return stripInternalFields(value as JsonValue);
+}
+
+/**
+ * Collapse null and empty-object values for override comparisons so
+ * semantically equivalent shapes match. The schema may default `mask: None`
+ * while the runtime camera config carries `mask: {}` — both mean "no
+ * masks", so collapsing them here keeps the equality check honest. We
+ * keep this off the public `normalizeConfigValue` so save-flow code paths
+ * (which serialize form data) aren't affected.
+ */
+function collapseEmpty(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    return value.map(collapseEmpty);
+  }
+  if (isJsonObject(value)) {
+    const cleaned: JsonObject = {};
+    for (const [key, val] of Object.entries(value as JsonObject)) {
+      if (val === null || val === undefined) continue;
+      const collapsed = collapseEmpty(val as JsonValue);
+      if (
+        isJsonObject(collapsed) &&
+        Object.keys(collapsed as JsonObject).length === 0
+      ) {
+        continue;
+      }
+      cleaned[key] = collapsed;
+    }
+    return cleaned;
+  }
+  return value;
 }
 
 export interface OverrideStatus {
@@ -96,6 +130,7 @@ export function useConfigOverride({
   sectionPath,
   compareFields,
 }: UseConfigOverrideOptions) {
+  const { data: schema } = useSWR<RJSFSchema>("config/schema.json");
   return useMemo(() => {
     if (!config) {
       return {
@@ -153,15 +188,29 @@ export function useConfigOverride({
       sectionPath,
     );
 
-    const normalizedGlobalValue = normalizeConfigValue(globalValue);
+    // Use the effective baseline (schema defaults when the global section
+    // is unset, e.g. motion). Without this, sections omitted from the global
+    // YAML would always read as "overridden" because the raw global value is
+    // null while every camera has populated defaults.
+    const normalizedGlobalValue = getEffectiveGlobalBaseline(
+      config,
+      sectionPath,
+      compareFields,
+      schema,
+    );
     const normalizedCameraValue = normalizeConfigValue(cameraValue);
 
+    // Collapse empty/null values for comparison so semantically equivalent
+    // shapes (e.g. schema default `mask: null` vs runtime `mask: {}`) match.
+    const collapsedGlobal = collapseEmpty(normalizedGlobalValue);
+    const collapsedCamera = collapseEmpty(normalizedCameraValue);
+
     const comparisonGlobal = compareFields
-      ? pickFields(normalizedGlobalValue, compareFields)
-      : normalizedGlobalValue;
+      ? pickFields(collapsedGlobal, compareFields)
+      : collapsedGlobal;
     const comparisonCamera = compareFields
-      ? pickFields(normalizedCameraValue, compareFields)
-      : normalizedCameraValue;
+      ? pickFields(collapsedCamera, compareFields)
+      : collapsedCamera;
 
     // Check if the entire section is overridden
     const isOverridden = compareFields
@@ -176,7 +225,10 @@ export function useConfigOverride({
       const cameraFieldValue = get(normalizedCameraValue, fieldPath);
 
       return {
-        isOverridden: !isEqual(globalFieldValue, cameraFieldValue),
+        isOverridden: !isEqual(
+          collapseEmpty(globalFieldValue as JsonValue),
+          collapseEmpty(cameraFieldValue as JsonValue),
+        ),
         globalValue: globalFieldValue,
         cameraValue: cameraFieldValue,
       };
@@ -199,7 +251,7 @@ export function useConfigOverride({
       getFieldOverride,
       resetToGlobal,
     };
-  }, [config, cameraName, sectionPath, compareFields]);
+  }, [config, cameraName, sectionPath, compareFields, schema]);
 }
 
 /**
@@ -252,6 +304,7 @@ export function useAllCameraOverrides(
   config: FrigateConfig | undefined,
   cameraName: string | undefined,
 ) {
+  const { data: schema } = useSWR<RJSFSchema>("config/schema.json");
   return useMemo(() => {
     if (!config || !cameraName) {
       return [];
@@ -265,17 +318,24 @@ export function useAllCameraOverrides(
     const overriddenSections: string[] = [];
 
     for (const { key, compareFields } of OVERRIDABLE_SECTIONS) {
-      const globalValue = normalizeConfigValue(get(config, key));
+      const globalValue = getEffectiveGlobalBaseline(
+        config,
+        key,
+        compareFields,
+        schema,
+      );
       const cameraValue = normalizeConfigValue(
         getBaseCameraSectionValue(config, cameraName, key),
       );
 
+      const collapsedGlobal = collapseEmpty(globalValue);
+      const collapsedCamera = collapseEmpty(cameraValue);
       const comparisonGlobal = compareFields
-        ? pickFields(globalValue, compareFields)
-        : globalValue;
+        ? pickFields(collapsedGlobal, compareFields)
+        : collapsedGlobal;
       const comparisonCamera = compareFields
-        ? pickFields(cameraValue, compareFields)
-        : cameraValue;
+        ? pickFields(collapsedCamera, compareFields)
+        : collapsedCamera;
 
       if (
         compareFields && compareFields.length === 0
@@ -287,7 +347,7 @@ export function useAllCameraOverrides(
     }
 
     return overriddenSections;
-  }, [config, cameraName]);
+  }, [config, cameraName, schema]);
 }
 
 export interface FieldDelta {
@@ -386,14 +446,40 @@ function isPathAllowed(path: string, compareFields?: string[]): boolean {
 }
 
 /**
- * Some Frigate sections (notably `motion`) are dumped by the backend with
- * `exclude_unset=True`, so when the user hasn't explicitly written the section
- * in their global YAML the API returns null even though every camera still
- * gets defaults applied at runtime. To still detect cross-camera differences
- * in those sections we synthesize a baseline by taking the modal (most common)
- * value at each leaf path across cameras — cameras whose value diverges from
- * the modal are treated as overriding.
+ * Resolve the effective global baseline used for override comparisons.
+ *
+ * - When the global section is explicitly set, return it (normalized).
+ * - Otherwise prefer the camera-level schema defaults so a camera that
+ *   diverges from the implicit Pydantic default registers as overriding
+ *   even with a single camera in the deployment. (Sections like `motion`
+ *   are dumped with `exclude_unset=True`, so the API returns null whenever
+ *   the user hasn't written the section globally.)
+ * - Fall back to a modal-across-cameras synthetic baseline when the schema
+ *   hasn't loaded yet or the section isn't in it.
  */
+function getEffectiveGlobalBaseline(
+  config: FrigateConfig,
+  sectionPath: string,
+  compareFields?: string[],
+  schema?: RJSFSchema,
+): JsonValue {
+  const rawGlobalValue = get(config, sectionPath);
+  if (rawGlobalValue != null) {
+    return normalizeConfigValue(rawGlobalValue);
+  }
+  if (schema) {
+    const sectionSchema = extractSectionSchema(schema, sectionPath, "camera");
+    if (sectionSchema) {
+      const defaults = applySchemaDefaults(sectionSchema, {});
+      return normalizeConfigValue(defaults as JsonValue);
+    }
+  }
+  const cameraSectionValues = Object.keys(config.cameras ?? {}).map((name) =>
+    normalizeConfigValue(getBaseCameraSectionValue(config, name, sectionPath)),
+  );
+  return deriveSyntheticGlobalValue(cameraSectionValues, compareFields);
+}
+
 function deriveSyntheticGlobalValue(
   cameraSectionValues: JsonValue[],
   compareFields?: string[],
@@ -461,6 +547,7 @@ export function useCamerasOverridingSection(
   config: FrigateConfig | undefined,
   sectionPath: string,
 ): CameraOverrideEntry[] {
+  const { data: schema } = useSWR<RJSFSchema>("config/schema.json");
   return useMemo(() => {
     if (!config?.cameras || !sectionPath) {
       return [];
@@ -476,11 +563,9 @@ export function useCamerasOverridingSection(
       ),
     );
 
-    const rawGlobalValue = get(config, sectionPath);
-    const globalValue: JsonValue =
-      rawGlobalValue == null
-        ? deriveSyntheticGlobalValue(cameraSectionValues, compareFields)
-        : normalizeConfigValue(rawGlobalValue);
+    const globalValue = collapseEmpty(
+      getEffectiveGlobalBaseline(config, sectionPath, compareFields, schema),
+    );
 
     const entries: CameraOverrideEntry[] = [];
     for (let idx = 0; idx < cameraNames.length; idx += 1) {
@@ -489,7 +574,7 @@ export function useCamerasOverridingSection(
       const deltasByPath = new Map<string, FieldDelta>();
 
       // 1. Camera-level overrides (uses base_config when a profile is active)
-      const cameraValue = cameraSectionValues[idx];
+      const cameraValue = collapseEmpty(cameraSectionValues[idx]);
       for (const delta of collectFieldDeltas(
         globalValue,
         cameraValue,
@@ -536,5 +621,5 @@ export function useCamerasOverridingSection(
     }
 
     return entries;
-  }, [config, sectionPath]);
+  }, [config, sectionPath, schema]);
 }

--- a/web/src/hooks/use-config-schema.ts
+++ b/web/src/hooks/use-config-schema.ts
@@ -24,7 +24,7 @@ const getSchemaDefinitions = (schema: RJSFSchema): Record<string, RJSFSchema> =>
  * Extracts and resolves a section schema from the full config schema
  * Uses caching to avoid repeated expensive resolution
  */
-function extractSectionSchema(
+export function extractSectionSchema(
   schema: RJSFSchema,
   sectionPath: string,
   level: "global" | "camera",

--- a/web/src/hooks/use-optimistic-state.ts
+++ b/web/src/hooks/use-optimistic-state.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 type OptimisticStateResult<T> = [T, (newValue: T) => void];
 
@@ -8,37 +8,32 @@ const useOptimisticState = <T>(
   delay: number = 20,
 ): OptimisticStateResult<T> => {
   const [optimisticValue, setOptimisticValue] = useState<T>(currentState);
-  const debounceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleValueChange = useCallback(
-    (newValue: T) => {
-      // Update the optimistic value immediately
-      setOptimisticValue(newValue);
-
-      // Clear any pending debounce timeout
-      if (debounceTimeout.current) {
-        clearTimeout(debounceTimeout.current);
-      }
-
-      // Set a new debounce timeout
-      debounceTimeout.current = setTimeout(() => {
-        // Update the actual value using the provided setter function
-        setState(newValue);
-      }, delay);
-    },
-    [delay, setState],
-  );
-
-  useEffect(() => {
-    return () => {
-      if (debounceTimeout.current) {
-        clearTimeout(debounceTimeout.current);
-      }
-    };
+  const handleValueChange = useCallback((newValue: T) => {
+    // Update the optimistic value immediately
+    setOptimisticValue(newValue);
   }, []);
 
+  // Push the optimistic value to the real setter after the delay. Scoping
+  // this to an effect keyed on optimisticValue ensures the cleanup only
+  // cancels the timer for the value it scheduled — so StrictMode's
+  // effect-rerun (and future re-running mechanisms) reschedules cleanly
+  // instead of dropping the pending update on the floor.
   useEffect(() => {
-    if (currentState != optimisticValue) {
+    if (Object.is(optimisticValue, currentState)) {
+      return;
+    }
+    const id = setTimeout(() => setState(optimisticValue), delay);
+    return () => clearTimeout(id);
+  }, [optimisticValue, currentState, delay, setState]);
+
+  // External updates to currentState should win over a stale optimistic value.
+  // The guard matters under StrictMode: this effect's re-run captures the
+  // *old* currentState in its closure, so without the equality check it
+  // would clobber an optimistic update that another effect (e.g. a search
+  // param sync) made earlier in the same commit.
+  useEffect(() => {
+    if (!Object.is(currentState, optimisticValue)) {
       setOptimisticValue(currentState);
     }
     // sometimes an external action will cause the currentState to change

--- a/web/src/hooks/use-stats.ts
+++ b/web/src/hooks/use-stats.ts
@@ -89,7 +89,7 @@ export default function useStats(stats: FrigateStats | undefined) {
       }
 
       const cameraName = config.cameras?.[name]?.friendly_name ?? name;
-      if (config.cameras[name].enabled && cam["camera_fps"] == 0) {
+      if (config.cameras?.[name]?.enabled && cam["camera_fps"] == 0) {
         problems.push({
           text: t("stats.cameraIsOffline", {
             camera: capitalizeFirstLetter(capitalizeAll(cameraName)),

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -885,6 +885,7 @@ export default function Settings() {
 
     // Refresh config from server once
     await mutate("config");
+    mutate("config/raw_paths");
 
     // Clear hasChanges in sidebar for all successfully saved sections
     if (savedKeys.length > 0) {

--- a/web/src/types/configForm.ts
+++ b/web/src/types/configForm.ts
@@ -13,6 +13,8 @@ export type JsonArray = JsonValue[];
 
 export type ConfigSectionData = JsonObject;
 
+export type HiddenFieldEntry = string | ((config: FrigateConfig) => string[]);
+
 export type ConfigFormContext = {
   level?: "global" | "camera";
   cameraName?: string;

--- a/web/src/utils/configUtil.ts
+++ b/web/src/utils/configUtil.ts
@@ -587,13 +587,14 @@ export function prepareSectionSavePayload(opts: {
   // For profile sections, also hide restart-required fields to match
   // effectiveHiddenFields in BaseSection (prevents spurious deletion markers
   // for fields that are hidden from the form during profile editing).
-  let hiddenFieldsForSanitize = sectionConfig.hiddenFields;
-  if (profileInfo.isProfile && sectionConfig.restartRequired?.length) {
-    const base = sectionConfig.hiddenFields ?? [];
-    hiddenFieldsForSanitize = [
-      ...new Set([...base, ...sectionConfig.restartRequired]),
-    ];
-  }
+  const resolvedHidden = resolveHiddenFieldEntries(
+    sectionConfig.hiddenFields,
+    config,
+  );
+  const hiddenFieldsForSanitize =
+    profileInfo.isProfile && sectionConfig.restartRequired?.length
+      ? [...new Set([...resolvedHidden, ...sectionConfig.restartRequired])]
+      : resolvedHidden;
 
   // Sanitize raw form data
   const rawData = sanitizeSectionData(
@@ -701,4 +702,37 @@ export function getSectionConfig(
         ? entry.replay
         : entry.camera;
   return mergeSectionConfig(entry.base, overrides);
+}
+
+/**
+ * Resolve the effective hidden-field patterns for a section. Each entry in
+ * `hiddenFields` is either a literal pattern or a function that produces
+ * patterns from the loaded config (e.g. `filters.<attr>` for each
+ * `model.all_attributes` entry on the objects section).
+ */
+export function getEffectiveHiddenFields(
+  sectionKey: string,
+  level: "global" | "camera" | "replay",
+  config: FrigateConfig | undefined,
+): string[] {
+  return resolveHiddenFieldEntries(
+    getSectionConfig(sectionKey, level).hiddenFields,
+    config,
+  );
+}
+
+export function resolveHiddenFieldEntries(
+  entries: SectionConfig["hiddenFields"] | undefined,
+  config: FrigateConfig | undefined,
+): string[] {
+  if (!entries || entries.length === 0) return [];
+  const result: string[] = [];
+  for (const entry of entries) {
+    if (typeof entry === "function") {
+      if (config) result.push(...entry(config));
+    } else {
+      result.push(entry);
+    }
+  }
+  return result;
 }

--- a/web/src/views/live/LiveCameraView.tsx
+++ b/web/src/views/live/LiveCameraView.tsx
@@ -1072,10 +1072,12 @@ function FrigateCameraFeatures({
               title={
                 recordState == "ON"
                   ? t("recording.disable")
-                  : t("recording.enable")
+                  : camera.record.enabled_in_config
+                    ? t("recording.enable")
+                    : t("recording.disabledInConfig")
               }
               onClick={() => sendRecord(recordState == "ON" ? "OFF" : "ON")}
-              disabled={!cameraEnabled}
+              disabled={!cameraEnabled || !camera.record.enabled_in_config}
             />
             <CameraFeatureToggle
               className="p-2 md:p-0"

--- a/web/src/views/settings/CameraManagementView.tsx
+++ b/web/src/views/settings/CameraManagementView.tsx
@@ -313,12 +313,18 @@ type CameraEnableSwitchProps = {
 function CameraEnableSwitch({ cameraName }: CameraEnableSwitchProps) {
   const { payload: enabledState, send: sendEnabled } =
     useEnabledState(cameraName);
+  const { data: config } = useSWR<FrigateConfig>("config");
+
+  const isChecked =
+    enabledState === "ON" || enabledState === "OFF"
+      ? enabledState === "ON"
+      : (config?.cameras?.[cameraName]?.enabled ?? false);
 
   return (
     <div className="flex flex-row items-center">
       <Switch
         id={`camera-enabled-${cameraName}`}
-        checked={enabledState === "ON"}
+        checked={isChecked}
         onCheckedChange={(isChecked) => {
           sendEnabled(isChecked ? "ON" : "OFF");
         }}

--- a/web/src/views/system/CameraMetrics.tsx
+++ b/web/src/views/system/CameraMetrics.tsx
@@ -2,6 +2,7 @@ import { useFrigateStats } from "@/api/ws";
 import { CameraLineGraph } from "@/components/graph/LineGraph";
 import CameraInfoDialog from "@/components/overlay/CameraInfoDialog";
 import { ConnectionQualityIndicator } from "@/components/camera/ConnectionQualityIndicator";
+import { EmptyCard } from "@/components/card/EmptyCard";
 import { Skeleton } from "@/components/ui/skeleton";
 import { FrigateConfig } from "@/types/frigateConfig";
 import { FrigateStats } from "@/types/stats";
@@ -13,6 +14,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { BsFillCameraVideoOffFill } from "react-icons/bs";
 import { MdInfo } from "react-icons/md";
 import {
   Tooltip,
@@ -173,7 +175,7 @@ export default function CameraMetrics({
       }
 
       Object.entries(stats.cameras).forEach(([key, camStats]) => {
-        if (!config?.cameras[key].enabled) {
+        if (!camStats || !config?.cameras[key]?.enabled) {
           return;
         }
 
@@ -228,6 +230,10 @@ export default function CameraMetrics({
       }
 
       Object.entries(stats.cameras).forEach(([key, camStats]) => {
+        if (!camStats) {
+          return;
+        }
+
         if (!(key in series)) {
           const camName = getCameraName(key);
           series[key] = {};
@@ -273,6 +279,17 @@ export default function CameraMetrics({
       setProbeCameraName("");
     }
   }, [showCameraInfoDialog]);
+
+  if (config && Object.keys(config.cameras).length === 0) {
+    return (
+      <div className="flex size-full items-center justify-center">
+        <EmptyCard
+          icon={<BsFillCameraVideoOffFill className="size-8" />}
+          title={t("cameras.noCameras.title")}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="scrollbar-container mt-4 flex size-full flex-col gap-3 overflow-y-auto">


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR makes a number of changes to the frontend:
- Hide camera overrides badge from all System sections in Settings
- Show empty card on camera metrics page when no cameras are defined
- Show correct enabled switch state in the Camera Management pane after adding a camera via the Wizard
- Guard camera enabled access in use-stats for new cameras added via the Wizard
- Fix `useOptimisticState` dropping debounced setState under StrictMode
  - The mount-only cleanup in `useOptimisticState` cleared the pending `setTimeout` when strict mode re-ran effects, so the debounced `setState` never fired and Settings panes wouldn't switch on URL navigation. The fix was to move the debounce into an effect keyed on the optimistic value so its cleanup only cancels the timer it scheduled, and keep the external-sync guard so strict mode's stale-closure re-run can't clobber in-flight optimistic updates.
- Sync object filter entries with tracked labels
  - When switching to a profile, object filter collapsibles did not show the correct object label list
- Revalidate raw paths swr cache after config save so CameraPathWidget shows updated credentials
- Keep recording button in single camera live view disabled until recording is enabled in config
- Improve override detection for sections unset in the global config - consolidate and use a single helper function
- Add support for config-aware pattern in `hiddenFields`, fixes an issue where objects and attribute_map interaction would cause the override badge to be incorrectly shown
- Small language tweaks and field error conditions
- Add special case for genai provider field - prevent validation errors from appearing on initial creation of genai provider by setting the first option in the select dropdown as default.

Backend: 
- Use OpenVINO on CPU as default detector and add detector and model to auto-generated config 
- Restore masked ffmpeg credentials when persisting camera config
  - The /config response masks RTSP credentials as `*:*`, so the settings UI ships them back unchanged when sibling fields like `hwaccel_args` are edited, clobbering the real credentials in yaml. This uses similar logic as `clean_camera_user_pass` and swaps any incoming `*:*@` (or `user=*&password=*`) ffmpeg input path with the existing in-memory value before writing the yaml config.
- Rebuild ffmpeg commands when enabling recording for the first time
  - Toggling record.enabled from the config UI updated the in-memory config but left ffmpeg running with its original command, so the record output args were never wired in and nothing landed in the cache for the maintainer to move. The record config update now rebuilds ffmpeg_cmds when enabled_in_config transitions, and the camera watchdog restarts ffmpeg on a false to true transition so the record output gets wired in. MQTT toggles, which only flip record.enabled at runtime, are unaffected and continue to work via the maintainer's drop/keep gate. 
- Make genai `provider` a required field

Docs:
- Update docs for new default detector
 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
