### PR TITLE
Allow GenAI providers to be initialized lazily

### DIFF
--- a/frigate/genai/__init__.py
+++ b/frigate/genai/__init__.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import time
 from typing import Any, AsyncGenerator, Callable, Optional
 
 import numpy as np
@@ -50,6 +51,10 @@ def register_genai_provider(key: GenAIProviderEnum) -> Callable:
 class GenAIClient:
     """Generative AI client for Frigate."""
 
+    # Minimum seconds between re-initialization attempts when the provider was
+    # offline at startup
+    REINIT_INTERVAL = 60.0
+
     def __init__(
         self,
         genai_config: GenAIConfig,
@@ -60,6 +65,34 @@ class GenAIClient:
         self.timeout = timeout
         self.validate_model = validate_model
         self.provider = self._init_provider()
+        self._last_init_attempt = time.monotonic()
+
+    def ensure_provider(self) -> bool:
+        """Ensure a provider is available, retrying initialization if needed.
+
+        Providers can fail to initialize at startup when their backing service
+        isn't online yet (common when both are started together). This retries
+        ``_init_provider`` lazily — throttled to ``REINIT_INTERVAL`` — so the
+        client recovers on its own once the service is reachable, without a
+        config reload.
+
+        Returns True if a provider is available.
+        """
+        if self.provider is not None:
+            return True
+
+        now = time.monotonic()
+        if now - self._last_init_attempt < self.REINIT_INTERVAL:
+            return False
+
+        self._last_init_attempt = now
+        self.provider = self._init_provider()
+        if self.provider is not None:
+            logger.info(
+                "GenAI provider %s is now available",
+                self.genai_config.provider,
+            )
+        return self.provider is not None
 
     def generate_review_description(
         self,

--- a/frigate/genai/manager.py
+++ b/frigate/genai/manager.py
@@ -80,7 +80,7 @@ class GenAIClientManager:
             return None
 
         try:
-            client: "GenAIClient" = provider_cls(genai_cfg)
+            client = provider_cls(genai_cfg)
         except Exception as e:
             logger.exception(
                 "Failed to create GenAI client for provider %s: %s",

--- a/frigate/genai/manager.py
+++ b/frigate/genai/manager.py
@@ -62,7 +62,9 @@ class GenAIClientManager:
     def _get_client(self, name: str) -> "Optional[GenAIClient]":
         """Return the client for *name*, creating it on first access."""
         if name in self._clients:
-            return self._clients[name]
+            client = self._clients[name]
+            client.ensure_provider()
+            return client
 
         from frigate.genai import PROVIDERS
 


### PR DESCRIPTION

_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

More robustly initializes GenAI providers so they can be initialized lazily even if they fail on initial load

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: closes #23481 
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
