### PR TITLE
Add zh-Hant (Traditional Chinese) translations for 5 view files (Wave 2a)

### DIFF
--- a/web/public/locales/zh-Hant/views/chat.json
+++ b/web/public/locales/zh-Hant/views/chat.json
@@ -1,1 +1,64 @@
-{}
+{
+  "documentTitle": "聊天 - Frigate",
+  "title": "Frigate 聊天",
+  "subtitle": "你的攝影機管理與智慧分析 AI 助手",
+  "placeholder": "嘗試問我任何事…",
+  "error": "出現錯誤，請稍後重試。",
+  "processing": "進行中…",
+  "toolsUsed": "使用：{{tools}}",
+  "showTools": "顯示工具（{{count}}）",
+  "hideTools": "隱藏工具",
+  "call": "呼叫",
+  "result": "結果",
+  "arguments": "引數：",
+  "response": "回應：",
+  "attachment_chip_label": "在 {{camera}} 的 {{label}}",
+  "attachment_chip_remove": "移除附件",
+  "open_in_explore": "從瀏覽中開啟",
+  "attach_event_aria": "關聯事件 {{eventId}}",
+  "attachment_picker_paste_label": "或貼上事件 ID",
+  "attachment_picker_attach": "關聯",
+  "attachment_picker_placeholder": "關聯一個事件",
+  "quick_reply_find_similar": "查詢相似抓拍事件",
+  "quick_reply_tell_me_more": "瞭解更多詳情",
+  "quick_reply_when_else": "還在哪些時段出現過？",
+  "quick_reply_find_similar_text": "查詢與此相似的抓拍記錄。",
+  "quick_reply_tell_me_more_text": "瞭解此條更多詳情。",
+  "quick_reply_when_else_text": "還在哪些時間出現過？",
+  "anchor": "來源",
+  "similarity_score": "相似度",
+  "no_similar_objects_found": "未找到相似目標。",
+  "semantic_search_required": "必須啟用語意搜尋才能查詢相似目標。",
+  "send": "傳送",
+  "suggested_requests": "嘗試問問：",
+  "starting_requests": {
+    "show_recent_events": "檢視近期事件",
+    "show_camera_status": "顯示攝影機狀態",
+    "recap": "我不在的時候發生了什麼？",
+    "watch_camera": "監控攝影機活動"
+  },
+  "starting_requests_prompts": {
+    "show_recent_events": "顯示最近一小時的事件",
+    "show_camera_status": "我的攝影機當前狀態如何？",
+    "recap": "我不在的時候發生了什麼事？",
+    "watch_camera": "監控前門，有人出現就通知我"
+  },
+  "new_chat": "新對話",
+  "settings": {
+    "title": "對話設定",
+    "show_stats": {
+      "title": "顯示統計",
+      "desc": "顯示對話回應的產生速度與上下文大小。",
+      "while_generating": "產生時",
+      "always": "一律顯示"
+    },
+    "auto_scroll": {
+      "title": "自動捲動",
+      "desc": "隨新訊息到來自動跟進。"
+    }
+  },
+  "stats": {
+    "context": "{{tokens}} 個 token",
+    "tokens_per_second": "{{rate}} tokens/秒"
+  }
+}

--- a/web/public/locales/zh-Hant/views/classificationModel.json
+++ b/web/public/locales/zh-Hant/views/classificationModel.json
@@ -8,7 +8,11 @@
       "trainedModel": "訓練模型成功。",
       "trainingModel": "已開始模型訓練。",
       "updatedModel": "已更新模型配置",
-      "renamedCategory": "成功修改分類名稱為{{name}}"
+      "renamedCategory": "成功修改分類名稱為{{name}}",
+      "reclassifiedImage": "成功重新分類圖片",
+      "deletedModel_one": "已成功刪除 {{count}} 個模型",
+      "deletedCategory_one": "已刪除 {{count}} 個類別",
+      "deletedImage_one": "已刪除 {{count}} 張圖片"
     },
     "error": {
       "deleteImageFailed": "刪除失敗：{{errorMessage}}",
@@ -18,7 +22,8 @@
       "trainingFailed": "模型訓練失敗。請至Frigate 日誌查看詳情。",
       "trainingFailedToStart": "模型訓練啟動失敗: {{errorMessage}}",
       "updateModelFailed": "模型更新失敗: {{errorMessage}}",
-      "renameCategoryFailed": "類別重新命名失敗: {{errorMessage}}"
+      "renameCategoryFailed": "類別重新命名失敗: {{errorMessage}}",
+      "reclassifyFailed": "重新分類圖片失敗：{{errorMessage}}"
     }
   },
   "documentTitle": "分類模型",
