### PR TITLE
Fix unbounded recordings_info growth for cameras with no cache segments

### DIFF
--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -42,6 +42,8 @@ from frigate.util.services import get_video_properties
 
 logger = logging.getLogger(__name__)
 
+STALE_RECORDINGS_INFO_TTL = MAX_SEGMENTS_IN_CACHE * MAX_SEGMENT_DURATION * 2
+
 
 class SegmentInfo:
     def __init__(
@@ -301,6 +303,8 @@ class RecordingMaintainer(threading.Thread):
                 RecordingsDataTypeEnum.saved.value,
             )
 
+        self._expire_stale_recordings_info(grouped_recordings)
+
         recordings_to_insert: list[Optional[dict[str, Any]]] = await asyncio.gather(
             *tasks
         )
@@ -310,6 +314,21 @@ class RecordingMaintainer(threading.Thread):
             INSERT_MANY_RECORDINGS,
             [r for r in recordings_to_insert if r is not None],
         )
+
+    def _expire_stale_recordings_info(
+        self, grouped_recordings: defaultdict[str, list[dict[str, Any]]]
+    ) -> None:
+        expire_before = datetime.datetime.now().timestamp() - STALE_RECORDINGS_INFO_TTL
+        for recordings_info in (
+            self.object_recordings_info,
+            self.audio_recordings_info,
+        ):
+            for camera in list(recordings_info.keys()):
+                if camera in grouped_recordings:
+                    continue
+                info = recordings_info[camera]
+                while info and info[0][0] < expire_before:
+                    info.pop(0)
 
     def drop_segment(self, cache_path: str) -> None:
         Path(cache_path).unlink(missing_ok=True)

--- a/frigate/test/test_maintainer.py
+++ b/frigate/test/test_maintainer.py
@@ -115,6 +115,46 @@ class TestMaintainer(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(result)
         maintainer.drop_segment.assert_called_once_with(cache_path)
 
+    async def test_expire_stale_recordings_info_drops_only_absent_cameras(self):
+        config = MagicMock(spec=FrigateConfig)
+        config.cameras = {}
+        stop_event = MagicMock()
+        maintainer = RecordingMaintainer(config, stop_event)
+
+        now = datetime.datetime.now().timestamp()
+        ancient = now - 86400
+        recent = now - 1
+
+        maintainer.object_recordings_info["present_cam"] = [(ancient, [], [], [])]
+        maintainer.audio_recordings_info["present_cam"] = [(ancient, 0, [])]
+
+        maintainer.object_recordings_info["absent_cam"] = [
+            (ancient, [], [], []),
+            (recent, [], [], []),
+        ]
+        maintainer.audio_recordings_info["absent_cam"] = [
+            (ancient, 0, []),
+            (recent, 0, []),
+        ]
+
+        grouped_recordings = {"present_cam": [{"start_time": ancient}]}
+
+        maintainer._expire_stale_recordings_info(grouped_recordings)
+
+        self.assertEqual(
+            maintainer.object_recordings_info["present_cam"], [(ancient, [], [], [])]
+        )
+        self.assertEqual(
+            maintainer.audio_recordings_info["present_cam"], [(ancient, 0, [])]
+        )
+
+        self.assertEqual(
+            maintainer.object_recordings_info["absent_cam"], [(recent, [], [], [])]
+        )
+        self.assertEqual(
+            maintainer.audio_recordings_info["absent_cam"], [(recent, 0, [])]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Proposed change

This PR fixes an edge case that results in a memory leak when a camera's recording stream is wedged for an extended period of time while its detect stream is still running. This will eventually result in an OOM condition and recording will stop for all cameras. This issue was reported in discussion #23451.

This PR makes the following changes:
- `_expire_stale_recordings_info()`, called from `move_files()`, prunes the buffers for cameras absent from `grouped_recordings`, dropping entries older than `MAX_SEGMENTS_IN_CACHE * MAX_SEGMENT_DURATION * 2` (older than any future segment could match). Cameras present in `grouped_recordings` are untouched (their existing per-camera prune is unchanged).
- Regression test added.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: reported in discussion https://github.com/blakeblackshear/frigate/discussions/23451
- Link to discussion with maintainers (**required** for any large or "planned" features): https://github.com/blakeblackshear/frigate/discussions/23451

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): Claude Code

**How AI was used** (e.g., code generation, code review, debugging, documentation): Claude Code was used for the following:
- Correlating log data stored in Graylog with system metrics to identify the root cause of a period of time during which no video was recorded.
- Building a fix and the test harness used to confirm that the fix resolved the issue.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): Claude Code generated the fix and the regression test.

**Human oversight**: I reviewed the following:
- The code generated by Claude Code.
- The system metrics, logs, and test data from ~17 hours of the patched build running in production, which confirmed the recording process memory stayed flat with the failure condition active over half the time.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
