### PR TITLE
fix: handle short reads from ffmpeg stdout in capture loop

### DIFF
--- a/frigate/test/test_video.py
+++ b/frigate/test/test_video.py
@@ -1,3 +1,4 @@
+import io
 import unittest
 
 import cv2
@@ -13,6 +14,7 @@ from frigate.util.object import (
     get_region_from_grid,
     reduce_detections,
 )
+from frigate.video.ffmpeg import _read_frame_into
 
 
 def draw_box(frame, box, color=(255, 0, 0), thickness=2):
@@ -352,3 +354,57 @@ class TestRegionGrid(unittest.TestCase):
 
         region = get_region_from_grid(frame_shape, box, 320, region_grid)
         assert region[2] - region[0] > 320
+
+
+class _ChunkedPipe(io.RawIOBase):
+    """Stub stdout that returns the queued chunks one readinto at a time."""
+
+    def __init__(self, chunks):
+        self._chunks = [bytes(c) for c in chunks]
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, b) -> int:
+        if not self._chunks:
+            return 0
+        chunk = self._chunks.pop(0)
+        n = min(len(b), len(chunk))
+        b[:n] = chunk[:n]
+        if n < len(chunk):
+            self._chunks.insert(0, chunk[n:])
+        return n
+
+
+class TestReadFrameInto(unittest.TestCase):
+    """Cover the partial-read path of the capture loop helper."""
+
+    def test_full_frame_in_one_call(self):
+        buf = bytearray(8)
+        n = _read_frame_into(_ChunkedPipe([b"\x01\x02\x03\x04\x05\x06\x07\x08"]), buf)
+        assert n == 8
+        assert bytes(buf) == b"\x01\x02\x03\x04\x05\x06\x07\x08"
+
+    def test_short_reads_are_reassembled(self):
+        buf = bytearray(8)
+        pipe = _ChunkedPipe([b"\x01\x02\x03", b"\x04\x05", b"\x06\x07\x08"])
+        n = _read_frame_into(pipe, buf)
+        assert n == 8
+        assert bytes(buf) == b"\x01\x02\x03\x04\x05\x06\x07\x08"
+
+    def test_eof_before_full_buffer_returns_partial_count(self):
+        buf = bytearray(8)
+        n = _read_frame_into(_ChunkedPipe([b"\x01\x02\x03"]), buf)
+        assert n == 3
+
+    def test_immediate_eof_returns_zero(self):
+        buf = bytearray(8)
+        n = _read_frame_into(_ChunkedPipe([]), buf)
+        assert n == 0
+
+    def test_writes_into_existing_memoryview(self):
+        backing = bytearray(8)
+        view = memoryview(backing)
+        n = _read_frame_into(_ChunkedPipe([b"abcdefgh"]), view)
+        assert n == 8
+        assert bytes(backing) == b"abcdefgh"

--- a/frigate/video/ffmpeg.py
+++ b/frigate/video/ffmpeg.py
@@ -52,6 +52,32 @@ def _get_record_segment_time(config: CameraConfig) -> int:
         return DEFAULT_RECORD_SEGMENT_TIME
 
 