@@ -52,7 +57,8 @@
   "deleteModel": {
     "title": "刪除分類模型",
     "single": "你確定要刪除{{name}}嗎? 這將永久刪除包含圖片和訓練資料在內的所有相關資料。這個操作無法被復原。",
-    "desc_other": "你確定要刪除{{count}}個模型? 這將永久刪除包含圖片和訓練資料在內的所有相關資料。這個操作無法被復原。"
+    "desc_other": "你確定要刪除{{count}}個模型? 這將永久刪除包含圖片和訓練資料在內的所有相關資料。這個操作無法被復原。",
+    "desc_one": "您確定要刪除 {{count}} 個模型嗎？這將永久刪除所有相關資料，包含圖片與訓練資料。此操作無法復原。"
   },
   "edit": {
     "title": "編輯分類模型",
@@ -62,11 +68,13 @@
   },
   "deleteDatasetImages": {
     "title": "刪除圖片資料集合",
-    "desc_other": "你確定要從{{dataset}}中刪除{{count}}個圖片嗎? 這個操作將無法被復原且將需要重新訓練模型。"
+    "desc_other": "你確定要從{{dataset}}中刪除{{count}}個圖片嗎? 這個操作將無法被復原且將需要重新訓練模型。",
+    "desc_one": "您確定要從 {{dataset}} 刪除 {{count}} 張圖片嗎？此操作無法復原，且需要重新訓練模型。"
   },
   "deleteTrainImages": {
     "title": "刪除訓練圖片",
-    "desc_other": "你確定要刪除{{count}}個圖片? 這個操作無法被復原。"
+    "desc_other": "你確定要刪除{{count}}個圖片? 這個操作無法被復原。",
+    "desc_one": "您確定要刪除 {{count}} 張圖片嗎？此操作無法復原。"
   },
   "renameCategory": {
     "title": "重新命名類別",
@@ -95,14 +103,81 @@
       "namePlaceholder": "請輸入模型名稱...",
       "type": "類別",
       "typeState": "狀態",
-      "typeObject": "物件"
+      "typeObject": "物件",
+      "classificationTypeDesc": "子標籤會為目標標籤新增附加文字（例如：“人員：美團”）。屬性是可搜尋的元資料，獨立儲存在目標的元資訊中。",
+      "classificationSubLabel": "子標籤",
+      "classificationAttribute": "屬性",
+      "classes": "類別",
+      "states": "狀態",
+      "classesTip": "瞭解類別",
+      "classesStateDesc": "定義攝影機區域內可能出現的不同狀態。例如：車庫門的“開啟”和“關閉”。",
+      "classesObjectDesc": "定義用於分類偵測目標的不同類別。例如：人員分類中的“快遞員”、“居民”、“陌生人”。",
+      "classPlaceholder": "請輸入分類名稱……",
+      "errors": {
+        "nameRequired": "模型名稱為必填項",
+        "nameLength": "模型名稱長度不能超過 64 個字元",
+        "nameOnlyNumbers": "模型名稱不能僅包含數字",
+        "classRequired": "至少需要一個類別",
+        "classesUnique": "類別名稱必須唯一",
+        "noneNotAllowed": "不能建立“none”（無標籤）類別",
+        "stateRequiresTwoClasses": "狀態模型至少需要兩個類別",
+        "objectLabelRequired": "請選擇一個目標標籤",
+        "objectTypeRequired": "請選擇一個目標標籤"
+      }
     },
     "steps": {
-      "chooseExamples": "選擇範本"
+      "chooseExamples": "選擇範本",
+      "nameAndDefine": "名稱與定義",
+      "stateArea": "狀態區域"
+    },
+    "title": "建立新分類",
+    "step2": {
+      "description": "選擇攝影機，併為攝影機定義要監控的區域。模型將對這些區域的狀態進行分類。",
+      "cameras": "攝影機",
+      "selectCamera": "選擇攝影機",
+      "noCameras": "點選 + 符號新增攝影機",
+      "selectCameraPrompt": "從清單中選擇一個攝影機以定義其偵測區域"
+    },
+    "step3": {
+      "selectImagesPrompt": "選擇所有屬於 {{className}} 的圖片",
+      "selectImagesDescription": "點選影像進行選擇，完成該類別後點選“繼續”。",
+      "allImagesRequired_other": "請對所有圖片進行分類。還有 {{count}} 張圖片需要分類。",
+      "generating": {
+        "title": "正在生成樣本圖片",
+        "description": "Frigate 正在從錄影中提取代表性圖片。這可能需要一些時間……"
+      },
+      "training": {
+        "title": "正在訓練模型",
+        "description": "系統正在後臺訓練模型。你可以關閉此對話方塊，訓練完成後模型將自動開始執行。"
+      },
+      "retryGenerate": "重新生成",
+      "noImages": "未生成樣本影像",
+      "classifying": "正在分類與訓練……",
+      "trainingStarted": "已開始模型訓練",
+      "modelCreated": "模型建立成功。請在“最近分類”頁面為缺失的狀態新增圖片，然後訓練模型。",
+      "errors": {
+        "noCameras": "未配置攝影機",
+        "noObjectLabel": "未選擇目標標籤",
+        "generateFailed": "示例生成失敗：{{error}}",
+        "generationFailed": "生成失敗，請重試。",
+        "classifyFailed": "圖片分類失敗：{{error}}"
+      },
+      "generateSuccess": "樣本圖片生成成功",
+      "refreshExamples": "生成新示例",
+      "refreshConfirm": {
+        "title": "需要生成新示例？",
+        "description": "此操作將生成一組新的圖片，並清除所有選擇內容（包括之前的所有類別）。你需要為所有類別重新選擇示例。"
+      },
+      "missingStatesWarning": {
+        "title": "缺失分類示例",
+        "description": "並非所有類別都有示例。可嘗試生成新示例以查詢缺失的類別，或繼續該步驟，之後透過 “最近分類” 頁面新增圖片。"
+      },
+      "allImagesRequired_one": "請分類所有圖片。剩下 {{count}} 張圖片。"
     }
   },
   "menu": {
-    "states": "狀態"
+    "states": "狀態",
+    "objects": "目標"
   },
   "noModels": {
     "object": {
@@ -111,7 +186,13 @@
       "buttonText": "建立物件模型"
     },
     "state": {
-      "description": "建立自訂模型，用於監控和分類特定攝影機區域的狀態變化。"
+      "description": "建立自訂模型，用於監控和分類特定攝影機區域的狀態變化。",
+      "title": "尚未建立狀態分類模型",
+      "buttonText": "建立狀態模型"
     }
-  }
+  },
+  "categorizeImageAs": "圖片分類為：",
+  "categorizeImage": "圖片分類",
+  "reclassifyImageAs": "重新分類圖片為：",
+  "reclassifyImage": "重新分類圖片"
 }

