### PR TITLE
perf(track): use sum()/len() instead of np.mean in average_boxes

### DIFF
--- a/frigate/test/test_obects.py
+++ b/frigate/test/test_obects.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 from frigate.track.tracked_object import TrackedObjectAttribute
-from frigate.util.object import average_boxes, interpolated_percentile
+from frigate.util.object import average_boxes
 
 
 class TestBoxStatistics(unittest.TestCase):
@@ -17,19 +17,6 @@ class TestBoxStatistics(unittest.TestCase):
             ]
             expected = [float(np.mean([b[i] for b in boxes])) for i in range(4)]
             self.assertEqual(average_boxes(boxes), expected)
-
-    def test_interpolated_percentile_matches_numpy(self) -> None:
-        rng = random.Random(1)
-        for _ in range(5000):
-            values = [rng.randint(0, 5000) for _ in range(rng.randint(1, 10))]
-            for q in (15, 85, 50):
-                self.assertEqual(
-                    interpolated_percentile(values, q),
-                    float(np.percentile(values, q)),
-                )
-
-    def test_interpolated_percentile_single_value(self) -> None:
-        self.assertEqual(interpolated_percentile([42], 15), 42.0)
 
 
 class TestAttribute(unittest.TestCase):

--- a/frigate/test/test_obects.py
+++ b/frigate/test/test_obects.py
@@ -1,6 +1,35 @@
+import random
 import unittest
 
+import numpy as np
+
 from frigate.track.tracked_object import TrackedObjectAttribute
+from frigate.util.object import average_boxes, interpolated_percentile
+
+
+class TestBoxStatistics(unittest.TestCase):
+    def test_average_boxes_matches_numpy(self) -> None:
+        rng = random.Random(0)
+        for _ in range(5000):
+            boxes = [
+                [rng.randint(0, 4000) for _ in range(4)]
+                for _ in range(rng.randint(1, 10))
+            ]
+            expected = [float(np.mean([b[i] for b in boxes])) for i in range(4)]
+            self.assertEqual(average_boxes(boxes), expected)
+
+    def test_interpolated_percentile_matches_numpy(self) -> None:
+        rng = random.Random(1)
+        for _ in range(5000):
+            values = [rng.randint(0, 5000) for _ in range(rng.randint(1, 10))]
+            for q in (15, 85, 50):
+                self.assertEqual(
+                    interpolated_percentile(values, q),
+                    float(np.percentile(values, q)),
+                )
+
+    def test_interpolated_percentile_single_value(self) -> None:
+        self.assertEqual(interpolated_percentile([42], 15), 42.0)
 
 
 class TestAttribute(unittest.TestCase):

--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -27,7 +27,11 @@ from frigate.util.image import (
     get_histogram,
     intersection_over_union,
 )
