### PR TITLE
UI tweaks

### DIFF
--- a/docs/docs/configuration/advanced/system.md
+++ b/docs/docs/configuration/advanced/system.md
@@ -72,10 +72,10 @@ Variables prefixed with `FRIGATE_` can be referenced in config fields that suppo
 
 Navigate to <NavPath path="Settings > System > Environment variables" /> to add or edit environment variables.
 
-| Field     | Description                                               |
-| --------- | --------------------------------------------------------- |
-| **Key**   | The environment variable name (e.g., `FRIGATE_MQTT_USER`) |
-| **Value** | The value for the variable                                |
+| Field             | Description                                               |
+| ----------------- | --------------------------------------------------------- |
+| **Variable name** | The environment variable name (e.g., `FRIGATE_MQTT_USER`) |
+| **Value**         | The value for the variable                                |
 
 Variables defined here can be referenced elsewhere in your configuration using the `{FRIGATE_VARIABLE_NAME}` syntax.
 

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -1490,7 +1490,14 @@
       "keyLabel": "Key",
       "valueLabel": "Value",
       "keyPlaceholder": "New key",
-      "remove": "Remove"
+      "remove": "Remove",
+      "providerNameLabel": "Provider name",
+      "providerNamePlaceholder": "e.g., openai",
+      "variableNameLabel": "Variable name",
+      "variableNamePlaceholder": "e.g., MY_VARIABLE",
+      "loggerNameLabel": "Logger name",
+      "loggerNamePlaceholder": "e.g., frigate.record",
+      "keyPatternError": "Use only letters, numbers, hyphens, and underscores (no spaces)"
     },
     "knownPlates": {
       "namePlaceholder": "e.g., Wife's Car",

--- a/web/src/components/config-form/section-configs/environment_vars.ts
+++ b/web/src/components/config-form/section-configs/environment_vars.ts
@@ -7,7 +7,13 @@ const environmentVars: SectionConfigOverrides = {
     advancedFields: [],
     uiSchema: {
       additionalProperties: {
-        "ui:options": { size: "lg" },
+        "ui:options": {
+          size: "lg",
+          additionalPropertyKeyLabel:
+            "configForm.additionalProperties.variableNameLabel",
+          additionalPropertyKeyPlaceholder:
+            "configForm.additionalProperties.variableNamePlaceholder",
+        },
       },
     },
   },

--- a/web/src/components/config-form/section-configs/genai.ts
+++ b/web/src/components/config-form/section-configs/genai.ts
@@ -9,7 +9,15 @@ const genai: SectionConfigOverrides = {
     uiSchema: {
       "ui:options": { disableNestedCard: true },
       "*": {
-        "ui:options": { disableNestedCard: true },
+        "ui:options": {
+          disableNestedCard: true,
+          additionalPropertyKeyLabel:
+            "configForm.additionalProperties.providerNameLabel",
+          additionalPropertyKeyPlaceholder:
+            "configForm.additionalProperties.providerNamePlaceholder",
+          additionalPropertyKeyPattern: "^[a-zA-Z0-9_-]+$",
+          preventKeyRename: true,
+        },
         "ui:order": [
           "provider",
           "api_key",

--- a/web/src/components/config-form/section-configs/logger.ts
+++ b/web/src/components/config-form/section-configs/logger.ts
@@ -12,7 +12,13 @@ const logger: SectionConfigOverrides = {
       },
       logs: {
         additionalProperties: {
-          "ui:options": { enumI18nPrefix: "logger.logLevel" },
+          "ui:options": {
+            enumI18nPrefix: "logger.logLevel",
+            additionalPropertyKeyLabel:
+              "configForm.additionalProperties.loggerNameLabel",
+            additionalPropertyKeyPlaceholder:
+              "configForm.additionalProperties.loggerNamePlaceholder",
+          },
         },
       },
     },

--- a/web/src/components/config-form/theme/templates/WrapIfAdditionalTemplate.tsx
+++ b/web/src/components/config-form/theme/templates/WrapIfAdditionalTemplate.tsx
@@ -6,12 +6,14 @@ import {
   StrictRJSFSchema,
   WrapIfAdditionalTemplateProps,
 } from "@rjsf/utils";
+import { useEffect, useMemo, useState, type FocusEvent } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { LuTrash2 } from "react-icons/lu";
+import type { ConfigFormContext } from "@/types/configForm";
 
 export function WrapIfAdditionalTemplate<
   T = unknown,
@@ -30,6 +32,7 @@ export function WrapIfAdditionalTemplate<
     onKeyRenameBlur,
     readonly,
     required,
+    registry,
     schema,
     uiSchema,
   } = props;
@@ -37,6 +40,55 @@ export function WrapIfAdditionalTemplate<
   const { t } = useTranslation(["views/settings"]);
 
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
+
+  const uiOptions = getUiOptions(uiSchema);
+  const keyIsReadonly = uiOptions.additionalPropertyKeyReadonly === true;
+
+  const keyLabelKey =
+    typeof uiOptions.additionalPropertyKeyLabel === "string"
+      ? uiOptions.additionalPropertyKeyLabel
+      : undefined;
+  const keyPlaceholderKey =
+    typeof uiOptions.additionalPropertyKeyPlaceholder === "string"
+      ? uiOptions.additionalPropertyKeyPlaceholder
+      : undefined;
+  const keyPattern =
+    typeof uiOptions.additionalPropertyKeyPattern === "string"
+      ? uiOptions.additionalPropertyKeyPattern
+      : undefined;
+  const preventKeyRename = uiOptions.preventKeyRename === true;
+
+  const formContext = registry?.formContext as ConfigFormContext | undefined;
+
+  // optionally, lock the key once it's been saved
+  const baseline = formContext?.baselineFormData;
+  const keyLocked =
+    preventKeyRename &&
+    typeof label === "string" &&
+    !!baseline &&
+    Object.prototype.hasOwnProperty.call(baseline, label);
+
+  // controlled key value so we can validate live and block invalid renames.
+  const [keyValue, setKeyValue] = useState<string>(label ?? "");
+  useEffect(() => {
+    setKeyValue(label ?? "");
+  }, [label]);
+
+  const keyRegex = useMemo(
+    () => (keyPattern ? new RegExp(keyPattern) : undefined),
+    [keyPattern],
+  );
+  const keyError = useMemo(() => {
+    if (!keyRegex || keyLocked) return null;
+    if (!keyRegex.test(keyValue)) {
+      return t("configForm.additionalProperties.keyPatternError", {
+        ns: "views/settings",
+        defaultValue:
+          "Use only letters, numbers, hyphens, and underscores (no spaces)",
+      });
+    }
+    return null;
+  }, [keyRegex, keyLocked, keyValue, t]);
 
   if (!additional) {
     return (
@@ -47,20 +99,26 @@ export function WrapIfAdditionalTemplate<
   }
 
   const keyId = `${id}-key`;
-  const keyLabel = t("configForm.additionalProperties.keyLabel", {
-    ns: "views/settings",
-  });
+  const keyLabel = keyLabelKey
+    ? t(keyLabelKey, { ns: "views/settings" })
+    : t("configForm.additionalProperties.keyLabel", { ns: "views/settings" });
   const valueLabel = t("configForm.additionalProperties.valueLabel", {
     ns: "views/settings",
   });
-  const keyPlaceholder = t("configForm.additionalProperties.keyPlaceholder", {
-    ns: "views/settings",
-  });
+  const keyPlaceholder = keyPlaceholderKey
+    ? t(keyPlaceholderKey, { ns: "views/settings" })
+    : t("configForm.additionalProperties.keyPlaceholder", {
+        ns: "views/settings",
+      });
   const removeLabel = t("configForm.additionalProperties.remove", {
     ns: "views/settings",
   });
-  const uiOptions = getUiOptions(uiSchema);
-  const keyIsReadonly = uiOptions.additionalPropertyKeyReadonly === true;
+
+  const commitKeyRename = (e: FocusEvent<HTMLInputElement>) => {
+    if (readonly) return;
+    if (keyError) return;
+    onKeyRenameBlur?.(e);
+  };
 
   return (
     <div
@@ -70,23 +128,30 @@ export function WrapIfAdditionalTemplate<
       {!keyIsReadonly && (
         <div className="col-span-12 space-y-2 md:col-span-2">
           {displayLabel && <Label htmlFor={keyId}>{keyLabel}</Label>}
-          {keyIsReadonly ? (
+          {keyLocked ? (
             <div
               id={keyId}
-              className="flex items-center text-sm text-muted-foreground"
+              className="flex items-center break-all text-sm text-primary-variant"
             >
               {label}
             </div>
           ) : (
-            <Input
-              id={keyId}
-              name={keyId}
-              required={required}
-              defaultValue={label}
-              placeholder={keyPlaceholder}
-              disabled={disabled || readonly}
-              onBlur={!readonly ? onKeyRenameBlur : undefined}
-            />
+            <>
+              <Input
+                id={keyId}
+                name={keyId}
+                required={required}
+                value={keyValue}
+                placeholder={keyPlaceholder}
+                disabled={disabled || readonly}
+                onChange={(e) => setKeyValue(e.target.value)}
+                onBlur={!readonly ? commitKeyRename : undefined}
+                aria-invalid={keyError ? true : undefined}
+              />
+              {keyError && (
+                <p className="text-xs text-destructive">{keyError}</p>
+              )}
+            </>
           )}
         </div>
       )}


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
Renaming a GenAI provider in the UI silently dropped its API key because the key is redacted and never sent back to the browser, so a rename (delete + recreate) can't preserve it. Renaming a GenAI block is a very rare operation, so the simplest, most honest fix is to just prevent renaming a saved provider key from the UI. Users can rename it via YAML if they really need to.

This PR also adds clearer key-field labels ("Provider name" / "Variable name" / "Logger name") in place of the generic "Key" and adds validation for new GenAI provider keys (alphanumeric, underscore, dash only).


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
