### PR TITLE
Miscellaneous fixes

### DIFF
--- a/frigate/api/chat.py
+++ b/frigate/api/chat.py
@@ -733,7 +733,14 @@ async def _execute_tool_internal(
                 "Arguments: %s",
                 json.dumps(arguments),
             )
-            return {"error": "Camera parameter is required"}
+            return {
+                "error": (
+                    "get_live_context requires a single camera name; "
+                    "wildcards and empty values are not supported. "
+                    "Call this tool once per camera."
+                ),
+                "available_cameras": allowed_cameras,
+            }
         return await _execute_get_live_context(request, camera, allowed_cameras)
     elif tool_name == "start_camera_watch":
         return await _execute_start_camera_watch(request, arguments)

--- a/frigate/api/chat.py
+++ b/frigate/api/chat.py
@@ -547,9 +547,21 @@ async def _execute_get_live_context(
     camera: str,
     allowed_cameras: List[str],
 ) -> Dict[str, Any]:
+    # Reject wildcards explicitly so models retry with a real camera name
+    # instead of silently fanning out across every camera.
+    if camera in ("*", "all"):
+        return {
+            "error": (
+                "get_live_context requires a single camera name; wildcards "
+                "are not supported. Call this tool once per camera."
+            ),
+            "available_cameras": allowed_cameras,
+        }
+
     if camera not in allowed_cameras:
         return {
             "error": f"Camera '{camera}' not found or access denied",
+            "available_cameras": allowed_cameras,
         }
 
     if camera not in request.app.frigate_config.cameras:

