### PR TITLE
Profiles fixes

### DIFF
--- a/docs/docs/configuration/profiles.md
+++ b/docs/docs/configuration/profiles.md
@@ -126,7 +126,9 @@ Only the fields you explicitly set in a profile override are applied. All other 
 
 ## Activating Profiles
 
-Profiles can be activated and deactivated from the Frigate UI. Open the Settings cog and select **Profiles** from the submenu to see all defined profiles. From there you can activate any profile or deactivate the current one. The active profile is indicated in the UI so you always know which profile is in effect.
+Profiles can be activated and deactivated via the Frigate UI, [MQTT](/integrations/mqtt#frigateprofileset), or the Home Assistant integration.
+
+In the Frigate UI, open the Settings cog and select **Profiles** from the submenu to see all defined profiles. From there you can activate any profile or deactivate the current one. The active profile is indicated in the UI so you always know which profile is in effect.
 
 ## Example: Home / Away Setup
 
@@ -207,3 +209,25 @@ In this example:
 - **Away profile**: The front door camera enables notifications and tracks specific alert labels. The indoor camera is fully enabled with detection and recording.
 - **Home profile**: The front door camera disables notifications. The indoor camera is completely disabled for privacy.
 - **No profile active**: All cameras use their base configuration values.
+
+## FAQ
+
+### Can I define a zone or mask in a profile but not have it in the base config?
+
+No. Profiles are pure overrides. Every zone and mask defined under a profile must reference an entry that already exists on the base camera config. Configurations that introduce profile-only zones or masks are rejected at startup.
+
+### How do I revert a profile zone or mask override back to the base configuration?
+
+Delete the override. In the Frigate UI, edit the profile and use the "Revert override" action (the trash can icon) on the zone or mask. The base entry is left untouched, and once the override is removed the profile inherits the base values for that zone or mask.
+
+### Can multiple profiles be active at the same time?
+
+No. Only one profile can be active at a time. Activating a new profile automatically deactivates the current one.
+
+### What happens to my profile overrides if I delete a zone or mask from the base?
+
+When you delete a base zone or mask in the Frigate UI, any profile overrides for that entry are deleted automatically as part of the same operation. If you remove a base entry by editing your config file directly and leave a profile override behind, the config will fail validation at startup until the orphaned override is removed as well.
+
+### Why are some settings missing when I configure a profile override?
+
+Fields that require a Frigate restart to take effect cannot be overridden by profiles, since profiles are applied at runtime without restarting. Those fields are hidden when editing a profile override and can only be changed on the base configuration.

--- a/docs/docs/configuration/profiles.md
+++ b/docs/docs/configuration/profiles.md
@@ -216,6 +216,8 @@ In this example:
 
 No. Profiles are pure overrides. Every zone and mask defined under a profile must reference an entry that already exists on the base camera config. Configurations that introduce profile-only zones or masks are rejected at startup.
 
+If you want a zone or mask to be active only under a specific profile, define it on the base config with `enabled: false`, then enable it in that profile's overrides.
+
 ### How do I revert a profile zone or mask override back to the base configuration?
 
 Delete the override. In the Frigate UI, edit the profile and use the "Revert override" action (the trash can icon) on the zone or mask. The base entry is left untouched, and once the override is removed the profile inherits the base values for that zone or mask.

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -326,6 +326,47 @@ def verify_required_zones_exist(camera_config: CameraConfig) -> None:
             )
 
 
