### PR TITLE
Fix multi-GPU OpenVINO detection for enrichments

### DIFF
--- a/frigate/detectors/detection_runners.py
+++ b/frigate/detectors/detection_runners.py
@@ -79,7 +79,11 @@ def is_openvino_gpu_npu_available() -> bool:
     available_devices = get_openvino_available_devices()
     # Check for GPU, NPU, or other acceleration devices (excluding CPU)
     acceleration_devices = ["GPU", "MYRIAD", "NPU", "GNA", "HDDL"]
-    return any(device in available_devices for device in acceleration_devices)
+    return any(
+        avail_dev == accel_dev or avail_dev.startswith(accel_dev + ".")
+        for avail_dev in available_devices
+        for accel_dev in acceleration_devices
+    )
 
 
 class BaseModelRunner(ABC):


### PR DESCRIPTION
## Proposed change

I run a dual Intel GPU setup (Arc A310 for detection, UHD 730 iGPU for VAAPI decode) with face recognition and semantic search both set to `model_size: large`. I noticed the enrichments were pegging the CPU at ~77% and not touching the GPU at all, even though the large model is supposed to be GPU-accelerated.

Traced it down to `is_openvino_gpu_npu_available()` in `detection_runners.py`. On multi-GPU systems, OpenVINO reports devices as `GPU.0`, `GPU.1` instead of just `GPU`. The current check does an exact list membership test (`"GPU" in available_devices`), which fails when there are multiple GPUs, so `get_optimized_runner()` never takes the OpenVINO path and falls back to `ONNXModelRunner` with `CPUExecutionProvider`.

The fix switches from exact match to prefix match so `GPU.0`, `GPU.1`, etc. are correctly recognized, while still matching plain `GPU` on single-GPU systems. Same logic applies to NPU and other accelerator types that could have suffixed device names.

After patching, enrichments CPU dropped from ~77% to ~27% on my 16-camera system, and detection inference improved from 40-60ms to 19ms since there's less contention on the box.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR is related to issue: #18958 (Improved Multi GPU support), #19144 (Define which gpu to use for onnx)
- Related discussions: #20893 (iGPU + dGPU detection split, same root cause likely affects enrichments there too), #19941 (different GPU for decode vs detection), #15739 (iGPU + Arc A310 setup issues), #16561 (restricting Frigate to specific renderD device)

## AI disclosure

- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude Code

**How AI was used**: Helped trace through the code path (`get_optimized_runner` -> `is_openvino_gpu_npu_available` -> exact match failure) to identify the root cause. Also helped with debugging and performance measurement on my running system.

**Extent of AI involvement**: AI identified the specific function and matching logic causing the issue. The fix is a straightforward one-line change from exact match to prefix match. I reviewed and tested it on my live system before and after.

**Human oversight**: Verified the bug by calling `is_openvino_gpu_npu_available()` directly inside the container (returned False despite two GPUs being present). Applied the fix, restarted, confirmed enrichments switched from ONNXModelRunner to OpenVINOModelRunner, and measured the CPU/inference improvements. I can explain every line.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] The code has been formatted using Ruff (`ruff format frigate`)