### PR TITLE
Use a distinct color palette for Frames / Detections graphs

### DIFF
--- a/web/src/components/graph/LineGraph.tsx
+++ b/web/src/components/graph/LineGraph.tsx
@@ -11,6 +11,9 @@ import useSWR from "swr";
 import { useTimeFormat } from "@/hooks/use-date-utils";
 
 const GRAPH_COLORS = ["#5C7CFA", "#ED5CFA", "#FAD75C"];
+// Distinct palette so the Frames / Detections graphs are easy to tell apart
+// from the CPU graphs at a glance.
+export const FPS_GRAPH_COLORS = ["#2DD4BF", "#818CFF", "#D17B88"];
 
 type CameraLineGraphProps = {
   graphId: string;
@@ -19,6 +22,7 @@ type CameraLineGraphProps = {
   updateTimes: number[];
   data: ApexAxisChartSeries;
   isActive?: boolean;
+  colors?: string[];
 };
 export function CameraLineGraph({
   graphId,
@@ -27,6 +31,7 @@ export function CameraLineGraph({
   updateTimes,
   data,
   isActive = true,
+  colors = GRAPH_COLORS,
 }: CameraLineGraphProps) {
   const { t } = useTranslation(["views/system", "common"]);
   const { data: config } = useSWR<FrigateConfig>("config", {
@@ -91,7 +96,7 @@ export function CameraLineGraph({
           enabled: false,
         },
       },
-      colors: GRAPH_COLORS,
+      colors,
       grid: {
         show: false,
       },
@@ -138,7 +143,7 @@ export function CameraLineGraph({
         min: 0,
       },
     } as ApexCharts.ApexOptions;
-  }, [graphId, systemTheme, theme, formatTime]);
+  }, [graphId, colors, systemTheme, theme, formatTime]);
 
   useEffect(() => {
     ApexCharts.exec(graphId, "updateOptions", options, true, true);
@@ -162,7 +167,7 @@ export function CameraLineGraph({
             <div key={label} className="flex items-center gap-1">
               <MdCircle
                 className="size-2"
-                style={{ color: GRAPH_COLORS[labelIdx] }}
+                style={{ color: colors[labelIdx] }}
               />
               <div className="text-xs text-secondary-foreground">
                 {t("cameras.label." + label)}

--- a/web/src/views/system/CameraMetrics.tsx
+++ b/web/src/views/system/CameraMetrics.tsx
@@ -1,5 +1,8 @@
 import { useFrigateStats } from "@/api/ws";
-import { CameraLineGraph } from "@/components/graph/LineGraph";
+import {
+  CameraLineGraph,
+  FPS_GRAPH_COLORS,
+} from "@/components/graph/LineGraph";
 import CameraInfoDialog from "@/components/overlay/CameraInfoDialog";
 import { ConnectionQualityIndicator } from "@/components/camera/ConnectionQualityIndicator";
 import { EmptyCard } from "@/components/card/EmptyCard";
@@ -308,6 +311,7 @@ export default function CameraMetrics({
               updateTimes={updateTimes}
               data={overallFpsSeries}
               isActive={isActive}
+              colors={FPS_GRAPH_COLORS}
             />
           </div>
         ) : (
@@ -411,6 +415,7 @@ export default function CameraMetrics({
                               cameraFpsSeries[camera.name] || {},
                             )}
                             isActive={isActive}
+                            colors={FPS_GRAPH_COLORS}
                           />
                         </div>
                       ) : (


### PR DESCRIPTION
## Proposed change

The CPU and Frames / Detections graphs on the system metrics page both render through CameraLineGraph with a single shared palette, making the two graphs hard to tell apart at a glance. I've never found this page that readable when scrolling through 10 cameras.

Add an optional `colors` prop to CameraLineGraph (defaulting to the existing palette so CPU graphs are unchanged) and give the Frames / Detections graphs their own green/orange/cyan palette. The colors are routed through both the chart lines and the legend dots so they stay in sync.

Colours can be adjusted according to taste! 

### Before
<img width="1205" height="632" alt="Screenshot 2026-06-25 224951" src="https://github.com/user-attachments/assets/aa8fa07d-befd-42ef-91bf-5ab27487f369" />

### After
<img width="1207" height="632" alt="Screenshot 2026-06-25 225000" src="https://github.com/user-attachments/assets/2815c5c2-241a-45aa-b7f7-f471886273d3" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [X] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):
Claude

**How AI was used** (e.g., code generation, code review, debugging, documentation):
Code generation

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):
Generated implementation

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.
Review, check idiomatic with Frigate UI code, test locally, run full lint / test suites on my fork

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
