### PR TITLE
fix(ptz/onvif): recover PTZConfiguration dropped by zeep on non-stand…

### DIFF
--- a/frigate/ptz/onvif.py
+++ b/frigate/ptz/onvif.py
@@ -24,6 +24,76 @@ from frigate.util.builtin import find_by_key
 logger = logging.getLogger(__name__)
 
 
+PTZ_CONFIGURATION_TAG_SUFFIX = "}PTZConfiguration"
+
+
+async def _reattach_orphaned_ptz_configurations(
+    onvif: ONVIFCamera, profiles: list[Any], camera_name: str
+) -> None:
+    """Repair profiles whose ``<PTZConfiguration>`` was dropped by zeep's parser.
+
+    Some camera firmwares emit a non-standard child element (commonly
+    ``<tt:AnalyticsEngineConfiguration>``) inside ``<trt:Profile>``. zeep's
+    strict-sequence XSD parser then drops every subsequent in-Profile element
+    (including ``<tt:PTZConfiguration>``) into ``profile._raw_elements``
+    instead of populating ``profile.PTZConfiguration``. The downstream filter
+    in :meth:`OnvifController._init_onvif` then rejects these profiles even
+    though the device exposes a working PTZ configuration via
+    ``PTZ.GetConfigurations()``.
+
+    For each profile that has ``PTZConfiguration is None`` but carries a raw
+    ``<PTZConfiguration>`` element in ``_raw_elements``, look up the matching
+    config returned by ``PTZ.GetConfigurations()`` and re-attach it. Profiles
+    that have no raw ``<PTZConfiguration>`` are left untouched.
+    """
+    needs_repair = [
+        p
+        for p in profiles
+        if getattr(p, "PTZConfiguration", None) is None
+        and any(
+            getattr(el, "tag", "").endswith(PTZ_CONFIGURATION_TAG_SUFFIX)
+            for el in (getattr(p, "_raw_elements", None) or [])
+        )
+    ]
+    if not needs_repair:
+        return
+
+    try:
+        ptz = await onvif.create_ptz_service()
+        configs = await ptz.GetConfigurations() or []
+    except (Fault, ONVIFError, TransportError, Exception) as e:
+        logger.warning(
+            "Unable to recover orphaned PTZConfiguration for %s: "
+            "PTZ.GetConfigurations failed: %s",
+            camera_name,
+            e,
+        )
+        return
+
+    by_token = {getattr(c, "token", None): c for c in configs}
+    for profile in needs_repair:
+        raw_token = next(
+            (
+                el.get("token")
+                for el in (profile._raw_elements or [])
+                if el.tag.endswith(PTZ_CONFIGURATION_TAG_SUFFIX)
+            ),
+            None,
+        )
+        config = by_token.get(raw_token)
+        if config is None:
+            continue
+        profile.PTZConfiguration = config
+        logger.info(
+            "Re-attached orphaned PTZ config '%s' to profile '%s' on %s "
+            "(camera firmware emitted a non-standard child element that "
+            "broke zeep's profile parsing).",
+            raw_token,
+            getattr(profile, "token", "?"),
+            camera_name,
+        )
+
+
 class OnvifCommandEnum(str, Enum):
     """Holds all possible move commands"""
 
@@ -209,6 +279,12 @@ class OnvifController:
                 f"Unable to get Onvif media profiles for camera: {camera_name}: {e}"
             )
             return False
+
+        # Some firmwares emit non-standard elements inside <Profile>, which
+        # makes zeep's strict-sequence parser drop <PTZConfiguration> into the
+        # profile's _raw_elements. Recover those so PTZ-capable profiles are
+        # not silently rejected by the filter below.
+        await _reattach_orphaned_ptz_configurations(onvif, profiles, camera_name)
 
         # build list of valid PTZ profiles
         valid_profiles = [


### PR DESCRIPTION
I got a camera from AliExpress, and it is very similar to another one that I got earlier from the same seller, but it was with upgraded specs. The first camera that I got worked perfectly with PTZ controls on Frigate, but the upgraded version had issues. 
I found that HA's built-in ONVIF integration parses the same camera correctly and exposes pan/tilt/zoom services, so it really is Frigate's stricter zeep-on-XSD parsing that bites here, not a camera-side comms issue.

## Proposed change
After the patch, on Frigate 0.17.1, /api/camera8/ptz/info returns {"name":"camera8","features":["pt","zoom","pt-r","zoom-r","zoom-a"],"presets":[]}, matching the sister camera (camera4) on a single-lens unit of the same family.

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

.
## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:
Cursor (Opus 4.7) wrote the helper based on root-cause analysis I ran with it; I validated it on the live affected camera and against the 5-case mock matrix above. The commit already carries a Co-authored-by: Cursor trailer.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