-from frigate.util.object import average_boxes, median_of_boxes
+from frigate.util.object import (
+    average_boxes,
+    interpolated_percentile,
+    median_of_boxes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -428,10 +432,10 @@ class NorfairTracker(ObjectTracker):
             position["xmaxs"].append(xmax)
             position["ymaxs"].append(ymax)
             # by using percentiles here, we hopefully remove outliers
-            position["xmin"] = np.percentile(position["xmins"], 15)
-            position["ymin"] = np.percentile(position["ymins"], 15)
-            position["xmax"] = np.percentile(position["xmaxs"], 85)
-            position["ymax"] = np.percentile(position["ymaxs"], 85)
+            position["xmin"] = interpolated_percentile(position["xmins"], 15)
+            position["ymin"] = interpolated_percentile(position["ymins"], 15)
+            position["xmax"] = interpolated_percentile(position["xmaxs"], 85)
+            position["ymax"] = interpolated_percentile(position["ymaxs"], 85)
 
         return True
 

--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -27,11 +27,7 @@ from frigate.util.image import (
     get_histogram,
     intersection_over_union,
 )
-from frigate.util.object import (
-    average_boxes,
-    interpolated_percentile,
-    median_of_boxes,
-)
+from frigate.util.object import average_boxes, median_of_boxes
 
 logger = logging.getLogger(__name__)
 
@@ -432,10 +428,10 @@ class NorfairTracker(ObjectTracker):
             position["xmaxs"].append(xmax)
             position["ymaxs"].append(ymax)
             # by using percentiles here, we hopefully remove outliers
-            position["xmin"] = interpolated_percentile(position["xmins"], 15)
-            position["ymin"] = interpolated_percentile(position["ymins"], 15)
-            position["xmax"] = interpolated_percentile(position["xmaxs"], 85)
-            position["ymax"] = interpolated_percentile(position["ymaxs"], 85)
+            position["xmin"] = np.percentile(position["xmins"], 15)
+            position["ymin"] = np.percentile(position["ymins"], 15)
+            position["xmax"] = np.percentile(position["xmaxs"], 85)
+            position["ymax"] = np.percentile(position["ymaxs"], 85)
 
         return True
 

--- a/frigate/util/object.py
+++ b/frigate/util/object.py
@@ -339,24 +339,38 @@ def reduce_boxes(boxes, iou_threshold=0.0):
 
 def average_boxes(boxes: list[list[int, int, int, int]]) -> list[int, int, int, int]:
     """Return a box that is the average of a list of boxes."""
-    x_mins = []
-    y_mins = []
-    x_max = []
-    y_max = []
-
-    for box in boxes:
-        x_mins.append(box[0])
-        y_mins.append(box[1])
-        x_max.append(box[2])
-        y_max.append(box[3])
-
-    return [np.mean(x_mins), np.mean(y_mins), np.mean(x_max), np.mean(y_max)]
+    n = len(boxes)
+    return [
+        sum(box[0] for box in boxes) / n,
+        sum(box[1] for box in boxes) / n,
+        sum(box[2] for box in boxes) / n,
+        sum(box[3] for box in boxes) / n,
+    ]
 
 
 def median_of_boxes(boxes: list[list[int, int, int, int]]) -> list[int, int, int, int]:
     """Return a box that is the median of a list of boxes."""
     sorted_boxes = sorted(boxes, key=lambda x: area(x))
     return sorted_boxes[int(len(sorted_boxes) / 2.0)]
+
+
+def interpolated_percentile(values: list[int], q: float) -> float:
+    """Linear-interpolated percentile, matching numpy.percentile for the small
+    lists used in position smoothing without the per-call numpy overhead."""
+    ordered = sorted(values)
+    n = len(ordered)
+    if n == 1:
+        return float(ordered[0])
+    rank = (q / 100.0) * (n - 1)
+    lo = int(rank)
+    frac = rank - lo
+    if frac == 0.0:
+        return float(ordered[lo])
+    diff = ordered[lo + 1] - ordered[lo]
+    # numpy's lerp switches sides at frac >= 0.5 to limit rounding error
+    if frac < 0.5:
+        return ordered[lo] + diff * frac
+    return ordered[lo + 1] - diff * (1.0 - frac)
 
 
 def intersects_any(box_a, boxes):

--- a/frigate/util/object.py
+++ b/frigate/util/object.py
@@ -354,25 +354,6 @@ def median_of_boxes(boxes: list[list[int, int, int, int]]) -> list[int, int, int
     return sorted_boxes[int(len(sorted_boxes) / 2.0)]
 
 
-def interpolated_percentile(values: list[int], q: float) -> float:
-    """Linear-interpolated percentile, matching numpy.percentile for the small
-    lists used in position smoothing without the per-call numpy overhead."""
-    ordered = sorted(values)
-    n = len(ordered)
-    if n == 1:
-        return float(ordered[0])
-    rank = (q / 100.0) * (n - 1)
-    lo = int(rank)
-    frac = rank - lo
-    if frac == 0.0:
-        return float(ordered[lo])
-    diff = ordered[lo + 1] - ordered[lo]
-    # numpy's lerp switches sides at frac >= 0.5 to limit rounding error
-    if frac < 0.5:
-        return ordered[lo] + diff * frac
-    return ordered[lo + 1] - diff * (1.0 - frac)
-
-
 def intersects_any(box_a, boxes):
     for box in boxes:
         if box_overlaps(box_a, box):


### PR DESCRIPTION
## Proposed change

`average_boxes` (called per stationary object per frame from the tracker) built four temporary lists and called `np.mean` four times on lists of at most 10 ints, where numpy's per-call overhead dominates. This replaces it with plain `sum()/len()`.

The result is **bit-identical** to the previous `np.mean`-based output (added test asserts equality against `numpy` over randomized small inputs).

> Note: an earlier revision of this PR also reimplemented `np.percentile` for the position-smoothing path. Per review that has been **dropped** (it hurt readability and risked diverging from numpy, e.g. for numpy 2.x); `update_position` keeps using `np.percentile`. This PR is now scoped to `average_boxes` only.

**Measured** in the release image (numpy 1.26.4), per call on a small box list: `np.mean`-based `average_boxes` ~7.5 µs → ~0.6 µs (~12×).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Claude Code).

**How AI was used**: profiling analysis to find the hot path, drafting the change, the test, and the micro-benchmark.

**Extent of AI involvement**: assisted with this isolated function; human-directed and reviewed.

**Human oversight**: I verified bit-identical output against `numpy.mean` over randomized inputs, ran the full `python3 -u -m unittest` suite in the Frigate release image, and verified `ruff format`/`ruff check` are clean.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
