### PR TITLE
perf(track): avoid per-frame allocations and list lookups in tracker

### DIFF
--- a/frigate/test/test_stationary_classifier.py
+++ b/frigate/test/test_stationary_classifier.py
@@ -1,0 +1,39 @@
+"""Tests for stationary object classification thresholds."""
+
+import unittest
+
+from frigate.track.stationary_classifier import (
+    DEFAULT_OBJECT_THRESHOLDS,
+    DYNAMIC_OBJECT_THRESHOLDS,
+    NON_STATIONARY_OBJECT_THRESHOLDS,
+    STATIONARY_OBJECT_THRESHOLDS,
+    StationaryThresholds,
+    get_stationary_threshold,
+)
+
+
+class TestStationaryThresholds(unittest.TestCase):
+    def test_known_labels_return_expected_singletons(self) -> None:
+        self.assertIs(get_stationary_threshold("package"), STATIONARY_OBJECT_THRESHOLDS)
+        self.assertIs(get_stationary_threshold("car"), DYNAMIC_OBJECT_THRESHOLDS)
+        self.assertIs(
+            get_stationary_threshold("license_plate"),
+            NON_STATIONARY_OBJECT_THRESHOLDS,
+        )
+
+    def test_unknown_label_returns_shared_default(self) -> None:
+        # an unknown label must reuse the shared default instance, not allocate
+        # a fresh one on every call (this runs per object per frame)
+        first = get_stationary_threshold("person")
+        second = get_stationary_threshold("dog")
+        self.assertIs(first, DEFAULT_OBJECT_THRESHOLDS)
+        self.assertIs(second, DEFAULT_OBJECT_THRESHOLDS)
+
+    def test_default_matches_a_fresh_instance(self) -> None:
+        # the shared default must be value-equivalent to the previous
+        # per-call StationaryThresholds()
+        self.assertEqual(DEFAULT_OBJECT_THRESHOLDS, StationaryThresholds())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frigate/track/norfair_tracker.py
+++ b/frigate/track/norfair_tracker.py
@@ -641,9 +641,11 @@ class NorfairTracker(ObjectTracker):
             self.deregister(self.track_id_map[e_id], e_id)
 
         # update list of object boxes that don't have a tracked object yet
-        tracked_object_boxes = [obj["box"] for obj in self.tracked_objects.values()]
+        tracked_object_boxes = {
+            tuple(obj["box"]) for obj in self.tracked_objects.values()
+        }
         self.untracked_object_boxes = [
-            o[2] for o in detections if o[2] not in tracked_object_boxes
+            o[2] for o in detections if tuple(o[2]) not in tracked_object_boxes
         ]
 
     def print_objects_as_table(self, tracked_objects: Sequence) -> None:

--- a/frigate/track/stationary_classifier.py
+++ b/frigate/track/stationary_classifier.py
@@ -63,6 +63,9 @@ NON_STATIONARY_OBJECT_THRESHOLDS = StationaryThresholds(
     max_stationary_history=4,
 )
 
+# Default thresholds for any other object label
+DEFAULT_OBJECT_THRESHOLDS = StationaryThresholds()
+
 
 def get_stationary_threshold(label: str) -> StationaryThresholds:
     """Get the stationary thresholds for a given object label."""
@@ -76,7 +79,7 @@ def get_stationary_threshold(label: str) -> StationaryThresholds:
     if label in NON_STATIONARY_OBJECT_THRESHOLDS.objects:
         return NON_STATIONARY_OBJECT_THRESHOLDS
 
-    return StationaryThresholds()
+    return DEFAULT_OBJECT_THRESHOLDS
 
 
 class StationaryMotionClassifier:


### PR DESCRIPTION
## Proposed change

Two small per-object-per-frame improvements in the tracker hot path (`NorfairTracker.match_and_update`), both **bit-identical**:

- **`get_stationary_threshold`** returned a freshly constructed `StationaryThresholds` (a dataclass *plus* a `list`) on every call for any label not in the three known lists — i.e. for common labels like `person`/`dog`/`cat`. The default thresholds are constant and never mutated, so it now returns a shared module-level singleton (`DEFAULT_OBJECT_THRESHOLDS`), exactly as the three known-label cases already do. Removes a per-object-per-frame allocation.
- **`untracked_object_boxes`** membership used `box not in [list of boxes]` (O(n) scan per detection). It now builds a `set` of box tuples for O(1) membership; boxes are hashable as tuples and output is unchanged.

No behavior, config, or API changes.

**Measured** in the release image: `get_stationary_threshold("person")` 87.7 ns → 59.6 ns/call (1.5×), and it no longer allocates a dataclass + list each call. `get_stationary_threshold` appeared in a live `py-spy --gil` profile of a camera `process_frames` worker.

---
**Validated on the live deployment**: deployed to the running 15-camera NVR and restarted clean with no errors or regressions; reverted to stock after validation.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Claude Code).

**How AI was used**: py-spy profiling to find the per-frame allocation, drafting the change, the tests, and the micro-benchmark.

**Extent of AI involvement**: assisted with these two isolated spots; human-directed and reviewed.

**Human oversight**: I confirmed the thresholds object is read-only at its only call site (never mutated, so a shared singleton is safe), verified the membership change is output-equivalent, added unit tests, ran the full `python3 -u -m unittest` suite in the Frigate release image, and verified `ruff format`/`ruff check` are clean.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