--- a/web/public/locales/zh-Hant/views/exports.json
+++ b/web/public/locales/zh-Hant/views/exports.json
@@ -2,7 +2,6 @@
   "search": "搜尋",
   "documentTitle": "匯出 - Frigate",
   "noExports": "找不到匯出內容",
-  "deleteExport": "刪除匯出內容",
   "editExport": {
     "saveExport": "儲存匯出內容",
     "title": "重新命名匯出內容",
@@ -10,14 +9,120 @@
   },
   "toast": {
     "error": {
-      "renameExportFailed": "重新命名匯出內容失敗：{{errorMessage}}"
+      "renameExportFailed": "重新命名匯出內容失敗：{{errorMessage}}",
+      "assignCaseFailed": "更新案件分配失敗：{{errorMessage}}",
+      "caseSaveFailed": "儲存案件失敗：{{errorMessage}}",
+      "caseDeleteFailed": "刪除案件失敗：{{errorMessage}}"
     }
   },
-  "deleteExport.desc": "你確定要刪除 {{exportName}} 嗎？",
+  "deleteExport": {
+    "desc": "你確定要刪除 {{exportName}} 嗎？",
+    "label": "刪除匯出"
+  },
   "tooltip": {
     "shareExport": "分享匯出",
     "downloadVideo": "下載影片",
     "editName": "編輯名稱",
-    "deleteExport": "刪除匯出"
+    "deleteExport": "刪除匯出",
+    "assignToCase": "加入案件",
+    "removeFromCase": "從案件中移除"
+  },
+  "headings": {
+    "cases": "案件",
+    "uncategorizedExports": "未分類匯出項"
+  },
+  "toolbar": {
+    "newCase": "新案件",
+    "addExport": "新匯出",
+    "editCase": "編輯案件",
+    "deleteCase": "刪除案件"
+  },
+  "deleteCase": {
+    "label": "刪除案件",
+    "desc": "你確定要刪除 {{caseName}} 嗎？",
+    "descKeepExports": "匯出檔案將繼續保留為未分類匯出。",
+    "descDeleteExports": "此案件中的所有匯出項都將被永久刪除。",
+    "deleteExports": "同時刪除匯出檔案"
+  },
+  "caseDialog": {
+    "title": "加入案件",
+    "description": "選擇現有案件或建立新案件。",
+    "selectLabel": "案件",
+    "newCaseOption": "建立新案件",
+    "nameLabel": "案件名稱",
+    "descriptionLabel": "描述"
+  },
+  "caseCard": {
+    "emptyCase": "暫無匯出檔案"
+  },
+  "jobCard": {
+    "defaultName": "{{camera}} 匯出",
+    "queued": "佇列中",
+    "running": "執行中",
+    "preparing": "準備中",
+    "copying": "複製中",
+    "encoding": "編碼中",
+    "encodingRetry": "重試編碼中",
+    "finalizing": "正在完成"
+  },
+  "caseView": {
+    "noDescription": "沒有描述",
+    "createdAt": "已建立 {{value}}",
+    "exportCount_one": "1 個匯出",
+    "exportCount_other": "{{count}} 個匯出",
+    "cameraCount_one": "1 個攝影機",
+    "cameraCount_other": "{{count}} 個攝影機",
+    "showMore": "顯示更多",
+    "showLess": "顯示更少",
+    "emptyTitle": "該案件為空",
+    "emptyDescription": "將現有未分類的匯出新增進來，以便整理該條目。",
+    "emptyDescriptionNoExports": "目前沒有可新增的未分類匯出項。"
+  },
+  "caseEditor": {
+    "createTitle": "建立案件",
+    "editTitle": "編輯案件",
+    "namePlaceholder": "案件名稱",
+    "descriptionPlaceholder": "為該案件新增備註或相關說明"
+  },
+  "addExportDialog": {
+    "title": "將匯出新增到 {{caseName}}",
+    "searchPlaceholder": "搜尋未分類的匯出項",
+    "empty": "未找到匹配的未分類匯出。",
+    "addButton_one": "新增 1 個匯出",
+    "addButton_other": "新增 {{count}} 個匯出",
+    "adding": "新增中…"
+  },
+  "selected_one": "已選擇 {{count}} 個",
+  "selected_other": "已選擇 {{count}} 個",
+  "bulkActions": {
+    "addToCase": "新增至案件",
+    "moveToCase": "移動至案件",
+    "removeFromCase": "從案件中移除",
+    "delete": "刪除",
+    "deleteNow": "立即刪除"
+  },
+  "bulkDelete": {
+    "title": "刪除匯出",
+    "desc_one": "你確定要刪除 {{count}} 個匯出嗎？",
+    "desc_other": "確定要刪除 {{count}} 個匯出嗎？"
+  },
+  "bulkRemoveFromCase": {
+    "title": "從案件中移除",
+    "desc_one": "你確定要從該案件中移除這 {{count}} 個匯出嗎？",
+    "desc_other": "你確定要從該案件中移除這 {{count}} 個匯出嗎？",
+    "descKeepExports": "匯出將被移至未分類。",
+    "descDeleteExports": "匯出將被永久刪除。",
+    "deleteExports": "選擇刪除匯出"
+  },
+  "bulkToast": {
+    "success": {
+      "delete": "已刪除匯出",
+      "reassign": "已更新案件分配",
+      "remove": "已從案件中移除匯出"
+    },
+    "error": {
+      "deleteFailed": "刪除匯出失敗：{{errorMessage}}",
+      "reassignFailed": "更新案件分配失敗：{{errorMessage}}"
+    }
   }
 }

