### PR TITLE
Miscellaneous fixes

### DIFF
--- a/frigate/detectors/detection_runners.py
+++ b/frigate/detectors/detection_runners.py
@@ -340,13 +340,6 @@ class OpenVINOModelRunner(BaseModelRunner):
 
         self.input_tensor: ov.Tensor | None = None
 
-        # Shared, process-wide lock serializing inference across all OpenVINO
-        # runners in this process. Needed both for the JinaV2 case (one runner
-        # shared between text and vision threads) and to prevent two *different*
-        # runners (e.g. an ArcFace face-model build thread and the LPR detector)
-        # from inferring concurrently and corrupting shared OpenVINO state.
-        self._inference_lock = _OPENVINO_LOCK
-
         if not self.complex_model:
             try:
                 input_shape = self.compiled_model.inputs[0].get_shape()
@@ -394,7 +387,7 @@ class OpenVINOModelRunner(BaseModelRunner):
         # process — both the shared-runner JinaV2 case (genai text thread +
         # embeddings vision thread) and distinct runners running on separate
         # threads (e.g. the ArcFace face-model build vs the LPR detector).
-        with self._inference_lock:
+        with _OPENVINO_LOCK:
             from frigate.embeddings.types import EnrichmentModelTypeEnum
 
             if self.model_type in [EnrichmentModelTypeEnum.arcface.value]:

--- a/frigate/detectors/detection_runners.py
+++ b/frigate/detectors/detection_runners.py
@@ -15,6 +15,9 @@ from frigate.util.rknn_converter import auto_convert_model, is_rknn_compatible
 
 logger = logging.getLogger(__name__)
 
+# Process-wide lock serializing all OpenVINO compile/inference calls
+_OPENVINO_LOCK = threading.Lock()
+
 
 def is_arm64_platform() -> bool:
     """Check if we're running on an ARM platform."""
@@ -326,18 +329,23 @@ class OpenVINOModelRunner(BaseModelRunner):
             except Exception as e:
                 logger.debug(f"NPU_TURBO not supported by driver: {e}")
 
-        # Compile model
-        self.compiled_model = self.ov_core.compile_model(
-            model=model_path, device_name=device
-        )
+        # Compile model under the shared lock
+        with _OPENVINO_LOCK:
+            self.compiled_model = self.ov_core.compile_model(
+                model=model_path, device_name=device
+            )
 
-        # Create reusable inference request
-        self.infer_request = self.compiled_model.create_infer_request()
+            # Create reusable inference request
+            self.infer_request = self.compiled_model.create_infer_request()
+
         self.input_tensor: ov.Tensor | None = None
 
-        # Thread lock to prevent concurrent inference (needed for JinaV2 which shares
-        # one runner between text and vision embeddings called from different threads)
-        self._inference_lock = threading.Lock()
+        # Shared, process-wide lock serializing inference across all OpenVINO
+        # runners in this process. Needed both for the JinaV2 case (one runner
+        # shared between text and vision threads) and to prevent two *different*
+        # runners (e.g. an ArcFace face-model build thread and the LPR detector)
+        # from inferring concurrently and corrupting shared OpenVINO state.
+        self._inference_lock = _OPENVINO_LOCK
 
         if not self.complex_model:
             try:
