### PR TITLE
Optimize motion activity endpoint

### DIFF
--- a/frigate/api/review.py
+++ b/frigate/api/review.py
@@ -605,9 +605,10 @@ def motion_activity(
         if not filtered:
             return JSONResponse(content=[])
         camera_list = list(filtered)
-        clauses.append((Recordings.camera << camera_list))
     else:
-        clauses.append((Recordings.camera << allowed_cameras))
+        camera_list = list(allowed_cameras)
+
+    clauses.append((Recordings.camera << camera_list))
 
     data: list[Recordings] = (
         Recordings.select(
@@ -635,14 +636,12 @@ def motion_activity(
     df.set_index(["start_time"], inplace=True)
 
     # normalize data
-    motion = (
-        df["motion"]
-        .resample(f"{scale}s")
-        .apply(lambda x: max(x, key=abs, default=0.0))
-        .fillna(0.0)
-        .to_frame()
-    )
-    cameras = df["camera"].resample(f"{scale}s").agg(lambda x: ",".join(set(x)))
+    motion = df["motion"].resample(f"{scale}s").max().fillna(0.0).to_frame()
+
+    if len(camera_list) == 1:
+        cameras = df["camera"].resample(f"{scale}s").first().fillna("")
+    else:
+        cameras = df["camera"].resample(f"{scale}s").agg(lambda x: ",".join(set(x)))
     df = motion.join(cameras)
 
     length = df.shape[0]


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
`/api/review/activity/motion` resamples recording motion into fixed time buckets, and it did so with two apply/agg lambdas: `max(x, key=abs)` for the motion value and `",".join(set(x))` for the camera. Pandas can't vectorize Python callbacks, so it falls back to a per-group pure-Python loop, which is fine for short ranges but becomes the dominant cost when zooming a wide window into tens of thousands of buckets ([a user's py-spy profile](https://github.com/blakeblackshear/frigate/discussions/23356#discussioncomment-17142419) on a busy camera showed ~100% of the time split between those two lambdas). 

This PR swaps them for native vectorized aggregations: `.max()` for motion (identical output since the query already filters `motion > 0`, so largest-magnitude equals largest value) and `.first()` for the common single-camera request, with the original set-join kept as the fallback when multiple cameras are requested so the comma-joined output is preserved. 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
