### PR TITLE
Register per-camera notifications MQTT callbacks

### DIFF
--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -41,6 +41,18 @@ class MqttClient(Communicator):
         self.publish("available", "stopped", retain=True)
         self.client.disconnect()
 
+    def _notifications_enabled_in_config(self) -> bool:
+        """Whether notifications are configured globally or on any camera.
+
+        Notifications can be enabled per camera with the global config left
+        disabled, so the global topics must consider both (matching how
+        app.py decides to create the WebPushClient).
+        """
+        return self.config.notifications.enabled_in_config or any(
+            cam.enabled and cam.notifications.enabled_in_config
+            for cam in self.config.cameras.values()
+        )
+
     def _set_initial_topics(self) -> None:
         """Set initial state topics."""
         for camera_name, camera in self.config.cameras.items():
@@ -157,7 +169,7 @@ class MqttClient(Communicator):
                     retain=True,
                 )
 
-        if self.config.notifications.enabled_in_config:
+        if self._notifications_enabled_in_config():
             self.publish(
                 "notifications/state",
                 "ON" if self.config.notifications.enabled else "OFF",
@@ -256,6 +268,7 @@ class MqttClient(Communicator):
             "review_detections",
             "object_descriptions",
             "review_descriptions",
+            "notifications",
         ]
 
         for name in self.config.cameras.keys():
@@ -264,6 +277,12 @@ class MqttClient(Communicator):
                     f"{self.mqtt_config.topic_prefix}/{name}/{callback}/set",
                     self.on_mqtt_command,
                 )
+
+            # notifications suspend doesn't follow the /set topic pattern
+            self.client.message_callback_add(
+                f"{self.mqtt_config.topic_prefix}/{name}/notifications/suspend",
+                self.on_mqtt_command,
+            )
 
             if self.config.cameras[name].onvif.host:
                 self.client.message_callback_add(
@@ -289,7 +308,7 @@ class MqttClient(Communicator):
                     self.on_mqtt_command,
                 )
 
-        if self.config.notifications.enabled_in_config:
+        if self._notifications_enabled_in_config():
             self.client.message_callback_add(
                 f"{self.mqtt_config.topic_prefix}/notifications/set",
                 self.on_mqtt_command,

--- a/frigate/test/test_mqtt_topic_registration.py
+++ b/frigate/test/test_mqtt_topic_registration.py
@@ -1,0 +1,100 @@
+"""Tests for MQTT command topic callback registration."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from frigate.comms.mqtt import MqttClient
+
+
+def _make_camera_mock(
+    *,
+    enabled: bool = True,
+    notifications_enabled_in_config: bool = False,
+) -> MagicMock:
+    """Build a camera config mock with the fields _start() reads."""
+    camera = MagicMock()
+    camera.enabled = enabled
+    camera.notifications.enabled_in_config = notifications_enabled_in_config
+    camera.onvif.host = None
+    camera.motion.mask = {}
+    camera.objects.mask = {}
+    camera.zones = {}
+    return camera
+
+
+def _registered_topics(
+    cameras: dict[str, MagicMock],
+    *,
+    global_notifications_enabled_in_config: bool = False,
+) -> set[str]:
+    """Start an MqttClient against a mocked paho client and collect the
+    topics registered via message_callback_add."""
+    config = MagicMock()
+    config.cameras = cameras
+    config.notifications.enabled_in_config = global_notifications_enabled_in_config
+    config.mqtt.topic_prefix = "frigate"
+    config.mqtt.client_id = "frigate"
+    config.mqtt.user = None
+    config.mqtt.tls_ca_certs = None
+    config.mqtt.tls_insecure = None
+
+    with patch("frigate.comms.mqtt.mqtt.Client") as client_cls:
+        mqtt_client = MqttClient(config)
+        mqtt_client.subscribe(MagicMock())
+
+    paho_client = client_cls.return_value
+    return {call.args[0] for call in paho_client.message_callback_add.call_args_list}
+
+
+class TestMqttTopicRegistration(unittest.TestCase):
+    def test_camera_notification_topics_registered(self):
+        """Per-camera notification set/suspend must be registered so paho
+        routes them to the dispatcher (unregistered topics drop silently)."""
+        topics = _registered_topics(
+            {"front_door": _make_camera_mock(notifications_enabled_in_config=True)}
+        )
+
+        self.assertIn("frigate/front_door/notifications/set", topics)
+        self.assertIn("frigate/front_door/notifications/suspend", topics)
+
+    def test_global_set_registered_with_camera_only_notifications(self):
+        """The global topic must work when notifications are enabled only at
+        the camera level, matching the WebPushClient gating in app.py."""
+        topics = _registered_topics(
+            {"front_door": _make_camera_mock(notifications_enabled_in_config=True)},
+            global_notifications_enabled_in_config=False,
+        )
+
+        self.assertIn("frigate/notifications/set", topics)
+
+    def test_global_set_registered_with_global_notifications(self):
+        topics = _registered_topics(
+            {"front_door": _make_camera_mock()},
+            global_notifications_enabled_in_config=True,
+        )
+
+        self.assertIn("frigate/notifications/set", topics)
+
+    def test_global_set_not_registered_when_notifications_unconfigured(self):
+        topics = _registered_topics(
+            {"front_door": _make_camera_mock()},
+            global_notifications_enabled_in_config=False,
+        )
+
+        self.assertNotIn("frigate/notifications/set", topics)
+
+    def test_disabled_camera_does_not_enable_global_set(self):
+        topics = _registered_topics(
+            {
+                "front_door": _make_camera_mock(
+                    enabled=False, notifications_enabled_in_config=True
+                )
+            },
+            global_notifications_enabled_in_config=False,
+        )
+
+        self.assertNotIn("frigate/notifications/set", topics)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR registers `notifications/set` and `notifications/suspend` callbacks for each camera, and gates the global notifications topics on per-camera config as well as global (matching WebPushClient creation in app.py). The original PR that improved notifications (https://github.com/blakeblackshear/frigate/pull/16453) for Frigate 0.16 worked fine for websockets but just never registered the per-camera topics for MQTT.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
