### PR TITLE
Add Qualcomm Hexagon NPU support (community board)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,31 @@ jobs:
           set: |
             synaptics.tags=${{ steps.setup.outputs.image-name }}-synaptics
             *.cache-from=type=gha
+  qualcomm_build:
+    runs-on: ubuntu-22.04-arm
+    name: Qualcomm Build
+    needs:
+      - arm64_build
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Set up QEMU and Buildx
+        id: setup
+        uses: ./.github/actions/setup
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Qualcomm build
+        uses: docker/bake-action@v7
+        with:
+          source: .
+          push: true
+          targets: qualcomm
+          files: docker/qualcomm/qualcomm.hcl
+          set: |
+            qualcomm.tags=${{ steps.setup.outputs.image-name }}-qualcomm
+            *.cache-from=type=gha
   # The majority of users running arm64 are rpi users, so the rpi
   # build should be the primary arm64 image
   assemble_default_build:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,4 @@
 /docker/rockchip/ @MarcA711
 /docker/rocm/ @harakas
 /docker/hailo8l/ @spanner3003
+/docker/qualcomm/ @ramalamadingdong

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -346,6 +346,9 @@ COPY web/package.json web/package-lock.json ./
 RUN npm install
 
 COPY web/ ./
+# Raise V8 heap ceiling so the vite/monaco production build doesn't OOM on
+# low-memory build hosts (e.g. 7 GB arm64 SBCs).
+ENV NODE_OPTIONS=--max-old-space-size=4096
 RUN npm run build \
     && mv dist/BASE_PATH/monacoeditorwork/* dist/assets/ \
     && rm -rf dist/BASE_PATH

--- a/docker/qualcomm/Dockerfile
+++ b/docker/qualcomm/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1.6
+
+# https://askubuntu.com/questions/972516/debian-frontend-environment-variable
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Globally set pip break-system-packages option to avoid having to specify it every time
+ARG PIP_BREAK_SYSTEM_PACKAGES=1
+
+FROM wheels AS qualcomm-wheels
+ARG TARGETARCH
+
+# No extra wheels needed — ai-edge-litert is already in the base image
+# and the QNN delegate library (libQnnTFLiteDelegate.so) is provided
+# by the host via CDI bind mounts at runtime.
+
+FROM deps AS qualcomm-deps
+ARG TARGETARCH
+ARG PIP_BREAK_SYSTEM_PACKAGES
+
+WORKDIR /opt/frigate/
+COPY --from=rootfs / /

--- a/docker/qualcomm/cdi/cdi-hw-acc-6490.json
+++ b/docker/qualcomm/cdi/cdi-hw-acc-6490.json
@@ -1,0 +1,1586 @@
+{
+  "cdiVersion": "0.6.0",
+  "kind": "qualcomm.com/device",
+  "devices": [
+    {
+      "name": "cdi-hw-acc",
+      "containerEdits": {
+        "env": [
+          "XDG_RUNTIME_DIR=/run/user/1000",
+          "WAYLAND_DISPLAY=wayland-0",
+          "GST_DEBUG_NO_COLOR=1",
+          "GST_DEBUG=2",
+          "GST_PLUGIN_SCANNER=\"/usr/lib/aarch64-linux-gnu/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner\""
+        ],
+        "deviceNodes": [
+          {
+            "path": "/dev/dri/card0"
+          },
+          {
+            "path": "/dev/dri/renderD128"
+          },
+          {
+            "path": "/dev/kgsl-3d0"
+          },
+          {
+            "path": "/dev/video32"
+          },
+          {
+            "path": "/dev/video33"
+          },
+          {
+            "path": "/dev/dma_heap/system"
+          },
+          {
+            "path": "/dev/dma_heap/qcom,system"
+          },
+          {
+            "path": "/dev/fastrpc-cdsp"
+          }
+        ],
+        "mounts": [
+          {
+            "hostPath": "/run/user/1000",
+            "containerPath": "/run/user/1000",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/tmp/socket/cam_server",
+            "containerPath": "/tmp/socket/cam_server",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/tmp/property-vault.socket",
+            "containerPath": "/tmp/property-vault.socket",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/etc/labels",
+            "containerPath": "/etc/labels",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/etc/media",
+            "containerPath": "/etc/media",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/etc/models",
+            "containerPath": "/etc/models",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/etc/configs",
+            "containerPath": "/etc/configs",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/meta",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/meta",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/ml",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/ml",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/mlmetaparser",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/mlmetaparser",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/pulseaudio",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/pulseaudio",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-activate-deactivate-streams-runtime-example",
+            "containerPath": "/usr/bin/gst-activate-deactivate-streams-runtime-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-add-remove-streams-runtime",
+            "containerPath": "/usr/bin/gst-add-remove-streams-runtime",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-add-streams-as-bundle-example",
+            "containerPath": "/usr/bin/gst-add-streams-as-bundle-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-audio-classification",
+            "containerPath": "/usr/bin/gst-ai-audio-classification",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-classification",
+            "containerPath": "/usr/bin/gst-ai-classification",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-daisychain-detection-classification",
+            "containerPath": "/usr/bin/gst-ai-daisychain-detection-classification",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-daisychain-detection-pose",
+            "containerPath": "/usr/bin/gst-ai-daisychain-detection-pose",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-face-detection",
+            "containerPath": "/usr/bin/gst-ai-face-detection",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-face-recognition",
+            "containerPath": "/usr/bin/gst-ai-face-recognition",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-metadata-parser-example",
+            "containerPath": "/usr/bin/gst-ai-metadata-parser-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-monodepth",
+            "containerPath": "/usr/bin/gst-ai-monodepth",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-multi-input-output-object-detection",
+            "containerPath": "/usr/bin/gst-ai-multi-input-output-object-detection",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-multistream-batch-inference",
+            "containerPath": "/usr/bin/gst-ai-multistream-batch-inference",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-multistream-inference",
+            "containerPath": "/usr/bin/gst-ai-multistream-inference",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-object-detection",
+            "containerPath": "/usr/bin/gst-ai-object-detection",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-parallel-inference",
+            "containerPath": "/usr/bin/gst-ai-parallel-inference",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-pose-detection",
+            "containerPath": "/usr/bin/gst-ai-pose-detection",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-segmentation",
+            "containerPath": "/usr/bin/gst-ai-segmentation",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-smartcodec-example",
+            "containerPath": "/usr/bin/gst-ai-smartcodec-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-superresolution",
+            "containerPath": "/usr/bin/gst-ai-superresolution",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-usb-camera-app",
+            "containerPath": "/usr/bin/gst-ai-usb-camera-app",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-appsink-example",
+            "containerPath": "/usr/bin/gst-appsink-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-audio-decode-example",
+            "containerPath": "/usr/bin/gst-audio-decode-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-audio-encode-example",
+            "containerPath": "/usr/bin/gst-audio-encode-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-audio-video-encode",
+            "containerPath": "/usr/bin/gst-audio-video-encode",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-audio-video-playback",
+            "containerPath": "/usr/bin/gst-audio-video-playback",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-burst-capture-example",
+            "containerPath": "/usr/bin/gst-camera-burst-capture-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-metadata-example",
+            "containerPath": "/usr/bin/gst-camera-metadata-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-shdr-ldc-eis-example",
+            "containerPath": "/usr/bin/gst-camera-shdr-ldc-eis-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-single-stream-example",
+            "containerPath": "/usr/bin/gst-camera-single-stream-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-switch-example",
+            "containerPath": "/usr/bin/gst-camera-switch-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-concurrent-videoplay-composition",
+            "containerPath": "/usr/bin/gst-concurrent-videoplay-composition",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-inspect-1.0",
+            "containerPath": "/usr/bin/gst-inspect-1.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-jpg-decode-example",
+            "containerPath": "/usr/bin/gst-jpg-decode-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-launch-1.0",
+            "containerPath": "/usr/bin/gst-launch-1.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-multi-camera-example",
+            "containerPath": "/usr/bin/gst-multi-camera-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-multi-stream-example",
+            "containerPath": "/usr/bin/gst-multi-stream-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-pipeline-app",
+            "containerPath": "/usr/bin/gst-pipeline-app",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-rtsp-server",
+            "containerPath": "/usr/bin/gst-rtsp-server",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-smartcodec-example",
+            "containerPath": "/usr/bin/gst-smartcodec-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-snapshot-stream-example",
+            "containerPath": "/usr/bin/gst-snapshot-stream-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-stats-1.0",
+            "containerPath": "/usr/bin/gst-stats-1.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-tester-1.0",
+            "containerPath": "/usr/bin/gst-tester-1.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-transform-example",
+            "containerPath": "/usr/bin/gst-transform-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-typefind-1.0",
+            "containerPath": "/usr/bin/gst-typefind-1.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-video-playback-example",
+            "containerPath": "/usr/bin/gst-video-playback-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-video-transcode-example",
+            "containerPath": "/usr/bin/gst-video-transcode-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-videocodec-concurrent-playback",
+            "containerPath": "/usr/bin/gst-videocodec-concurrent-playback",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-warmboot-app",
+            "containerPath": "/usr/bin/gst-warmboot-app",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-webrtc-sendrecv-example",
+            "containerPath": "/usr/bin/gst-webrtc-sendrecv-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-weston-composition-example",
+            "containerPath": "/usr/bin/gst-weston-composition-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/overlay_blit_bgra_kernel.cl",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/overlay_blit_bgra_kernel.cl",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/overlay_blit_rgba_kernel.cl",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/overlay_blit_rgba_kernel.cl",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/overlay_mask_kernel.cl",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/overlay_mask_kernel.cl",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gbm/default_fmt_alignment.xml",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gbm/default_fmt_alignment.xml",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gbm/dri_gbm.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gbm/dri_gbm.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gbm/msm_gbm.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gbm/msm_gbm.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstcoreelements.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstcoreelements.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstpulseaudio.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstpulseaudio.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtibatch.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtibatch.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimetamux.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimetamux.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimetatransform.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimetatransform.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlaclassification.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlaclassification.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlaconverter.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlaconverter.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimldemux.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimldemux.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlmetaparser.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlmetaparser.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlqnn.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlqnn.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlsnpe.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlsnpe.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimltflite.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimltflite.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvclassification.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvclassification.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvconverter.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvconverter.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvdetection.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvdetection.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvpose.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvpose.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvsegmentation.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvsegmentation.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvsuperresolution.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvsuperresolution.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimsgpub.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimsgpub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimsgsub.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimsgsub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtiobjtracker.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtiobjtracker.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtiqmmfsrc.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtiqmmfsrc.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtirestrictedzonedbg.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtirestrictedzonedbg.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtirtspbin.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtirtspbin.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtismartvencbin.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtismartvencbin.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivcomposer.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivcomposer.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivoverlay.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivoverlay.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivsplit.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivsplit.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivtransform.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivtransform.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstvideo4linux2.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstvideo4linux2.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstwaylandsink.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstwaylandsink.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtioverlay.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtioverlay.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtiredissink.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtiredissink.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtisocketsink.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtisocketsink.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtisocketsrc.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtisocketsrc.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libCB.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libCB.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libEGL.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libEGL.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libEGL.so.1.0.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libEGL.so.1.0.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libEGL_adreno.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libEGL_adreno.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libGLESv1_CM.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libGLESv1_CM.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libGLESv1_CM.so.1.0.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libGLESv1_CM.so.1.0.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libGLESv1_CM_adreno.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libGLESv1_CM_adreno.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libGLESv2.so.2",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libGLESv2.so.2",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libGLESv2.so.2.0.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libGLESv2.so.2.0.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libGLESv2_adreno.so.2",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libGLESv2_adreno.so.2",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libIB2C.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libIB2C.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libOpenCL.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libOpenCL.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libOpenCL_adreno.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libOpenCL_adreno.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libVideoCtrl.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libVideoCtrl.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libadreno_utils.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libadreno_utils.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libadsprpc.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libadsprpc.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libatomic.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libatomic.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libcdsprpc.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libcdsprpc.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libdmabufheap.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libdmabufheap.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libeglSubDriverWayland.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libeglSubDriverWayland.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libenv_time.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libenv_time.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libevaluation_proto.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libevaluation_proto.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libfarmhash.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libfarmhash.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libfastcvdsp_stub.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libfastcvdsp_stub.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libfastcvopt.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libfastcvopt.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgallium-25.0.7-0ubuntu0.24.04.1.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgallium-25.0.7-0ubuntu0.24.04.1.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgbm.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgbm.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgsl.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgsl.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstappsutils.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstappsutils.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstbase-1.0.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstbase-1.0.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtiallocatorsbase.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtiallocatorsbase.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqticvbase.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqticvbase.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtimemorybase.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtimemorybase.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtimlbase.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtimlbase.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtimqttadaptor.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtimqttadaptor.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtimsgadaptor.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtimsgadaptor.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtiutilsbase.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtiutilsbase.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtivideobase.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtivideobase.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstreamer-1.0.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstreamer-1.0.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstvideo-1.0.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstvideo-1.0.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstwayland-1.0.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstwayland-1.0.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libimage_metrics.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libimage_metrics.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libjpeg_internal.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libjpeg_internal.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libllvm-glnext.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libllvm-glnext.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libllvm-qcom.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libllvm-qcom.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libllvm-qgl.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libllvm-qgl.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/liboverlay_lib.so.SOVERSION",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/liboverlay_lib.so.SOVERSION",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libpropertyvault.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libpropertyvault.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libpulse-simple.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libpulse-simple.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libpulse.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libpulse.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libq3dtools_adreno.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libq3dtools_adreno.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libq3dtools_esx.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libq3dtools_esx.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libqtimlmeta.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libqtimlmeta.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libtensorflowlite_c.so.2",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libtensorflowlite_c.so.2",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libtf_logging.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libtf_logging.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libvulkan_adreno.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libvulkan_adreno.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libwayland-client.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libwayland-client.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libwayland-egl.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libwayland-egl.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/dsp/cdsp/cv/v68/KODIAK/libfastcvadsp.so",
+            "containerPath": "/usr/lib/dsp/cdsp/cv/v68/KODIAK/libfastcvadsp.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/dsp/cdsp/cv/v68/KODIAK/libfastcvdsp_skel.so",
+            "containerPath": "/usr/lib/dsp/cdsp/cv/v68/KODIAK/libfastcvdsp_skel.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libPlatformValidatorShared.so",
+            "containerPath": "/usr/lib/libPlatformValidatorShared.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnChrometraceProfilingReader.so",
+            "containerPath": "/usr/lib/libQnnChrometraceProfilingReader.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnCpu.so",
+            "containerPath": "/usr/lib/libQnnCpu.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnDsp.so",
+            "containerPath": "/usr/lib/libQnnDsp.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnDspNetRunExtensions.so",
+            "containerPath": "/usr/lib/libQnnDspNetRunExtensions.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnGenAiTransformer.so",
+            "containerPath": "/usr/lib/libQnnGenAiTransformer.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnGenAiTransformerCpuOpPkg.so",
+            "containerPath": "/usr/lib/libQnnGenAiTransformerCpuOpPkg.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnGenAiTransformerModel.so",
+            "containerPath": "/usr/lib/libQnnGenAiTransformerModel.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnGpu.so",
+            "containerPath": "/usr/lib/libQnnGpu.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnGpuNetRunExtensions.so",
+            "containerPath": "/usr/lib/libQnnGpuNetRunExtensions.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnGpuProfilingReader.so",
+            "containerPath": "/usr/lib/libQnnGpuProfilingReader.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHta.so",
+            "containerPath": "/usr/lib/libQnnHta.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtaNetRunExtensions.so",
+            "containerPath": "/usr/lib/libQnnHtaNetRunExtensions.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtp.so",
+            "containerPath": "/usr/lib/libQnnHtp.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtpNetRunExtensions.so",
+            "containerPath": "/usr/lib/libQnnHtpNetRunExtensions.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtpOptraceProfilingReader.so",
+            "containerPath": "/usr/lib/libQnnHtpOptraceProfilingReader.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtpPrepare.so",
+            "containerPath": "/usr/lib/libQnnHtpPrepare.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtpProfilingReader.so",
+            "containerPath": "/usr/lib/libQnnHtpProfilingReader.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtpV68CalculatorStub.so",
+            "containerPath": "/usr/lib/libQnnHtpV68CalculatorStub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtpV68Stub.so",
+            "containerPath": "/usr/lib/libQnnHtpV68Stub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnIr.so",
+            "containerPath": "/usr/lib/libQnnIr.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnJsonProfilingReader.so",
+            "containerPath": "/usr/lib/libQnnJsonProfilingReader.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnModelDlc.so",
+            "containerPath": "/usr/lib/libQnnModelDlc.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnSaver.so",
+            "containerPath": "/usr/lib/libQnnSaver.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnSystem.so",
+            "containerPath": "/usr/lib/libQnnSystem.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnTFLiteDelegate.so",
+            "containerPath": "/usr/lib/libQnnTFLiteDelegate.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libSNPE.so",
+            "containerPath": "/usr/lib/libSNPE.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libSnpeDspStub.so",
+            "containerPath": "/usr/lib/libSnpeDspStub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libSnpeHta.so",
+            "containerPath": "/usr/lib/libSnpeHta.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libSnpeHtpPrepare.so",
+            "containerPath": "/usr/lib/libSnpeHtpPrepare.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libSnpeHtpV68CalculatorStub.so",
+            "containerPath": "/usr/lib/libSnpeHtpV68CalculatorStub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libSnpeHtpV68Stub.so",
+            "containerPath": "/usr/lib/libSnpeHtpV68Stub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libcamera_metadata.so.0",
+            "containerPath": "/usr/lib/libcamera_metadata.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libhta_hexagon_runtime.so",
+            "containerPath": "/usr/lib/libhta_hexagon_runtime.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libhta_hexagon_runtime_snpe.so",
+            "containerPath": "/usr/lib/libhta_hexagon_runtime_snpe.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libqmmf_camera_metadata.so.1",
+            "containerPath": "/usr/lib/libqmmf_camera_metadata.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libqmmf_propertyvault.so",
+            "containerPath": "/usr/lib/libqmmf_propertyvault.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libqmmf_proto.so.1",
+            "containerPath": "/usr/lib/libqmmf_proto.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libqmmf_recorder_client.so.1",
+            "containerPath": "/usr/lib/libqmmf_recorder_client.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libqmmf_utils.so.1",
+            "containerPath": "/usr/lib/libqmmf_utils.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/qcm6490/libcamera_metadata.so.0",
+            "containerPath": "/usr/lib/qcm6490/libcamera_metadata.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/qcm6490/libqmmf_camera_metadata.so.1",
+            "containerPath": "/usr/lib/qcm6490/libqmmf_camera_metadata.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/qcm6490/libqmmf_propertyvault.so",
+            "containerPath": "/usr/lib/qcm6490/libqmmf_propertyvault.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/qcm6490/libqmmf_proto.so.1",
+            "containerPath": "/usr/lib/qcm6490/libqmmf_proto.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/qcm6490/libqmmf_recorder_client.so.1",
+            "containerPath": "/usr/lib/qcm6490/libqmmf_recorder_client.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/qcm6490/libqmmf_utils.so.1",
+            "containerPath": "/usr/lib/qcm6490/libqmmf_utils.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/hexagon-v68/libCalculator_skel.so",
+            "containerPath": "/usr/lib/rfsa/adsp/hexagon-v68/libCalculator_skel.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/hexagon-v68/libQnnSaver.so",
+            "containerPath": "/usr/lib/rfsa/adsp/hexagon-v68/libQnnSaver.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/hexagon-v68/libQnnSystem.so",
+            "containerPath": "/usr/lib/rfsa/adsp/hexagon-v68/libQnnSystem.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libCalculator_skel.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libCalculator_skel.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libQnnHtpV68.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libQnnHtpV68.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libQnnHtpV68Skel.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libQnnHtpV68Skel.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libQnnSaver.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libQnnSaver.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libQnnSystem.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libQnnSystem.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libSnpeHtpV68Skel.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libSnpeHtpV68Skel.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libcdsprpc.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libcdsprpc.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libadsprpc.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libadsprpc.so",
+            "options": [
+              "bind"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docker/qualcomm/cdi/cdi-hw-acc-9100.json
+++ b/docker/qualcomm/cdi/cdi-hw-acc-9100.json
@@ -1,0 +1,1724 @@
+{
+  "cdiVersion": "0.6.0",
+  "kind": "qualcomm.com/device",
+  "devices": [
+    {
+      "name": "cdi-hw-acc",
+      "containerEdits": {
+        "env": [
+          "XDG_RUNTIME_DIR=/run/user/1000",
+          "WAYLAND_DISPLAY=wayland-0",
+          "GST_DEBUG_NO_COLOR=1",
+          "GST_DEBUG=2",
+          "ADSP_LIBRARY_PATH=\"/usr/lib/dsp/cdsp;/usr/lib/dsp/cdsp1;${ADSP_LIBRARY_PATH}\"",
+          "GST_PLUGIN_SCANNER=\"/usr/lib/aarch64-linux-gnu/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner\""
+        ],
+        "deviceNodes": [
+          {
+            "path": "/dev/dri/card0"
+          },
+          {
+            "path": "/dev/dri/renderD128"
+          },
+          {
+            "path": "/dev/video32"
+          },
+          {
+            "path": "/dev/video33"
+          },
+          {
+            "path": "/dev/dma_heap/system"
+          },
+          {
+            "path": "/dev/dma_heap/qcom,system"
+          },
+          {
+            "path": "/dev/fastrpc-cdsp"
+          }
+        ],
+        "mounts": [
+          {
+            "hostPath": "/run/user/1000",
+            "containerPath": "/run/user/1000",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/tmp/socket/cam_server",
+            "containerPath": "/tmp/socket/cam_server",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/tmp/property-vault.socket",
+            "containerPath": "/tmp/property-vault.socket",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/etc/labels",
+            "containerPath": "/etc/labels",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/etc/media",
+            "containerPath": "/etc/media",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/etc/models",
+            "containerPath": "/etc/models",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/etc/configs",
+            "containerPath": "/etc/configs",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/meta",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/meta",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/ml",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/ml",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/mlmetaparser",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/mlmetaparser",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/pulseaudio",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/pulseaudio",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-activate-deactivate-streams-runtime-example",
+            "containerPath": "/usr/bin/gst-activate-deactivate-streams-runtime-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-add-remove-streams-runtime",
+            "containerPath": "/usr/bin/gst-add-remove-streams-runtime",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-add-streams-as-bundle-example",
+            "containerPath": "/usr/bin/gst-add-streams-as-bundle-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-audio-classification",
+            "containerPath": "/usr/bin/gst-ai-audio-classification",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-classification",
+            "containerPath": "/usr/bin/gst-ai-classification",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-daisychain-detection-classification",
+            "containerPath": "/usr/bin/gst-ai-daisychain-detection-classification",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-daisychain-detection-pose",
+            "containerPath": "/usr/bin/gst-ai-daisychain-detection-pose",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-face-detection",
+            "containerPath": "/usr/bin/gst-ai-face-detection",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-face-recognition",
+            "containerPath": "/usr/bin/gst-ai-face-recognition",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-metadata-parser-example",
+            "containerPath": "/usr/bin/gst-ai-metadata-parser-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-monodepth",
+            "containerPath": "/usr/bin/gst-ai-monodepth",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-multi-input-output-object-detection",
+            "containerPath": "/usr/bin/gst-ai-multi-input-output-object-detection",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-multistream-batch-inference",
+            "containerPath": "/usr/bin/gst-ai-multistream-batch-inference",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-multistream-inference",
+            "containerPath": "/usr/bin/gst-ai-multistream-inference",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-object-detection",
+            "containerPath": "/usr/bin/gst-ai-object-detection",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-object-detection.py",
+            "containerPath": "/usr/bin/gst-ai-object-detection.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-parallel-inference",
+            "containerPath": "/usr/bin/gst-ai-parallel-inference",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-pose-detection",
+            "containerPath": "/usr/bin/gst-ai-pose-detection",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-segmentation",
+            "containerPath": "/usr/bin/gst-ai-segmentation",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-smartcodec-example",
+            "containerPath": "/usr/bin/gst-ai-smartcodec-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-superresolution",
+            "containerPath": "/usr/bin/gst-ai-superresolution",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-ai-usb-camera-app",
+            "containerPath": "/usr/bin/gst-ai-usb-camera-app",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-appsink-example",
+            "containerPath": "/usr/bin/gst-appsink-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-audio-decode-example",
+            "containerPath": "/usr/bin/gst-audio-decode-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-audio-encode-example",
+            "containerPath": "/usr/bin/gst-audio-encode-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-audio-video-encode",
+            "containerPath": "/usr/bin/gst-audio-video-encode",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-audio-video-playback",
+            "containerPath": "/usr/bin/gst-audio-video-playback",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-burst-capture-example",
+            "containerPath": "/usr/bin/gst-camera-burst-capture-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-encode.py",
+            "containerPath": "/usr/bin/gst-camera-encode.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-metadata-example",
+            "containerPath": "/usr/bin/gst-camera-metadata-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-opencv-resize.py",
+            "containerPath": "/usr/bin/gst-camera-opencv-resize.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-rotate-downscale-file.py",
+            "containerPath": "/usr/bin/gst-camera-rotate-downscale-file.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-shdr-ldc-eis-example",
+            "containerPath": "/usr/bin/gst-camera-shdr-ldc-eis-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-single-stream-example",
+            "containerPath": "/usr/bin/gst-camera-single-stream-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-switch-example",
+            "containerPath": "/usr/bin/gst-camera-switch-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-three-stream-encode-file-detection-display-classification-rtsp.py",
+            "containerPath": "/usr/bin/gst-camera-three-stream-encode-file-detection-display-classification-rtsp.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-two-stream-detection-and-classification-side-by-side.py",
+            "containerPath": "/usr/bin/gst-camera-two-stream-detection-and-classification-side-by-side.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-camera-two-stream-encode-file-detection-display.py",
+            "containerPath": "/usr/bin/gst-camera-two-stream-encode-file-detection-display.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-concurrent-videoplay-composition",
+            "containerPath": "/usr/bin/gst-concurrent-videoplay-composition",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-concurrent-videoplay-composition.py",
+            "containerPath": "/usr/bin/gst-concurrent-videoplay-composition.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-daisychain-detection-pose.py",
+            "containerPath": "/usr/bin/gst-daisychain-detection-pose.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-filesrc-2detection-classification-segmentation-side-by-side.py",
+            "containerPath": "/usr/bin/gst-filesrc-2detection-classification-segmentation-side-by-side.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-gui-launcher-app.py",
+            "containerPath": "/usr/bin/gst-gui-launcher-app.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-inspect-1.0",
+            "containerPath": "/usr/bin/gst-inspect-1.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-jpg-decode-example",
+            "containerPath": "/usr/bin/gst-jpg-decode-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-jpg-image-decode.py",
+            "containerPath": "/usr/bin/gst-jpg-image-decode.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-launch-1.0",
+            "containerPath": "/usr/bin/gst-launch-1.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-multi-camera-example",
+            "containerPath": "/usr/bin/gst-multi-camera-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-multi-camera-stream-example.py",
+            "containerPath": "/usr/bin/gst-multi-camera-stream-example.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-multi-stream-example",
+            "containerPath": "/usr/bin/gst-multi-stream-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-opencv-transform.py",
+            "containerPath": "/usr/bin/gst-opencv-transform.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-parallel-inference.py",
+            "containerPath": "/usr/bin/gst-parallel-inference.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-pipeline-app",
+            "containerPath": "/usr/bin/gst-pipeline-app",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-rtsp-server",
+            "containerPath": "/usr/bin/gst-rtsp-server",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-rtspsrc-detection-display.py",
+            "containerPath": "/usr/bin/gst-rtspsrc-detection-display.py",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-smartcodec-example",
+            "containerPath": "/usr/bin/gst-smartcodec-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-snapshot-stream-example",
+            "containerPath": "/usr/bin/gst-snapshot-stream-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-stats-1.0",
+            "containerPath": "/usr/bin/gst-stats-1.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-tester-1.0",
+            "containerPath": "/usr/bin/gst-tester-1.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-transform-example",
+            "containerPath": "/usr/bin/gst-transform-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-typefind-1.0",
+            "containerPath": "/usr/bin/gst-typefind-1.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-video-playback-example",
+            "containerPath": "/usr/bin/gst-video-playback-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-video-transcode-example",
+            "containerPath": "/usr/bin/gst-video-transcode-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-videocodec-concurrent-playback",
+            "containerPath": "/usr/bin/gst-videocodec-concurrent-playback",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-warmboot-app",
+            "containerPath": "/usr/bin/gst-warmboot-app",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-webrtc-sendrecv-example",
+            "containerPath": "/usr/bin/gst-webrtc-sendrecv-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/bin/gst-weston-composition-example",
+            "containerPath": "/usr/bin/gst-weston-composition-example",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/overlay_blit_bgra_kernel.cl",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/overlay_blit_bgra_kernel.cl",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/overlay_blit_rgba_kernel.cl",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/overlay_blit_rgba_kernel.cl",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/overlay_mask_kernel.cl",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/overlay_mask_kernel.cl",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gbm/default_fmt_alignment.xml",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gbm/default_fmt_alignment.xml",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gbm/dri_gbm.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gbm/dri_gbm.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gbm/msm_gbm.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gbm/msm_gbm.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstcoreelements.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstcoreelements.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstpulseaudio.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstpulseaudio.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtibatch.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtibatch.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimetamux.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimetamux.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimetatransform.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimetatransform.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlaclassification.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlaclassification.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlaconverter.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlaconverter.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimldemux.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimldemux.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlmetaparser.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlmetaparser.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlqnn.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlqnn.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlsnpe.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlsnpe.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimltflite.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimltflite.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvclassification.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvclassification.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvconverter.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvconverter.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvdetection.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvdetection.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvpose.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvpose.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvsegmentation.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvsegmentation.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvsuperresolution.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimlvsuperresolution.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimsgpub.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimsgpub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimsgsub.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtimsgsub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtiobjtracker.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtiobjtracker.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtiqmmfsrc.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtiqmmfsrc.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtirestrictedzonedbg.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtirestrictedzonedbg.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtirtspbin.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtirtspbin.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtismartvencbin.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtismartvencbin.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivcomposer.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivcomposer.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivoverlay.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivoverlay.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivsplit.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivsplit.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivtransform.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstqtivtransform.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstvideo4linux2.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstvideo4linux2.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstwaylandsink.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstwaylandsink.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtioverlay.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtioverlay.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtiredissink.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtiredissink.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtisocketsink.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtisocketsink.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtisocketsrc.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libqtisocketsrc.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libCB.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libCB.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libEGL.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libEGL.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libEGL.so.1.0.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libEGL.so.1.0.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libEGL_adreno.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libEGL_adreno.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libGLESv1_CM.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libGLESv1_CM.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libGLESv1_CM.so.1.0.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libGLESv1_CM.so.1.0.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libGLESv1_CM_adreno.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libGLESv1_CM_adreno.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libGLESv2.so.2",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libGLESv2.so.2",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libGLESv2.so.2.0.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libGLESv2.so.2.0.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libGLESv2_adreno.so.2",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libGLESv2_adreno.so.2",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libIB2C.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libIB2C.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libOpenCL.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libOpenCL.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libOpenCL_adreno.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libOpenCL_adreno.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libVideoCtrl.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libVideoCtrl.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libadreno_utils.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libadreno_utils.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libadsprpc.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libadsprpc.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libatomic.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libatomic.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libcdsprpc.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libcdsprpc.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libdmabufheap.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libdmabufheap.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libeglSubDriverWayland.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libeglSubDriverWayland.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libenv_time.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libenv_time.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libevaluation_proto.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libevaluation_proto.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libfarmhash.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libfarmhash.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libfastcvdsp_stub.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libfastcvdsp_stub.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libfastcvopt.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libfastcvopt.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgallium-25.0.7-0ubuntu0.24.04.1.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgallium-25.0.7-0ubuntu0.24.04.1.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgbm.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgbm.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgsl.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgsl.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstappsutils.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstappsutils.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstbase-1.0.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstbase-1.0.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtiallocatorsbase.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtiallocatorsbase.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqticvbase.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqticvbase.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtimemorybase.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtimemorybase.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtimlbase.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtimlbase.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtimqttadaptor.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtimqttadaptor.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtimsgadaptor.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtimsgadaptor.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtiutilsbase.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtiutilsbase.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstqtivideobase.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstqtivideobase.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstreamer-1.0.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstreamer-1.0.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstvideo-1.0.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstvideo-1.0.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libgstwayland-1.0.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libgstwayland-1.0.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libimage_metrics.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libimage_metrics.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libjpeg_internal.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libjpeg_internal.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libllvm-glnext.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libllvm-glnext.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libllvm-qcom.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libllvm-qcom.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libllvm-qgl.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libllvm-qgl.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/liboverlay_lib.so.SOVERSION",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/liboverlay_lib.so.SOVERSION",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libpropertyvault.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libpropertyvault.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libpulse-simple.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libpulse-simple.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libpulse.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libpulse.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libq3dtools_adreno.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libq3dtools_adreno.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libq3dtools_esx.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libq3dtools_esx.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libqtimlmeta.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libqtimlmeta.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libtensorflowlite_c.so.2",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libtensorflowlite_c.so.2",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libtf_logging.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libtf_logging.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libvulkan_adreno.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libvulkan_adreno.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libwayland-client.so.0",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libwayland-client.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libwayland-egl.so.1",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libwayland-egl.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/dsp/cdsp/cv/v73/LEMANS/libfastcvadsp.so",
+            "containerPath": "/usr/lib/dsp/cdsp/cv/v73/LEMANS/libfastcvadsp.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/dsp/cdsp/cv/v73/LEMANS/libfastcvdsp_skel.so",
+            "containerPath": "/usr/lib/dsp/cdsp/cv/v73/LEMANS/libfastcvdsp_skel.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libPlatformValidatorShared.so",
+            "containerPath": "/usr/lib/libPlatformValidatorShared.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnChrometraceProfilingReader.so",
+            "containerPath": "/usr/lib/libQnnChrometraceProfilingReader.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnCpu.so",
+            "containerPath": "/usr/lib/libQnnCpu.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnCpuNetRunExtensions.so",
+            "containerPath": "/usr/lib/libQnnCpuNetRunExtensions.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnDsp.so",
+            "containerPath": "/usr/lib/libQnnDsp.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnDspNetRunExtensions.so",
+            "containerPath": "/usr/lib/libQnnDspNetRunExtensions.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnGenAiTransformer.so",
+            "containerPath": "/usr/lib/libQnnGenAiTransformer.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnGenAiTransformerCpuOpPkg.so",
+            "containerPath": "/usr/lib/libQnnGenAiTransformerCpuOpPkg.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnGenAiTransformerModel.so",
+            "containerPath": "/usr/lib/libQnnGenAiTransformerModel.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnGpu.so",
+            "containerPath": "/usr/lib/libQnnGpu.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnGpuNetRunExtensions.so",
+            "containerPath": "/usr/lib/libQnnGpuNetRunExtensions.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnGpuProfilingReader.so",
+            "containerPath": "/usr/lib/libQnnGpuProfilingReader.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHta.so",
+            "containerPath": "/usr/lib/libQnnHta.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtaNetRunExtensions.so",
+            "containerPath": "/usr/lib/libQnnHtaNetRunExtensions.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtp.so",
+            "containerPath": "/usr/lib/libQnnHtp.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtpNetRunExtensions.so",
+            "containerPath": "/usr/lib/libQnnHtpNetRunExtensions.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtpOptraceProfilingReader.so",
+            "containerPath": "/usr/lib/libQnnHtpOptraceProfilingReader.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtpPrepare.so",
+            "containerPath": "/usr/lib/libQnnHtpPrepare.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtpProfilingReader.so",
+            "containerPath": "/usr/lib/libQnnHtpProfilingReader.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtpV73CalculatorStub.so",
+            "containerPath": "/usr/lib/libQnnHtpV73CalculatorStub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnHtpV73Stub.so",
+            "containerPath": "/usr/lib/libQnnHtpV73Stub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnIr.so",
+            "containerPath": "/usr/lib/libQnnIr.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnJsonProfilingReader.so",
+            "containerPath": "/usr/lib/libQnnJsonProfilingReader.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnModelDlc.so",
+            "containerPath": "/usr/lib/libQnnModelDlc.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnSaver.so",
+            "containerPath": "/usr/lib/libQnnSaver.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnSystem.so",
+            "containerPath": "/usr/lib/libQnnSystem.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libQnnTFLiteDelegate.so",
+            "containerPath": "/usr/lib/libQnnTFLiteDelegate.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libSNPE.so",
+            "containerPath": "/usr/lib/libSNPE.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libSnpeDspStub.so",
+            "containerPath": "/usr/lib/libSnpeDspStub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libSnpeHta.so",
+            "containerPath": "/usr/lib/libSnpeHta.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libSnpeHtpPrepare.so",
+            "containerPath": "/usr/lib/libSnpeHtpPrepare.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libSnpeHtpV73CalculatorStub.so",
+            "containerPath": "/usr/lib/libSnpeHtpV73CalculatorStub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libSnpeHtpV73Stub.so",
+            "containerPath": "/usr/lib/libSnpeHtpV73Stub.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libcamera_metadata.so.0",
+            "containerPath": "/usr/lib/libcamera_metadata.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libhta_hexagon_runtime.so",
+            "containerPath": "/usr/lib/libhta_hexagon_runtime.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libhta_hexagon_runtime_snpe.so",
+            "containerPath": "/usr/lib/libhta_hexagon_runtime_snpe.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libqmmf_camera_metadata.so.1",
+            "containerPath": "/usr/lib/libqmmf_camera_metadata.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libqmmf_propertyvault.so",
+            "containerPath": "/usr/lib/libqmmf_propertyvault.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libqmmf_proto.so.1",
+            "containerPath": "/usr/lib/libqmmf_proto.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libqmmf_recorder_client.so.1",
+            "containerPath": "/usr/lib/libqmmf_recorder_client.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/libqmmf_utils.so.1",
+            "containerPath": "/usr/lib/libqmmf_utils.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/qcs9100/libcamera_metadata.so.0",
+            "containerPath": "/usr/lib/qcs9100/libcamera_metadata.so.0",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/qcs9100/libqmmf_camera_metadata.so.1",
+            "containerPath": "/usr/lib/qcs9100/libqmmf_camera_metadata.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/qcs9100/libqmmf_propertyvault.so",
+            "containerPath": "/usr/lib/qcs9100/libqmmf_propertyvault.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/qcs9100/libqmmf_proto.so.1",
+            "containerPath": "/usr/lib/qcs9100/libqmmf_proto.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/qcs9100/libqmmf_recorder_client.so.1",
+            "containerPath": "/usr/lib/qcs9100/libqmmf_recorder_client.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/qcs9100/libqmmf_utils.so.1",
+            "containerPath": "/usr/lib/qcs9100/libqmmf_utils.so.1",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/hexagon-v73/libCalculator_skel.so",
+            "containerPath": "/usr/lib/rfsa/adsp/hexagon-v73/libCalculator_skel.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/hexagon-v73/libQnnSaver.so",
+            "containerPath": "/usr/lib/rfsa/adsp/hexagon-v73/libQnnSaver.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/hexagon-v73/libQnnSystem.so",
+            "containerPath": "/usr/lib/rfsa/adsp/hexagon-v73/libQnnSystem.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libCalculator_skel.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libCalculator_skel.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libQnnHtpV73.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libQnnHtpV73.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libQnnHtpV73QemuDriver.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libQnnHtpV73QemuDriver.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libQnnHtpV73Skel.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libQnnHtpV73Skel.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libQnnSaver.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libQnnSaver.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libQnnSystem.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libQnnSystem.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libSnpeHtpV73Skel.so",
+            "containerPath": "/usr/lib/rfsa/adsp/libSnpeHtpV73Skel.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libqnnhtpv73.cat",
+            "containerPath": "/usr/lib/rfsa/adsp/libqnnhtpv73.cat",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/rfsa/adsp/libsnpehtpv73.cat",
+            "containerPath": "/usr/lib/rfsa/adsp/libsnpehtpv73.cat",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libcdsprpc.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libcdsprpc.so",
+            "options": [
+              "bind"
+            ]
+          },
+          {
+            "hostPath": "/usr/lib/aarch64-linux-gnu/libadsprpc.so",
+            "containerPath": "/usr/lib/aarch64-linux-gnu/libadsprpc.so",
+            "options": [
+              "bind"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docker/qualcomm/cdi/install_cdi.py
+++ b/docker/qualcomm/cdi/install_cdi.py
@@ -1,0 +1,51 @@
+import argparse
+import json
+import os
+
+parser = argparse.ArgumentParser(description="Install CDI on Dragonwing IoT boards")
+parser.add_argument("--file", type=str, required=True, help="CDI input file")
+args, unknown = parser.parse_known_args()
+
+if os.path.exists("/etc/cdi/cdi-hw-acc.json"):
+    print("/etc/cdi/cdi-hw-acc.json already exists. Remove it first before continuing.")
+    exit(1)
+
+if not os.path.exists(args.file):
+    print(f"{args.file} (via --file) does not exist")
+    exit(1)
+
+# Check if directory exists
+if not os.path.exists("/etc/cdi"):
+    # Check if we can create it in /etc
+    if not os.access(os.path.dirname("/etc/cdi"), os.W_OK):
+        print(
+            f"{os.path.dirname('/etc/cdi')} is not writable. Re-run this script with sudo."
+        )
+        exit(1)
+    os.mkdir("/etc/cdi")
+else:
+    # Directory exists → check if writable
+    if not os.access("/etc/cdi", os.W_OK):
+        print("/etc/cdi is not writable. Re-run this script with sudo.")
+        exit(1)
+
+with open(args.file, "r") as f:
+    cdi = json.loads(f.read())
+
+print("Finding missing mount paths...")
+for device in cdi["devices"]:
+    new_mounts = []
+
+    for mount in device["containerEdits"]["mounts"]:
+        if not os.path.exists(mount["hostPath"]):
+            print(f"    Missing {mount['hostPath']}")
+        else:
+            new_mounts.append(mount)
+
+    device["containerEdits"]["mounts"] = new_mounts
+
+print("")
+print("Writing to /etc/cdi/cdi-hw-acc.json...")
+with open("/etc/cdi/cdi-hw-acc.json", "w") as f:
+    f.write(json.dumps(cdi, indent=4))
+print("Writing to /etc/cdi/cdi-hw-acc.json OK")

--- a/docker/qualcomm/qualcomm.hcl
+++ b/docker/qualcomm/qualcomm.hcl
@@ -1,0 +1,27 @@
+target wheels {
+  dockerfile = "docker/main/Dockerfile"
+  platforms = ["linux/arm64"]
+  target = "wheels"
+}
+
+target deps {
+  dockerfile = "docker/main/Dockerfile"
+  platforms = ["linux/arm64"]
+  target = "deps"
+}
+
+target rootfs {
+  dockerfile = "docker/main/Dockerfile"
+  platforms = ["linux/arm64"]
+  target = "rootfs"
+}
+
+target qualcomm {
+  dockerfile = "docker/qualcomm/Dockerfile"
+  contexts = {
+    wheels = "target:wheels",
+    deps = "target:deps",
+    rootfs = "target:rootfs"
+  }
+  platforms = ["linux/arm64"]
+}

--- a/docker/qualcomm/qualcomm.mk
+++ b/docker/qualcomm/qualcomm.mk
@@ -1,0 +1,15 @@
+BOARDS += qualcomm
+
+local-qualcomm: version
+	docker buildx bake --file=docker/qualcomm/qualcomm.hcl qualcomm \
+		--set qualcomm.tags=frigate:latest-qualcomm \
+		--load
+
+build-qualcomm: version
+	docker buildx bake --file=docker/qualcomm/qualcomm.hcl qualcomm \
+		--set qualcomm.tags=$(IMAGE_REPO):${GITHUB_REF_NAME}-$(COMMIT_HASH)-qualcomm
+
+push-qualcomm: build-qualcomm
+	docker buildx bake --file=docker/qualcomm/qualcomm.hcl qualcomm \
+		--set qualcomm.tags=$(IMAGE_REPO):${GITHUB_REF_NAME}-$(COMMIT_HASH)-qualcomm \
+		--push

--- a/docs/docs/configuration/object_detectors.md
+++ b/docs/docs/configuration/object_detectors.md
@@ -51,6 +51,10 @@ Frigate supports multiple different detectors that work on different types of ha
 
 - [RKNN](#rockchip-platform): RKNN models can run on Rockchip devices with included NPUs.
 
+**Qualcomm** <CommunityBadge />
+
+- [Qualcomm](#qualcomm): TFLite models can run on Qualcomm SoCs with a Hexagon NPU (e.g. IQ9100, QCS6490) via the QNN TFLite delegate.
+
 **Synaptics** <CommunityBadge />
 
 - [Synaptics](#synaptics): synap models can run on Synaptics devices(e.g astra machina) with included NPUs.
@@ -1872,6 +1876,53 @@ model: # required
 
 </TabItem>
 </ConfigTabs>
+
+## Qualcomm
+
+Hardware accelerated object detection is supported on the following Qualcomm SoCs with a Hexagon NPU:
+
+- IQ9100 / IQ-9075 EVK
+- QCS6490 / RB3 Gen 2 Vision Kit / Rubik Pi 3
+
+This implementation uses the QNN TFLite delegate (`libQnnTFLiteDelegate.so`) to accelerate TFLite model inference on the Qualcomm Hexagon Tensor Processor (HTP / NPU). The delegate library and device drivers are provided by the host operating system and made available to the container via [CDI (Container Device Interface)](https://docs.docker.com/build/building/cdi/).
+
+See the [installation docs](../frigate/installation.md#qualcomm) for information on setting up CDI and configuring the hardware.
+
+### Supported Boards
+
+| Board | SoC | CDI Config File |
+| ----- | --- | --------------- |
+| IQ-9075 EVK | IQ9100 | `cdi-hw-acc-9100.json` |
+| RB3 Gen 2 Vision Kit / Rubik Pi 3 | QCS6490 | `cdi-hw-acc-6490.json` |
+
+### Configuration
+
+The default SSD MobileDet TFLite model (`/cpu_model.tflite`) bundled with the Frigate container is used automatically. This model is INT8 quantized and compatible with the QNN HTP backend.
+
+```yaml
+detectors:
+  qualcomm_npu:
+    type: qualcomm_tfl
+```
+
+To use a custom model, specify the path at the top-level `model` config:
+
+```yaml
+detectors:
+  qualcomm_npu:
+    type: qualcomm_tfl
+
+model:
+  path: /config/your_custom_model.tflite
+  width: 320
+  height: 320
+```
+
+:::note
+
+Only `.tflite` models are supported with this detector. The model must be quantized (INT8) for optimal performance on the Hexagon NPU.
+
+:::
 
 ## Rockchip platform
 

--- a/docs/docs/frigate/hardware.md
+++ b/docs/docs/frigate/hardware.md
@@ -296,6 +296,18 @@ The inference time of a rk3588 with all 3 cores enabled is typically 25-30 ms fo
 | ---------------- | ----------------------------------- |
 | yolov9-tiny      | ~ 4 ms                              |
 
+### Qualcomm
+
+Frigate supports hardware object detection on Qualcomm SoCs with a Hexagon NPU, including the IQ9100 and QCS6490 (RB3 Gen 2). The QNN TFLite delegate is used to accelerate inference on the HTP (Hexagon Tensor Processor).
+
+A single detector is typically sufficient for multiple camera streams. The default model is **SSD MobileDet** (INT8 quantized).
+
+| Name          | IQ9100 Inference Time | QCS6490 Inference Time |
+| ------------- | --------------------- | ---------------------- |
+| ssd_mobiledet | ~ 0.8 ms              | ~ 5.55 ms              |
+
+Detailed information is available [in the detector docs](/configuration/object_detectors#qualcomm).
+
 ## What does Frigate use the CPU for and what does it use a detector for? (ELI5 Version)
 
 This is taken from a [user question on reddit](https://www.reddit.com/r/homeassistant/comments/q8mgau/comment/hgqbxh5/?utm_source=share&utm_medium=web2x&context=3). Modified slightly for clarity.

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -472,6 +472,117 @@ If you are using `docker run`, add this option to your command `--device /dev/ax
 #### Configuration
 
 Finally, configure [hardware object detection](/configuration/object_detectors#axera) to complete the setup.
+### Qualcomm
+
+Hardware accelerated object detection is supported on the following Qualcomm SoCs:
+
+| Board | SoC | CDI Config File |
+| ----- | --- | --------------- |
+| IQ-9075 EVK | IQ9100 | `cdi-hw-acc-9100.json` |
+| RB3 Gen 2 Vision Kit / Rubik Pi 3 | QCS6490 | `cdi-hw-acc-6490.json` |
+
+The Qualcomm integration uses [CDI (Container Device Interface)](https://docs.docker.com/build/building/cdi/) to provide the container with access to the NPU device nodes and the QNN delegate libraries from the host.
+
+#### Prerequisites
+
+- **Qualcomm Linux BSP**: Your board must be running the official Qualcomm Linux Board Support Package image. The QNN runtime libraries (including `libQnnTFLiteDelegate.so` and `libQnnHtp.so`) and NPU device nodes (`/dev/fastrpc-cdsp`) are provided by the BSP and are bind-mounted into the container via CDI.
+- **Docker 25.0+**: CDI device support requires Docker 25.0 or later. Check with `docker --version`.
+- **arm64 architecture**: The Qualcomm Docker image is built for `linux/arm64` only. If building locally, you must run the build on the target board itself.
+
+#### CDI Installation
+
+1. Download or copy the CDI setup files from the [Frigate repository](https://github.com/blakeblackshear/frigate/tree/dev/docker/qualcomm/cdi).
+
+2. Install the CDI configuration for your board:
+
+   ```bash
+   # IQ9100 / IQ-9075 EVK
+   sudo python3 install_cdi.py --file cdi-hw-acc-9100.json
+
+   # QCS6490 / RB3 Gen 2 Vision Kit / Rubik Pi 3
+   sudo python3 install_cdi.py --file cdi-hw-acc-6490.json
+   ```
+
+   This writes a CDI descriptor to `/etc/cdi/cdi-hw-acc.json`. The script will automatically skip any host paths that do not exist on your system.
+
+3. Verify CDI is set up by checking the file exists:
+
+   ```bash
+   ls -l /etc/cdi/cdi-hw-acc.json
+   ```
+
+#### Setup
+
+Follow Frigate's default installation instructions, but use a docker image with `-qualcomm` suffix, for example `ghcr.io/blakeblackshear/frigate:stable-qualcomm`.
+
+:::note
+
+The pre-built `stable-qualcomm` image is not yet published. Until it is available, you must build the image locally:
+
+```bash
+git clone https://github.com/blakeblackshear/frigate.git
+cd frigate
+make local-qualcomm
+```
+
+This builds `frigate:latest-qualcomm` on your device. Use `frigate:latest-qualcomm` as the image name in the examples below instead of the `ghcr.io` URL.
+
+:::
+
+Grant Docker access to your Qualcomm hardware by passing the CDI device. In your `docker-compose.yml`:
+
+```yaml
+services:
+  frigate:
+    container_name: frigate
+    restart: unless-stopped
+    image: ghcr.io/blakeblackshear/frigate:stable-qualcomm
+    devices:
+      - qualcomm.com/device=cdi-hw-acc
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /path/to/your/config:/config
+      - /path/to/your/storage:/media/frigate
+      - type: tmpfs
+        target: /tmp/cache
+        tmpfs:
+          size: 1000000000
+    ports:
+      - "8971:8971"
+      - "8554:8554"
+      - "8555:8555/tcp"
+      - "8555:8555/udp"
+```
+
+If using `docker run`, pass the CDI device with:
+
+```bash
+docker run -d \
+  --name frigate \
+  --restart=unless-stopped \
+  --device qualcomm.com/device=cdi-hw-acc \
+  --mount type=tmpfs,target=/tmp/cache,tmpfs-size=1000000000 \
+  --shm-size=256m \
+  -v /path/to/your/storage:/media/frigate \
+  -v /path/to/your/config:/config \
+  -v /etc/localtime:/etc/localtime:ro \
+  -e FRIGATE_RTSP_PASSWORD='password' \
+  -p 8971:8971 \
+  -p 8554:8554 \
+  -p 8555:8555/tcp \
+  -p 8555:8555/udp \
+  ghcr.io/blakeblackshear/frigate:stable-qualcomm
+```
+
+:::tip
+
+Unlike other hardware integrations that pass individual `/dev/` device nodes, the Qualcomm CDI approach bundles all required device nodes, library bind mounts, and environment variables into a single `--device qualcomm.com/device=cdi-hw-acc` flag.
+
+:::
+
+#### Configuration
+
+Next, you should configure [hardware object detection](/configuration/object_detectors#qualcomm).
 
 ## Docker
 
@@ -558,6 +669,7 @@ The community supported docker image tags for the current stable version are:
 
 - `stable-tensorrt-jp6` - Frigate build optimized for Nvidia Jetson devices running Jetpack 6
 - `stable-rk` - Frigate build for SBCs with Rockchip SoC
+- `stable-qualcomm` - Frigate build for Qualcomm SoCs with Hexagon NPU (IQ9100, QCS6490)
 
 ## Home Assistant App
 

--- a/frigate/detectors/plugins/qualcomm_tfl.py
+++ b/frigate/detectors/plugins/qualcomm_tfl.py
@@ -1,0 +1,48 @@
+"""Qualcomm QNN TFLite delegate detector for Qualcomm NPU acceleration."""
+
+import logging
+
+from pydantic import ConfigDict
+from typing_extensions import Literal
+
+from frigate.detectors.detection_api import DetectionApi
+from frigate.detectors.detector_config import BaseDetectorConfig
+
+from ..detector_utils import (
+    tflite_detect_raw,
+    tflite_init,
+    tflite_load_delegate_interpreter,
+)
+
+logger = logging.getLogger(__name__)
+
+# Use _tfl suffix to default to the bundled tflite model
+DETECTOR_KEY = "qualcomm_tfl"
+
+
+class QualcommDetectorConfig(BaseDetectorConfig):
+    """Qualcomm NPU detector using the QNN TFLite delegate to accelerate inference on Qualcomm SoCs with a Hexagon NPU (e.g. IQ9100, QCS6490)."""
+
+    model_config = ConfigDict(
+        title="Qualcomm",
+    )
+
+    type: Literal[DETECTOR_KEY]
+
+
+class QualcommTfl(DetectionApi):
+    type_key = DETECTOR_KEY
+
+    def __init__(self, detector_config: QualcommDetectorConfig):
+        # The QNN TFLite delegate library is provided by the host via CDI bind mounts
+        delegate_library = "libQnnTFLiteDelegate.so"
+        # Use the Hexagon Tensor Processor (HTP / NPU) backend
+        device_config = {"backend_type": "htp"}
+
+        interpreter = tflite_load_delegate_interpreter(
+            delegate_library, detector_config, device_config
+        )
+        tflite_init(self, interpreter)
+
+    def detect_raw(self, tensor_input):
+        return tflite_detect_raw(self, tensor_input)


### PR DESCRIPTION
## Proposed change

Community board build for Qualcomm Hexagon-NPU SoCs (IQ9100 / IQ-9075 EVK, QCS6490 / RB3 Gen 2 / Rubik Pi 3); TFLite detection via the QNN delegate on the HTP; device access bundled through a single CDI descriptor; docs + CI + CODEOWNERS included. It is a pretty easy change as I followed the other tflite option just with a different delegate.

There were some other code changes that I've removed to keep this PR directly releated to Qualcomm Hexagon NPU:
- docker/main/Dockerfile heap fix (so that I can build on low-mem arm64 RubikPi 3 directly)
- install_cdi.py portability fix (nested-quote f-string would crash on host Python < 3.12)
- Markdown blank-line fixes before the new headings



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

GenAI was used for this but was validated and double checked by me. My personal system also runs on a RubikPi 3. This should also work on the new Arduino VentunoQ / IQ8 EVK, waiting validation before adding support (will add support once validated) either to this PR or in a new one.
