### PR TITLE
docs: add Frigate Notify Alert to third party extensions

### DIFF
--- a/docs/docs/integrations/third_party_extensions.md
+++ b/docs/docs/integrations/third_party_extensions.md
@@ -31,6 +31,10 @@ This is a fork (with fixed errors and new features) of [original Double Take](ht
 
 [Frigate Notify](https://github.com/0x2142/frigate-notify) is a simple app designed to send notifications from Frigate to your favorite platforms. Intended to be used with standalone Frigate installations - Home Assistant not required, MQTT is optional but recommended.
 
+## [Frigate Notify Alert](https://github.com/Sysoev86/frigate-notify-alert)
+
+[Frigate Notify Alert](https://github.com/Sysoev86/frigate-notify-alert) sends Frigate events to Telegram as a photo + video media group. It supports multiple camera groups (each notifying its own chat), optional zone filtering (notify only when an object enters a chosen zone), and in-chat buttons to pause notifications for a set time. Works with standalone Frigate over MQTT; Home Assistant not required.
+
 ## [Frigate Snap-Sync](https://github.com/thequantumphysicist/frigate-snap-sync/)
 
 [Frigate Snap-Sync](https://github.com/thequantumphysicist/frigate-snap-sync/) is a program that works in tandem with Frigate. It responds to Frigate when a snapshot or a review is made (and more can be added), and uploads them to one or more remote server(s) of your choice.


### PR DESCRIPTION
## Proposed change

Adds **Frigate Notify Alert** to the Third Party Extensions documentation page
(`docs/docs/integrations/third_party_extensions.md`).

[Sysoev86/frigate-notify-alert](https://github.com/Sysoev86/frigate-notify-alert) sends
Frigate events to Telegram as a photo + video media group. It supports multiple camera
groups (each notifying its own chat), optional zone filtering (notify only when an object
enters a chosen zone), and in-chat buttons to pause notifications for a set time. It works
with standalone Frigate over the unauthenticated API on port 5000 and MQTT; Home Assistant
is not required.

The entry is added alphabetically and follows the existing one-heading + one-paragraph
format used on the page. Docs-only change, no code touched.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features): N/A (small docs addition)

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (via Claude Code).

**How AI was used**: documentation — drafting the one-paragraph extension entry and this PR description, and formatting the change to match the existing page style.

**Extent of AI involvement**: assisted with writing the documentation entry only. No Frigate source code was modified. The linked project itself is authored and maintained by the submitter.

**Human oversight**: the submitter (repo owner) reviewed the wording for accuracy against the project's actual features, verified the alphabetical placement and Markdown formatting, and confirmed the description matches what the tool does.

## Checklist

- [x] The code change is tested and works locally. (Docs-only; Markdown renders correctly.)
- [x] Local tests pass. **Your PR cannot be merged unless tests pass** (docs-only change)
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale. (N/A — no UI changes)
- [ ] The code has been formatted using Ruff (`ruff format frigate`) (N/A — no Python changes)
