### PR TITLE
Guard norfair distance() against zero-area boxes (fix 'Received nan values from distance function' crash)

### DIFF
--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -42,8 +42,13 @@ def distance(detection: np.ndarray, estimate: np.ndarray) -> float:
     # ultimately, this should try and estimate distance in 3-dimensional space
     # consider change in location, width, and height
 
-    estimate_dim = np.diff(estimate, axis=0).flatten()
-    detection_dim = np.diff(detection, axis=0).flatten()
+    # Guard against degenerate (zero-area) boxes: a collapsed Kalman estimate or
+    # a zero-dimension detection makes the divisions below produce NaN, which
+    # norfair rejects by raising ValueError ("Received nan values from distance
+    # function") and crashes the camera process. Clamp dims to >= 1px (these are
+    # pixel coordinates, so a dimension < 1 is meaningless).
+    estimate_dim = np.maximum(np.abs(np.diff(estimate, axis=0).flatten()), 1.0)
+    detection_dim = np.maximum(np.abs(np.diff(detection, axis=0).flatten()), 1.0)
 
     # get bottom center positions
     detection_position = np.array(


### PR DESCRIPTION
## Problem

`frigate/track/norfair_tracker.py::distance()` divides the change-in-position and the width/height ratios by the box dimensions:

```python
distance[0] /= estimate_dim[0]
distance[1] /= estimate_dim[1]
width_ratio  = widths[1]  / widths[0]  - 1.0
height_ratio = heights[1] / heights[0] - 1.0
```

When a Kalman estimate collapses or a detection box is clamped to zero width/height, those divisions produce `inf`/`nan`. norfair's `_update_objects_in_place` then raises `ValueError: Received nan values from distance function`, and because this runs in `process_frames`, the per-camera process exits (and is not respawned).

We hit this intermittently (~2-3×/month) on an autotracking PTZ camera with a **healthy Coral EdgeTPU detector** — i.e. not the bad-model cause discussed in #9742; the degenerate box comes from the tracker/autotracking geometry during camera motion. Because the error is generic, the guard also covers #9742's symptom.

## Fix

Clamp the box dimensions to `>= 1px` (pixel coordinates, so `< 1` is meaningless). One change protects all four division sites with no behavior change for valid boxes:

```python
estimate_dim  = np.maximum(np.abs(np.diff(estimate,  axis=0).flatten()), 1.0)
detection_dim = np.maximum(np.abs(np.diff(detection, axis=0).flatten()), 1.0)
```

## Notes

- Discussed in https://github.com/blakeblackshear/frigate/discussions/23471.
- Reproduction is intermittent (tied to autotracking motion), but the divide-by-zero is deterministic given a zero-dim estimate/detection. We run a live autotracking PTZ and are happy to run this patched build to confirm the crash stops over time.
- The separate resilience gap (a camera process killed by an unhandled tracker exception is not respawned) is out of scope for this PR.
