### PR TITLE
Add logout endpoint to Nginx configuration to prevent a new token on logout

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -274,6 +274,13 @@ http {
                 include proxy.conf;
             }
 
+            location /api/logout {
+                auth_request off;
+                rewrite ^/api(/.*)$ $1 break;
+                proxy_pass http://frigate_api;
+                include proxy.conf;
+            }
+
             # Allow unauthenticated access to the first_time_login endpoint
             # so the login page can load help text before authentication.
             location /api/auth/first_time_login {

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -415,7 +415,7 @@ def create_encoded_jwt(user, role, expiration, secret):
     )
 
 
-def set_jwt_cookie(response: Response, cookie_name, encoded_jwt, expiration, secure):
+def set_jwt_cookie(response: Response, cookie_name, encoded_jwt, max_age, secure):
     # TODO: ideally this would set secure as well, but that requires TLS
     # SameSite is intentionally left unset (browsers default to Lax). Setting
     # SameSite=Lax/Strict would stop the cookie from being sent in cross-origin
@@ -427,7 +427,7 @@ def set_jwt_cookie(response: Response, cookie_name, encoded_jwt, expiration, sec
         key=cookie_name,
         value=encoded_jwt,
         httponly=True,
-        expires=expiration,
+        max_age=max_age,
         secure=secure,
     )
 
@@ -762,7 +762,7 @@ def auth(request: Request):
                 success_response,
                 JWT_COOKIE_NAME,
                 new_encoded_jwt,
-                new_expiration,
+                JWT_SESSION_LENGTH,
                 JWT_COOKIE_SECURE,
             )
 
@@ -875,7 +875,7 @@ def login(request: Request, body: AppPostLoginBody):
         encoded_jwt = create_encoded_jwt(user, role, expiration, request.app.jwt_token)
         response = Response("", 200)
         set_jwt_cookie(
-            response, JWT_COOKIE_NAME, encoded_jwt, expiration, JWT_COOKIE_SECURE
+            response, JWT_COOKIE_NAME, encoded_jwt, JWT_SESSION_LENGTH, JWT_COOKIE_SECURE
         )
         # Clear admin_first_time_login flag after successful admin login so the
         # UI stops showing the first-time login documentation link.
@@ -1037,7 +1037,7 @@ async def update_password(
         )
         # Set new JWT cookie on response
         set_jwt_cookie(
-            response, JWT_COOKIE_NAME, encoded_jwt, expiration, JWT_COOKIE_SECURE
+            response, JWT_COOKIE_NAME, encoded_jwt, JWT_SESSION_LENGTH, JWT_COOKIE_SECURE
         )
 
     return response

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -875,7 +875,11 @@ def login(request: Request, body: AppPostLoginBody):
         encoded_jwt = create_encoded_jwt(user, role, expiration, request.app.jwt_token)
         response = Response("", 200)
         set_jwt_cookie(
-            response, JWT_COOKIE_NAME, encoded_jwt, JWT_SESSION_LENGTH, JWT_COOKIE_SECURE
+            response,
+            JWT_COOKIE_NAME,
+            encoded_jwt,
+            JWT_SESSION_LENGTH,
+            JWT_COOKIE_SECURE,
         )
         # Clear admin_first_time_login flag after successful admin login so the
         # UI stops showing the first-time login documentation link.
@@ -1037,7 +1041,11 @@ async def update_password(
         )
         # Set new JWT cookie on response
         set_jwt_cookie(
-            response, JWT_COOKIE_NAME, encoded_jwt, JWT_SESSION_LENGTH, JWT_COOKIE_SECURE
+            response,
+            JWT_COOKIE_NAME,
+            encoded_jwt,
+            JWT_SESSION_LENGTH,
+            JWT_COOKIE_SECURE,
         )
 
     return response


### PR DESCRIPTION

## Proposed change

Prevents /api/logout from silently generating a new frigate_token cookie if called within the `refresh_time`, preventing the user from actually being logged out when they explicitly click "Logout" in the WebUI. This is done by setting `auth_request off;` on `/api/logout` via the nginx config.

Additionally while the exp claim on the JWT is set properly (which is the most important and all that matters for security), there is the cosmetic issue of the cookie itself having an expiry date far (56+ years) into the future. This is due to the fact that the cookies were setting `expires` with a unix timestamp, when `expires` when set to an integer is actually the relative number of seconds a cookie is valid for. 

This is fixed by having the cookies set `max_age = JWT_SESSION_LENGTH`

See issue #23677

I've now tested both of these changes locally and can confirm there are no longer 2 Set-Cookie response headers sent from /api/logout, therefore the cookie is successfully deleted on logout, and the cookies themselves have the appropriate expiration time. 

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #23677
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [X] No AI tools were used in this PR.
- [ ] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
