### PR TITLE
Performance: run preview generation in a threadpool

### DIFF
--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -16,6 +16,7 @@ import cv2
 import numpy as np
 import pytz
 from fastapi import APIRouter, Depends, Path, Query, Request, Response
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from pathvalidate import sanitize_filename
 from peewee import DoesNotExist, fn
@@ -1270,7 +1271,7 @@ async def event_preview(request: Request, event_id: str):
     end_ts = start_ts + (
         min(event.end_time - event.start_time, 20) if event.end_time else 20
     )
-    return preview_gif(request, event.camera, start_ts, end_ts)
+    return await run_in_threadpool(preview_gif, request, event.camera, start_ts, end_ts)
 
 
 @router.get(
@@ -1657,9 +1658,13 @@ async def review_preview(
     )
 
     if format == "gif":
-        return preview_gif(request, review.camera, start_ts, end_ts)
+        return await run_in_threadpool(
+            preview_gif, request, review.camera, start_ts, end_ts
+        )
     else:
-        return preview_mp4(request, review.camera, start_ts, end_ts)
+        return await run_in_threadpool(
+            preview_mp4, request, review.camera, start_ts, end_ts
+        )
 
 
 @router.get(


### PR DESCRIPTION
## Proposed change

The HTTP API runs a single uvicorn worker ([`app.py` L634](https://github.com/blakeblackshear/frigate/blob/e2ce0c82ff1c7e3626e705d36c4add85ec89939f/frigate/app.py#L634)), so any blocking call on the event loop serializes every concurrent request. [`event_preview`](https://github.com/blakeblackshear/frigate/blob/e2ce0c82ff1c7e3626e705d36c4add85ec89939f/frigate/api/media.py#L1259) and [`review_preview`](https://github.com/blakeblackshear/frigate/blob/e2ce0c82ff1c7e3626e705d36c4add85ec89939f/frigate/api/media.py#L1638) are `async` but call the ffmpeg-based `preview_gif`/`preview_mp4` directly on the loop ([media.py#L1273](https://github.com/blakeblackshear/frigate/blob/e2ce0c82ff1c7e3626e705d36c4add85ec89939f/frigate/api/media.py#L1273), [#L1660](https://github.com/blakeblackshear/frigate/blob/e2ce0c82ff1c7e3626e705d36c4add85ec89939f/frigate/api/media.py#L1660), [#L1662](https://github.com/blakeblackshear/frigate/blob/e2ce0c82ff1c7e3626e705d36c4add85ec89939f/frigate/api/media.py#L1662)), so opening Review — which fires many preview requests at once — is effectively serial.

Running the generators with `run_in_threadpool` keeps the event loop free.

Measured on an RTX 2060 host, `GET /api/review/{id}/preview`, p50 server-side latency:

| concurrency | before | after |
|---|---|---|
| 4 | 0.75s | 0.19s |
| 8 | 1.68s | 0.29s |
| 16 | 2.68s | 0.40s |

Throughput goes from a flat ~5 req/s to scaling with concurrency.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Claude Code)

**How AI was used**: profiling/diagnosis, the code change, and drafting this description.

**Extent of AI involvement**: identified the event-loop serialization and made the targeted change — wrapping the existing `preview_gif`/`preview_mp4` calls in `run_in_threadpool`.

**Human oversight**: built into a custom image and run on a live Frigate instance (RTX 2060); confirmed the container stays healthy and measured before/after latency for the preview endpoint (table above).

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
