### PR TITLE
Refactor move_preview_frames function

### DIFF
--- a/frigate/output/output.py
+++ b/frigate/output/output.py
@@ -342,20 +342,30 @@ def move_preview_frames(loc: str) -> None:
     preview_holdover = os.path.join(CLIPS_DIR, "preview_restart_cache")
     preview_cache = os.path.join(CACHE_DIR, "preview_frames")
 
+    if loc == "clips":
+        src = preview_cache
+        dst = preview_holdover
+    elif loc == "cache":
+        src = preview_holdover
+        dst = preview_cache
+    else:
+        return
+
     try:
-        if loc == "clips":
-            shutil.move(preview_cache, preview_holdover)
-        elif loc == "cache":
-            if not os.path.exists(preview_holdover):
-                return
+        if not os.path.exists(src):
+            return
 
-            if not os.access(preview_holdover, os.R_OK | os.W_OK):
-                logger.error(
-                    "Insufficient permissions on preview restart cache at %s",
-                    preview_holdover,
-                )
-                return
+        shutil.move(src, dst)
 
-            shutil.move(preview_holdover, preview_cache)
+    except PermissionError:
+        logger.error(
+            "Insufficient permissions while moving preview restart cache from %s to %s",
+            src,
+            dst,
+        )
     except shutil.Error:
-        logger.error("Failed to restore preview cache.")
+        logger.error(
+            "Failed to move preview restart cache from %s to %s",
+            src,
+            dst,
+        )


### PR DESCRIPTION
Refactor move_preview_frames to simplify logic and improve error handling.

_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

Fixes a regression on my system specifically from https://github.com/blakeblackshear/frigate/pull/23082

Discussion here: https://github.com/blakeblackshear/frigate/discussions/23086#discussioncomment-16911201

For some reason, due to my NFS mount and permissions to it, this os.access check doesn't work right even though I can actually read/write just fine. This change refactors it a bit to have the exact same logging/intent but functions on my system.

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [X] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): chatgpt

**How AI was used** (e.g., code generation, code review, debugging, documentation): A little of everything, I know how to write it myself as well though

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