+def _read_frame_into(stream, buffer) -> int:
+    """Read len(buffer) bytes from stream directly into buffer.
+
+    Returns the number of bytes actually read. A return value less than
+    len(buffer) indicates the stream reached EOF (or the pipe was closed)
+    before the buffer could be filled — the contents of buffer past the
+    returned offset must be treated as undefined.
+
+    BufferedReader.read(n) is documented to return "up to" n bytes, and a
+    subprocess pipe will hand back a short read if the producer closes
+    mid-frame even on a blocking pipe. Reading directly into the
+    pre-allocated frame buffer also avoids the extra Python bytes
+    allocation and copy that ``buffer[:] = stream.read(n)`` performs on
+    every frame.
+    """
+    target = len(buffer)
+    view = memoryview(buffer)
+    pos = 0
+    while pos < target:
+        n = stream.readinto(view[pos:])
+        if not n:
+            return pos
+        pos += n
+    return pos
+
+
 def capture_frames(
     ffmpeg_process: sp.Popen[Any],
     config: CameraConfig,
@@ -92,7 +118,7 @@ def capture_frames(
             frame_name = f"{config.name}_frame{frame_index}"
             frame_buffer = frame_manager.write(frame_name)
             try:
-                frame_buffer[:] = ffmpeg_process.stdout.read(frame_size)
+                bytes_read = _read_frame_into(ffmpeg_process.stdout, frame_buffer)
             except Exception:
                 # shutdown has been initiated
                 if stop_event.is_set():
@@ -109,6 +135,23 @@ def capture_frames(
                     break
 
                 continue
+
+            if bytes_read < frame_size:
+                # ffmpeg's stdout pipe was closed (or returned EOF) before
+                # the full frame could be received. The buffer holds a
+                # partial frame, so don't pass it to detection: a
+                # half-frame in shared memory will produce garbage
+                # detections, and continuing to read would resume in the
+                # middle of the next frame, putting capture out of sync
+                # with frame boundaries until the next watchdog restart.
+                if stop_event.is_set():
+                    break
+
+                logger.error(
+                    f"{config.name}: ffmpeg returned an incomplete frame "
+                    f"({bytes_read}/{frame_size} bytes); exiting capture thread..."
+                )
+                break
 
             frame_rate.update()
 


### PR DESCRIPTION
## Proposed change

### The Problem

In `frigate/video/ffmpeg.py:95` the capture loop assigns the result of a single `read()` call straight into the shared-memory frame buffer:

```python
frame_buffer[:] = ffmpeg_process.stdout.read(frame_size)
```

`io.BufferedReader.read(n)` is documented to return *up to* `n` bytes, and a subprocess pipe will return a short read whenever the producer closes the pipe mid-frame — even on a blocking pipe. When that happens:

1. The slice assignment on `frame_buffer` (a `memoryview` over a fixed-size shared-memory segment) raises `ValueError`, because the right-hand side is shorter than `frame_size`.
2. The bare `except Exception` catches it.
3. If `ffmpeg_process.poll()` still returns `None` (the process is alive but the pipe was momentarily empty — e.g. an RTSP source that dropped a chunk and recovered) the code hits `continue` and goes around the loop again.

The next iteration reads again — but the producer has already moved on, so the new read picks up data from somewhere in the *middle* of the next frame. Capture is now permanently out of sync with frame boundaries until the watchdog notices the FPS dropping and forces a restart, which can take 10+ seconds. In the meantime detection is fed garbage frames.

The same bug also makes it harder than it needs to be to distinguish "ffmpeg has died" from "ffmpeg dropped a chunk", because both surface as the same `ValueError` from the slice assignment.

### The Fix

Read into the pre-allocated buffer in a loop and treat any short read as the end of the stream, so the watchdog can respawn ffmpeg from a clean state rather than continuing at the wrong offset:

```python
def _read_frame_into(stream, buffer) -> int:
    target = len(buffer)
    view = memoryview(buffer)
    pos = 0
    while pos < target:
        n = stream.readinto(view[pos:])
        if not n:
            return pos
        pos += n
    return pos
```

The call site becomes:

```python
bytes_read = _read_frame_into(ffmpeg_process.stdout, frame_buffer)
...
if bytes_read < frame_size:
    logger.error(
        f"{config.name}: ffmpeg returned an incomplete frame "
        f"({bytes_read}/{frame_size} bytes); exiting capture thread..."
    )
    break
```

Two side benefits:

- `readinto` writes directly into the shared-memory buffer, eliminating the per-frame Python `bytes` allocation and copy that ``buffer[:] = stream.read(n)`` performs.
- A short read from a still-alive ffmpeg now produces a clear `incomplete frame (N/M bytes)` log line instead of the slightly misleading `Unable to read frames from ffmpeg process`.

### How to Reproduce

1. Point a camera at an upstream RTSP source whose connection is unstable (a Reolink doorbell on a flaky LAN, or a go2rtc proxy whose upstream camera occasionally drops a chunk are typical examples).
2. Watch the camera log for sequences of `Unable to read frames from ffmpeg process` *not* followed by `ffmpeg process is not running` (i.e. ffmpeg recovered).
3. Compare the camera's reported FPS over the next 10 seconds — it sits below the configured `detect.fps` until the watchdog forces a restart, even though ffmpeg itself is alive and producing frames.

### Tests

Added `frigate/test/test_video.py::TestReadFrameInto` covering the four behaviours of the helper: full read in one call, assembled short reads, EOF before the buffer is full, and immediate EOF.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## AI disclosure

- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): Claude (Anthropic)

**How AI was used** (e.g., code generation, code review, debugging, documentation): Bug discovery during a broader audit of the Frigate capture loop; drafting the patch and unit tests for the short-read handling.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): AI proposed the specific defect (slice-assignment `ValueError` on short read from a still-alive ffmpeg) after I asked it to audit subprocess handling, and drafted the `_read_frame_into` helper and the four unit-test cases.

**Human oversight**: I read the upstream capture loop end-to-end, verified the bug claim against the actual code path on dev, confirmed `memoryview` supports `readinto` on shared-memory frame buffers (the `SharedMemoryFrameManager.write()` return type), ran the new tests locally, and reviewed the final diff before pushing.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)