### PR TITLE
Allow non-admin users to use PTZ controls for cameras they have access to

### DIFF
--- a/frigate/comms/ws.py
+++ b/frigate/comms/ws.py
@@ -34,6 +34,7 @@ from frigate.const import (
     UPDATE_REVIEW_DESCRIPTION,
     UPSERT_REVIEW_SEGMENT,
 )
+from frigate.models import User
 
 logger = logging.getLogger(__name__)
 
@@ -69,11 +70,16 @@ _WS_VIEWER_TOPICS = frozenset(
     }
 )
 
+# Camera-scoped command topics a camera-authorized (non-admin) user may send.
+_WS_CAMERA_COMMAND_TOPICS = frozenset({"ptz"})
+
 
 def _check_ws_authorization(
     topic: str,
     role_header: str | None,
     separator: str,
+    roles_config: dict[str, list[str]] | None = None,
+    camera_names: set[str] | None = None,
 ) -> bool:
     """Check if a WebSocket message is authorized.
 
@@ -81,6 +87,10 @@ def _check_ws_authorization(
         topic: The message topic.
         role_header: The HTTP_REMOTE_ROLE header value, or None.
         separator: The role separator character from proxy config.
+        roles_config: The auth.roles mapping (role -> allowed cameras), used to
+            authorize camera-scoped commands for non-admin users.
+        camera_names: All configured camera names, used to resolve a role's
+            allowed cameras.
 
     Returns:
         True if authorized, False if blocked.
@@ -90,16 +100,33 @@ def _check_ws_authorization(
         return False
 
     # No role header: default to viewer (fail-closed)
-    if role_header is None:
-        return topic in _WS_VIEWER_TOPICS
+    roles = [r.strip() for r in role_header.split(separator)] if role_header else []
 
-    # Check if any role is admin
-    roles = [r.strip() for r in role_header.split(separator)]
+    # Admin can send anything
     if "admin" in roles:
         return True
 
-    # Non-admin: only viewer topics allowed
-    return topic in _WS_VIEWER_TOPICS
+    # Read-only topics any authenticated user can send
+    if topic in _WS_VIEWER_TOPICS:
+        return True
+
+    # Camera-scoped command like "<camera>/ptz": allow when the user's role(s)
+    # grant access to that camera.
+    parts = topic.split("/")
+    if (
+        roles_config is not None
+        and len(parts) == 2
+        and parts[1] in _WS_CAMERA_COMMAND_TOPICS
+    ):
+        allowed: set[str] = set()
+        # No role header maps to the default viewer role (e.g. proxy-only setups)
+        for role in roles or ["viewer"]:
+            allowed.update(
+                User.get_allowed_cameras(role, roles_config, camera_names or set())
+            )
+        return parts[0] in allowed
+
+    return False
 
 
 class WebSocket(WebSocket_):  # type: ignore[misc]
@@ -131,6 +158,8 @@ class WebSocketClient(Communicator):
         class _WebSocketHandler(WebSocket):
             receiver = self._dispatcher
             role_separator = self.config.proxy.separator or ","
+            roles_config = self.config.auth.roles
+            camera_names = set(self.config.cameras.keys())
 
             def received_message(self, message: WebSocket.received_message) -> None:  # type: ignore[name-defined]
                 try:
@@ -152,7 +181,11 @@ class WebSocketClient(Communicator):
                     self.environ.get("HTTP_REMOTE_ROLE") if self.environ else None
                 )
                 if self.environ is not None and not _check_ws_authorization(
-                    topic, role_header, self.role_separator
+                    topic,
+                    role_header,
+                    self.role_separator,
+                    self.roles_config,
+                    self.camera_names,
                 ):
                     logger.warning(
                         "Blocked unauthorized WebSocket message: topic=%s, role=%s",

--- a/frigate/test/test_ws_auth.py
+++ b/frigate/test/test_ws_auth.py
@@ -11,6 +11,16 @@ class TestCheckWsAuthorization(unittest.TestCase):
 
     DEFAULT_SEPARATOR = ","
 
+    # admin/viewer are reserved and always map to all cameras (empty list);
+    # custom roles map to a specific set of cameras.
+    ROLES_CONFIG = {
+        "admin": [],
+        "viewer": [],
+        "yard": ["front_door", "backyard"],
+        "garage_only": ["garage"],
+    }
+    CAMERA_NAMES = {"front_door", "backyard", "garage"}
+
     # --- IPC topic blocking (unconditional, regardless of role) ---
 
     def test_ipc_topic_blocked_for_admin(self):
@@ -159,6 +169,124 @@ class TestCheckWsAuthorization(unittest.TestCase):
     def test_no_role_header_allows_viewer_topics(self):
         self.assertTrue(
             _check_ws_authorization("onConnect", None, self.DEFAULT_SEPARATOR)
+        )
+
+    # --- Camera-scoped PTZ access (non-admin with camera access) ---
+
+    def test_viewer_can_ptz_camera_with_access(self):
+        # viewer maps to all cameras, so PTZ is allowed
+        self.assertTrue(
+            _check_ws_authorization(
+                "front_door/ptz",
+                "viewer",
+                self.DEFAULT_SEPARATOR,
+                self.ROLES_CONFIG,
+                self.CAMERA_NAMES,
+            )
+        )
+
+    def test_custom_role_can_ptz_assigned_camera(self):
+        self.assertTrue(
+            _check_ws_authorization(
+                "front_door/ptz",
+                "yard",
+                self.DEFAULT_SEPARATOR,
+                self.ROLES_CONFIG,
+                self.CAMERA_NAMES,
+            )
+        )
+
+    def test_custom_role_blocked_from_ptz_unassigned_camera(self):
+        self.assertFalse(
+            _check_ws_authorization(
+                "garage/ptz",
+                "yard",
+                self.DEFAULT_SEPARATOR,
+                self.ROLES_CONFIG,
+                self.CAMERA_NAMES,
+            )
+        )
+
+    def test_multiple_roles_union_camera_access_for_ptz(self):
+        # "yard" covers front_door/backyard, "garage_only" covers garage
+        self.assertTrue(
+            _check_ws_authorization(
+                "garage/ptz",
+                "yard,garage_only",
+                self.DEFAULT_SEPARATOR,
+                self.ROLES_CONFIG,
+                self.CAMERA_NAMES,
+            )
+        )
+
+    def test_unknown_role_blocked_from_ptz(self):
+        self.assertFalse(
+            _check_ws_authorization(
+                "front_door/ptz",
+                "nonexistent",
+                self.DEFAULT_SEPARATOR,
+                self.ROLES_CONFIG,
+                self.CAMERA_NAMES,
+            )
+        )
+
+    def test_no_role_header_treated_as_viewer_for_ptz(self):
+        # proxy-only / auth-disabled setups default to the viewer role
+        self.assertTrue(
+            _check_ws_authorization(
+                "front_door/ptz",
+                None,
+                self.DEFAULT_SEPARATOR,
+                self.ROLES_CONFIG,
+                self.CAMERA_NAMES,
+            )
+        )
+
+    def test_camera_access_does_not_grant_set_commands(self):
+        # camera access enables PTZ only, not config-changing "set" commands
+        self.assertFalse(
+            _check_ws_authorization(
+                "front_door/detect/set",
+                "yard",
+                self.DEFAULT_SEPARATOR,
+                self.ROLES_CONFIG,
+                self.CAMERA_NAMES,
+            )
+        )
+
+    def test_ptz_autotracker_stays_admin_only(self):
+        # ptz_autotracker is a config toggle, not a live-view action
+        self.assertFalse(
+            _check_ws_authorization(
+                "front_door/ptz_autotracker/set",
+                "viewer",
+                self.DEFAULT_SEPARATOR,
+                self.ROLES_CONFIG,
+                self.CAMERA_NAMES,
+            )
+        )
+
+    def test_admin_can_ptz_any_camera_with_config(self):
+        self.assertTrue(
+            _check_ws_authorization(
+                "garage/ptz",
+                "admin",
+                self.DEFAULT_SEPARATOR,
+                self.ROLES_CONFIG,
+                self.CAMERA_NAMES,
+            )
+        )
+
+    def test_ipc_topic_still_blocked_with_camera_access(self):
+        # IPC topics are blocked unconditionally, even with camera access
+        self.assertFalse(
+            _check_ws_authorization(
+                UPDATE_CAMERA_ACTIVITY,
+                "viewer",
+                self.DEFAULT_SEPARATOR,
+                self.ROLES_CONFIG,
+                self.CAMERA_NAMES,
+            )
         )
 
 


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
The ws auth gate added in #22710 restricted all non-read-only topics to admins, which swept PTZ into admin-only and prevented viewers/custom roles from moving cameras they can already view. This PR wires the existing per-camera access model (`User.get_allowed_cameras`) into the WS gate so `<camera>/ptz` is allowed when the user's role grants access to that camera.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/23577
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
