### PR TITLE
perf(motion): compute contrast percentiles from a histogram instead of np.percentile

### DIFF
--- a/frigate/motion/improved_motion.py
+++ b/frigate/motion/improved_motion.py
@@ -13,6 +13,25 @@ from frigate.util.image import grab_cv2_contours
 logger = logging.getLogger(__name__)
 
 
+def percentiles_from_uint8(
+    frame: np.ndarray, quantiles: tuple[float, ...]
+) -> tuple[np.uint8, ...]:
+    """Linear-interpolated percentiles of a uint8 image, matching
+    numpy.percentile, but computed from a 256-bin histogram so the frame is
+    scanned once instead of being partitioned once per quantile."""
+    csum = np.cumsum(cv2.calcHist([frame], [0], None, [256], [0, 256]).ravel())
+    n = csum[-1]
+    results = []
+    for q in quantiles:
+        rank = q / 100.0 * (n - 1)
+        lo = int(np.floor(rank))
+        hi = int(np.ceil(rank))
+        v_lo = float(np.searchsorted(csum, lo, side="right"))
+        v_hi = float(np.searchsorted(csum, hi, side="right"))
+        results.append(np.uint8(v_lo + (rank - lo) * (v_hi - v_lo)))
+    return tuple(results)
+
+
 class ImprovedMotionDetector(MotionDetector):
     def __init__(
         self,
@@ -87,8 +106,7 @@ class ImprovedMotionDetector(MotionDetector):
         # Improve contrast
         if self.config.improve_contrast:
             # TODO tracking moving average of min/max to avoid sudden contrast changes
-            min_value = np.percentile(resized_frame, 4).astype(np.uint8)
-            max_value = np.percentile(resized_frame, 96).astype(np.uint8)
+            min_value, max_value = percentiles_from_uint8(resized_frame, (4, 96))
             # skip contrast calcs if the image is a single color
             if min_value < max_value:
                 # keep track of the last 50 contrast values

--- a/frigate/test/test_motion_detector.py
+++ b/frigate/test/test_motion_detector.py
@@ -3,7 +3,29 @@ import unittest
 import numpy as np
 
 from frigate.config.camera.motion import MotionConfig
-from frigate.motion.improved_motion import ImprovedMotionDetector
+from frigate.motion.improved_motion import (
+    ImprovedMotionDetector,
+    percentiles_from_uint8,
+)
+
+
+class TestPercentilesFromUint8(unittest.TestCase):
+    def test_matches_numpy_percentile(self) -> None:
+        rng = np.random.default_rng(0)
+        for trial in range(2000):
+            shape = (int(rng.integers(60, 200)), int(rng.integers(60, 260)))
+            kind = trial % 4
+            if kind == 0:
+                frame = rng.integers(0, 256, size=shape, dtype=np.uint8)
+            elif kind == 1:  # low contrast
+                frame = rng.integers(100, 140, size=shape, dtype=np.uint8)
+            elif kind == 2:  # single color
+                frame = np.full(shape, 7, dtype=np.uint8)
+            else:  # bimodal
+                frame = (rng.random(shape) * 40 + rng.choice([0, 200])).astype(np.uint8)
+            lo, hi = percentiles_from_uint8(frame, (4, 96))
+            self.assertEqual(int(lo), int(np.percentile(frame, 4)))
+            self.assertEqual(int(hi), int(np.percentile(frame, 96)))
 
 
 class TestImprovedMotionDetector(unittest.TestCase):


### PR DESCRIPTION
## Proposed change

`ImprovedMotionDetector.detect()` runs on **every frame of every camera**. With `improve_contrast` enabled (the default), it called `np.percentile` **twice per frame** to get the 4th/96th percentile of the resized motion frame — each call partitions the whole array.

This computes both percentiles from a single 256-bin `uint8` histogram (`cv2.calcHist` + `cumsum` + linear interpolation) instead. No new dependencies (cv2/numpy already used).

The result is **bit-identical** to `int(np.percentile(...))` — the values are used as `uint8` contrast bounds, and a new test asserts equality against `numpy` across uniform, low-contrast, single-color and bimodal frames (2000 cases). Existing motion-behavior tests (skip-threshold, calibration) are unchanged.

**Measured in the release image** (Python 3.11, numpy 1.26), on a height-100 motion frame (the default size):

- the percentile step alone: `np.percentile` ×2 **~225 µs → ~11 µs** per frame (~20×);
- the **whole `detect()`** on identical frames (stock image vs this branch): **417.2 µs → 179.9 µs per frame (2.3×)** — the percentile was over half the function's cost.

Because `detect()` runs per frame per camera, this scales with camera count (a 10–15 camera setup runs it thousands of times per second).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Claude Code).

**How AI was used**: py-spy profiling of a live camera worker to find the per-frame cost, drafting the change, the test, and the benchmarks.

**Extent of AI involvement**: assisted with this isolated function; human-directed and reviewed.

**Human oversight**: I verified bit-identical output against `numpy.percentile` over thousands of randomized frames, confirmed the existing motion tests still pass, benchmarked the whole `detect()` old-vs-new in the release image, validated on the live deployment (patch + restart, motion detection continues, no errors), ran the full `python3 -u -m unittest` suite, and verified `ruff format`/`ruff check` are clean.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
