### PR TITLE
docker: cap compose log rotation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   devcontainer:
     container_name: frigate-devcontainer
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     # Check host system's actual render/video/plugdev group IDs with 'getent group render', 'getent group video', and 'getent group plugdev'
     # Must add these exact IDs in container's group_add section or OpenVINO GPU acceleration will fail
     group_add:
@@ -39,6 +44,11 @@ services:
   mqtt:
     container_name: mqtt
     image: eclipse-mosquitto:2.0
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     command: mosquitto -c /mosquitto-no-auth.conf # enable no-auth mode
     ports:
       - "1883:1883"


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

Adds Docker `json-file` log rotation to both services in the development Docker Compose file:

```yaml
logging:
  driver: json-file
  options:
    max-size: "10m"
    max-file: "3"
```

This keeps the devcontainer and local MQTT container from accumulating unbounded Docker JSON logs during long-running development sessions. It does not change images, ports, volumes, runtime commands, networking, or Frigate application behavior.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to discussion with maintainers (**required** for any large or "planned" features): N/A — small Docker Compose maintenance change only.

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): ChatGPT / Codex CLI-style agent.

**How AI was used** (e.g., code generation, code review, debugging, documentation): Added the requested Docker Compose logging blocks and checked the resulting Compose config.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): The AI agent made this small YAML-only change.

**Human oversight**: The change is intentionally mechanical and limited to `docker-compose.yml`; validation was run with `docker compose -f docker-compose.yml config`, plus a YAML audit confirming both services have `driver: json-file`, `max-size: 10m`, and `max-file: 3`.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
