### PR TITLE
Fix config corruption when deleting the last commented mask via config/set

### DIFF
--- a/frigate/test/test_update_yaml.py
+++ b/frigate/test/test_update_yaml.py
@@ -1,0 +1,85 @@
+"""Test in-place yaml config updates."""
+
+import os
+import tempfile
+import unittest
+
+from ruamel.yaml import YAML
+
+from frigate.util.builtin import update_yaml_file_bulk
+
+
+class TestUpdateYaml(unittest.TestCase):
+    def setUp(self) -> None:
+        self.yaml = YAML()
+        fd, self.config_path = tempfile.mkstemp(suffix=".yml")
+        os.close(fd)
+
+    def tearDown(self) -> None:
+        os.unlink(self.config_path)
+
+    def _write(self, text: str) -> None:
+        with open(self.config_path, "w") as f:
+            f.write(text)
+
+    def _load(self):
+        with open(self.config_path) as f:
+            return self.yaml.load(f)
+
+    def test_delete_key(self):
+        """Deleting a key removes it and leaves valid yaml."""
+        self._write(
+            "cameras:\n"
+            "  cam1:\n"
+            "    objects:\n"
+            "      filters:\n"
+            "        car:\n"
+            "          mask: 0,0.45,0.245,0.45\n"
+        )
+        update_yaml_file_bulk(
+            self.config_path, {"cameras.cam1.objects.filters.car.mask": ""}
+        )
+        data = self._load()
+        assert "mask" not in data["cameras"]["cam1"]["objects"]["filters"]["car"]
+
+    def test_delete_commented_key_emptying_map(self):
+        """Deleting the only key of a map whose key carries comments must not
+        emit unparseable yaml (orphaned comment tokens above a flow-style {})."""
+        self._write(
+            "cameras:\n"
+            "  cam1:\n"
+            "    objects:\n"
+            "      filters:\n"
+            "        car:\n"
+            "          # cars parked across the street\n"
+            "          # second comment line\n"
+            "          mask: 0,0.45,0.245,0.45\n"
+            "    motion:\n"
+            "      mask: 0,0.449,0.686,0.395\n"
+        )
+        update_yaml_file_bulk(
+            self.config_path, {"cameras.cam1.objects.filters.car.mask": ""}
+        )
+        # must re-parse cleanly
+        data = self._load()
+        assert "mask" not in data["cameras"]["cam1"]["objects"]["filters"]["car"]
+        assert data["cameras"]["cam1"]["motion"]["mask"] == "0,0.449,0.686,0.395"
+
+    def test_update_value_preserves_comments(self):
+        """Updating a value keeps surrounding comments intact."""
+        self._write(
+            "cameras:\n"
+            "  cam1:\n"
+            "    detect:\n"
+            "      # tuned for the pi\n"
+            "      fps: 4\n"
+        )
+        update_yaml_file_bulk(self.config_path, {"cameras.cam1.detect.fps": 5})
+        data = self._load()
+        assert data["cameras"]["cam1"]["detect"]["fps"] == 5
+        with open(self.config_path) as f:
+            assert "# tuned for the pi" in f.read()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/frigate/test/test_update_yaml.py
+++ b/frigate/test/test_update_yaml.py
@@ -64,15 +64,61 @@ class TestUpdateYaml(unittest.TestCase):
         data = self._load()
         assert "mask" not in data["cameras"]["cam1"]["objects"]["filters"]["car"]
         assert data["cameras"]["cam1"]["motion"]["mask"] == "0,0.449,0.686,0.395"
+        # the orphaned comments must be gone from the file, not just parseable
+        with open(self.config_path) as f:
+            content = f.read()
+        assert "cars parked across the street" not in content
+        assert "second comment line" not in content
+
+    def test_delete_key_preserves_siblings(self):
+        """Deleting one key among several keeps the sibling entries and any
+        comments on keys preceding the deleted one."""
+        self._write(
+            "cameras:\n"
+            "  cam1:\n"
+            "    objects:\n"
+            "      filters:\n"
+            "        car:\n"
+            "          # mask drawn around the parked suv\n"
+            "          mask: 0,0.45,0.245,0.45\n"
+            "          threshold: 0.8\n"
+        )
+        update_yaml_file_bulk(
+            self.config_path, {"cameras.cam1.objects.filters.car.threshold": ""}
+        )
+        data = self._load()
+        car = data["cameras"]["cam1"]["objects"]["filters"]["car"]
+        assert "threshold" not in car
+        assert car["mask"] == "0,0.45,0.245,0.45"
+        with open(self.config_path) as f:
+            content = f.read()
+        assert "# mask drawn around the parked suv" in content
+
+    def test_delete_first_commented_key_keeps_map_valid(self):
+        """Deleting a commented key from a map that still has other keys
+        leaves the remaining entries intact and the file parseable."""
+        self._write(
+            "cameras:\n"
+            "  cam1:\n"
+            "    objects:\n"
+            "      filters:\n"
+            "        car:\n"
+            "          # comment on the deleted key\n"
+            "          mask: 0,0.45,0.245,0.45\n"
+            "          threshold: 0.8\n"
+        )
+        update_yaml_file_bulk(
+            self.config_path, {"cameras.cam1.objects.filters.car.mask": ""}
+        )
+        data = self._load()
+        car = data["cameras"]["cam1"]["objects"]["filters"]["car"]
+        assert "mask" not in car
+        assert car["threshold"] == 0.8
 
     def test_update_value_preserves_comments(self):
         """Updating a value keeps surrounding comments intact."""
         self._write(
-            "cameras:\n"
-            "  cam1:\n"
-            "    detect:\n"
-            "      # tuned for the pi\n"
-            "      fps: 4\n"
+            "cameras:\n  cam1:\n    detect:\n      # tuned for the pi\n      fps: 4\n"
         )
         update_yaml_file_bulk(self.config_path, {"cameras.cam1.detect.fps": 5})
         data = self._load()

