### PR TITLE
Fix autotracking camera crash from non-finite tracker distance values

### DIFF
--- a/frigate/ptz/autotrack.py
+++ b/frigate/ptz/autotrack.py
@@ -48,6 +48,22 @@ def ptz_moving_at_frame_time(frame_time, ptz_start_time, ptz_stop_time):
     )
 
 
+def transform_is_finite(coord_transformations) -> bool:
+    """Return True if a norfair coordinate transform contains only finite values.
+
+    A near-singular homography (common when the motion estimator can't find
+    enough stable features during zoom on a low-texture scene) can produce
+    inf/nan matrix entries. norfair accumulates the homography across frames, so
+    a single bad transform poisons every subsequent one and propagates nan into
+    the tracker's distance function, crashing the camera process.
+    """
+    for attr in ("homography_matrix", "inverse_homography_matrix", "movement_vector"):
+        value = getattr(coord_transformations, attr, None)
+        if value is not None and not np.all(np.isfinite(value)):
+            return False
+    return True
+
+
 class PtzMotionEstimator:
     def __init__(self, config: CameraConfig, ptz_metrics: PTZMetrics) -> None:
         self.frame_manager = SharedMemoryFrameManager()
@@ -134,6 +150,19 @@ class PtzMotionEstimator:
                     f"Autotracker: motion estimator couldn't get transformations for {camera} at frame time {frame_time}"
                 )
                 self.coord_transformations = None
+
+            # A degenerate homography can yield non-finite transform values that
+            # norfair would accumulate and feed to the tracker as nan estimates.
+            # Drop the bad transform and request a reset so the estimator rebuilds
+            # a fresh reference frame instead of poisoning every following frame.
+            if self.coord_transformations is not None and not transform_is_finite(
+                self.coord_transformations
+            ):
+                logger.warning(
+                    f"Autotracker: motion estimator produced a non-finite transform for {camera} at frame time {frame_time}, resetting"
+                )
+                self.coord_transformations = None
+                self.ptz_metrics.reset.set()
 
             try:
                 logger.debug(

--- a/frigate/test/test_norfair_distance.py
+++ b/frigate/test/test_norfair_distance.py
@@ -1,0 +1,91 @@
+import math
+import unittest
+
+import numpy as np
+from norfair.camera_motion import (
+    HomographyTransformation,
+    TranslationTransformation,
+)
+
+from frigate.ptz.autotrack import transform_is_finite
+from frigate.track.norfair_tracker import distance
+
+
+class TestNorfairDistance(unittest.TestCase):
+    """Regression tests for the tracker distance guard.
+
+    norfair raises a hard ValueError on any nan distance, which kills the camera
+    process. During autotracking, an ill-conditioned homography can hand the
+    tracker a non-finite or degenerate estimate box, so distance() must never
+    return nan for any input.
+    """
+
+    def setUp(self) -> None:
+        # boxes are [[x1, y1], [x2, y2]]
+        self.detection = np.array([[805.0, 402.0], [864.0, 521.0]])
+        self.estimate = np.array([[800.0, 400.0], [860.0, 520.0]])
+
+    def test_finite_boxes_give_finite_distance(self) -> None:
+        d = distance(self.detection, self.estimate)
+        self.assertTrue(math.isfinite(d))
+
+    def test_inf_estimate_corner_does_not_return_nan(self) -> None:
+        estimate = np.array([[np.inf, 400.0], [860.0, 520.0]])
+        d = distance(self.detection, estimate)
+        self.assertFalse(math.isnan(d))
+        self.assertEqual(d, float("inf"))
+
+    def test_nan_estimate_corner_does_not_return_nan(self) -> None:
+        # the actual autotracking crash: a positive-only guard would miss this
+        # because nan <= 0 is False
+        estimate = np.array([[np.nan, 400.0], [860.0, 520.0]])
+        d = distance(self.detection, estimate)
+        self.assertFalse(math.isnan(d))
+        self.assertEqual(d, float("inf"))
+
+    def test_zero_area_estimate_does_not_return_nan(self) -> None:
+        estimate = np.array([[900.0, 500.0], [900.0, 500.0]])
+        d = distance(self.detection, estimate)
+        self.assertFalse(math.isnan(d))
+        self.assertEqual(d, float("inf"))
+
+    def test_zero_area_detection_does_not_return_nan(self) -> None:
+        detection = np.array([[805.0, 402.0], [805.0, 521.0]])
+        d = distance(detection, self.estimate)
+        self.assertFalse(math.isnan(d))
+        self.assertEqual(d, float("inf"))
+
+    def test_inverted_estimate_corners_do_not_return_nan(self) -> None:
+        # Kalman estimates can occasionally cross corners (x2 < x1)
+        estimate = np.array([[860.0, 520.0], [800.0, 400.0]])
+        d = distance(self.detection, estimate)
+        self.assertFalse(math.isnan(d))
+        self.assertEqual(d, float("inf"))
+
+
+class TestTransformIsFinite(unittest.TestCase):
+    def test_finite_homography_is_finite(self) -> None:
+        matrix = np.array([[1.0, 0.0, 5.0], [0.0, 1.0, 3.0], [0.0, 0.0, 1.0]])
+        self.assertTrue(transform_is_finite(HomographyTransformation(matrix)))
+
+    def test_finite_translation_is_finite(self) -> None:
+        self.assertTrue(
+            transform_is_finite(TranslationTransformation(np.array([12.0, -4.0])))
+        )
+
+    def test_non_finite_homography_is_not_finite(self) -> None:
+        transform = HomographyTransformation(np.eye(3))
+        # simulate accumulation overflowing to a non-finite matrix
+        transform.homography_matrix = np.array(
+            [[1.0, 0.0, np.inf], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+        )
+        self.assertFalse(transform_is_finite(transform))
+
+    def test_nan_translation_is_not_finite(self) -> None:
+        self.assertFalse(
+            transform_is_finite(TranslationTransformation(np.array([np.nan, 0.0])))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -45,6 +45,17 @@ def distance(detection: np.ndarray, estimate: np.ndarray) -> float:
     estimate_dim = np.diff(estimate, axis=0).flatten()
     detection_dim = np.diff(detection, axis=0).flatten()
 
+    # Guard against degenerate or non-finite boxes
+    if (
+        not np.all(np.isfinite(estimate_dim))
+        or not np.all(np.isfinite(detection_dim))
+        or estimate_dim[0] <= 0
+        or estimate_dim[1] <= 0
+        or detection_dim[0] <= 0
+        or detection_dim[1] <= 0
+    ):
+        return float("inf")
+
     # get bottom center positions
     detection_position = np.array(
         [np.average(detection[:, 0]), np.max(detection[:, 1])]


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
During PTZ autotracking, homography calculated from motion estimation in difficult circumstances (very few correct transform points on a scene like a lake or gravel road) can hand the tracker a non-finite or zero-area estimate box, making norfair raise "Received nan values from distance function" and kill the camera process. This PR guards the distance function with an `np.isfinite`/positive-dimension check that returns `inf` (which norfair tolerates) instead of `nan`, and resets the motion estimator when its transform goes non-finite so tracking recovers rather than degrading until the next preset return.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/23471
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
