### PR TITLE
Publish segment end time for valid recording segment updates

### DIFF
--- a/frigate/record/maintainer.py
+++ b/frigate/record/maintainer.py
@@ -383,8 +383,11 @@ class RecordingMaintainer(threading.Thread):
                 return None
 
             # this segment has a valid duration and has video data, so publish an update
+            # publish the segment end time so the watchdog measures the age of the
+            # newest validated video data; the start time is already ~2x segment
+            # duration old by the time the next segment finishes and is validated
             self.recordings_publisher.publish(
-                (camera, start_time.timestamp(), cache_path),
+                (camera, end_time.timestamp(), cache_path),
                 RecordingsDataTypeEnum.valid.value,
             )
 


### PR DESCRIPTION
The record watchdog compares latest_valid_segment_time against now() with the record_stale_threshold. Publishing the segment start time means the newest validated timestamp is already ~2x segment duration old in healthy steady state (own duration + next segment recording + maintainer latency), leaving little margin before a working ffmpeg record process is restarted. Publish the end time so staleness measures the actual age of the newest validated video data.

## Proposed change

Patch to record/maintainer.py to complement the earlier change in frigate/video/ffmpeg.py:172.  Replaces start_time.timestamp() with end_time.timestamp() so latest_valid_segment_time represents the actual end/frontier of the segment.   This makes now - latest_valid_segment_time = "wall time since validated video coverage ended" giving ~90 seconds of actual margin with a 60 second segment length or threshold − 1×segment_time instead of threshold − 2×segment_time at any segment length.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR is related to issue: 23038

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):
Claude, ChatGPT

**How AI was used** (e.g., code generation, code review, debugging, documentation):
Troubleshooting and enhancing stability of long running frigate install

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):
Diagnosis, fixing, and testing of the issue over several days

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.
Validation of testing performed by Claude, then cross-review with GPT


## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
