### PR TITLE
fix: prevent uint16 wrap of negative YuNet bbox coords crashing face recognition

### DIFF
--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -161,11 +161,16 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
             if potential_face[-1] < threshold:
                 continue
 
-            raw_bbox = potential_face[0:4].astype(np.uint16)
-            x: int = int(max(raw_bbox[0], 0) / scale_factor)
-            y: int = int(max(raw_bbox[1], 0) / scale_factor)
-            w: int = int(raw_bbox[2] / scale_factor)
-            h: int = int(raw_bbox[3] / scale_factor)
+            # YuNet can return slightly negative x/y when the face extends to the
+            # image border. Clamp to zero BEFORE any integer cast: casting a
+            # negative float to np.uint16 wraps it (e.g. -5.5 → 65530), and the
+            # subsequent max(…, 0) never has a chance to correct it. The wrapped
+            # value is used as a slice index, producing an empty crop that crashes
+            # cv2.cvtColor with "!_src.empty()" in align_face / classify.
+            x: int = int(max(potential_face[0], 0) / scale_factor)
+            y: int = int(max(potential_face[1], 0) / scale_factor)
+            w: int = int(max(potential_face[2], 0) / scale_factor)
+            h: int = int(max(potential_face[3], 0) / scale_factor)
             bbox = (x, y, x + w, y + h)
 
             if face is None or area(bbox) > area(face):  # type: ignore[unreachable]


### PR DESCRIPTION
## What

`cv2.FaceDetectorYN` (YuNet) can return slightly negative `x` or `y` values when a detected face extends to or beyond the image border — for example, a face flush with the top of the frame may have `y = -5.5`.

The original code in `__detect_face` cast the raw bounding box to `np.uint16` before clamping:

```python
raw_bbox = potential_face[0:4].astype(np.uint16)
x: int = int(max(raw_bbox[0], 0) / scale_factor)
y: int = int(max(raw_bbox[1], 0) / scale_factor)
```

`np.uint16` wraps negative values silently via modular arithmetic:

```
-5.5  →  int(-5.5) = -5  →  uint16(-5) = 65531
```

The `max(65531, 0)` never fires — the clamp sees a large positive integer, not a negative one. The wrapped value then becomes a NumPy slice index:

```python
face = img[65531 : 65531 + h, x : x + w]
# → shape (0, w, 3)  — empty array
```

This empty array is passed directly to `align_face()`, which calls `cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)`. OpenCV asserts the input is non-empty and raises:

```
cv2.error: (-215:Assertion failed) !_src.empty() in function 'cvtColor'
```

The exception propagates through `classify()` → `handle_request()` → logged as `Unable to handle embeddings request` → every face recognition API call and every real-time face detection event returns HTTP 500 or silently no-ops until Frigate is restarted.

## Why it's easy to miss

The intent of `max(raw_bbox[0], 0)` was clearly to guard against negative coordinates. The bug is that the guard is applied *after* the type narrowing step that destroys the sign information, so it looks correct on a quick read.

The `np.uint16` cast was probably added to convert float pixel coordinates to integers (reasonable goal), but `int(float_value)` already does that and is sign-preserving.

## Fix

Remove the intermediate `np.uint16` cast and clamp the raw float values before the integer conversion:

```python
x: int = int(max(potential_face[0], 0) / scale_factor)
y: int = int(max(potential_face[1], 0) / scale_factor)
w: int = int(max(potential_face[2], 0) / scale_factor)
h: int = int(max(potential_face[3], 0) / scale_factor)
```

This is the minimal correct fix: the float values are clamped to ≥ 0 before `int()` truncates them, so no wrapping can occur.

## Reproduction

Any setup where a tracked person's face is near the edge of a camera frame — particularly high-angle door cameras or wide-angle cameras where the person is close — will trigger this. The failure manifests as:

- `Unable to handle embeddings request` in Frigate logs
- `cv2.error: (-215:Assertion failed) !_src.empty() in function 'cvtColor'`
- Face recognition API returns 500 on every request
- Real-time face sub-labels never appear on person events

## Testing

Verified end-to-end on `stable-rocm` (Frigate 0.17.1, Mesa 25.0.7, AMD Strix Point GPU). After the fix, the training image recognized at 0.99 confidence and the `!_src.empty()` crash is gone.