### PR TITLE
fix: format placeholder in remove_empty_directories debug log

### DIFF
--- a/frigate/util/media.py
+++ b/frigate/util/media.py
@@ -94,7 +94,7 @@ def remove_empty_directories(root: Path, paths: Iterable[Path]) -> None:
 
         paths = parents
 
-    logger.debug("Removed {count} empty directories")
+    logger.debug(f"Removed {count} empty directories")
 
 
 def sync_recordings(


### PR DESCRIPTION
## Proposed change

### The Problem

In ``frigate/util/media.py:97``:

```python
logger.debug("Removed {count} empty directories")
```

The literal string is missing the ``f`` prefix, so the ``{count}`` placeholder is emitted verbatim rather than substituted. The debug log line for the recording cleanup pass therefore reads:

```
DEBUG    util.media : Removed {count} empty directories
```

…regardless of how many directories were actually removed.

### The Fix

Convert the call to an f-string:

```python
logger.debug(f"Removed {count} empty directories")
```

That's the whole change.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## AI disclosure

- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): Claude (Anthropic)

**How AI was used** (e.g., code generation, code review, debugging, documentation): Spotted the missing ``f`` prefix during a broader audit of the recording cleanup path.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): AI flagged the missing prefix; the fix is a single character.

**Human oversight**: I read the surrounding code, confirmed ``count`` is in scope at the log call, and verified ``ruff check`` and ``ruff format --check`` pass.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the ``en`` locale.
- [x] The code has been formatted using Ruff (``ruff format frigate``)