@@ -382,8 +390,10 @@ class OpenVINOModelRunner(BaseModelRunner):
         Returns:
             List of output tensors
         """
-        # Lock prevents concurrent access to infer_request
-        # Needed for JinaV2: genai thread (text) + embeddings thread (vision)
+        # Shared lock serializes inference across every OpenVINO runner in this
+        # process — both the shared-runner JinaV2 case (genai text thread +
+        # embeddings vision thread) and distinct runners running on separate
+        # threads (e.g. the ArcFace face-model build vs the LPR detector).
         with self._inference_lock:
             from frigate.embeddings.types import EnrichmentModelTypeEnum
 

--- a/web/login.html
+++ b/web/login.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/images/branding/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Frigate</title>
     <link
       rel="apple-touch-icon"

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -1908,7 +1908,11 @@
       "fpsGreaterThanFive": "Setting the detect FPS higher than 5 is not recommended. Higher values may cause performance issues and will not provide any benefit.",
       "disabled": "Object detection is disabled. Snapshots, review items, and enrichments such as face recognition, license plate recognition, and Generative AI will not function.",
       "resolutionShouldBeMultipleOfFour": "For best results, detect width and height should be multiples of 4. Other even values may produce visual artifacts or slight distortion in the detect stream.",
-      "aspectRatioMismatch": "The width and height you've entered don't match the aspect ratio of your current detect resolution. This may produce a stretched or distorted image."
+      "aspectRatioMismatch": "The width and height you've entered don't match the aspect ratio of your current detect resolution. This may produce a stretched or distorted image.",
+      "maxFramesSet": "Setting max frames overrides default behavior and disables stationary object tracking. There are very few situations where this is needed, use with caution.",
+      "squareResolution": "A square detect resolution is unusual. The detect width and height should match your camera's aspect ratio (for example, 16:9), not the dimensions of the object detection model. A mismatched aspect ratio can stretch the image and reduce detection accuracy.",
+      "resolutionHigh": "This detect resolution is higher than recommended and may cause increased resource usage without improving detection accuracy. A detect resolution at or below 1080p is recommended for most cameras.",
+      "globalResolutionMultipleCameras": "A global detect resolution is set while multiple cameras are configured. Unless all cameras share the same resolution and aspect ratio, the detect width and height should be defined per camera to match each camera's native aspect ratio."
     },
     "objects": {
       "genaiNoDescriptionsProvider": "You must configure a GenAI provider with the 'descriptions' role for descriptions to be generated."

--- a/web/src/components/config-form/ConfigFieldMessage.tsx
+++ b/web/src/components/config-form/ConfigFieldMessage.tsx
@@ -15,13 +15,13 @@ const severityVariantMap: Record<
 function SeverityIcon({ severity }: { severity: string }) {
   switch (severity) {
     case "info":
-      return <LuInfo className="size-4" />;
+      return <LuInfo className="size-4 shrink-0" />;
     case "warning":
-      return <LuTriangleAlert className="size-4" />;
+      return <LuTriangleAlert className="size-4 shrink-0" />;
     case "error":
-      return <LuCircleAlert className="size-4" />;
+      return <LuCircleAlert className="size-4 shrink-0" />;
     default:
-      return <LuInfo className="size-4" />;
+      return <LuInfo className="size-4 shrink-0" />;
   }
 }
 

--- a/web/src/components/config-form/ConfigMessageBanner.tsx
+++ b/web/src/components/config-form/ConfigMessageBanner.tsx
@@ -18,11 +18,11 @@ const severityVariantMap: Record<
 function SeverityIcon({ severity }: { severity: MessageSeverity }) {
   switch (severity) {
     case "info":
-      return <LuInfo className="size-4" />;
+      return <LuInfo className="size-4 shrink-0" />;
     case "warning":
-      return <LuTriangleAlert className="size-4" />;
+      return <LuTriangleAlert className="size-4 shrink-0" />;
     case "error":
-      return <LuCircleAlert className="size-4" />;
+      return <LuCircleAlert className="size-4 shrink-0" />;
   }
 }
 

--- a/web/src/components/config-form/section-configs/detect.ts
+++ b/web/src/components/config-form/section-configs/detect.ts
@@ -11,8 +11,12 @@ const detect: SectionConfigOverrides = {
         condition: (ctx) =>
           ctx.level === "camera" && ctx.formData?.enabled === false,
       },
+    ],
+    fieldMessages: [
       {
         key: "detect-resolution-not-multiple-of-four",
+        field: "width",
+        position: "before",
         messageKey: "configMessages.detect.resolutionShouldBeMultipleOfFour",
         severity: "warning",
         condition: (ctx) => {
@@ -24,7 +28,58 @@ const detect: SectionConfigOverrides = {
         },
       },
       {
+        key: "detect-global-resolution-multiple-cameras",
+        field: "width",
+        position: "before",
+        messageKey: "configMessages.detect.globalResolutionMultipleCameras",
+        severity: "info",
+        condition: (ctx) => {
+          if (ctx.level !== "global") return false;
+          const width = ctx.formData?.width as number | null | undefined;
+          const height = ctx.formData?.height as number | null | undefined;
+          if (typeof width !== "number" && typeof height !== "number") {
+            return false;
+          }
+          const cameraCount = Object.keys(ctx.fullConfig?.cameras ?? {}).length;
+          return cameraCount > 1;
+        },
+      },
+      {
+        key: "detect-resolution-high",
+        field: "width",
+        position: "before",
+        messageKey: "configMessages.detect.resolutionHigh",
+        severity: "warning",
+        condition: (ctx) => {
+          const width = ctx.formData?.width as number | null | undefined;
+          const height = ctx.formData?.height as number | null | undefined;
+          if (typeof width !== "number" || typeof height !== "number") {
+            return false;
+          }
+          return Math.min(width, height) > 1080;
+        },
+      },
+      {
+        key: "detect-square-resolution",
+        field: "width",
+        position: "before",
+        messageKey: "configMessages.detect.squareResolution",
+        severity: "warning",
+        condition: (ctx) => {
+          const width = ctx.formData?.width as number | null | undefined;
+          const height = ctx.formData?.height as number | null | undefined;
+          return (
+            typeof width === "number" &&
+            typeof height === "number" &&
+            width > 0 &&
+            width === height
+          );
+        },
+      },
+      {
         key: "detect-aspect-ratio-mismatch",
+        field: "width",
+        position: "before",
         messageKey: "configMessages.detect.aspectRatioMismatch",
         severity: "warning",
         condition: (ctx) => {
@@ -55,8 +110,6 @@ const detect: SectionConfigOverrides = {
           return Math.abs(newRatio - savedRatio) > 0.01;
         },
       },
-    ],
-    fieldMessages: [
       {
         key: "fps-greater-than-five",
         field: "fps",
@@ -71,6 +124,31 @@ const detect: SectionConfigOverrides = {
           return detectFps != null && streamFps != null && detectFps > 5;
         },
       },
+      {
+        key: "max-frames-set",
+        field: "stationary.max_frames",
+        messageKey: "configMessages.detect.maxFramesSet",
+        severity: "warning",
+        position: "after",
+        condition: (ctx) => {
+          const stationary = ctx.formData?.stationary as
+            | {
+                max_frames?: {
+                  default?: number | null;
+                  objects?: Record<string, number>;
+                } | null;
+              }
+            | null
+            | undefined;
+          const maxFrames = stationary?.max_frames;
+          if (!maxFrames) return false;
+          return (
+            typeof maxFrames.default === "number" ||
+            (maxFrames.objects != null &&
+              Object.keys(maxFrames.objects).length > 0)
+          );
+        },
+      },
     ],
     fieldOrder: [
       "enabled",
@@ -81,9 +159,9 @@ const detect: SectionConfigOverrides = {
       "max_disappeared",
       "annotation_offset",
       "stationary",
-      "interval",
-      "threshold",
-      "max_frames",
+      "stationary.interval",
+      "stationary.threshold",
+      "stationary.max_frames",
     ],
     restartRequired: [],
     fieldGroups: {
@@ -129,9 +207,6 @@ const detect: SectionConfigOverrides = {
       "max_disappeared",
       "annotation_offset",
       "stationary",
-      "interval",
-      "threshold",
-      "max_frames",
     ],
     advancedFields: [],
   },

--- a/web/src/components/filter/CameraGroupSelector.tsx
+++ b/web/src/components/filter/CameraGroupSelector.tsx
@@ -283,7 +283,7 @@ export function CameraGroupSelector({ className }: CameraGroupSelectorProps) {
             afterSelect?.();
           }}
         >
-          <LuPencil className="size-5 text-primary" />
+          <LuPencil className="size-5 text-primary-variant" />
         </Button>,
       );
     }
@@ -376,7 +376,7 @@ export function CameraGroupSelector({ className }: CameraGroupSelectorProps) {
                   onMouseEnter={() => showTooltip("edit")}
                   onMouseLeave={() => showTooltip(undefined)}
                 >
-                  <LuPencil className="size-4 text-primary" />
+                  <LuPencil className="size-4 text-primary-variant" />
                 </Button>
               </TooltipTrigger>
               <TooltipPortal>


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
- OpenVINO shares device-plugin state across all `ov.Core()` instances in a process, so two threads running inference on different runners (e.g. the ArcFace face-model build thread racing the LPR detector at startup) corrupt that shared state and segfault the embeddings process. The existing per-runner lock only guarded the single-shared-runner JinaV2 case and couldn't coordinate distinct runners, replace it with one process-wide lock covering both compile and inference. 
  - Serializing all OpenVINO inference in the process costs no real throughput, since enrichment models already run inline on the single embeddings maintainer thread, the lock only makes things like the background arcface build take turns with live inference instead of racing it.
- Add max scaling meta to login page
- Add more field messages to `detect` section in settings UI
- Fix icon from being squashed with longer field messages
- Camera group edit icon color tweak



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
