### PR TITLE
Gracefully handle transiently failing os.stat calls

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -144,7 +144,7 @@ class FrigateApp:
         for d in dirs:
             if not os.path.exists(d) and not os.path.islink(d):
                 logger.info(f"Creating directory: {d}")
-                os.makedirs(d)
+                os.makedirs(d, exist_ok=True)
             else:
                 logger.debug(f"Skipping directory: {d}")
 

--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -610,8 +610,7 @@ class RecordingMaintainer(threading.Thread):
             camera,
         )
 
-        if not os.path.exists(directory):
-            os.makedirs(directory)
+        os.makedirs(directory, exist_ok=True)
 
         # file will be in utc due to start_time being in utc
         file_name = f"{start_time.strftime('%M.%S.mp4')}"

--- a/frigate/track/tracked_object.py
+++ b/frigate/track/tracked_object.py
@@ -531,8 +531,7 @@ class TrackedObject:
 
         directory = os.path.join(THUMB_DIR, self.camera_config.name)
 
-        if not os.path.exists(directory):
-            os.makedirs(directory)
+        os.makedirs(directory, exist_ok=True)
 
         thumb_bytes = self.get_thumbnail("webp")
 


### PR DESCRIPTION
## Proposed change
Make some directory creation flows more resilient to transient filesystem errors.

I have a very repeatable reproduction of an issue where most of my cameras show a "No frames have been received, check error logs" image in the UI, but restreaming in HomeAssistant is working flawlessly. The only errors in the logs I saw were some like this:

`OSError: [Errno 121] Remote I/O error`.

Doing a bit more debugging, it looked like Frigate was failing to create the thumbnail directory for a camera because it already existed. This error was a clue as to the class of error. I was surprised to learn that `os.path.exists` [silently suppresses errors from
`os.stat` and returns `False`](https://github.com/python/cpython/blob/main/Lib/genericpath.py#L22). This makes for a plausible series of events: a transient stat call fails, so Frigate takes the creation path, which gets upset that the directory already exists.

AI found a few other possible cases to fix but did not make an exhaustive search. It seems that this `exist_ok` flag is used elsewhere within Frigate so I thought it would be a good solution.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update


## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Codex CLI gpt-5.5 xhigh

**How AI was used**: I used AI to diagnose my issue. It then wrote some initialization code to patch my live deployment to add logging, and then test out a fix.

**Extent of AI involvement**: After it had patched my live deployment into a working state, I asked it to translate its init-time patches to the container source into this repo so that I could make this PR. I reviewed and lightly simplified the code afterwards.

**Human oversight**: I verified that its patches solved the problem I was facing and that its patches to my live deployment matched the changes to the code repo. We discussed root cause and its theory fits the facts - I am using a distributed file system and I saw the `OSError` for Remote I/O in my logs. I checked the upstream Python code to verify the error suppression behavior, and read the corresponding Frigate code.

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