--- a/web/public/locales/zh-Hant/views/motionSearch.json
+++ b/web/public/locales/zh-Hant/views/motionSearch.json
@@ -1,1 +1,75 @@
-{}
+{
+  "documentTitle": "變動搜尋 - Frigate",
+  "title": "畫面變動搜尋",
+  "description": "繪製一個多邊形以劃定感興趣區域，並指定時間範圍，檢索該區域內的動態變化。",
+  "selectCamera": "畫面變動搜尋正在載入中",
+  "startSearch": "開始搜尋",
+  "searchStarted": "搜尋已開始",
+  "searchCancelled": "搜尋已取消",
+  "cancelSearch": "取消",
+  "searching": "搜尋進行中。",
+  "searchComplete": "搜尋完成",
+  "noResultsYet": "在所選區域內執行搜尋，查詢異常變化",
+  "noChangesFound": "所選區域未偵測到像素變化",
+  "changesFound_other": "偵測到 {{count}} 處畫面變化",
+  "framesProcessed": "已處理 {{count}} 幀畫面",
+  "jumpToTime": "跳轉到該時間",
+  "results": "結果",
+  "showSegmentHeatmap": "熱力圖",
+  "newSearch": "新的搜尋",
+  "clearResults": "清除結果",
+  "clearROI": "清除多邊形選區",
+  "polygonControls": {
+    "points_other": "{{count}} 個點位",
+    "undo": "撤銷上一個點位",
+    "reset": "重設多邊形",
+    "points_one": "{{count}} 個點"
+  },
+  "motionHeatmapLabel": "畫面變動熱力圖",
+  "dialog": {
+    "title": "畫面變動搜尋",
+    "cameraLabel": "攝影機",
+    "previewAlt": "{{camera}} 攝影機即時預覽"
+  },
+  "timeRange": {
+    "title": "搜尋範圍",
+    "start": "開始時間",
+    "end": "結束時間"
+  },
+  "settings": {
+    "title": "搜尋設定",
+    "parallelMode": "並行模式",
+    "parallelModeDesc": "同時掃描多個錄製片段（速度更快，但 CPU 佔用會顯著升高）",
+    "threshold": "靈敏度閾值",
+    "thresholdDesc": "數值越低，可偵測到越小的變化（取值範圍 1-255）",
+    "minArea": "最小變化區域",
+    "minAreaDesc": "最小感興趣區域變化佔比，達到該比例才會判定為有效變動",
+    "frameSkip": "幀跳過",
+    "frameSkipDesc": "每隔 N 幀進行一次處理。將該值設定為攝影機的幀率，即可實現每秒處理一幀畫面（例如：5 幀 / 秒的攝影機設為 5，30 幀 / 秒的攝影機設為 30）。數值越高處理速度越快，但有可能遺漏短時移動偵測事件。",
+    "maxResults": "最大結果數",
+    "maxResultsDesc": "匹配到設定條數的錄影事件後，就自動停止檢索"
+  },
+  "errors": {
+    "noCamera": "請選擇攝影機",
+    "noROI": "請繪製感興趣的區域",
+    "noTimeRange": "請選擇時間範圍",
+    "invalidTimeRange": "結束時間必須在開始時間之後",
+    "searchFailed": "搜尋失敗：{{message}}",
+    "polygonTooSmall": "多邊形至少需要 3 個頂點",
+    "unknown": "未知錯誤"
+  },
+  "changePercentage": "{{percentage}}% 已變化",
+  "metrics": {
+    "title": "搜尋指標",
+    "segmentsScanned": "已掃描片段數",
+    "segmentsProcessed": "已處理",
+    "segmentsSkippedInactive": "已跳過（無活動）",
+    "segmentsSkippedHeatmap": "已跳過（不在感興趣區域）",
+    "fallbackFullRange": "備用全範圍掃描",
+    "framesDecoded": "畫面已解碼",
+    "wallTime": "搜尋時間",
+    "segmentErrors": "片段異常",
+    "seconds": "{{seconds}} 秒"
+  },
+  "changesFound_one": "找到 {{count}} 個動態變化"
+}

