### PR TITLE
Allow rtsps:// in camera wizard URL validation

### DIFF
--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -320,7 +320,7 @@
         "nameLength": "Camera name must be 64 characters or less",
         "invalidCharacters": "Camera name contains invalid characters",
         "nameExists": "Camera name already exists",
-        "customUrlRtspRequired": "Custom URLs must begin with \"rtsp://\". Manual configuration is required for non-RTSP camera streams."
+        "customUrlRtspRequired": "Custom URLs must begin with \"rtsp://\" or \"rtsps://\". Manual configuration is required for non-RTSP camera streams."
       }
     },
     "step2": {

--- a/web/src/components/settings/wizard/Step1NameCamera.tsx
+++ b/web/src/components/settings/wizard/Step1NameCamera.tsx
@@ -87,7 +87,8 @@ export default function Step1NameCamera({
         .string()
         .optional()
         .refine(
-          (val) => !val || val.startsWith("rtsp://"),
+          (val) =>
+            !val || val.startsWith("rtsp://") || val.startsWith("rtsps://"),
           t("cameraWizard.step1.errors.customUrlRtspRequired"),
         ),
     })


### PR DESCRIPTION

_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

Allow rtsps:// as valid input for "Custom Stream URL" field in Add Camera wizard
For Wyze camera with Secure RTSP, rtsps://... URL is required for the connection.
The rtsps:// url is fully functional when manually configured in /config/config.yaml.
The UI input check is only an artificial check.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update


## AI disclosure

- [ ] No AI tools were used in this PR.
- [X] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):
Claude
**How AI was used** (e.g., code generation, code review, debugging, documentation):
Code review / documentation translation
**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.


## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [X] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
