### PR TITLE
Miscellaneous fixes

### DIFF
--- a/docs/docs/configuration/genai/config.md
+++ b/docs/docs/configuration/genai/config.md
@@ -49,15 +49,14 @@ You should have at least 8 GB of RAM available (or VRAM if running on GPU) to ru
 
 ### Model Types: Instruct vs Thinking
 
-Most vision-language models are available as **instruct** models, which are fine-tuned to follow instructions and respond concisely to prompts. However, some models (such as certain Qwen-VL or minigpt variants) offer both **instruct** and **thinking** versions.
+Vision-language models come in **instruct** variants (fine-tuned to follow instructions and respond concisely), **thinking** variants (fine-tuned for free-form, speculative reasoning), and **hybrid** variants that support both modes per request. Most modern vision-language models are hybrid.
 
-- **Instruct models** are always recommended for use with Frigate. These models generate direct, relevant, actionable descriptions that best fit Frigate's object and event summary use case.
-- **Reasoning / Thinking models** are fine-tuned for more free-form, open-ended, and speculative outputs, which are typically not concise and may not provide the practical summaries Frigate expects. For this reason, Frigate does **not** recommend or support using thinking models.
+Frigate manages reasoning per task automatically:
 
-Some models are labeled as **hybrid** (capable of both thinking and instruct tasks). In these cases, it is recommended to disable reasoning / thinking, which is generally model specific (see your models documentation).
+- **Description tasks** (object descriptions, review descriptions, review summaries) are synthesis-only and benefit from concise, direct output, so Frigate disables thinking for these calls when the model exposes a per-request toggle.
+- **Chat** lets you toggle thinking on or off from the composer when the configured model supports it.
 
-**Recommendation:**
-Always select the `-instruct` or documented instruct/tagged variant of any model you use in your Frigate configuration. If in doubt, refer to your model provider's documentation or model library for guidance on the correct model variant to use.
+You can use a pure instruct, hybrid, or thinking-capable model with Frigate — no extra configuration is required to disable thinking for descriptions.
 
 ### llama.cpp
 

--- a/docs/docs/configuration/review.md
+++ b/docs/docs/configuration/review.md
@@ -23,7 +23,7 @@ In 0.14 and later, all of that is bundled into a single review item which starts
 
 ## Alerts and Detections
 
-Not every segment of video captured by Frigate may be of the same level of interest to you. Video of people who enter your property may be a different priority than those walking by on the sidewalk. For this reason, Frigate 0.14 categorizes review items as _alerts_ and _detections_. By default, all person and car objects are considered alerts. You can refine categorization of your review items by configuring required zones for them.
+Not every segment of video captured by Frigate may be of the same level of interest to you. Video of people who enter your property may be a different priority than those walking by on the sidewalk. For this reason, Frigate categorizes review items as _alerts_ and _detections_. By default, all person and car objects are considered alerts. You can refine categorization of your review items by configuring required zones for them.
 
 :::note
 

--- a/docs/docs/troubleshooting/dummy-camera.md
+++ b/docs/docs/troubleshooting/dummy-camera.md
@@ -56,6 +56,7 @@ Only one replay session can be active at a time. If a session is already running
 - The replay will not always produce identical results to the original run. Different frames may be selected on replay, which can change detections and tracking.
 - Motion detection depends on the exact frames used; small frame shifts can change motion regions and therefore what gets passed to the detector.
 - Object detection is not fully deterministic: models and post-processing can yield slightly different results across runs.
+- In cases where a detection is short and a replay may only be a small number of frames, it is recommended to manually add some padding before and after the detection so that the motion and object detectors have time to settle into the scene. Rather than starting Debug Replay from Explore, navigate to History for your camera, choose Debug Replay from the Actions menu, and click the "From Timeline" or "Custom" option.
 
 Treat the replay as a close approximation rather than an exact reproduction. Run multiple loops and examine the debug overlays and logs to understand the behavior.
 

