### PR TITLE
fix(cuda): gracefully fallback when CUDA graph capture is unsupported

### DIFF
--- a/frigate/detectors/detection_runners.py
+++ b/frigate/detectors/detection_runners.py
@@ -601,16 +601,31 @@ def get_optimized_runner(
         CudaGraphRunner.is_model_supported(model_type)
         and providers[0] == "CUDAExecutionProvider"
     ):
-        options[0] = {
+        # Try to enable CUDA graph capture for maximum performance.
+        # If the model has ops that can't be fully partitioned to CUDA
+        # (e.g. Memcpy nodes), fall back gracefully without graph capture.
+        graph_options = {
             **options[0],
             "enable_cuda_graph": True,
         }
-        return CudaGraphRunner(
-            ort.InferenceSession(
+        try:
+            session = ort.InferenceSession(
+                model_path,
+                providers=providers,
+                provider_options=[graph_options] + options[1:],
+            )
+        except Exception:
+            logger.warning(
+                "CUDA graph capture not supported for this model, "
+                "falling back to CUDA execution without graph capture"
+            )
+            session = ort.InferenceSession(
                 model_path,
                 providers=providers,
                 provider_options=options,
-            ),
+            )
+        return CudaGraphRunner(
+            session,
             options[0]["device_id"],
         )
 


### PR DESCRIPTION
## Proposed change

When `enable_cuda_graph: True` is set and the ONNX model contains operations that cannot be fully partitioned to CUDA (e.g. Memcpy nodes from reshape or concat ops), ONNX Runtime fails session creation with a fatal error. This prevents models like YOLOv8 from running on GPU with `device: cuda`.

Wrap the CudaGraphRunner session creation in try/except. If CUDA graph capture fails:
1. Log a warning
2. Create the session without `enable_cuda_graph`
3. Return CudaGraphRunner as normal (it works as a regular IOBinding runner without graph capture)

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## AI disclosure

- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: DeepSeek V4 Flash (via OpenCode)

**How AI was used**: Code generation, debugging, testing

**Extent of AI involvement**: Identified root cause, generated fix, tested locally on production hardware

**Human oversight**: Full code review, verification on production Frigate deployment with 4 ONNX detectors running on CUDA. Inference speed confirmed at ~10ms per detector.

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)