--- a/frigate/util/builtin.py
+++ b/frigate/util/builtin.py
@@ -295,16 +295,20 @@ def update_yaml_file_bulk(file_path: str, updates: Dict[str, Any]):
 
 def update_yaml(data, key_path, new_value):
     temp = data
+    parent = None
+    parent_key = None
     for key in key_path[:-1]:
         if isinstance(key, tuple):
             if key[0] not in temp:
                 temp[key[0]] = [{}] * max(1, key[1] + 1)
             elif len(temp[key[0]]) <= key[1]:
                 temp[key[0]] += [{}] * (key[1] - len(temp[key[0]]) + 1)
+            parent, parent_key = temp[key[0]], key[1]
             temp = temp[key[0]][key[1]]
         else:
             if key not in temp or temp[key] is None:
                 temp[key] = {}
+            parent, parent_key = temp, key
             temp = temp[key]
 
     last_key = key_path[-1]
@@ -313,6 +317,16 @@ def update_yaml(data, key_path, new_value):
             del temp[last_key[0]][last_key[1]]
         else:
             del temp[last_key]
+            # Deleting a key whose entry carried comments orphans the comment
+            # tokens; once the mapping is empty ruamel emits them above a
+            # flow-style `{}` at column 0, producing unparseable yaml. Drop
+            # the stale comment metadata so the dump stays valid.
+            if hasattr(temp, "ca"):
+                temp.ca.items.pop(last_key, None)
+                if len(temp) == 0:
+                    temp.ca.comment = None
+                    if parent is not None and hasattr(parent, "ca"):
+                        parent.ca.items.pop(parent_key, None)
     else:
         if isinstance(last_key, tuple):
             if last_key[0] not in temp:

--- a/frigate/util/builtin.py
+++ b/frigate/util/builtin.py
@@ -300,9 +300,9 @@ def update_yaml(data, key_path, new_value):
     for key in key_path[:-1]:
         if isinstance(key, tuple):
             if key[0] not in temp:
-                temp[key[0]] = [{}] * max(1, key[1] + 1)
+                temp[key[0]] = [{} for _ in range(max(1, key[1] + 1))]
             elif len(temp[key[0]]) <= key[1]:
-                temp[key[0]] += [{}] * (key[1] - len(temp[key[0]]) + 1)
+                temp[key[0]].extend({} for _ in range(key[1] - len(temp[key[0]]) + 1))
             parent, parent_key = temp[key[0]], key[1]
             temp = temp[key[0]][key[1]]
         else:
@@ -320,13 +320,13 @@ def update_yaml(data, key_path, new_value):
             # Deleting a key whose entry carried comments orphans the comment
             # tokens; once the mapping is empty ruamel emits them above a
             # flow-style `{}` at column 0, producing unparseable yaml. Drop
-            # the stale comment metadata so the dump stays valid.
-            if hasattr(temp, "ca"):
-                temp.ca.items.pop(last_key, None)
-                if len(temp) == 0:
-                    temp.ca.comment = None
-                    if parent is not None and hasattr(parent, "ca"):
-                        parent.ca.items.pop(parent_key, None)
+            # the stale comment metadata so the dump stays valid. Non-empty
+            # mappings are left alone so sibling comments are preserved.
+            if hasattr(temp, "ca") and len(temp) == 0:
+                temp.ca.items.clear()
+                temp.ca.comment = None
+                if parent is not None and hasattr(parent, "ca"):
+                    parent.ca.items.pop(parent_key, None)
     else:
         if isinstance(last_key, tuple):
             if last_key[0] not in temp:


### PR DESCRIPTION
## Proposed change

Fixes silent config corruption (and rollback) when deleting the last object/motion mask through the UI if the mask's key in `config.yml` has YAML comments attached.

**The bug:** the masks & zones editor deletes the last remaining mask by calling `PUT /api/config/set?cameras.<cam>....mask` (bare key = delete). `update_yaml()` deletes the key, but when that key carried comments, ruamel's comment tokens are orphaned. If the deletion empties the containing mapping, the emitter writes the orphaned comments above a flow-style `{}` at column 0:

```yaml
    objects:
      filters:
        car:
          # cars parked across the street
{}
```

This is unparseable, so `config_set`'s validation step fails and rolls the file back — from the user's perspective the delete silently never sticks, with no error in the UI pointing at the cause.

**Repro (0.17.2 and current dev):**
1. Hand-edit `config.yml` so a camera has a single object filter mask with a `#` comment line above it (a common pattern for people who annotate their configs).
2. Restart, open Settings → Masks & Zones, delete that mask.
3. Delete appears to succeed but the mask returns; the log shows a `ScannerError` from the failed re-parse.

**The fix:** when a deletion empties a mapping, clear the stale ruamel comment metadata (the map's own `ca` and the parent's `ca.items` entry for it) so the dump stays valid. Non-empty mappings are left untouched, so comments on sibling keys are preserved.

Also fixes an adjacent latent bug in the same function: list gap-filling used `[{}] * n`, which fills the list with n references to a single shared dict, so writing through one generated index mutated all of them.

Added `frigate/test/test_update_yaml.py` covering: plain key deletion, the commented-empty-map corruption case (fails on current dev, passes with this fix), sibling preservation on partial deletes, and comment preservation on value updates.

*This fix was developed with AI assistance (Claude Code); the root cause analysis, fix, and tests were verified by running the test suite against both the unpatched and patched code.*

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale. (n/a — backend only)
- [x] The code has been formatted using Ruff (`ruff format frigate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