--- a/web/public/locales/zh-Hant/views/replay.json
+++ b/web/public/locales/zh-Hant/views/replay.json
@@ -1,1 +1,59 @@
-{}
+{
+  "title": "除錯回放",
+  "description": "回放攝影機錄影以供除錯。目標清單會延時展示已偵測目標的彙總資訊，訊息分頁則即時展示回放錄影對應的 Frigate 內部日誌資訊流。",
+  "websocket_messages": "訊息",
+  "dialog": {
+    "title": "開始除錯回放",
+    "description": "建立臨時回放攝影機，迴圈播放歷史錄製影片，用於除錯目標偵測與追蹤相關問題。臨時回放的攝影機將沿用原攝影機的偵測配置。請選擇一個時間範圍開始。",
+    "camera": "原攝影機",
+    "timeRange": "時間範圍",
+    "preset": {
+      "1m": "最後 1 分鐘",
+      "5m": "最後 5 分鐘",
+      "timeline": "從時間線",
+      "custom": "自訂"
+    },
+    "startButton": "開始回放",
+    "selectFromTimeline": "選擇",
+    "starting": "開始回放…",
+    "startLabel": "開始",
+    "endLabel": "結束",
+    "toast": {
+      "error": "除錯回放啟動失敗：{{error}}",
+      "alreadyActive": "已有回放工作階段正在執行",
+      "stopError": "除錯回放停止失敗：{{error}}",
+      "goToReplay": "進入回放"
+    }
+  },
+  "page": {
+    "noSession": "沒有正在進行的除錯回放工作階段",
+    "noSessionDesc": "從歷史回放頁面啟動除錯回放：點選工具列中的操作按鈕，選擇除錯回放即可。",
+    "goToRecordings": "檢視歷史記錄",
+    "preparingClip": "正在準備片段…",
+    "preparingClipDesc": "Frigate 正在拼接所選時間範圍的錄影片段。時間跨度較大時，該過程可能需要一分鐘左右。",
+    "startingCamera": "開始除錯回放中…",
+    "startError": {
+      "title": "除錯回放啟動失敗",
+      "back": "返回歷史記錄"
+    },
+    "sourceCamera": "源攝影機",
+    "replayCamera": "回放攝影機",
+    "initializingReplay": "初始化除錯回放中…",
+    "stoppingReplay": "正在停止除錯回放…",
+    "stopReplay": "停止回放",
+    "confirmStop": {
+      "title": "要停止除錯回放嗎？",
+      "description": "這將終止工作階段並清除所有臨時資料。是否確定？",
+      "confirm": "停止回放",
+      "cancel": "取消"
+    },
+    "activity": "活動",
+    "objects": "目標清單",
+    "audioDetections": "音訊偵測",
+    "noActivity": "未偵測到活動",
+    "activeTracking": "活動追蹤中",
+    "noActiveTracking": "沒有活動追蹤",
+    "configuration": "配置",
+    "configurationDesc": "微調除錯回放攝影機的移動偵測與目標追蹤引數。本次調整不會儲存到你的 Frigate 設定檔中。"
+  }
+}


