### PR TITLE
fix: fix chat request params miss runtime_options

### DIFF
--- a/frigate/genai/openai.py
+++ b/frigate/genai/openai.py
@@ -203,6 +203,7 @@ class OpenAIClient(GenAIClient):
                 "model": self.genai_config.model,
                 "messages": messages,
                 "timeout": self.timeout,
+                **self.genai_config.runtime_options,
             }
 
             if tools:
@@ -315,6 +316,7 @@ class OpenAIClient(GenAIClient):
                 "timeout": self.timeout,
                 "stream": True,
                 "stream_options": {"include_usage": True},
+                **self.genai_config.runtime_options,
             }
 
             if tools:

--- a/frigate/genai/openai.py
+++ b/frigate/genai/openai.py
@@ -220,7 +220,7 @@ class OpenAIClient(GenAIClient):
                 }
                 request_params.update(provider_opts)
 
-            result = self.provider.chat.completions.create(**request_params)  # type: ignore[call-overload]
+            result = self.provider.chat.completions.create(**request_params)
 
             if (
                 result is None
@@ -339,7 +339,7 @@ class OpenAIClient(GenAIClient):
             finish_reason = "stop"
             usage_stats: Optional[dict[str, Any]] = None
 
-            stream = self.provider.chat.completions.create(**request_params)  # type: ignore[call-overload]
+            stream = self.provider.chat.completions.create(**request_params)
 
             for chunk in stream:
                 chunk_usage = getattr(chunk, "usage", None)


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

During previous tests with the DeepSeek API, I noticed that the model kept operating in thinking mode, even though I had configured `runtime_options`.  
After debugging, I found that the parameters set in `runtime_options` were never actually sent to the API. It turned out that `chat_with_tools`'s `request_params` did not include the `runtime_options` parameters at all, meaning the configured option to disable thinking never took effect.  

I've confirmed that other providers likely suffer from a similar issue, but since I don't have access to their APIs for testing, I'm only providing a fix for the OpenAI provider here.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [x] No AI tools were used in this PR.
- [ ] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
