### PR TITLE
perf(track): add __slots__ to TrackedObjectAttribute

### DIFF
--- a/frigate/test/test_obects.py
+++ b/frigate/test/test_obects.py
@@ -3,6 +3,21 @@ import unittest
 from frigate.track.tracked_object import TrackedObjectAttribute
 
 
+class TestAttributeSlots(unittest.TestCase):
+    def test_attribute_uses_slots(self) -> None:
+        attribute = TrackedObjectAttribute(
+            ("amazon", 0.8, (847, 242, 883, 255), 468, 2.77, (702, 134, 1050, 482))
+        )
+        # __slots__ means no per-instance __dict__
+        self.assertFalse(hasattr(attribute, "__dict__"))
+        # all declared fields are still populated and readable
+        self.assertEqual(attribute.label, "amazon")
+        self.assertEqual(attribute.region, (702, 134, 1050, 482))
+        # setting an undeclared attribute must raise (catches accidental drift)
+        with self.assertRaises(AttributeError):
+            attribute.unexpected = 1
+
+
 class TestAttribute(unittest.TestCase):
     def test_overlapping_object_selection(self) -> None:
         attribute = TrackedObjectAttribute(

--- a/frigate/track/tracked_object.py
+++ b/frigate/track/tracked_object.py
@@ -574,6 +574,8 @@ def zone_filtered(obj: TrackedObject, object_config: dict[str, FilterConfig]) ->
 
 
 class TrackedObjectAttribute:
+    __slots__ = ("label", "score", "box", "area", "ratio", "region")
+
     def __init__(self, raw_data: tuple) -> None:
         self.label = raw_data[0]
         self.score = raw_data[1]


### PR DESCRIPTION
## Proposed change

`TrackedObjectAttribute` is constructed per attribute (face, license plate, logo, …) per frame in `process_frames`. It holds exactly six fixed fields (`label`, `score`, `box`, `area`, `ratio`, `region`) and is never mutated beyond `__init__`, so adding `__slots__` removes the per-instance `__dict__`.

No behavior, config, or API changes.

**Measured** in the release image: 352 B/instance (56 B object + 296 B `__dict__`) → ~104 B with `__slots__` — ~70% smaller — on a high-churn per-frame object. Validated on the live deployment (face recognition + LPR enabled): the running NVR restarted clean with the change, the slotted class enforces its fields (no `__dict__`), and attribute tracking continues to work.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Claude Code).

**How AI was used**: profiling/analysis to find the high-churn per-frame object, drafting the change and the test.

**Extent of AI involvement**: assisted with this single class; human-directed and reviewed.

**Human oversight**: I confirmed the class sets exactly those six attributes and is never mutated or pickled, measured the per-instance size reduction in the release image, added a unit test (no `__dict__`; undeclared attribute raises), validated the change on the live deployment (patch + restart, no errors), ran the full `python3 -u -m unittest` suite in the Frigate release image, and verified `ruff format`/`ruff check` are clean.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