--- a/frigate/debug_replay.py
+++ b/frigate/debug_replay.py
@@ -238,6 +238,10 @@ class DebugReplayManager:
             zone_dump.setdefault("coordinates", zone_config.coordinates)
             zones_dict[zone_name] = zone_dump
 
+        # Extract LPR and face recognition configs
+        lpr_dict = source_config.lpr.model_dump()
+        face_recognition_dict = source_config.face_recognition.model_dump()
+
         # Extract motion config (exclude runtime fields)
         motion_dict = {}
         if source_config.motion is not None:
@@ -287,8 +291,8 @@ class DebugReplayManager:
             },
             "birdseye": {"enabled": False},
             "audio": {"enabled": False},
-            "lpr": {"enabled": False},
-            "face_recognition": {"enabled": False},
+            "lpr": lpr_dict,
+            "face_recognition": face_recognition_dict,
         }
 
     def _cleanup_db(self, camera_name: str) -> None:

--- a/frigate/genai/plugins/gemini.py
+++ b/frigate/genai/plugins/gemini.py
@@ -1,5 +1,7 @@
 """Gemini Provider for Frigate AI."""
 
+import base64
+import binascii
 import json
 import logging
 from typing import Any, AsyncGenerator, Optional
@@ -12,6 +14,27 @@ from frigate.config import GenAIProviderEnum
 from frigate.genai import GenAIClient, register_genai_provider
 
 logger = logging.getLogger(__name__)
+
+
+def _decode_thought_signature(value: Any) -> Optional[bytes]:
+    """Decode a base64-encoded thought_signature carried across conversation turns."""
+    if not value:
+        return None
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        try:
+            return base64.b64decode(value)
+        except (binascii.Error, ValueError):
+            return None
+    return None
+
+
+def _encode_thought_signature(signature: Optional[bytes]) -> Optional[str]:
+    """Encode bytes thought_signature as base64 so it survives JSON-friendly transport."""
+    if not signature:
+        return None
+    return base64.b64encode(signature).decode("ascii")
 
 
 def _stats_from_gemini_usage(usage: Any) -> Optional[dict[str, Any]]:
@@ -169,11 +192,17 @@ class GeminiClient(GenAIClient):
                         if not isinstance(tc_args, dict):
                             tc_args = {}
                         if tc_name:
-                            parts.append(
-                                types.Part.from_function_call(
-                                    name=tc_name, args=tc_args
-                                )
+                            fc_part = types.Part.from_function_call(
+                                name=tc_name, args=tc_args
                             )
+                            # Thinking-capable Gemini models require the original
+                            # thought_signature to be echoed back on functionCall
+                            # parts after a tool response, or the next request
+                            # fails with INVALID_ARGUMENT.
+                            sig = _decode_thought_signature(tc.get("thought_signature"))
+                            if sig:
+                                fc_part.thought_signature = sig
+                            parts.append(fc_part)
                     if not parts:
                         parts.append(types.Part.from_text(text=" "))
                     gemini_messages.append(types.Content(role="model", parts=parts))
@@ -310,6 +339,9 @@ class GeminiClient(GenAIClient):
                                 "id": part.function_call.name or "",
                                 "name": part.function_call.name or "",
                                 "arguments": arguments,
+                                "thought_signature": _encode_thought_signature(
+                                    getattr(part, "thought_signature", None)
+                                ),
                             }
                         )
 
@@ -415,11 +447,17 @@ class GeminiClient(GenAIClient):
                         if not isinstance(tc_args, dict):
                             tc_args = {}
                         if tc_name:
-                            parts.append(
-                                types.Part.from_function_call(
-                                    name=tc_name, args=tc_args
-                                )
+                            fc_part = types.Part.from_function_call(
+                                name=tc_name, args=tc_args
                             )
+                            # Thinking-capable Gemini models require the original
+                            # thought_signature to be echoed back on functionCall
+                            # parts after a tool response, or the next request
+                            # fails with INVALID_ARGUMENT.
+                            sig = _decode_thought_signature(tc.get("thought_signature"))
+                            if sig:
+                                fc_part.thought_signature = sig
+                            parts.append(fc_part)
                     if not parts:
                         parts.append(types.Part.from_text(text=" "))
                     gemini_messages.append(types.Content(role="model", parts=parts))
@@ -585,6 +623,7 @@ class GeminiClient(GenAIClient):
                                     "id": tool_call_id,
                                     "name": tool_call_name,
                                     "arguments": "",
+                                    "thought_signature": None,
                                 }
 
                             # Accumulate arguments
@@ -594,6 +633,13 @@ class GeminiClient(GenAIClient):
                                     if isinstance(arguments, dict)
                                     else str(arguments)
                                 )
+
+                            # Capture latest thought_signature for this call
+                            chunk_sig = getattr(part, "thought_signature", None)
+                            if chunk_sig:
+                                tool_calls_by_index[found_index][
+                                    "thought_signature"
+                                ] = chunk_sig
 
             # Build final message
             full_content = "".join(content_parts).strip() or None
@@ -615,6 +661,9 @@ class GeminiClient(GenAIClient):
                             "id": tc["id"],
                             "name": tc["name"],
                             "arguments": parsed_args,
+                            "thought_signature": _encode_thought_signature(
+                                tc.get("thought_signature")
+                            ),
                         }
                     )
                 finish_reason = "tool_calls"

--- a/frigate/genai/utils.py
+++ b/frigate/genai/utils.py
@@ -69,6 +69,14 @@ def build_assistant_message_for_conversation(
                     "name": tc["name"],
                     "arguments": json.dumps(tc.get("arguments") or {}),
                 },
+                # Gemini-only: opaque signature that must be echoed back on
+                # the same functionCall part in the next turn. Other providers
+                # do not set or read this.
+                **(
+                    {"thought_signature": tc["thought_signature"]}
+                    if tc.get("thought_signature")
+                    else {}
+                ),
             }
             for tc in tool_calls_raw
         ]

--- a/frigate/object_detection/base.py
+++ b/frigate/object_detection/base.py
@@ -167,8 +167,9 @@ class DetectorRunner(FrigateProcess):
 
             # detect and send the output
             self.start_time.value = datetime.datetime.now().timestamp()
+            mono_start = time.monotonic()
             detections = object_detector.detect_raw(input_frame)
-            duration = datetime.datetime.now().timestamp() - self.start_time.value
+            duration = time.monotonic() - mono_start
             frame_manager.close(connection_id)
 
             if connection_id not in self.outputs:

--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -1331,6 +1331,8 @@ class PtzAutoTracker:
         return self.tracked_object[camera]["region"]
 
     def autotrack_object(self, camera: str, obj: TrackedObject):
+        if camera not in self.config.cameras:
+            return
         camera_config = self.config.cameras[camera]
 
         if camera_config.onvif.autotracking.enabled:

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -484,11 +484,15 @@
       "reorderHandle": "Drag to reorder",
       "saving": "Saving…",
       "saved": "Saved",
