### PR TITLE
docs: correct face recognition min_area default (500 to 750)

### DIFF
--- a/docs/docs/configuration/face_recognition.md
+++ b/docs/docs/configuration/face_recognition.md
@@ -86,7 +86,7 @@ Navigate to <NavPath path="Settings > Enrichments > Face recognition" />.
 - **Detection threshold**: Face detection confidence score required before recognition runs. This field only applies to the standalone face detection model; `min_score` should be used to filter for models that have face detection built in.
   - Default: `0.7`
 - **Minimum face area**: Minimum size (in pixels) a face must be before recognition runs. Depending on the resolution of your camera's `detect` stream, you can increase this value to ignore small or distant faces.
-  - Default: `500` pixels
+  - Default: `750` pixels
 
 </TabItem>
 <TabItem value="yaml">
@@ -95,7 +95,7 @@ Navigate to <NavPath path="Settings > Enrichments > Face recognition" />.
 face_recognition:
   enabled: true
   detection_threshold: 0.7
-  min_area: 500
+  min_area: 750
 ```
 
 </TabItem>


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

Documentation fix. The face recognition docs list the `min_area` default as `500`, but the code default is `750`, which is misleading for anyone tuning this value.

In `frigate/config/classification.py` on `dev`:
- `FaceRecognitionConfig.min_area` is `Field(default=750, ...)`
- `CameraFaceRecognitionConfig.min_area` is also `Field(default=750, ...)`

This updates `docs/docs/configuration/face_recognition.md` so the documented "Minimum face area" default and the YAML example both read `750` instead of `500`. `detection_threshold` already matches the code at `0.7` and is left unchanged. Documentation only; no code or behavior change.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): Claude (Claude Code).

**How AI was used** (e.g., code generation, code review, debugging, documentation): Documentation. While configuring face recognition on my own Frigate instance, I had Claude cross-check the docs against `frigate/config/classification.py`, and it flagged that the documented `min_area` default did not match the code.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): It suggested the one-line documentation fix (changing `500` to `750` in two places). No code was generated.

**Human oversight**: I verified the discrepancy directly against the source on `dev` (both `FaceRecognitionConfig.min_area` and `CameraFaceRecognitionConfig.min_area` default to `750`), confirmed `detection_threshold` already matched at `0.7`, and reviewed the rendered diff before submitting. The change is a trivial factual correction with no code impact.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