### PR DESCRIPTION
## Proposed change

Continued work from #23224 — improve Traditional Chinese (`zh-Hant`) translation coverage for 5 view files:

| File | Before | After | Added |
|---|---|---|---|
| `views/chat.json` | 0% | **100%** | +40 keys |
| `views/replay.json` | 0% | **100%** | +45 keys |
| `views/motionSearch.json` | 0% | **100%** | +59 keys |
| `views/exports.json` | 14% | **100%** | +74 keys |
| `views/classificationModel.json` | 52% | **100%** | +58 keys |

Overall `zh-Hant` coverage: **~39% → ~45%**.

Also removed 1 obsolete key (`deleteExport` as string in `views/exports.json`) which was replaced by a nested `deleteExport.*` structure in the `en` locale but the `zh-Hant` file was not updated.

## Type of change

- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to: #23224 (Wave 1 zh-Hant translation work — same pipeline, dictionary, and reviewer)

## AI disclosure

- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Anthropic)

**How AI was used**:
1. OpenCC `s2twp` for base conversion from existing `zh-CN` translations
2. Custom Taiwan Microsoft-style terminology dictionary applied as post-processing patches. New terms added in this batch based on AI review of the output: `響應→回應` (response, chat UI), `語義→語意` (semantic, Taiwan convention), `檢測→偵測` (detect, MS style), `合集→案件` (Frigate Case files), `異動變化→動態變化` (motion search description), `事兒→事` (remove Beijing colloquialism)
3. 19 plural-one variants (`*_one` keys) were manually translated from English because Chinese has no plural form distinction and these were not present in the `zh-CN` source either

**Extent of AI involvement**: Generated initial translations + applied terminology fixes. All output was reviewed manually before commit.

**Human oversight**: As a native Traditional Chinese speaker in Taiwan and an active Frigate user, I reviewed every new translation for naturalness in Taiwan UI conventions, fixed `zh-CN`-isms that OpenCC did not catch, and verified context-sensitive terms (Frigate Case files, chat response, motion search) against the English source.

## Checklist

- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
