### PR TITLE
Misc backend performance improvements

### DIFF
--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -412,19 +412,20 @@ def events_explore(
 
     # Single query: per-label COUNT and top-N ranking by start_time computed
     # via window functions in a CTE, then filtered to rn <= limit
-    event_count = fn.COUNT(Event.id).over(partition_by=[Event.label]).alias("event_count")
-    rn = fn.ROW_NUMBER().over(
-        partition_by=[Event.label], order_by=[Event.start_time.desc()]
-    ).alias("rn")
-
-    base_query = (
-        Event.select(
-            *explore_columns,
-            event_count,
-            rn,
-        )
-        .where(Event.camera << allowed_cameras)
+    event_count = (
+        fn.COUNT(Event.id).over(partition_by=[Event.label]).alias("event_count")
     )
+    rn = (
+        fn.ROW_NUMBER()
+        .over(partition_by=[Event.label], order_by=[Event.start_time.desc()])
+        .alias("rn")
+    )
+
+    base_query = Event.select(
+        *explore_columns,
+        event_count,
+        rn,
+    ).where(Event.camera << allowed_cameras)
     ranked = base_query.cte("ranked")
     query = (
         Event.select(
@@ -482,9 +483,7 @@ def events_explore(
             "false_positive": event.false_positive,
             "box": event.box,
             "data": {
-                k: v
-                for k, v in (event.data or {}).items()
-                if k in allowed_data_keys
+                k: v for k, v in (event.data or {}).items() if k in allowed_data_keys
             },
             "event_count": event.event_count,
         }

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -411,22 +411,20 @@ def events_explore(
     )
 
     # Single query: per-label COUNT and top-N ranking by start_time computed
-    # via window functions in a CTE, then filtered to rn <= limit. Replaces
-    # the previous loop that issued 2 queries per distinct label.
-    event_count = (
-        fn.COUNT(Event.id).over(partition_by=[Event.label]).alias("event_count")
-    )
-    rn = (
-        fn.ROW_NUMBER()
-        .over(partition_by=[Event.label], order_by=[Event.start_time.desc()])
-        .alias("rn")
-    )
+    # via window functions in a CTE, then filtered to rn <= limit
+    event_count = fn.COUNT(Event.id).over(partition_by=[Event.label]).alias("event_count")
+    rn = fn.ROW_NUMBER().over(
+        partition_by=[Event.label], order_by=[Event.start_time.desc()]
+    ).alias("rn")
 
-    base_query = Event.select(
-        *explore_columns,
-        event_count,
-        rn,
-    ).where(Event.camera << allowed_cameras)
+    base_query = (
+        Event.select(
+            *explore_columns,
+            event_count,
+            rn,
+        )
+        .where(Event.camera << allowed_cameras)
+    )
     ranked = base_query.cte("ranked")
     query = (
         Event.select(
@@ -484,7 +482,9 @@ def events_explore(
             "false_positive": event.false_positive,
             "box": event.box,
             "data": {
-                k: v for k, v in (event.data or {}).items() if k in allowed_data_keys
+                k: v
+                for k, v in (event.data or {}).items()
+                if k in allowed_data_keys
             },
             "event_count": event.event_count,
         }

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -399,13 +399,31 @@ def events_explore(
 
     label_counts = {}
 
+    explore_columns = (
+        Event.id,
+        Event.camera,
+        Event.label,
+        Event.sub_label,
+        Event.zones,
+        Event.start_time,
+        Event.end_time,
+        Event.has_clip,
+        Event.has_snapshot,
+        Event.plus_id,
+        Event.retain_indefinitely,
+        Event.top_score,
+        Event.false_positive,
+        Event.box,
+        Event.data,
+    )
+
     def event_generator():
         for label_obj in distinct_labels.iterator():
             label = label_obj.label
 
             # get most recent events for this label
             label_events = (
-                Event.select()
+                Event.select(*explore_columns)
                 .where((Event.label == label) & (Event.camera << allowed_cameras))
                 .order_by(Event.start_time.desc())
                 .limit(limit)

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -474,21 +474,17 @@ async def event_ids(ids: str, request: Request):
             status_code=400,
         )
 
-    for event_id in ids:
-        try:
-            event = Event.get(Event.id == event_id)
-            await require_camera_access(event.camera, request=request)
-        except DoesNotExist:
-            # we should not fail the entire request if an event is not found
-            continue
-
     try:
-        events = Event.select().where(Event.id << ids).dicts().iterator()
-        return JSONResponse(list(events))
+        events = list(Event.select().where(Event.id << ids).dicts().iterator())
     except Exception:
         return JSONResponse(
             content=({"success": False, "message": "Events not found"}), status_code=400
         )
+
+    for event in events:
+        await require_camera_access(event["camera"], request=request)
+
+    return JSONResponse(events)
 
 
 @router.get(

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -389,100 +389,69 @@ def events_explore(
     limit: int = 10,
     allowed_cameras: List[str] = Depends(get_allowed_cameras_for_filter),
 ):
-    # get distinct labels for all events
-    distinct_labels = (
-        Event.select(Event.label)
-        .where(Event.camera << allowed_cameras)
-        .distinct()
-        .order_by(Event.label)
-    )
+    if not allowed_cameras:
+        return JSONResponse(content=[])
 
-    label_counts = {}
+    # Single query: per-label COUNT and top-N ranking by start_time computed
+    # via window functions in a CTE, then filtered to rn <= limit. Replaces
+    # the previous loop that issued 2 queries per distinct label.
+    camera_placeholders = ",".join(["?"] * len(allowed_cameras))
+    sql = f"""
+        WITH ranked AS (
+            SELECT
+                id, camera, label, sub_label, zones, start_time, end_time,
+                has_clip, has_snapshot, plus_id, retain_indefinitely,
+                top_score, false_positive, box, data,
+                COUNT(*) OVER (PARTITION BY label) AS event_count,
+                ROW_NUMBER() OVER (
+                    PARTITION BY label ORDER BY start_time DESC
+                ) AS rn
+            FROM event
+            WHERE camera IN ({camera_placeholders})
+        )
+        SELECT * FROM ranked
+        WHERE rn <= ?
+        ORDER BY event_count DESC, start_time DESC
+    """
 
-    explore_columns = (
-        Event.id,
-        Event.camera,
-        Event.label,
-        Event.sub_label,
-        Event.zones,
-        Event.start_time,
-        Event.end_time,
-        Event.has_clip,
-        Event.has_snapshot,
-        Event.plus_id,
-        Event.retain_indefinitely,
-        Event.top_score,
-        Event.false_positive,
-        Event.box,
-        Event.data,
-    )
+    allowed_data_keys = {
+        "type",
+        "score",
+        "top_score",
+        "description",
+        "sub_label_score",
+        "average_estimated_speed",
+        "velocity_angle",
+        "path_data",
+        "recognized_license_plate",
+        "recognized_license_plate_score",
+    }
 
-    def event_generator():
-        for label_obj in distinct_labels.iterator():
-            label = label_obj.label
-
-            # get most recent events for this label
-            label_events = (
-                Event.select(*explore_columns)
-                .where((Event.label == label) & (Event.camera << allowed_cameras))
-                .order_by(Event.start_time.desc())
-                .limit(limit)
-                .iterator()
-            )
-
-            # count total events for this label
-            label_counts[label] = (
-                Event.select()
-                .where((Event.label == label) & (Event.camera << allowed_cameras))
-                .count()
-            )
-
-            yield from label_events
-
-    def process_events():
-        for event in event_generator():
-            processed_event = {
-                "id": event.id,
-                "camera": event.camera,
-                "label": event.label,
-                "zones": event.zones,
-                "start_time": event.start_time,
-                "end_time": event.end_time,
-                "has_clip": event.has_clip,
-                "has_snapshot": event.has_snapshot,
-                "plus_id": event.plus_id,
-                "retain_indefinitely": event.retain_indefinitely,
-                "sub_label": event.sub_label,
-                "top_score": event.top_score,
-                "false_positive": event.false_positive,
-                "box": event.box,
-                "data": {
-                    k: v
-                    for k, v in event.data.items()
-                    if k
-                    in [
-                        "type",
-                        "score",
-                        "top_score",
-                        "description",
-                        "sub_label_score",
-                        "average_estimated_speed",
-                        "velocity_angle",
-                        "path_data",
-                        "recognized_license_plate",
-                        "recognized_license_plate_score",
-                    ]
-                },
-                "event_count": label_counts[event.label],
-            }
-            yield processed_event
-
-    # convert iterator to list and sort
-    processed_events = sorted(
-        process_events(),
-        key=lambda x: (x["event_count"], x["start_time"]),
-        reverse=True,
-    )
+    processed_events = [
+        {
+            "id": event.id,
+            "camera": event.camera,
+            "label": event.label,
+            "zones": event.zones,
+            "start_time": event.start_time,
+            "end_time": event.end_time,
+            "has_clip": event.has_clip,
+            "has_snapshot": event.has_snapshot,
+            "plus_id": event.plus_id,
+            "retain_indefinitely": event.retain_indefinitely,
+            "sub_label": event.sub_label,
+            "top_score": event.top_score,
+            "false_positive": event.false_positive,
+            "box": event.box,
+            "data": {
+                k: v
+                for k, v in (event.data or {}).items()
+                if k in allowed_data_keys
+            },
+            "event_count": event.event_count,
+        }
+        for event in Event.raw(sql, *allowed_cameras, limit)
+    ]
 
     return JSONResponse(content=processed_events)
 

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -392,6 +392,15 @@ def events_explore(
     if not allowed_cameras:
         return JSONResponse(content=[])
 
+    distinct_labels = (
+        Event.select(Event.label)
+        .where(Event.camera << allowed_cameras)
+        .distinct()
+        .order_by(Event.label)
+    )
+
+    label_counts = {}
+
     explore_columns = (
         Event.id,
         Event.camera,
@@ -410,85 +419,72 @@ def events_explore(
         Event.data,
     )
 
-    # Single query: per-label COUNT and top-N ranking by start_time computed
-    # via window functions in a CTE, then filtered to rn <= limit
-    event_count = (
-        fn.COUNT(Event.id).over(partition_by=[Event.label]).alias("event_count")
-    )
-    rn = (
-        fn.ROW_NUMBER()
-        .over(partition_by=[Event.label], order_by=[Event.start_time.desc()])
-        .alias("rn")
-    )
+    def event_generator():
+        for label_obj in distinct_labels.iterator():
+            label = label_obj.label
 
-    base_query = Event.select(
-        *explore_columns,
-        event_count,
-        rn,
-    ).where(Event.camera << allowed_cameras)
-    ranked = base_query.cte("ranked")
-    query = (
-        Event.select(
-            ranked.c.id,
-            ranked.c.camera,
-            ranked.c.label,
-            ranked.c.sub_label,
-            ranked.c.zones,
-            ranked.c.start_time,
-            ranked.c.end_time,
-            ranked.c.has_clip,
-            ranked.c.has_snapshot,
-            ranked.c.plus_id,
-            ranked.c.retain_indefinitely,
-            ranked.c.top_score,
-            ranked.c.false_positive,
-            ranked.c.box,
-            ranked.c.data,
-            ranked.c.event_count,
-        )
-        .from_(ranked)
-        .with_cte(ranked)
-        .where(ranked.c.rn <= limit)
-        .order_by(ranked.c.event_count.desc(), ranked.c.start_time.desc())
-        .objects()
+            # get most recent events for this label
+            label_events = (
+                Event.select(*explore_columns)
+                .where((Event.label == label) & (Event.camera << allowed_cameras))
+                .order_by(Event.start_time.desc())
+                .limit(limit)
+                .iterator()
+            )
+
+            # count total events for this label
+            label_counts[label] = (
+                Event.select()
+                .where((Event.label == label) & (Event.camera << allowed_cameras))
+                .count()
+            )
+
+            yield from label_events
+
+    def process_events():
+        for event in event_generator():
+            processed_event = {
+                "id": event.id,
+                "camera": event.camera,
+                "label": event.label,
+                "zones": event.zones,
+                "start_time": event.start_time,
+                "end_time": event.end_time,
+                "has_clip": event.has_clip,
+                "has_snapshot": event.has_snapshot,
+                "plus_id": event.plus_id,
+                "retain_indefinitely": event.retain_indefinitely,
+                "sub_label": event.sub_label,
+                "top_score": event.top_score,
+                "false_positive": event.false_positive,
+                "box": event.box,
+                "data": {
+                    k: v
+                    for k, v in event.data.items()
+                    if k
+                    in [
+                        "type",
+                        "score",
+                        "top_score",
+                        "description",
+                        "sub_label_score",
+                        "average_estimated_speed",
+                        "velocity_angle",
+                        "path_data",
+                        "recognized_license_plate",
+                        "recognized_license_plate_score",
+                    ]
+                },
+                "event_count": label_counts[event.label],
+            }
+            yield processed_event
+
+    # convert iterator to list and sort
+    processed_events = sorted(
+        process_events(),
+        key=lambda x: (x["event_count"], x["start_time"]),
+        reverse=True,
     )
-
-    allowed_data_keys = {
-        "type",
-        "score",
-        "top_score",
-        "description",
-        "sub_label_score",
-        "average_estimated_speed",
-        "velocity_angle",
-        "path_data",
-        "recognized_license_plate",
-        "recognized_license_plate_score",
-    }
-
-    processed_events = [
-        {
-            "id": event.id,
-            "camera": event.camera,
-            "label": event.label,
-            "zones": event.zones,
-            "start_time": event.start_time,
-            "end_time": event.end_time,
-            "has_clip": event.has_clip,
-            "has_snapshot": event.has_snapshot,
-            "plus_id": event.plus_id,
-            "retain_indefinitely": event.retain_indefinitely,
-            "sub_label": event.sub_label,
-            "top_score": event.top_score,
-            "false_positive": event.false_positive,
-            "box": event.box,
-            "data": {
-                k: v for k, v in (event.data or {}).items() if k in allowed_data_keys
-            },
-            "event_count": event.event_count,
-        }
-        for event in query
-    ]
 
     return JSONResponse(content=processed_events)
 

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -392,27 +392,66 @@ def events_explore(
     if not allowed_cameras:
         return JSONResponse(content=[])
 
+    explore_columns = (
+        Event.id,
+        Event.camera,
+        Event.label,
+        Event.sub_label,
+        Event.zones,
+        Event.start_time,
+        Event.end_time,
+        Event.has_clip,
+        Event.has_snapshot,
+        Event.plus_id,
+        Event.retain_indefinitely,
+        Event.top_score,
+        Event.false_positive,
+        Event.box,
+        Event.data,
+    )
+
     # Single query: per-label COUNT and top-N ranking by start_time computed
     # via window functions in a CTE, then filtered to rn <= limit. Replaces
     # the previous loop that issued 2 queries per distinct label.
-    camera_placeholders = ",".join(["?"] * len(allowed_cameras))
-    sql = f"""
-        WITH ranked AS (
-            SELECT
-                id, camera, label, sub_label, zones, start_time, end_time,
-                has_clip, has_snapshot, plus_id, retain_indefinitely,
-                top_score, false_positive, box, data,
-                COUNT(*) OVER (PARTITION BY label) AS event_count,
-                ROW_NUMBER() OVER (
-                    PARTITION BY label ORDER BY start_time DESC
-                ) AS rn
-            FROM event
-            WHERE camera IN ({camera_placeholders})
+    event_count = fn.COUNT(Event.id).over(partition_by=[Event.label]).alias("event_count")
+    rn = fn.ROW_NUMBER().over(
+        partition_by=[Event.label], order_by=[Event.start_time.desc()]
+    ).alias("rn")
+
+    base_query = (
+        Event.select(
+            *explore_columns,
+            event_count,
+            rn,
         )
-        SELECT * FROM ranked
-        WHERE rn <= ?
-        ORDER BY event_count DESC, start_time DESC
-    """
+        .where(Event.camera << allowed_cameras)
+    )
+    ranked = base_query.cte("ranked")
+    query = (
+        Event.select(
+            ranked.c.id,
+            ranked.c.camera,
+            ranked.c.label,
+            ranked.c.sub_label,
+            ranked.c.zones,
+            ranked.c.start_time,
+            ranked.c.end_time,
+            ranked.c.has_clip,
+            ranked.c.has_snapshot,
+            ranked.c.plus_id,
+            ranked.c.retain_indefinitely,
+            ranked.c.top_score,
+            ranked.c.false_positive,
+            ranked.c.box,
+            ranked.c.data,
+            ranked.c.event_count,
+        )
+        .from_(ranked)
+        .with_cte(ranked)
+        .where(ranked.c.rn <= limit)
+        .order_by(ranked.c.event_count.desc(), ranked.c.start_time.desc())
+        .objects()
+    )
 
     allowed_data_keys = {
         "type",
@@ -450,7 +489,7 @@ def events_explore(
             },
             "event_count": event.event_count,
         }
-        for event in Event.raw(sql, *allowed_cameras, limit)
+        for event in query
     ]
 
     return JSONResponse(content=processed_events)

--- a/frigate/api/event.py
+++ b/frigate/api/event.py
@@ -413,19 +413,20 @@ def events_explore(
     # Single query: per-label COUNT and top-N ranking by start_time computed
     # via window functions in a CTE, then filtered to rn <= limit. Replaces
     # the previous loop that issued 2 queries per distinct label.
-    event_count = fn.COUNT(Event.id).over(partition_by=[Event.label]).alias("event_count")
-    rn = fn.ROW_NUMBER().over(
-        partition_by=[Event.label], order_by=[Event.start_time.desc()]
-    ).alias("rn")
-
-    base_query = (
-        Event.select(
-            *explore_columns,
-            event_count,
-            rn,
-        )
-        .where(Event.camera << allowed_cameras)
+    event_count = (
+        fn.COUNT(Event.id).over(partition_by=[Event.label]).alias("event_count")
     )
+    rn = (
+        fn.ROW_NUMBER()
+        .over(partition_by=[Event.label], order_by=[Event.start_time.desc()])
+        .alias("rn")
+    )
+
+    base_query = Event.select(
+        *explore_columns,
+        event_count,
+        rn,
+    ).where(Event.camera << allowed_cameras)
     ranked = base_query.cte("ranked")
     query = (
         Event.select(
@@ -483,9 +484,7 @@ def events_explore(
             "false_positive": event.false_positive,
             "box": event.box,
             "data": {
-                k: v
-                for k, v in (event.data or {}).items()
-                if k in allowed_data_keys
+                k: v for k, v in (event.data or {}).items() if k in allowed_data_keys
             },
             "event_count": event.event_count,
         }

--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -10,7 +10,7 @@ import pandas as pd
 from fastapi import APIRouter, Request
 from fastapi.params import Depends
 from fastapi.responses import JSONResponse
-from peewee import Case, DoesNotExist, IntegrityError, fn, operator
+from peewee import Case, DoesNotExist, fn, operator
 from playhouse.shortcuts import model_to_dict
 
 from frigate.api.auth import (
@@ -173,7 +173,9 @@ async def review_ids(request: Request, ids: str):
         )
 
     try:
-        reviews = list(ReviewSegment.select().where(ReviewSegment.id << ids).dicts().iterator())
+        reviews = list(
+            ReviewSegment.select().where(ReviewSegment.id << ids).dicts().iterator()
+        )
     except Exception:
         return JSONResponse(
             content=({"success": False, "message": "Review segments not found"}),
@@ -490,54 +492,52 @@ async def set_multiple_reviewed(
 
     user_id = current_user["username"]
 
-    reviews = list(ReviewSegment.select(ReviewSegment.id, ReviewSegment.camera).where(ReviewSegment.id << body.ids))
-    
-    for review in reviews:
-        await require_camera_access(review.camera, request=request)
-        
-    found_ids = [r.id for r in reviews]
-
-    if not found_ids:
-        return JSONResponse(
-            content=(
-                {
-                    "success": True,
-                    "message": f"Marked multiple items as {'reviewed' if body.reviewed else 'unreviewed'}",
-                }
-            ),
-            status_code=200,
-        )
-
-    existing_statuses = list(
-        UserReviewStatus.select().where(
-            (UserReviewStatus.user_id == user_id) &
-            (UserReviewStatus.review_segment << found_ids)
+    reviews = list(
+        ReviewSegment.select(ReviewSegment.id, ReviewSegment.camera).where(
+            ReviewSegment.id << body.ids
         )
     )
-    
-    status_by_review = {s.review_segment_id: s for s in existing_statuses}
 
-    to_update = []
-    to_create = []
+    for review in reviews:
+        await require_camera_access(review.camera, request=request)
 
-    for review_id in found_ids:
-        if review_id in status_by_review:
-            status = status_by_review[review_id]
-            if status.has_been_reviewed != body.reviewed:
-                status.has_been_reviewed = body.reviewed
-                to_update.append(status)
-        else:
-            to_create.append({
-                "user_id": user_id,
-                "review_segment_id": review_id,
-                "has_been_reviewed": body.reviewed,
-            })
+    found_ids = [r.id for r in reviews]
 
-    if to_update:
-        UserReviewStatus.bulk_update(to_update, fields=[UserReviewStatus.has_been_reviewed], batch_size=100)
-    
-    if to_create:
-        UserReviewStatus.insert_many(to_create).execute()
+    if found_ids:
+        existing_statuses = list(
+            UserReviewStatus.select().where(
+                (UserReviewStatus.user_id == user_id)
+                & (UserReviewStatus.review_segment << found_ids)
+            )
+        )
+
+        status_by_review = {s.review_segment_id: s for s in existing_statuses}
+
+        to_update = []
+        to_create = []
+
+        for review_id in found_ids:
+            if review_id in status_by_review:
+                status = status_by_review[review_id]
+                if status.has_been_reviewed != body.reviewed:
+                    status.has_been_reviewed = body.reviewed
+                    to_update.append(status)
+            else:
+                to_create.append(
+                    {
+                        "user_id": user_id,
+                        "review_segment_id": review_id,
+                        "has_been_reviewed": body.reviewed,
+                    }
+                )
+
+        if to_update:
+            UserReviewStatus.bulk_update(
+                to_update, fields=[UserReviewStatus.has_been_reviewed], batch_size=100
+            )
+
+        if to_create:
+            UserReviewStatus.insert_many(to_create).execute()
 
     return JSONResponse(
         content=(

--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -537,7 +537,7 @@ async def set_multiple_reviewed(
             )
 
         if to_create:
-            UserReviewStatus.insert_many(to_create).execute()
+            UserReviewStatus.insert_many(to_create).on_conflict_ignore().execute()
 
     return JSONResponse(
         content=(

--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -172,11 +172,17 @@ async def review_ids(request: Request, ids: str):
             status_code=400,
         )
 
+    try:
+        reviews = list(ReviewSegment.select().where(ReviewSegment.id << ids).dicts().iterator())
+    except Exception:
+        return JSONResponse(
+            content=({"success": False, "message": "Review segments not found"}),
+            status_code=400,
+        )
+
+    found_ids = {r["id"] for r in reviews}
     for review_id in ids:
-        try:
-            review = ReviewSegment.get(ReviewSegment.id == review_id)
-            await require_camera_access(review.camera, request=request)
-        except DoesNotExist:
+        if review_id not in found_ids:
             return JSONResponse(
                 content=(
                     {"success": False, "message": f"Review {review_id} not found"}
@@ -184,16 +190,10 @@ async def review_ids(request: Request, ids: str):
                 status_code=404,
             )
 
-    try:
-        reviews = (
-            ReviewSegment.select().where(ReviewSegment.id << ids).dicts().iterator()
-        )
-        return JSONResponse(list(reviews))
-    except Exception:
-        return JSONResponse(
-            content=({"success": False, "message": "Review segments not found"}),
-            status_code=400,
-        )
+    for review in reviews:
+        await require_camera_access(review["camera"], request=request)
+
+    return JSONResponse(reviews)
 
 
 @router.get(
@@ -490,27 +490,54 @@ async def set_multiple_reviewed(
 
     user_id = current_user["username"]
 
-    for review_id in body.ids:
-        try:
-            review = ReviewSegment.get(ReviewSegment.id == review_id)
-            await require_camera_access(review.camera, request=request)
-            review_status = UserReviewStatus.get(
-                UserReviewStatus.user_id == user_id,
-                UserReviewStatus.review_segment == review_id,
-            )
-            # Update based on the reviewed parameter
-            if review_status.has_been_reviewed != body.reviewed:
-                review_status.has_been_reviewed = body.reviewed
-                review_status.save()
-        except DoesNotExist:
-            try:
-                UserReviewStatus.create(
-                    user_id=user_id,
-                    review_segment=ReviewSegment.get(id=review_id),
-                    has_been_reviewed=body.reviewed,
-                )
-            except (DoesNotExist, IntegrityError):
-                pass
+    reviews = list(ReviewSegment.select(ReviewSegment.id, ReviewSegment.camera).where(ReviewSegment.id << body.ids))
+    
+    for review in reviews:
+        await require_camera_access(review.camera, request=request)
+        
+    found_ids = [r.id for r in reviews]
+
+    if not found_ids:
+        return JSONResponse(
+            content=(
+                {
+                    "success": True,
+                    "message": f"Marked multiple items as {'reviewed' if body.reviewed else 'unreviewed'}",
+                }
+            ),
+            status_code=200,
+        )
+
+    existing_statuses = list(
+        UserReviewStatus.select().where(
+            (UserReviewStatus.user_id == user_id) &
+            (UserReviewStatus.review_segment << found_ids)
+        )
+    )
+    
+    status_by_review = {s.review_segment_id: s for s in existing_statuses}
+
+    to_update = []
+    to_create = []
+
+    for review_id in found_ids:
+        if review_id in status_by_review:
+            status = status_by_review[review_id]
+            if status.has_been_reviewed != body.reviewed:
+                status.has_been_reviewed = body.reviewed
+                to_update.append(status)
+        else:
+            to_create.append({
+                "user_id": user_id,
+                "review_segment_id": review_id,
+                "has_been_reviewed": body.reviewed,
+            })
+
+    if to_update:
+        UserReviewStatus.bulk_update(to_update, fields=[UserReviewStatus.has_been_reviewed], batch_size=100)
+    
+    if to_create:
+        UserReviewStatus.insert_many(to_create).execute()
 
     return JSONResponse(
         content=(

--- a/frigate/test/http_api/test_http_review.py
+++ b/frigate/test/http_api/test_http_review.py
@@ -497,6 +497,43 @@ class TestHttpReview(BaseTestHttp):
             )
             assert user_review.has_been_reviewed == True
 
+    def test_post_reviews_viewed_concurrent_duplicate_does_not_raise(self):
+        """Regression: concurrent requests marking the same review must not 500.
+
+        Two requests can both SELECT and find no existing status, then both try
+        to INSERT, hitting the unique (user_id, review_segment) constraint.
+        on_conflict_ignore() must silently skip the duplicate instead of raising
+        an IntegrityError (which was previously caught with try/except).
+        """
+        id = "123456.random"
+        with AuthTestClient(self.app):
+            super().insert_mock_review_segment(id)
+
+            # Simulate the first request having already committed its insert.
+            self._insert_user_review_status(id, reviewed=True)
+
+            # Simulate the second concurrent request attempting the same insert.
+            UserReviewStatus.insert_many(
+                [
+                    {
+                        "user_id": self.user_id,
+                        "review_segment_id": id,
+                        "has_been_reviewed": True,
+                    }
+                ]
+            ).on_conflict_ignore().execute()
+
+            # Exactly one row should exist; no exception should have been raised.
+            count = (
+                UserReviewStatus.select()
+                .where(
+                    (UserReviewStatus.user_id == self.user_id)
+                    & (UserReviewStatus.review_segment == id)
+                )
+                .count()
+            )
+            assert count == 1
+
     ####################################################################################################################
     ###################################  POST reviews/delete Endpoint   ################################################
     ####################################################################################################################

--- a/frigate/test/http_api/test_http_review.py
+++ b/frigate/test/http_api/test_http_review.py
@@ -497,8 +497,8 @@ class TestHttpReview(BaseTestHttp):
             )
             assert user_review.has_been_reviewed == True
 
-    def test_post_reviews_viewed_concurrent_duplicate_does_not_raise(self):
-        """Regression: concurrent requests marking the same review must not 500.
+    def test_reviews_concurrent_insert_peewee_ignore(self):
+        """Validates that on_conflict_ignore() silently skips a duplicate insert
 
         Two requests can both SELECT and find no existing status, then both try
         to INSERT, hitting the unique (user_id, review_segment) constraint.

--- a/migrations/036_add_perf_indexes.py
+++ b/migrations/036_add_perf_indexes.py
@@ -21,17 +21,7 @@ def migrate(migrator, database, fake=False, **kwargs):
         'CREATE INDEX IF NOT EXISTS "event_camera_start_time" '
         'ON "event" ("camera", "start_time" DESC)'
     )
-    migrator.sql(
-        'CREATE INDEX IF NOT EXISTS "reviewsegment_camera_start_time" '
-        'ON "reviewsegment" ("camera", "start_time" DESC)'
-    )
-    migrator.sql(
-        'CREATE INDEX IF NOT EXISTS "reviewsegment_end_time" '
-        'ON "reviewsegment" ("end_time")'
-    )
 
 
 def rollback(migrator, database, fake=False, **kwargs):
     migrator.sql('DROP INDEX IF EXISTS "event_camera_start_time"')
-    migrator.sql('DROP INDEX IF EXISTS "reviewsegment_camera_start_time"')
-    migrator.sql('DROP INDEX IF EXISTS "reviewsegment_end_time"')

--- a/migrations/036_add_perf_indexes.py
+++ b/migrations/036_add_perf_indexes.py
@@ -1,14 +1,8 @@
 """Peewee migrations -- 036_add_perf_indexes.py.
 
-Adds composite/single-column indexes to speed up the most common queries
-issued by the web UI on initial page load:
+Adds composite/single-column indexes to speed up single-camera queries
+issued by the web UI.
 
-- event(camera, start_time DESC): /events list filtered by camera + time range
-- reviewsegment(camera, start_time DESC): /api/review filtered by camera + time range
-- reviewsegment(end_time): supports the end_time > after half of /api/review's range
-
-The existing event(label, start_time DESC) index from migration 027 already
-covers /events/explore, so it is intentionally not duplicated here.
 """
 
 import peewee as pw

--- a/migrations/036_add_perf_indexes.py
+++ b/migrations/036_add_perf_indexes.py
@@ -1,0 +1,37 @@
+"""Peewee migrations -- 036_add_perf_indexes.py.
+
+Adds composite/single-column indexes to speed up the most common queries
+issued by the web UI on initial page load:
+
+- event(camera, start_time DESC): /events list filtered by camera + time range
+- reviewsegment(camera, start_time DESC): /api/review filtered by camera + time range
+- reviewsegment(end_time): supports the end_time > after half of /api/review's range
+
+The existing event(label, start_time DESC) index from migration 027 already
+covers /events/explore, so it is intentionally not duplicated here.
+"""
+
+import peewee as pw
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.sql(
+        'CREATE INDEX IF NOT EXISTS "event_camera_start_time" '
+        'ON "event" ("camera", "start_time" DESC)'
+    )
+    migrator.sql(
+        'CREATE INDEX IF NOT EXISTS "reviewsegment_camera_start_time" '
+        'ON "reviewsegment" ("camera", "start_time" DESC)'
+    )
+    migrator.sql(
+        'CREATE INDEX IF NOT EXISTS "reviewsegment_end_time" '
+        'ON "reviewsegment" ("end_time")'
+    )
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.sql('DROP INDEX IF EXISTS "event_camera_start_time"')
+    migrator.sql('DROP INDEX IF EXISTS "reviewsegment_camera_start_time"')
+    migrator.sql('DROP INDEX IF EXISTS "reviewsegment_end_time"')


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

Rewrite some logic to avoid looping through a list of items and issuing many DB queries - also rewrite the explore handler to use a common table expression to do label ranking and sorting within the SQL query itself. All changes are intended to be a no-op for actual application behavior 


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: General performance
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

N/A

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):
Claude + gemini via vscode integration.


**How AI was used** (e.g., code generation, code review, debugging, documentation):

AI was used to identify areas for improvement, and suggest methods of speeding up responses. Initial rewrite using the CTE was AI-driven, but I later re-translated it back into peewee to make sure I fully understood the implications. 

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):
Generated initial implementation, assisted with refinements.


**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

All code was fully reviewed, and tested with a copy of my personal frigate instance (storage + database + config) to ensure everything remained functional. Changes were broken up into minimal chunks, and no 'yolo' coding was allowed (meaning all AI-actuated items were required to have a reviewed plan prior to editing code)


## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
