### PR TITLE
Add zh-Hant (Traditional Chinese) translations for dialog, groups, validation (Wave 2b)

### DIFF
--- a/web/public/locales/zh-Hant/components/dialog.json
+++ b/web/public/locales/zh-Hant/components/dialog.json
@@ -6,7 +6,8 @@
       "title": "Frigate 正在重新啟動",
       "content": "此頁面將在 {{countdown}} 秒後重新載入。",
       "button": "立即重新載入"
-    }
+    },
+    "description": "Frigate 在重啟期間將短暫停止執行。"
   },
   "explore": {
     "plus": {
@@ -42,7 +43,8 @@
       "end": {
         "title": "結束時間",
         "label": "選擇結束時間"
-      }
+      },
+      "lastHour_one": "過去一小時"
     },
     "name": {
       "placeholder": "替匯出資料命名"
@@ -57,11 +59,68 @@
         "endTimeMustAfterStartTime": "結束時間必須要在開始時間之後",
         "noVaildTimeSelected": "沒有選取有效的時間範圍"
       },
-      "view": "查看"
+      "view": "查看",
+      "queued": "匯出已加入佇列。請在匯出頁面檢視進度。",
+      "batchSuccess_other": "已開始 {{count}} 個匯出，正在開啟案件。",
+      "batchPartial": "已開始 {{total}} 個匯出中的 {{successful}} 個。失敗的攝影機：{{failedCameras}}",
+      "batchFailed": "啟動匯出失敗（共 {{total}} 個）。失敗的攝影機：{{failedCameras}}",
+      "batchQueuedSuccess_other": "已排隊 {{count}} 個匯出，正在開啟案件。",
+      "batchQueuedPartial": "已將 {{total}} 個匯出中的 {{successful}} 個加入佇列。失敗的攝影機：{{failedCameras}}",
+      "batchQueueFailed": "未能將 {{total}} 個匯出加入佇列。失敗的攝影機：{{failedCameras}}",
+      "batchSuccess_one": "已開始 1 個匯出。正在開啟案件。",
+      "batchQueuedSuccess_one": "已將 1 個匯出加入佇列。正在開啟案件。"
     },
     "fromTimeline": {
       "saveExport": "保存匯出資料",
-      "previewExport": "預覽匯出資料"
+      "previewExport": "預覽匯出資料",
+      "queueingExport": "正在加入匯出佇列…",
+      "useThisRange": "使用此範圍"
+    },
+    "case": {
+      "newCaseOption": "建立新案件",
+      "newCaseNamePlaceholder": "新案件名稱",
+      "newCaseDescriptionPlaceholder": "案件描述",
+      "label": "案件",
+      "nonAdminHelp": "將為這些匯出檔案建立一個新的案件。",
+      "placeholder": "選擇案件"
+    },
+    "queueing": "正在加入匯出佇列…",
+    "tabs": {
+      "export": "單個攝影機",
+      "multiCamera": "多個攝影機"
+    },
+    "multiCamera": {
+      "timeRange": "時間範圍",
+      "selectFromTimeline": "從時間線選擇",
+      "cameraSelection": "攝影機",
+      "cameraSelectionHelp": "在此時間範圍內具有追蹤目標的攝影機會被預先選中",
+      "checkingActivity": "正在檢查攝影機活動…",
+      "noCameras": "沒有可用的攝影機",
+      "detectionCount_other": "{{count}} 個追蹤目標",
+      "nameLabel": "匯出名稱",
+      "namePlaceholder": "這些匯出檔案的可選基礎名稱",
+      "queueingButton": "正在加入匯出佇列…",
+      "exportButton_other": "匯出 {{count}} 個攝影機",
+      "detectionCount_one": "1 個追蹤目標",
+      "exportButton_one": "匯出 1 個攝影機"
+    },
+    "multi": {
+      "title_other": "匯出 {{count}} 個審閱",
+      "description": "匯出每個選定的審閱項。所有匯出檔案將歸入同一個案件。",
+      "descriptionNoCase": "匯出每個選定的審閱項。",
+      "caseNamePlaceholder": "審閱匯出 - {{date}}",
+      "exportButton_other": "匯出 {{count}} 個審閱",
+      "exportingButton": "匯出中…",
+      "toast": {
+        "started_other": "已開始 {{count}} 個匯出。正在開啟案件。",
+        "startedNoCase_other": "已開始 {{count}} 個匯出。",
+        "partial": "已啟動 {{total}} 個匯出，其中 {{successful}} 個成功。失敗項：{{failedItems}}",
+        "failed": "啟動匯出失敗（共 {{total}} 個）。失敗項：{{failedItems}}",
+        "started_one": "已開始 1 個匯出。正在開啟案件。",
+        "startedNoCase_one": "已開始 1 個匯出。"
+      },
+      "title_one": "匯出 1 個審閱",
+      "exportButton_one": "匯出 1 個審閱"
     }
   },
   "streaming": {
@@ -69,8 +128,7 @@
     "restreaming": {
       "disabled": "此鏡頭並未啟用串流重導向。",
       "desc": {
-        "title": "設定 go2rtc 以啟用更多此鏡頭的預覽選項及音訊。",
-        "readTheDocumentation": "閱讀文件"
+        "title": "設定 go2rtc 以啟用更多此鏡頭的預覽選項及音訊。"
       }
     },
     "showStats": {
@@ -109,6 +167,14 @@
       "markAsReviewed": "標記為已審核",
       "deleteNow": "立即刪除",
       "markAsUnreviewed": "標記為未審核"
+    },
+    "shareTimestamp": {
+      "label": "分享該時間片段",
+      "title": "分享該時間片段",
+      "description": "分享帶當前錄製播放時間的網址，或選擇自訂時間。請注意這不是公開的分享連結，只有具備 Frigate 及此攝影機存取權限的使用者才能存取。",
+      "custom": "自訂時間",
+      "button": "分享時間片段網址",
+      "shareTitle": "Frigate 審閱時間：{{camera}}"
     }
   },
   "imagePicker": {

--- a/web/public/locales/zh-Hant/config/groups.json
+++ b/web/public/locales/zh-Hant/config/groups.json
@@ -1,1 +1,73 @@
-{}
+{
+  "audio": {
+    "global": {
+      "detection": "全域性偵測",
+      "sensitivity": "全域性靈敏度"
+    },
+    "cameras": {
+      "detection": "偵測",
+      "sensitivity": "靈敏度"
+    }
+  },
+  "timestamp_style": {
+    "global": {
+      "appearance": "全域性外觀"
+    },
+    "cameras": {
+      "appearance": "外觀"
+    }
+  },
+  "motion": {
+    "global": {
+      "sensitivity": "全域性靈敏度",
+      "algorithm": "全域性演算法"
+    },
+    "cameras": {
+      "sensitivity": "靈敏度",
+      "algorithm": "演算法"
+    }
+  },
+  "snapshots": {
+    "global": {
+      "display": "全域性顯示"
+    },
+    "cameras": {
+      "display": "顯示"
+    }
+  },
+  "detect": {
+    "global": {
+      "resolution": "全域性解析度",
+      "tracking": "全域性追蹤"
+    },
+    "cameras": {
+      "resolution": "解析度",
+      "tracking": "追蹤"
+    }
+  },
+  "objects": {
+    "global": {
+      "tracking": "全域性追蹤",
+      "filtering": "全域性篩選"
+    },
+    "cameras": {
+      "tracking": "追蹤",
+      "filtering": "篩選"
+    }
+  },
+  "record": {
+    "global": {
+      "retention": "全域性保留",
+      "events": "全域性事件"
+    },
+    "cameras": {
+      "retention": "保留",
+      "events": "事件"
+    }
+  },
+  "ffmpeg": {
+    "cameras": {
+      "cameraFfmpeg": "攝影機特定的 FFmpeg 引數"
+    }
+  }
+}

--- a/web/public/locales/zh-Hant/config/validation.json
+++ b/web/public/locales/zh-Hant/config/validation.json
@@ -1,1 +1,32 @@
-{}
+{
+  "minimum": "必須至少為 {{limit}}",
+  "maximum": "最大值不能超過 {{limit}}",
+  "exclusiveMinimum": "必須大於 {{limit}}",
+  "exclusiveMaximum": "必須小於 {{limit}}",
+  "minLength": "長度至少為 {{limit}} 個字元",
+  "maxLength": "長度最多為 {{limit}} 個字元",
+  "minItems": "至少包含 {{limit}} 項",
+  "maxItems": "最多包含 {{limit}} 項",
+  "pattern": "格式無效",
+  "required": "此欄位為必填項",
+  "type": "值型別無效",
+  "enum": "必須是允許的值之一",
+  "const": "值與預期的常量不匹配",
+  "uniqueItems": "所有項必須唯一",
+  "format": "格式無效",
+  "additionalProperties": "不允許未知屬性",
+  "oneOf": "必須完全匹配一個允許的模式",
+  "anyOf": "必須至少匹配一個允許的模式",
+  "proxy": {
+    "header_map": {
+      "roleHeaderRequired": "設定角色對應時必須要有 role 標頭。"
+    }
+  },
+  "ffmpeg": {
+    "inputs": {
+      "rolesUnique": "每個角色只能分配給一個輸入串流。",
+      "detectRequired": "必須至少有一個輸入串流分配為 'detect' 角色。",
+      "hwaccelDetectOnly": "只有分配了 detect 角色的輸入串流才能定義硬體加速引數。"
+    }
+  }
+}


### PR DESCRIPTION
## Proposed change

Continued work from #23224 / #23225 — improve Traditional Chinese (`zh-Hant`) translation coverage for 3 files:

| File | Before | After | Added |
|---|---|---|---|
| `components/dialog.json` | 50% | **100%** | +46 keys (+9 manual plural-one) |
| `config/groups.json` | 0% | **100%** | +25 keys |
| `config/validation.json` | 0% | **100%** | +22 keys |

Overall `zh-Hant` coverage: **~45% → ~47%**.

Also removed 1 obsolete key (`streaming.restreaming.desc.readTheDocumentation` in `components/dialog.json`) that no longer exists in the `en` locale.

## Type of change

- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to: #23224 / #23225 (same pipeline, dictionary, contributor)

## AI disclosure

- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Anthropic)

**How AI was used**:
1. OpenCC `s2twp` for base conversion from existing `zh-CN` translations
2. Custom Taiwan Microsoft-style terminology dictionary. New terms added in this batch based on AI review: `訪問→存取` (access, MS style), `許可權→權限` (permission, Taiwan convention overwhelmingly prefers 權限)
3. 9 plural-one variants in `components/dialog.json` were manually translated from English (Chinese has no plural form distinction)
4. Manual correction of 4 keys in `config/validation.json` where the upstream `zh-CN` had mistranslated "role" as "功能" (feature) — corrected to "角色" (role) by checking the English source. Also rewrote `dialog.json` `recording.shareTimestamp.description` for clarity.

**Extent of AI involvement**: Generated initial translations + applied terminology fixes. All output was reviewed manually before commit.

**Human oversight**: As a native Traditional Chinese speaker in Taiwan and an active Frigate user, I reviewed every new translation for naturalness in Taiwan UI conventions, fixed `zh-CN`-isms that OpenCC did not catch, and corrected mistranslations inherited from the `zh-CN` source by comparing against the English original.

## Checklist

- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