-      "friendlyName": {
-        "edit": "Edit camera display name",
-        "title": "Edit Display Name",
-        "description": "Set the friendly name shown for this camera throughout the Frigate UI. Leave blank to use the camera ID.",
-        "rename": "Rename"
+      "details": {
+        "edit": "Edit camera details",
+        "title": "Edit Camera Details",
+        "description": "Update the display name and external URL used for this camera throughout the Frigate UI.",
+        "friendlyNameLabel": "Display Name",
+        "friendlyNameHelp": "Friendly name shown for this camera throughout the Frigate UI. Leave blank to use the camera ID.",
+        "webuiUrlLabel": "Camera Web UI URL",
+        "webuiUrlHelp": "URL to visit the camera's web UI directly from the Debug view. Leave blank to disable the link.",
+        "webuiUrlInvalid": "Must be a valid URL (e.g., https://example.com)."
       }
     },
     "cameraConfig": {

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -1820,7 +1820,8 @@
       "mixedTypesSuggestion": "All detectors must use the same type. Remove existing detectors or select {{type}}."
     },
     "semanticSearch": {
-      "jinav2SmallModelSize": "The 'small' size with the Jina V2 model has high RAM and inference cost. The 'large' model with a discrete GPU is recommended."
+      "jinav2SmallModelSize": "The 'small' size with the Jina V2 model has high RAM and inference cost. The 'large' model with a discrete GPU is recommended.",
+      "modelSizeIgnoredForProvider": "Model size only applies to the built-in Jina models. This value will be ignored when using a GenAI embedding provider."
     }
   }
 }

--- a/web/src/components/config-form/FieldMessagesContext.ts
+++ b/web/src/components/config-form/FieldMessagesContext.ts
@@ -1,0 +1,13 @@
+import { createContext } from "react";
+import type { FieldConditionalMessage } from "./section-configs/types";
+
+// Provides currently-active field messages to FieldTemplate without going
+// through RJSF's per-field uiSchema. RJSF caches state.uiSchema across renders
+// in a way that can leave stale ui:messages attached to a field when the
+// triggering condition flips back to false (see processPendingChange in
+// @rjsf/core Form.js — formData is updated immediately, uiSchema is not).
+// useContext re-runs consumers directly on provider value change, sidestepping
+// that staleness.
+export const FieldMessagesContext = createContext<FieldConditionalMessage[]>(
+  [],
+);

--- a/web/src/components/config-form/section-configs/semantic_search.ts
+++ b/web/src/components/config-form/section-configs/semantic_search.ts
@@ -29,6 +29,22 @@ const semanticSearch: SectionConfigOverrides = {
           ctx.formData?.model === "jinav2" &&
           ctx.formData?.model_size === "small",
       },