--- a/frigate/genai/prompts.py
+++ b/frigate/genai/prompts.py
@@ -518,16 +518,21 @@ def get_tool_definitions(
             "function": {
                 "name": "get_live_context",
                 "description": (
-                    "Get the current live image and detection information for a camera: objects being tracked, "
+                    "Get the current live image and detection information for a single camera: objects being tracked, "
                     "zones, timestamps. Use this to understand what is visible in the live view. "
-                    "Call this when answering questions about what is happening right now on a specific camera."
+                    "Call this when answering questions about what is happening right now on a specific camera. "
+                    "Operates on one camera at a time; call the tool again for each additional camera. "
+                    "Wildcards and empty values are not accepted."
                 ),
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "camera": {
                             "type": "string",
-                            "description": "Camera name to get live context for.",
+                            "description": (
+                                "Exact name of a single camera to get live context for. "
+                                "Wildcards (e.g. '*', 'all') and empty strings are not accepted."
+                            ),
                         },
                     },
                     "required": ["camera"],

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -579,7 +579,7 @@ class RecordingExporter(threading.Thread):
         else:
             chapters_path = self._build_chapter_metadata_file(recordings)
             chapter_args = (
-                f" -i {chapters_path} -map 0 -map_metadata 1" if chapters_path else ""
+                f" -i {chapters_path} -map 0 -dn -map_metadata 1" if chapters_path else ""
             )
             ffmpeg_cmd = (
                 f"{self.config.ffmpeg.ffmpeg_path} -hide_banner {ffmpeg_input}{chapter_args} -c copy -movflags +faststart"

--- a/frigate/record/export.py
+++ b/frigate/record/export.py
@@ -579,7 +579,9 @@ class RecordingExporter(threading.Thread):
         else:
             chapters_path = self._build_chapter_metadata_file(recordings)
             chapter_args = (
-                f" -i {chapters_path} -map 0 -dn -map_metadata 1" if chapters_path else ""
+                f" -i {chapters_path} -map 0 -dn -map_metadata 1"
+                if chapters_path
+                else ""
             )
             ffmpeg_cmd = (
                 f"{self.config.ffmpeg.ffmpeg_path} -hide_banner {ffmpeg_input}{chapter_args} -c copy -movflags +faststart"

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -478,7 +478,7 @@ def get_intel_gpu_stats(
         overall_pct = min(100.0, compute_pct + dec_pct)
 
         entry: dict[str, Any] = {
-            "name": names.get(pdev) or f"Intel GPU {pdev}",
+            "name": names.get(pdev) or "Intel iGPU",
             "vendor": "intel",
             "gpu": f"{round(overall_pct, 2)}%",
             "mem": "-%",

--- a/web/src/components/menu/SearchResultActions.tsx
+++ b/web/src/components/menu/SearchResultActions.tsx
@@ -130,9 +130,15 @@ export default function SearchResultActions({
               },
             );
           } else {
-            toast.error(t("dialog.toast.error", { error: errorMessage }), {
-              position: "top-center",
-            });
+            toast.error(
+              t("dialog.toast.error", {
+                ns: "views/replay",
+                error: errorMessage,
+              }),
+              {
+                position: "top-center",
+              },
+            );
           }
         })
         .finally(() => {
@@ -206,7 +212,7 @@ export default function SearchResultActions({
             <span>{t("itemMenu.addTrigger.label")}</span>
           </MenuItem>
         )}
-      {searchResult.has_clip && (
+      {isAdmin && searchResult.has_clip && (
         <MenuItem
           className="cursor-pointer"
           aria-label={t("itemMenu.debugReplay.aria")}

--- a/web/src/components/overlay/ActionsDropdown.tsx
+++ b/web/src/components/overlay/ActionsDropdown.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from "react-i18next";
 import { FaFilm } from "react-icons/fa6";
 
 type ActionsDropdownProps = {
-  onDebugReplayClick: () => void;
+  onDebugReplayClick?: () => void;
   onExportClick: () => void;
   onShareTimestampClick: () => void;
 };
@@ -42,9 +42,11 @@ export default function ActionsDropdown({
         <DropdownMenuItem onClick={onShareTimestampClick}>
           {t("recording.shareTimestamp.label", { ns: "components/dialog" })}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={onDebugReplayClick}>
-          {t("title", { ns: "views/replay" })}
-        </DropdownMenuItem>
+        {onDebugReplayClick && (
+          <DropdownMenuItem onClick={onDebugReplayClick}>
+            {t("title", { ns: "views/replay" })}
+          </DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
+++ b/web/src/components/overlay/MobileReviewSettingsDrawer.tsx
@@ -29,6 +29,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { StartExportResponse } from "@/types/export";
 import { ShareTimestampContent } from "./ShareTimestampDialog";
+import { useIsAdmin } from "@/hooks/use-is-admin";
 
 type DrawerMode =
   | "none"
@@ -109,6 +110,7 @@ export default function MobileReviewSettingsDrawer({
     "views/replay",
     "common",
   ]);
+  const isAdmin = useIsAdmin();
   const navigate = useNavigate();
   const [drawerMode, setDrawerMode] = useState<DrawerMode>("none");
   const [exportTab, setExportTab] = useState<ExportTab>("export");
@@ -388,7 +390,7 @@ export default function MobileReviewSettingsDrawer({
             {t("filter")}
           </Button>
         )}
-        {features.includes("debug-replay") && (
+        {isAdmin && features.includes("debug-replay") && (
           <Button
             className="flex w-full items-center justify-center gap-2"
             aria-label={t("title", { ns: "views/replay" })}

--- a/web/src/components/overlay/detail/DetailActionsMenu.tsx
+++ b/web/src/components/overlay/detail/DetailActionsMenu.tsx
@@ -95,9 +95,15 @@ export default function DetailActionsMenu({
             ),
           });
         } else {
-          toast.error(t("dialog.toast.error", { error: errorMessage }), {
-            position: "top-center",
-          });
+          toast.error(
+            t("dialog.toast.error", {
+              ns: "views/replay",
+              error: errorMessage,
+            }),
+            {
+              position: "top-center",
+            },
+          );
         }
       })
       .finally(() => {
@@ -229,7 +235,7 @@ export default function DetailActionsMenu({
               </DropdownMenuItem>
             )}
 
-          {search.has_clip && (
+          {isAdmin && search.has_clip && (
             <DropdownMenuItem
               className="cursor-pointer"
               aria-label={t("itemMenu.debugReplay.aria")}

--- a/web/src/components/timeline/EventMenu.tsx
+++ b/web/src/components/timeline/EventMenu.tsx
@@ -94,9 +94,15 @@ export default function EventMenu({
               },
             );
           } else {
-            toast.error(t("dialog.toast.error", { error: errorMessage }), {
-              position: "top-center",
-            });
+            toast.error(
+              t("dialog.toast.error", {
+                ns: "views/replay",
+                error: errorMessage,
+              }),
+              {
+                position: "top-center",
+              },
+            );
           }
         })
         .finally(() => {
@@ -177,7 +183,7 @@ export default function EventMenu({
                 {t("itemMenu.findSimilar.label")}
               </DropdownMenuItem>
             )}
-            {event.has_clip && (
+            {isAdmin && event.has_clip && (
               <DropdownMenuItem
                 className="cursor-pointer"
                 disabled={isStarting}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -16,6 +16,11 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Drawer, DrawerContent, DrawerTrigger } from "@/components/ui/drawer";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Button } from "@/components/ui/button";
 import {
   useCallback,
@@ -589,7 +594,7 @@ function MobileMenuItem({
   return (
     <div
       className={cn(
-        "inline-flex h-10 w-full cursor-pointer items-center justify-between whitespace-nowrap rounded-md px-4 py-2 pr-2 text-sm font-medium text-primary-variant disabled:pointer-events-none disabled:opacity-50",
+        "inline-flex h-10 w-full cursor-pointer items-center whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium text-primary-variant disabled:pointer-events-none disabled:opacity-50",
         className,
       )}
       onClick={() => {
@@ -600,7 +605,6 @@ function MobileMenuItem({
       <div className="w-full">
         {label ?? <div>{t("menu." + item.key)}</div>}
       </div>
-      <LuChevronRight className="size-4" />
     </div>
   );
 }
@@ -613,6 +617,39 @@ export default function Settings() {
   const [sectionStatusByKey, setSectionStatusByKey] = useState<
     Partial<Record<SettingsType, SectionStatus>>
   >({});
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    () =>
+      // all collapsed by default
+      new Set(
+        settingsGroups.filter((g) => g.items.length > 1).map((g) => g.label),
+      ),
+  );
+
+  const toggleGroupCollapsed = useCallback((label: string) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) {
+        next.delete(label);
+      } else {
+        next.add(label);
+      }
+      return next;
+    });
+  }, []);
+
+  // Auto-expand the group containing the active page whenever pageToggle changes
+  useEffect(() => {
+    const containingGroup = settingsGroups.find((group) =>
+      group.items.some((item) => item.key === pageToggle),
+    );
+    if (!containingGroup) return;
+    setCollapsedGroups((prev) => {
+      if (!prev.has(containingGroup.label)) return prev;
+      const next = new Set(prev);
+      next.delete(containingGroup.label);
+      return next;
+    });
+  }, [pageToggle]);
 
   const { data: config } = useSWR<FrigateConfig>("config");
   const { data: profilesData } = useSWR<ProfilesApiResponse>("profiles");
@@ -1611,34 +1648,49 @@ export default function Settings() {
                   visibleSettingsViews.includes(item.key as SettingsType),
                 );
                 if (filteredItems.length === 0) return null;
+                const isMultiItem = filteredItems.length > 1;
+                const renderedExpanded =
+                  !isMultiItem || !collapsedGroups.has(group.label);
+                const items = filteredItems.map((item) => (
+                  <MobileMenuItem
+                    key={item.key}
+                    item={item}
+                    className={cn(filteredItems.length == 1 && "pl-2")}
+                    label={renderMenuItemLabel(item.key as SettingsType)}
+                    onSelect={(key) => {
+                      if (
+                        !isAdmin &&
+                        !ALLOWED_VIEWS_FOR_VIEWER.includes(key as SettingsType)
+                      ) {
+                        setPageToggle("uiSettings");
+                      } else {
+                        setPageToggle(key as SettingsType);
+                      }
+                      setContentMobileOpen(true);
+                    }}
+                  />
+                ));
                 return (
                   <div key={group.label} className="mb-3">
-                    {filteredItems.length > 1 && (
-                      <h3 className="mb-2 ml-2 text-sm font-medium text-secondary-foreground">
-                        <div>{t("menu." + group.label)}</div>
-                      </h3>
+                    {isMultiItem ? (
+                      <Collapsible
+                        open={renderedExpanded}
+                        onOpenChange={() => toggleGroupCollapsed(group.label)}
+                      >
+                        <CollapsibleTrigger className="flex min-h-10 w-full items-center justify-between rounded-md py-2 pl-2 pr-2 text-sm font-medium text-secondary-foreground">
+                          <div>{t("menu." + group.label)}</div>
+                          <LuChevronRight
+                            className={cn(
+                              "size-4 shrink-0 transition-transform duration-200",
+                              renderedExpanded && "rotate-90",
+                            )}
+                          />
+                        </CollapsibleTrigger>
+                        <CollapsibleContent>{items}</CollapsibleContent>
+                      </Collapsible>
+                    ) : (
+                      items
                     )}
-                    {filteredItems.map((item) => (
-                      <MobileMenuItem
-                        key={item.key}
-                        item={item}
-                        className={cn(filteredItems.length == 1 && "pl-2")}
-                        label={renderMenuItemLabel(item.key as SettingsType)}
-                        onSelect={(key) => {
-                          if (
-                            !isAdmin &&
-                            !ALLOWED_VIEWS_FOR_VIEWER.includes(
-                              key as SettingsType,
-                            )
-                          ) {
-                            setPageToggle("uiSettings");
-                          } else {
-                            setPageToggle(key as SettingsType);
-                          }
-                          setContentMobileOpen(true);
-                        }}
-                      />
-                    ))}
                   </div>
                 );
               })}
@@ -1940,48 +1992,74 @@ export default function Settings() {
                         </SidebarMenuItem>
                       </SidebarMenu>
                     ) : (
-                      <>
-                        <SidebarGroupLabel
-                          className={cn(
-                            "ml-2 cursor-default pl-0 text-sm",
-                            filteredItems.some(
-                              (item) => pageToggle === item.key,
-                            )
-                              ? "text-primary"
-                              : "text-sidebar-foreground/80",
-                          )}
-                        >
-                          <div>{t("menu." + group.label)}</div>
-                        </SidebarGroupLabel>
-                        <SidebarMenuSub className="mx-2 border-0">
-                          {filteredItems.map((item) => (
-                            <SidebarMenuSubItem key={item.key}>
-                              <SidebarMenuSubButton
-                                className="h-auto w-full py-1.5"
-                                isActive={pageToggle === item.key}
-                                onClick={() => {
-                                  if (
-                                    !isAdmin &&
-                                    !ALLOWED_VIEWS_FOR_VIEWER.includes(
-                                      item.key as SettingsType,
-                                    )
-                                  ) {
-                                    setPageToggle("uiSettings");
-                                  } else {
-                                    setPageToggle(item.key as SettingsType);
-                                  }
-                                }}
-                              >
-                                <div className="w-full cursor-pointer">
-                                  {renderMenuItemLabel(
-                                    item.key as SettingsType,
+                      (() => {
+                        const hasActiveItem = filteredItems.some(
+                          (item) => pageToggle === item.key,
+                        );
+                        const renderedExpanded = !collapsedGroups.has(
+                          group.label,
+                        );
+                        return (
+                          <Collapsible
+                            open={renderedExpanded}
+                            onOpenChange={() =>
+                              toggleGroupCollapsed(group.label)
+                            }
+                          >
+                            <SidebarGroupLabel
+                              asChild
+                              className={cn(
+                                "ml-2 pl-0 text-sm",
+                                hasActiveItem
+                                  ? "text-primary"
+                                  : "text-sidebar-foreground/80",
+                              )}
+                            >
+                              <CollapsibleTrigger className="flex w-full items-center justify-between">
+                                <div>{t("menu." + group.label)}</div>
+                                <LuChevronRight
+                                  className={cn(
+                                    "size-4 shrink-0 transition-transform duration-200",
+                                    renderedExpanded && "rotate-90",
                                   )}
-                                </div>
-                              </SidebarMenuSubButton>
-                            </SidebarMenuSubItem>
-                          ))}
-                        </SidebarMenuSub>
-                      </>
+                                />
+                              </CollapsibleTrigger>
+                            </SidebarGroupLabel>
+                            <CollapsibleContent>
+                              <SidebarMenuSub className="mx-2 border-0 md:mx-0">
+                                {filteredItems.map((item) => (
+                                  <SidebarMenuSubItem key={item.key}>
+                                    <SidebarMenuSubButton
+                                      className="h-auto w-full py-1.5"
+                                      isActive={pageToggle === item.key}
+                                      onClick={() => {
+                                        if (
+                                          !isAdmin &&
+                                          !ALLOWED_VIEWS_FOR_VIEWER.includes(
+                                            item.key as SettingsType,
+                                          )
+                                        ) {
+                                          setPageToggle("uiSettings");
+                                        } else {
+                                          setPageToggle(
+                                            item.key as SettingsType,
+                                          );
+                                        }
+                                      }}
+                                    >
+                                      <div className="w-full cursor-pointer">
+                                        {renderMenuItemLabel(
+                                          item.key as SettingsType,
+                                        )}
+                                      </div>
+                                    </SidebarMenuSubButton>
+                                  </SidebarMenuSubItem>
+                                ))}
+                              </SidebarMenuSub>
+                            </CollapsibleContent>
+                          </Collapsible>
+                        );
+                      })()
                     )}
                   </SidebarGroup>
                 );

--- a/web/src/views/events/EventView.tsx
+++ b/web/src/views/events/EventView.tsx
@@ -66,6 +66,7 @@ import SummaryTimeline from "@/components/timeline/SummaryTimeline";
 import { RecordingStartingPoint } from "@/types/record";
 import VideoControls from "@/components/player/VideoControls";
 import { TimeRange } from "@/types/timeline";
+import { useAllowedCameras } from "@/hooks/use-allowed-cameras";
 import {
   useCameraMotionNextTimestamp,
   useCameraMotionOnlyRanges,
@@ -1008,27 +1009,29 @@ function MotionReview({
   const { t } = useTranslation(["views/events", "common"]);
   const segmentDuration = 30;
   const { data: config } = useSWR<FrigateConfig>("config");
+  const allowedCameras = useAllowedCameras();
 
   const reviewCameras = useMemo(() => {
     if (!config) {
       return [];
     }
 
-    let cameras;
-    if (!filter || !filter.cameras) {
-      cameras = Object.values(config.cameras).filter(
-        (cam) => !isReplayCamera(cam.name),
-      );
-    } else {
-      const filteredCams = filter.cameras;
-
-      cameras = Object.values(config.cameras).filter(
-        (cam) => filteredCams.includes(cam.name) && !isReplayCamera(cam.name),
-      );
-    }
+    const selectedCams = filter?.cameras;
+    const cameras = Object.values(config.cameras).filter((cam) => {
+      if (isReplayCamera(cam.name)) {
+        return false;
+      }
+      if (!allowedCameras.includes(cam.name)) {
+        return false;
+      }
+      if (selectedCams && !selectedCams.includes(cam.name)) {
+        return false;
+      }
+      return true;
+    });
 
     return cameras.sort((a, b) => a.ui.order - b.ui.order);
-  }, [config, filter]);
+  }, [config, filter, allowedCameras]);
 
   const videoPlayersRef = useRef<{ [camera: string]: PreviewController }>({});
 

--- a/web/src/views/live/LiveDashboardView.tsx
+++ b/web/src/views/live/LiveDashboardView.tsx
@@ -13,6 +13,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useAllowedCameras } from "@/hooks/use-allowed-cameras";
 import { useUserPersistence } from "@/hooks/use-user-persistence";
 import {
   AllGroupsStreamingSettings,
@@ -90,6 +91,7 @@ export default function LiveDashboardView({
   // recent events
 
   const eventUpdate = useFrigateReviews();
+  const allowedCameras = useAllowedCameras();
 
   const alertCameras = useMemo(() => {
     if (!config) {
@@ -98,14 +100,16 @@ export default function LiveDashboardView({
 
     if (cameraGroup == "default") {
       return Object.values(config.cameras)
-        .filter((cam) => cam.ui.dashboard)
+        .filter((cam) => cam.ui.dashboard && allowedCameras.includes(cam.name))
         .map((cam) => cam.name)
         .join(",");
     }
 
     if (includeBirdseye && cameras.length == 0) {
       return Object.values(config.cameras)
-        .filter((cam) => cam.birdseye.enabled)
+        .filter(
+          (cam) => cam.birdseye.enabled && allowedCameras.includes(cam.name),
+        )
         .map((cam) => cam.name)
         .join(",");
     }
@@ -114,7 +118,7 @@ export default function LiveDashboardView({
       .map((cam) => cam.name)
       .filter((cam) => config.camera_groups[cameraGroup]?.cameras.includes(cam))
       .join(",");
-  }, [cameras, cameraGroup, config, includeBirdseye]);
+  }, [cameras, cameraGroup, config, includeBirdseye, allowedCameras]);
 
   const { data: allEvents, mutate: updateEvents } = useSWR<ReviewSegment[]>([
     "review",

--- a/web/src/views/recording/RecordingView.tsx
+++ b/web/src/views/recording/RecordingView.tsx
@@ -44,6 +44,7 @@ import {
 import { IoMdArrowRoundBack } from "react-icons/io";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Toaster } from "@/components/ui/sonner";
+import { useIsAdmin } from "@/hooks/use-is-admin";
 import useSWR from "swr";
 import { TimeRange, TimelineType } from "@/types/timeline";
 import MobileCameraDrawer from "@/components/overlay/MobileCameraDrawer";
@@ -109,6 +110,7 @@ export function RecordingView({
 }: RecordingViewProps) {
   const { t } = useTranslation(["views/events", "components/dialog"]);
   const { data: config } = useSWR<FrigateConfig>("config");
+  const isAdmin = useIsAdmin();
   const navigate = useNavigate();
   const location = useLocation();
   const contentRef = useRef<HTMLDivElement | null>(null);
@@ -723,13 +725,17 @@ export function RecordingView({
                   setCustomShareTimestamp(initialTimestamp);
                   setShareTimestampOpen(true);
                 }}
-                onDebugReplayClick={() => {
-                  setDebugReplayRange({
-                    after: timeRange.before - 60,
-                    before: timeRange.before,
-                  });
-                  setDebugReplayMode("select");
-                }}
+                onDebugReplayClick={
+                  isAdmin
+                    ? () => {
+                        setDebugReplayRange({
+                          after: timeRange.before - 60,
+                          before: timeRange.before,
+                        });
+                        setDebugReplayMode("select");
+                      }
+                    : undefined
+                }
                 onExportClick={() => {
                   const now = new Date(timeRange.before * 1000);
                   now.setHours(now.getHours() - 1);


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
- Filter MotionReview by allowed cameras
- Filter filmstrip alertCameras by allowed cameras so the recent alerts query for restricted roles doesn't reference cameras they can't access
- Skip data streams in chapter exports to avoid ffmpeg segfault on some cameras
  - Exports that overlapped review items could segfault ffmpeg during MP4 muxer init, causing the export to silently fail (the in-progress row is cleaned up on ffmpeg failure, so it never appears in the Exports tab). The `-map 0` added in #23052 forces nginx-vod-module's `timed_id3` HLS data stream into the output, which NULL-derefs the MP4 muxer when combined with `-map_metadata 1` chapters. Adding `-dn` drops data streams while preserving video, audio, and chapters. User issue reported here: https://github.com/blakeblackshear/frigate/discussions/23236#discussioncomment-17024619
  - `-dn` only drops timed data streams (timed_id3, KLV, GPS, etc.), it doesn't affect container metadata, chapters, subtitles, attachments, or stream-level metadata, all of which use different flags. The only future feature it would block is embedding a separate timed payload track in the MP4 (which Frigate doesn't produce today), and that would naturally require updating the mapping flags anyway.
- Restrict debug replay entry points in the UI to admin users 
- Make top level nav groups collapsible (by default) in Settings

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
