### PR TITLE
Record watchdog: corroborate heartbeat staleness against the cache dir before restarting

### DIFF
--- a/frigate/video/ffmpeg.py
+++ b/frigate/video/ffmpeg.py
@@ -9,6 +9,7 @@ from collections import deque
 from datetime import datetime, timedelta, timezone
 from multiprocessing import Queue, Value
 from multiprocessing.synchronize import Event as MpEvent
+from pathlib import Path
 from typing import Any
 
 from frigate.camera import CameraMetrics
@@ -22,7 +23,7 @@ from frigate.config.camera.updater import (
     CameraConfigUpdateEnum,
     CameraConfigUpdateSubscriber,
 )
-from frigate.const import PROCESS_PRIORITY_HIGH
+from frigate.const import CACHE_DIR, PROCESS_PRIORITY_HIGH
 from frigate.log import LogPipe
 from frigate.util.builtin import EventsPerSecond, get_record_segment_time
 from frigate.util.ffmpeg import start_or_restart_ffmpeg, stop_ffmpeg
@@ -453,6 +454,38 @@ class CameraWatchdog(threading.Thread):
                     invalid_stale = invalid_stale_condition
 
                     if cache_stale or valid_stale or invalid_stale:
+                        # The staleness above is measured from the recording
+                        # maintainer's IPC heartbeat, which lags whenever the
+                        # maintainer falls behind (e.g. "Unable to keep up with
+                        # recording segments in cache"). A late message is not
+                        # a dead recorder: corroborate against the cache dir
+                        # before restarting, otherwise every camera restarts
+                        # together on maintainer lag and the resulting segment
+                        # churn makes the overload worse.
+                        if not invalid_stale:
+                            newest_on_disk = max(
+                                (
+                                    f.stat().st_mtime
+                                    for f in Path(CACHE_DIR).glob(
+                                        f"{self.config.name}@*"
+                                    )
+                                ),
+                                default=0.0,
+                            )
+                            if (
+                                newest_on_disk > 0
+                                and now_utc.timestamp() - newest_on_disk
+                                < self.record_stale_threshold
+                            ):
+                                self.logger.warning(
+                                    f"Recording heartbeat for {self.config.name} is stale but a cache "
+                                    f"segment is only {now_utc.timestamp() - newest_on_disk:.0f}s old — "
+                                    "skipping the record process restart (maintainer heartbeat lag, "
+                                    "not a recording failure)."
+                                )
+                                self.latest_cache_segment_time = newest_on_disk
+                                continue
+
                         if cache_stale:
                             reason = "No new recording segments were created"
                         elif valid_stale:


### PR DESCRIPTION
## Proposed change

The per-camera record watchdog restarts the record ffmpeg when the maintainer heartbeat (`latest_cache_segment_time` / valid-segment time) is older than `record_stale_threshold`. That heartbeat is published by the **recording maintainer**, not measured locally — so whenever the maintainer lags behind (the `Unable to keep up with recording segments in cache` overload, #9661-class), **every camera goes "stale" at the same moment and every record process is restarted while recording is actually healthy**. The synchronized restart cuts segments short at the restart points, giving the maintainer even more files per pass — a self-reinforcing storm.

We traced this live on a 26-camera production deployment (0.17.1): fleet-wide record-ffmpeg restarts on a steady cadence (52/hour at peak) while the cameras' newest cache segments on disk were only seconds old at the very moment each watchdog declared them >120s stale. (On 0.17 the effect is severely amplified when a user raises `ffmpeg.retry_interval`, which there is also the watchdog lap period; dev's 1s lap already removes that amplifier, but genuine maintainer lag still produces the same false positive on dev.)

This change corroborates against reality before restarting on staleness: stat the camera's newest `CACHE_DIR` segment, and if a segment fresher than the staleness threshold exists, the recorder is demonstrably writing — log a warning, adopt the disk mtime as the heartbeat, and skip the restart. The `invalid_stale` path (an actual invalid-segment report) is deliberately untouched, as are restarts when the cache is genuinely dry.

Validation on the production deployment (backport of exactly this check to 0.17.1, running since 2026-06-11): synchronized mass restarts went **52/hour → 0**; heartbeat-stale events still occur under load (~2/hour) and are now logged as maintainer lag and skipped, with recordings confirmed continuous on disk throughout; the storm-driven 1-2s segment shredding stopped entirely.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #9661

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): Claude (Claude Code)

**How AI was used** (e.g., code generation, code review, debugging, documentation): Debugging/diagnosis of the production storm (live tracing, log analysis), drafting the patch, and writing this description.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): The diagnosis and the patch were produced with AI assistance end-to-end, directed and reviewed by the maintainer of the affected deployment.

**Human oversight**: The equivalent change has been running on a 26-camera production 0.17.1 deployment since 2026-06-11 with the results described above (mass restarts 52/hour → 0, recordings verified continuous on disk during heartbeat-stale events). The deployment owner reviewed the change and the claims in this PR.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)