+      {
+        key: "model-size-ignored-for-provider",
+        field: "model_size",
+        messageKey: "configMessages.semanticSearch.modelSizeIgnoredForProvider",
+        severity: "info",
+        position: "after",
+        condition: (ctx) => {
+          const model = ctx.formData?.model;
+          return (
+            typeof model === "string" &&
+            model !== "" &&
+            model !== "jinav1" &&
+            model !== "jinav2"
+          );
+        },
+      },
     ],
     uiSchema: {
       model: {

--- a/web/src/components/config-form/sections/BaseSection.tsx
+++ b/web/src/components/config-form/sections/BaseSection.tsx
@@ -86,6 +86,7 @@ import type {
 } from "../section-configs/types";
 import { useConfigMessages } from "@/hooks/use-config-messages";
 import { ConfigMessageBanner } from "../ConfigMessageBanner";
+import { FieldMessagesContext } from "../FieldMessagesContext";
 
 export interface SectionConfig {
   /** Field ordering within the section */
@@ -627,44 +628,6 @@ export function ConfigSection({
     messageContext,
   );
 
-  // Merge field-level conditional messages into uiSchema
-  const effectiveUiSchema = useMemo(() => {
-    if (activeFieldMessages.length === 0) return sectionConfig.uiSchema;
-    const merged = { ...(sectionConfig.uiSchema ?? {}) };
-    for (const msg of activeFieldMessages) {
-      const segments = msg.field.split(".");
-      // Navigate to the nested uiSchema node, shallow-cloning along the way
-      let node = merged;
-      for (let i = 0; i < segments.length - 1; i++) {
-        const seg = segments[i];
-        node[seg] = { ...(node[seg] as Record<string, unknown>) };
-        node = node[seg] as Record<string, unknown>;
-      }
-      const leafKey = segments[segments.length - 1];
-      const existing = node[leafKey] as Record<string, unknown> | undefined;
-      const existingMessages = ((existing?.["ui:messages"] as unknown[]) ??
-        []) as Array<{
-        key: string;
-        messageKey: string;
-        severity: string;
-        position?: string;
-      }>;
-      node[leafKey] = {
-        ...existing,
-        "ui:messages": [
-          ...existingMessages,
-          {
-            key: msg.key,
-            messageKey: msg.messageKey,
-            severity: msg.severity,
-            position: msg.position ?? "before",
-          },
-        ],
-      };
-    }
-    return merged;
-  }, [sectionConfig.uiSchema, activeFieldMessages]);
-
   const currentOverrides = useMemo(() => {
     if (!currentFormData || typeof currentFormData !== "object") {
       return undefined;
@@ -1034,59 +997,61 @@ export function ConfigSection({
   const sectionContent = (
     <div className="space-y-6">
       <ConfigMessageBanner messages={activeMessages} />
-      <ConfigForm
-        key={formKey}
-        schema={modifiedSchema}
-        formData={currentFormData}
-        onChange={handleChange}
-        onValidationChange={setHasValidationErrors}
-        fieldOrder={sectionConfig.fieldOrder}
-        fieldGroups={sectionConfig.fieldGroups}
-        hiddenFields={effectiveHiddenFields}
-        advancedFields={sectionConfig.advancedFields}
-        liveValidate={sectionConfig.liveValidate}
-        uiSchema={effectiveUiSchema}
-        disabled={disabled || isSaving}
-        readonly={readonly}
-        showSubmit={false}
-        i18nNamespace={configNamespace}
-        customValidate={customValidate}
-        formContext={{
-          level: effectiveLevel,
-          cameraName,
-          globalValue,
-          cameraValue,
-          hasChanges,
-          extraHasChanges,
-          setExtraHasChanges,
-          overrides: uiOverrides as JsonValue | undefined,
-          formData: currentFormData as ConfigSectionData,
-          baselineFormData: effectiveBaselineFormData as ConfigSectionData,
-          pendingDataBySection,
-          onPendingDataChange,
-          onFormDataChange: (data: ConfigSectionData) => handleChange(data),
-          // For widgets that need access to full camera config (e.g., zone names)
-          fullCameraConfig:
-            effectiveLevel === "camera" && cameraName
-              ? config?.cameras?.[cameraName]
-              : undefined,
-          fullConfig: config,
-          // When rendering camera-level sections, provide the section path so
-          // field templates can look up keys under the `config/cameras` namespace
-          // When using a consolidated global namespace, keys are nested
-          // under the section name (e.g., `audio.label`) so provide the
-          // section prefix to templates so they can attempt `${section}.${field}` lookups.
-          sectionI18nPrefix: sectionPath,
-          t,
-          renderers: wrappedRenderers,
-          sectionDocs: sectionConfig.sectionDocs,
-          fieldDocs: sectionConfig.fieldDocs,
-          hiddenFields: effectiveHiddenFields,
-          restartRequired: sectionConfig.restartRequired,
-          requiresRestart,
-          isProfile: !!profileName,
-        }}
-      />
+      <FieldMessagesContext.Provider value={activeFieldMessages}>
+        <ConfigForm
+          key={formKey}
+          schema={modifiedSchema}
+          formData={currentFormData}
+          onChange={handleChange}
+          onValidationChange={setHasValidationErrors}
+          fieldOrder={sectionConfig.fieldOrder}
+          fieldGroups={sectionConfig.fieldGroups}
+          hiddenFields={effectiveHiddenFields}
+          advancedFields={sectionConfig.advancedFields}
+          liveValidate={sectionConfig.liveValidate}
+          uiSchema={sectionConfig.uiSchema}
+          disabled={disabled || isSaving}
+          readonly={readonly}
+          showSubmit={false}
+          i18nNamespace={configNamespace}
+          customValidate={customValidate}
+          formContext={{
+            level: effectiveLevel,
+            cameraName,
+            globalValue,
+            cameraValue,
+            hasChanges,
+            extraHasChanges,
+            setExtraHasChanges,
+            overrides: uiOverrides as JsonValue | undefined,
+            formData: currentFormData as ConfigSectionData,
+            baselineFormData: effectiveBaselineFormData as ConfigSectionData,
+            pendingDataBySection,
+            onPendingDataChange,
+            onFormDataChange: (data: ConfigSectionData) => handleChange(data),
+            // For widgets that need access to full camera config (e.g., zone names)
+            fullCameraConfig:
+              effectiveLevel === "camera" && cameraName
+                ? config?.cameras?.[cameraName]
+                : undefined,
+            fullConfig: config,
+            // When rendering camera-level sections, provide the section path so
+            // field templates can look up keys under the `config/cameras` namespace
+            // When using a consolidated global namespace, keys are nested
+            // under the section name (e.g., `audio.label`) so provide the
+            // section prefix to templates so they can attempt `${section}.${field}` lookups.
+            sectionI18nPrefix: sectionPath,
+            t,
+            renderers: wrappedRenderers,
+            sectionDocs: sectionConfig.sectionDocs,
+            fieldDocs: sectionConfig.fieldDocs,
+            hiddenFields: effectiveHiddenFields,
+            restartRequired: sectionConfig.restartRequired,
+            requiresRestart,
+            isProfile: !!profileName,
+          }}
+        />
+      </FieldMessagesContext.Provider>
 
       {!embedded && (
         <div

--- a/web/src/components/config-form/theme/templates/FieldTemplate.tsx
+++ b/web/src/components/config-form/theme/templates/FieldTemplate.tsx
@@ -5,8 +5,9 @@ import {
   getUiOptions,
   ADDITIONAL_PROPERTY_FLAG,
 } from "@rjsf/utils";
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, ReactNode, useContext } from "react";
 import { isValidElement } from "react";
+import { FieldMessagesContext } from "../../FieldMessagesContext";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
@@ -95,6 +96,7 @@ export function FieldTemplate(props: FieldTemplateProps) {
     "views/settings",
   ]);
   const { getLocaleDocUrl } = useDocDomain();
+  const allFieldMessages = useContext(FieldMessagesContext);
 
   if (hidden) {
     return <div className="hidden">{children}</div>;
@@ -384,21 +386,15 @@ export function FieldTemplate(props: FieldTemplateProps) {
   const beforeContent = renderCustom(beforeSpec);
   const afterContent = renderCustom(afterSpec);
 
-  // Render conditional field messages from ui:messages
-  const fieldMessageSpecs = uiSchema?.["ui:messages"] as
-    | Array<{
-        key: string;
-        messageKey: string;
-        severity: string;
-        position?: string;
-      }>
-    | undefined;
-  const beforeMessages = fieldMessageSpecs?.filter(
+  // Read field-level conditional messages from FieldMessagesContext
+  const fieldPathStr = pathSegments.join(".");
+  const fieldMessageSpecs = allFieldMessages.filter(
+    (m) => m.field === fieldPathStr,
+  );
+  const beforeMessages = fieldMessageSpecs.filter(
     (m) => (m.position ?? "before") === "before",
   );
-  const afterMessages = fieldMessageSpecs?.filter(
-    (m) => m.position === "after",
-  );
+  const afterMessages = fieldMessageSpecs.filter((m) => m.position === "after");
   const beforeMessagesContent =
     beforeMessages && beforeMessages.length > 0 ? (
       <div className="space-y-2">

--- a/web/src/views/settings/CameraManagementView.tsx
+++ b/web/src/views/settings/CameraManagementView.tsx
@@ -36,7 +36,15 @@ import axios from "axios";
 import ActivityIndicator from "@/components/indicators/activity-indicator";
 import RestartDialog from "@/components/overlay/dialog/RestartDialog";
 import RestartRequiredIndicator from "@/components/indicators/RestartRequiredIndicator";
-import TextEntryDialog from "@/components/overlay/dialog/TextEntryDialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import {
   Tooltip,
   TooltipContent,
@@ -53,6 +61,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
 
 const REORDER_SAVED_INDICATOR_MS = 1500;
 
@@ -482,7 +501,7 @@ function EnabledCameraRow({
           <LuGripVertical className="size-4" />
         </button>
         <CameraNameLabel camera={camera} />
-        <CameraFriendlyNameEditor
+        <CameraDetailsEditor
           cameraName={camera}
           onConfigChanged={onConfigChanged}
         />
@@ -519,25 +538,91 @@ function CameraEnableSwitch({ cameraName }: CameraEnableSwitchProps) {
   );
 }
 
-type CameraFriendlyNameEditorProps = {
+type CameraDetailsEditorProps = {
   cameraName: string;
   onConfigChanged: () => Promise<unknown>;
 };
 
-function CameraFriendlyNameEditor({
+type CameraDetailsFormValues = {
+  friendlyName: string;
+  webuiUrl: string;
+};
+
+function CameraDetailsEditor({
   cameraName,
   onConfigChanged,
-}: CameraFriendlyNameEditorProps) {
+}: CameraDetailsEditorProps) {
   const { t } = useTranslation(["views/settings", "common"]);
   const { data: config } = useSWR<FrigateConfig>("config");
   const [open, setOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
   const currentFriendlyName = config?.cameras?.[cameraName]?.friendly_name;
+  const currentWebuiUrl = config?.cameras?.[cameraName]?.webui_url;
 
-  const onSave = useCallback(
-    async (text: string) => {
+  const formSchema = useMemo(
+    () =>
+      z.object({
+        friendlyName: z.string(),
+        webuiUrl: z.string().refine(
+          (val) => {
+            const trimmed = val.trim();
+            if (!trimmed) return true;
+            try {
+              new URL(trimmed);
+              return true;
+            } catch {
+              return false;
+            }
+          },
+          {
+            message: t("cameraManagement.streams.details.webuiUrlInvalid", {
+              ns: "views/settings",
+            }),
+          },
+        ),
+      }),
+    [t],
+  );
+
+  const form = useForm<CameraDetailsFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      friendlyName: currentFriendlyName ?? "",
+      webuiUrl: currentWebuiUrl ?? "",
+    },
+  });
+
+  // Reset form values from config whenever the dialog is opened.
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        friendlyName: currentFriendlyName ?? "",
+        webuiUrl: currentWebuiUrl ?? "",
+      });
+    }
+  }, [open, currentFriendlyName, currentWebuiUrl, form]);
+
+  const onSubmit = useCallback(
+    async (values: CameraDetailsFormValues) => {
       if (isSaving) return;
+
+      // only send fields the user actually changed
+      const newFriendly = values.friendlyName.trim() || null;
+      const newWebui = values.webuiUrl.trim() || null;
+      const cameraUpdate: Record<string, string | null> = {};
+      if (newFriendly !== (currentFriendlyName ?? null)) {
+        cameraUpdate.friendly_name = newFriendly;
+      }
+      if (newWebui !== (currentWebuiUrl ?? null)) {
+        cameraUpdate.webui_url = newWebui;
+      }
+
+      if (Object.keys(cameraUpdate).length === 0) {
+        setOpen(false);
+        return;
+      }
+
       setIsSaving(true);
 
       try {
@@ -545,9 +630,7 @@ function CameraFriendlyNameEditor({
           requires_restart: 0,
           config_data: {
             cameras: {
-              [cameraName]: {
-                friendly_name: text.trim() || null,
-              },
+              [cameraName]: cameraUpdate,
             },
           },
         });
@@ -573,10 +656,17 @@ function CameraFriendlyNameEditor({
         setIsSaving(false);
       }
     },
-    [cameraName, isSaving, onConfigChanged, t],
+    [
+      cameraName,
+      currentFriendlyName,
+      currentWebuiUrl,
+      isSaving,
+      onConfigChanged,
+      t,
+    ],
   );
 
-  const renameLabel = t("cameraManagement.streams.friendlyName.rename", {
+  const editLabel = t("cameraManagement.streams.details.edit", {
     ns: "views/settings",
   });
 
@@ -588,30 +678,107 @@ function CameraFriendlyNameEditor({
             variant="ghost"
             size="icon"
             className="size-7"
-            aria-label={renameLabel}
+            aria-label={editLabel}
             onClick={() => setOpen(true)}
             disabled={isSaving}
           >
             <LuPencil className="size-3.5" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>{renameLabel}</TooltipContent>
+        <TooltipContent>{editLabel}</TooltipContent>
       </Tooltip>
-      <TextEntryDialog
-        open={open}
-        setOpen={setOpen}
-        title={t("cameraManagement.streams.friendlyName.title", {
-          ns: "views/settings",
-        })}
-        description={t("cameraManagement.streams.friendlyName.description", {
-          ns: "views/settings",
-        })}
-        defaultValue={currentFriendlyName ?? ""}
-        placeholder={currentFriendlyName ? undefined : cameraName}
-        allowEmpty
-        isSaving={isSaving}
-        onSave={onSave}
-      />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t("cameraManagement.streams.details.title", {
+                ns: "views/settings",
+              })}
+            </DialogTitle>
+            <DialogDescription>
+              {t("cameraManagement.streams.details.description", {
+                ns: "views/settings",
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="friendlyName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("cameraManagement.streams.details.friendlyNameLabel", {
+                        ns: "views/settings",
+                      })}
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder={cameraName}
+                        disabled={isSaving}
+                        autoFocus
+                      />
+                    </FormControl>
+                    <p className="text-xs text-muted-foreground">
+                      {t("cameraManagement.streams.details.friendlyNameHelp", {
+                        ns: "views/settings",
+                      })}
+                    </p>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="webuiUrl"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("cameraManagement.streams.details.webuiUrlLabel", {
+                        ns: "views/settings",
+                      })}
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder="https://"
+                        disabled={isSaving}
+                      />
+                    </FormControl>
+                    <p className="text-xs text-muted-foreground">
+                      {t("cameraManagement.streams.details.webuiUrlHelp", {
+                        ns: "views/settings",
+                      })}
+                    </p>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <DialogFooter className="pt-2">
+                <Button
+                  type="button"
+                  disabled={isSaving}
+                  onClick={() => setOpen(false)}
+                >
+                  {t("button.cancel", { ns: "common" })}
+                </Button>
+                <Button variant="select" type="submit" disabled={isSaving}>
+                  {isSaving ? (
+                    <div className="flex flex-row items-center gap-2">
+                      <ActivityIndicator className="size-4" />
+                      <span>{t("button.saving", { ns: "common" })}</span>
+                    </div>
+                  ) : (
+                    t("button.save", { ns: "common" })
+                  )}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
- Use monotonic clock for detector inference duration to prevent negative values from wall clock steps (fixes https://github.com/blakeblackshear/frigate/discussions/23263)
- Add ability to set camera's webui_url from camera management pane
- Copy lpr and face configs to replay camera from source
- Add guard in autotracking to prevent crash when camera is dynamically removed
- Route field-level conditional messages through a dedicated React Context instead of merging them into uiSchema
  - RJSF's Form keeps state.uiSchema sticky across renders during processPendingChange (formData is updated, uiSchema is not), so a previously injected ui:messages array stays attached to a field even after the triggering condition flips back to false. Context propagation re-runs FieldTemplate directly on every provider value change.
- Add a fieldMessage on semantic search's model_size noting that the value is ignored when a GenAI embedding provider is selected


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
