### PR TITLE
Fix multi-GPU OpenVINO detection for enrichments

### DIFF
--- a/frigate/detectors/detection_runners.py
+++ b/frigate/detectors/detection_runners.py
@@ -79,7 +79,11 @@ def is_openvino_gpu_npu_available() -> bool:
     available_devices = get_openvino_available_devices()
     # Check for GPU, NPU, or other acceleration devices (excluding CPU)
     acceleration_devices = ["GPU", "MYRIAD", "NPU", "GNA", "HDDL"]
-    return any(device in available_devices for device in acceleration_devices)
+    return any(
+        avail_dev == accel_dev or avail_dev.startswith(accel_dev + ".")
+        for avail_dev in available_devices
+        for accel_dev in acceleration_devices
+    )
 
 
 class BaseModelRunner(ABC):


### PR DESCRIPTION
## Proposed change

On multi-GPU systems (e.g., Intel Arc A310 + Intel UHD 730 iGPU), OpenVINO enumerates devices as `GPU.0`, `GPU.1`, etc. rather than a single `GPU` entry. The function `is_openvino_gpu_npu_available()` in `detection_runners.py` uses exact list membership (`device in available_devices`) to check for acceleration devices, which fails on multi-GPU systems because `"GPU"` is not in `["CPU", "GPU.0", "GPU.1"]`.

This causes enrichments (face recognition, semantic search) to silently fall back to CPU-only inference via `ONNXModelRunner` instead of using `OpenVINOModelRunner` on GPU — even when `model_size: large` is configured specifically for GPU acceleration.

The fix changes the matching from exact string match to prefix match, correctly detecting both single-GPU (`GPU`) and multi-GPU (`GPU.0`, `GPU.1`) device names, as well as any future suffixed variants for NPU and other accelerators.

**Measured impact on a 16-camera system (Arc A310 + UHD 730 iGPU):**
- Enrichments CPU usage: **77% → 27%** (face recognition + semantic search)
- Detection inference: **40-60ms → 19ms** (reduced CPU/memory contention)

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: N/A (no existing issue found)
- This PR is related to issue: N/A

## AI disclosure

- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude Code (Claude Opus)

**How AI was used**: Assisted with debugging the root cause (tracing through `get_optimized_runner()` → `is_openvino_gpu_npu_available()` → exact match failure), verifying the fix, and drafting the PR.

**Extent of AI involvement**: The bug was discovered during hands-on performance tuning of a dual Intel GPU Frigate deployment. AI assisted with code analysis to identify the exact line causing the fallback, and suggested the prefix-match fix. The one-line code change was human-reviewed and tested.

**Human oversight**: Verified the bug by running `is_openvino_gpu_npu_available()` inside the Frigate container (returned `False` despite GPUs being available). Applied the fix, restarted Frigate, and confirmed enrichments switched from `ONNXModelRunner` (CPU) to `OpenVINOModelRunner` (GPU) with measured CPU reduction from 77% to 27%. Tested that single-GPU device names (`GPU`) still match correctly.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] The code has been formatted using Ruff (`ruff format frigate`)