### PR TITLE
feat: add Traditional Chinese (zh-Hant) language option

### DIFF
--- a/web/public/locales/en/common.json
+++ b/web/public/locales/en/common.json
@@ -177,6 +177,7 @@
       "en": "English (English)",
       "es": "Español (Spanish)",
       "zhCN": "简体中文 (Simplified Chinese)",
+      "zhHant": "繁體中文 (Traditional Chinese)",
       "hi": "हिन्दी (Hindi)",
       "fr": "Français (French)",
       "ar": "العربية (Arabic)",

--- a/web/src/components/menu/GeneralSettings.tsx
+++ b/web/src/components/menu/GeneralSettings.tsx
@@ -109,6 +109,7 @@ export default function GeneralSettings({ className }: GeneralSettingsProps) {
       "nb-NO": "nb",
       "yue-Hant": "yue",
       "zh-CN": "zhCN",
+      "zh-Hant": "zhHant",
       "pt-BR": "ptBR",
     };
 

--- a/web/src/hooks/use-date-locale.ts
+++ b/web/src/hooks/use-date-locale.ts
@@ -34,6 +34,8 @@ const localeMap: Record<string, () => Promise<Locale>> = {
   sk: () => import("date-fns/locale/sk").then((module) => module.sk),
   "yue-Hant": () =>
     import("date-fns/locale/zh-HK").then((module) => module.zhHK),
+  "zh-Hant": () =>
+    import("date-fns/locale/zh-TW").then((module) => module.zhTW),
   lt: () => import("date-fns/locale/lt").then((module) => module.lt),
   th: () => import("date-fns/locale/th").then((module) => module.th),
   ca: () => import("date-fns/locale/ca").then((module) => module.ca),

--- a/web/src/lib/const.ts
+++ b/web/src/lib/const.ts
@@ -29,6 +29,7 @@ export const supportedLanguageKeys = [
   "nb-NO",
   "sv",
   "zh-CN",
+  "zh-Hant",
   "yue-Hant",
   "ja",
   "vi",


### PR DESCRIPTION
## Proposed change

Traditional Chinese (`zh-Hant`) translations are synced from Weblate and are currently **98% complete** — more complete than several already-enabled languages (e.g. Cantonese `yue-Hant` at ~63%). However, `zh-Hant` was never registered in the frontend language selector, so users had no way to select it even though the translations already ship in `web/public/locales/zh-Hant/`.

This looks like an oversight: the `zh-Hant` locale directory was added to the repo after the language list was last updated, and the registration step was missed. This PR wires it up so the existing translations become selectable.

Changes:
- Register `zh-Hant` in `supportedLanguageKeys` (`web/src/lib/const.ts`) — the source for the language menu.
- Add its display label `繁體中文 (Traditional Chinese)` to the `en` locale (`web/public/locales/en/common.json`).
- Map the language key to its label in `GeneralSettings` (`specialKeyMap`).
- Map `zh-Hant` to the `zh-TW` date-fns locale for date formatting (`web/src/hooks/use-date-locale.ts`).

All four changes mirror the existing handling for `zh-CN` and `yue-Hant`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Claude Code)

**How AI was used**: Investigation of why `zh-Hant` was missing from the selector, and code generation for the four edits.

**Extent of AI involvement**: Assisted with locating the relevant files and producing the small, pattern-following edits.

**Human oversight**: The author reviewed the full diff, confirmed the changes match the existing `zh-CN` / `yue-Hant` pattern, verified `common.json` parses as valid JSON, and confirmed `date-fns` (3.6.0) ships the `zh-TW` locale used here.

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)

> Note: this is a frontend-only change and `web/node_modules` was not installed in my environment, so I could not run the dev server or the JS lint/format/test suite locally. The two boxes above are left unchecked for honesty. The `en` locale label was added and the diff follows Prettier-conformant 2-space indentation with trailing commas matching surrounding lines. Ruff is N/A (no Python changed). Please run CI to confirm.