+def verify_profile_overrides_match_base(camera_config: CameraConfig) -> None:
+    """Verify that profile zone and mask IDs reference entries defined on the base camera."""
+    for profile_name, profile in camera_config.profiles.items():
+        if profile.zones:
+            for zone_name in profile.zones:
+                if zone_name not in camera_config.zones:
+                    raise ValueError(
+                        f"Camera '{camera_config.name}' profile '{profile_name}' defines "
+                        f"zone '{zone_name}' that does not exist on the base config"
+                    )
+
+        if profile.motion and profile.motion.mask:
+            for mask_name in profile.motion.mask:
+                if mask_name not in camera_config.motion.mask:
+                    raise ValueError(
+                        f"Camera '{camera_config.name}' profile '{profile_name}' defines "
+                        f"motion mask '{mask_name}' that does not exist on the base config"
+                    )
+
+        if profile.objects:
+            for mask_name in profile.objects.mask or {}:
+                if mask_name not in (camera_config.objects.mask or {}):
+                    raise ValueError(
+                        f"Camera '{camera_config.name}' profile '{profile_name}' defines "
+                        f"object mask '{mask_name}' that does not exist on the base config"
+                    )
+            for label, filter_config in (profile.objects.filters or {}).items():
+                base_filter = (camera_config.objects.filters or {}).get(label)
+                profile_filter_masks = (
+                    filter_config.mask if filter_config else None
+                ) or {}
+                base_filter_masks = (base_filter.mask if base_filter else None) or {}
+                for mask_name in profile_filter_masks:
+                    if mask_name not in base_filter_masks:
+                        raise ValueError(
+                            f"Camera '{camera_config.name}' profile '{profile_name}' defines "
+                            f"object mask '{mask_name}' for '{label}' that does not exist "
+                            f"on the base config"
+                        )
+
+
 def verify_autotrack_zones(camera_config: CameraConfig) -> ValueError | None:
     """Verify that required_zones are specified when autotracking is enabled."""
     if (
@@ -952,6 +993,7 @@ class FrigateConfig(FrigateBaseModel):
             verify_recording_segments_setup_with_reasonable_time(camera_config)
             verify_zone_objects_are_tracked(camera_config)
             verify_required_zones_exist(camera_config)
+            verify_profile_overrides_match_base(camera_config)
             verify_autotrack_zones(camera_config)
             verify_motion_and_detect(camera_config)
             verify_objects_track(camera_config, labelmap_objects)

--- a/frigate/test/test_profiles.py
+++ b/frigate/test/test_profiles.py
@@ -178,6 +178,141 @@ class TestCameraProfileConfig(unittest.TestCase):
         with self.assertRaises(ValidationError):
             FrigateConfig(**config_data)
 
+    def test_profile_zone_without_base_rejected(self):
+        """Profile defining a zone not present on the base camera is rejected."""
+        from pydantic import ValidationError
+
+        config_data = {
+            "mqtt": {"host": "mqtt"},
+            "profiles": {
+                "armed": {"friendly_name": "Armed"},
+            },
+            "cameras": {
+                "front": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {
+                                "path": "rtsp://10.0.0.1:554/video",
+                                "roles": ["detect"],
+                            }
+                        ]
+                    },
+                    "detect": {"height": 1080, "width": 1920, "fps": 5},
+                    "zones": {
+                        "front_yard": {"coordinates": "0,0,100,0,100,100,0,100"},
+                    },
+                    "profiles": {
+                        "armed": {
+                            "zones": {
+                                "phantom": {
+                                    "coordinates": "0,0,50,0,50,50,0,50",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            FrigateConfig(**config_data)
+        self.assertIn("phantom", str(ctx.exception))
+
+    def test_profile_motion_mask_without_base_rejected(self):
+        """Profile defining a motion mask not present on the base camera is rejected."""
+        from pydantic import ValidationError
+
+        config_data = {
+            "mqtt": {"host": "mqtt"},
+            "profiles": {
+                "armed": {"friendly_name": "Armed"},
+            },
+            "cameras": {
+                "front": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {
+                                "path": "rtsp://10.0.0.1:554/video",
+                                "roles": ["detect"],
+                            }
+                        ]
+                    },
+                    "detect": {"height": 1080, "width": 1920, "fps": 5},
+                    "motion": {
+                        "mask": {
+                            "base_mask": {
+                                "coordinates": "0,0,100,0,100,100,0,100",
+                            },
+                        },
+                    },
+                    "profiles": {
+                        "armed": {
+                            "motion": {
+                                "mask": {
+                                    "phantom_mask": {
+                                        "coordinates": "0,0,50,0,50,50,0,50",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            FrigateConfig(**config_data)
+        self.assertIn("phantom_mask", str(ctx.exception))
+
+    def test_profile_overrides_matching_base_accepted(self):
+        """Profile overrides that reference existing base zones/masks parse cleanly."""
+        config_data = {
+            "mqtt": {"host": "mqtt"},
+            "profiles": {
+                "armed": {"friendly_name": "Armed"},
+            },
+            "cameras": {
+                "front": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {
+                                "path": "rtsp://10.0.0.1:554/video",
+                                "roles": ["detect"],
+                            }
+                        ]
+                    },
+                    "detect": {"height": 1080, "width": 1920, "fps": 5},
+                    "zones": {
+                        "front_yard": {"coordinates": "0,0,100,0,100,100,0,100"},
+                    },
+                    "motion": {
+                        "mask": {
+                            "tree": {
+                                "coordinates": "0,0,100,0,100,100,0,100",
+                            },
+                        },
+                    },
+                    "profiles": {
+                        "armed": {
+                            "zones": {
+                                "front_yard": {
+                                    "coordinates": "0,0,50,0,50,50,0,50",
+                                    "inertia": 5,
+                                },
+                            },
+                            "motion": {
+                                "mask": {
+                                    "tree": {
+                                        "coordinates": "0,0,75,0,75,75,0,75",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        config = FrigateConfig(**config_data)
+        assert "armed" in config.cameras["front"].profiles
+
 
 class TestProfileInConfig(unittest.TestCase):
     """Test that profiles parse correctly in FrigateConfig."""

--- a/web/src/components/input/NameAndIdFields.tsx
+++ b/web/src/components/input/NameAndIdFields.tsx
@@ -26,6 +26,7 @@ type NameAndIdFieldsProps<T extends FieldValues = FieldValues> = {
   placeholderName?: string;
   placeholderId?: string;
   idVisible?: boolean;
+  idDisabled?: boolean;
 };
 
 export default function NameAndIdFields<T extends FieldValues = FieldValues>({
@@ -41,6 +42,7 @@ export default function NameAndIdFields<T extends FieldValues = FieldValues>({
   placeholderName,
   placeholderId,
   idVisible,
+  idDisabled,
 }: NameAndIdFieldsProps<T>) {
   const { t } = useTranslation(["common"]);
   const { watch, setValue, trigger, formState } = useFormContext<T>();
@@ -59,6 +61,9 @@ export default function NameAndIdFields<T extends FieldValues = FieldValues>({
   const effectiveProcessId = processId || defaultProcessId;
 
   useEffect(() => {
+    if (idDisabled) {
+      return;
+    }
     const subscription = watch((value, { name }) => {
       if (name === nameField) {
         hasUserTypedRef.current = true;
@@ -68,7 +73,15 @@ export default function NameAndIdFields<T extends FieldValues = FieldValues>({
       }
     });
     return () => subscription.unsubscribe();
-  }, [watch, setValue, trigger, nameField, idField, effectiveProcessId]);
+  }, [
+    watch,
+    setValue,
+    trigger,
+    nameField,
+    idField,
+    effectiveProcessId,
+    idDisabled,
+  ]);
 
   // Auto-expand if there's an error on the ID field after user has typed
   useEffect(() => {
@@ -123,6 +136,7 @@ export default function NameAndIdFields<T extends FieldValues = FieldValues>({
                 <Input
                   className="text-md"
                   placeholder={placeholderId}
+                  disabled={idDisabled}
                   {...field}
                 />
               </FormControl>

--- a/web/src/components/settings/MotionMaskEditPane.tsx
+++ b/web/src/components/settings/MotionMaskEditPane.tsx
@@ -258,8 +258,9 @@ export default function MotionMaskEditPane({
               },
             );
             updateConfig();
-            // Only publish WS state for base config when mask has a name
-            if (!editingProfile && maskName) {
+            // Only publish WS state for base config when mask has a name and
+            // wasn't renamed (the hook is bound to the old name).
+            if (!editingProfile && maskName && !renamingMask) {
               sendMotionMaskState(enabled ? "ON" : "OFF");
             }
           } else {
@@ -414,6 +415,7 @@ export default function MotionMaskEditPane({
               nameLabel={t("masksAndZones.motionMasks.name.title")}
               nameDescription={t("masksAndZones.motionMasks.name.description")}
               placeholderName={t("masksAndZones.motionMasks.name.placeholder")}
+              idDisabled={!!editingProfile && polygon.name.length > 0}
             />
             <FormField
               control={form.control}

--- a/web/src/components/settings/ObjectMaskEditPane.tsx
+++ b/web/src/components/settings/ObjectMaskEditPane.tsx
@@ -263,8 +263,9 @@ export default function ObjectMaskEditPane({
               },
             );
             updateConfig();
-            // Only publish WS state for base config when mask has a name
-            if (!editingProfile && maskName) {
+            // Only publish WS state for base config when mask has a name and
+            // wasn't renamed (the hook is bound to the old name).
+            if (!editingProfile && maskName && !renamingMask) {
               sendObjectMaskState(enabled ? "ON" : "OFF");
             }
           } else {
@@ -389,6 +390,7 @@ export default function ObjectMaskEditPane({
                 placeholderName={t(
                   "masksAndZones.objectMasks.name.placeholder",
                 )}
+                idDisabled={!!editingProfile && polygon.name.length > 0}
               />
               <FormField
                 control={form.control}

--- a/web/src/components/settings/ZoneEditPane.tsx
+++ b/web/src/components/settings/ZoneEditPane.tsx
@@ -94,6 +94,28 @@ export default function ZoneEditPane({
   const zoneName = polygon?.name || "";
   const { send: sendZoneState } = useZoneState(polygon?.camera || "", zoneName);
 
+  const isExistingZone = !!polygon && polygon.name.length > 0;
+
+  const idDisabled = useMemo(() => {
+    if (!isExistingZone || !polygon) {
+      return false;
+    }
+    if (editingProfile) {
+      return true;
+    }
+    const cam = config?.cameras[polygon.camera];
+    if (!cam) {
+      return false;
+    }
+    const inRequiredZones =
+      cam.review.alerts.required_zones.includes(polygon.name) ||
+      cam.review.detections.required_zones.includes(polygon.name);
+    const hasProfileOverride = Object.values(cam.profiles ?? {}).some(
+      (profile) => profile?.zones && polygon.name in profile.zones,
+    );
+    return inRequiredZones || hasProfileOverride;
+  }, [config, polygon, editingProfile, isExistingZone]);
+
   const cameraConfig = useMemo(() => {
     if (polygon?.camera && config) {
       return config.cameras[polygon.camera];
@@ -419,6 +441,7 @@ export default function ZoneEditPane({
             toast.error(t("toast.save.error.noMessage", { ns: "common" }), {
               position: "top-center",
             });
+            setIsLoading(false);
             return;
           }
 
@@ -444,6 +467,7 @@ export default function ZoneEditPane({
             toast.error(t("toast.save.error.noMessage", { ns: "common" }), {
               position: "top-center",
             });
+            setIsLoading(false);
             return;
           }
         }
@@ -527,8 +551,9 @@ export default function ZoneEditPane({
               },
             );
             updateConfig();
-            // Only publish WS state for base config when zone has a name
-            if (!editingProfile && polygon?.name) {
+            // Only publish WS state for base config when zone has a name and
+            // wasn't renamed (the hook is bound to the old name).
+            if (!editingProfile && polygon?.name && !renamingZone) {
               sendZoneState(enabled ? "ON" : "OFF");
             }
           } else {
@@ -650,6 +675,7 @@ export default function ZoneEditPane({
             nameLabel={t("masksAndZones.zones.name.title")}
             nameDescription={t("masksAndZones.zones.name.tips")}
             placeholderName={t("masksAndZones.zones.name.inputPlaceHolder")}
+            idDisabled={idDisabled}
           />
           <FormField
             control={form.control}


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR fixes a small bug and makes several improvements to using masks and zones with profiles.
- Disable the `id` field when editing a profile-specific mask or zone. The `id` is what the profile override is keyed off of, so editing it would create an orphaned mask/zone.
- Disable the `id` field when editing a base config mask or zone if the zone is used in `required_zones` or has a profile override set.
- Add backend validation to reject profile-only masks/zones. It must always be an override of a base config mask/zone.
- Add tests
- Update docs with a small FAQ

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
