### PR TITLE
Fix enabled flag for custom classification models

### DIFF
--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -200,6 +200,9 @@ class EmbeddingMaintainer(threading.Thread):
             )
 
         for model_config in self.config.classification.custom.values():
+            if not model_config.enabled:
+                continue
+
             self.realtime_processors.append(
                 CustomStateClassificationProcessor(
                     self.config, model_config, self.requestor, self.metrics
@@ -332,6 +335,25 @@ class EmbeddingMaintainer(threading.Thread):
         for processor in self.post_processors:
             processor.update_config(topic, payload)
 
+    def _remove_custom_classification_processor(self, model_name: str) -> None:
+        """Shut down and drop any running processor for a custom model."""
+        remaining = []
+        for processor in self.realtime_processors:
+            if (
+                isinstance(
+                    processor,
+                    (
+                        CustomStateClassificationProcessor,
+                        CustomObjectClassificationProcessor,
+                    ),
+                )
+                and processor.model_config.name == model_name
+            ):
+                processor.shutdown()
+            else:
+                remaining.append(processor)
+        self.realtime_processors = remaining
+
     def _handle_custom_classification_update(
         self, topic: str, model_config: Any
     ) -> None:
@@ -339,29 +361,20 @@ class EmbeddingMaintainer(threading.Thread):
         model_name = topic.split("/")[-1]
 
         if model_config is None:
-            remaining = []
-            for processor in self.realtime_processors:
-                if (
-                    isinstance(
-                        processor,
-                        (
-                            CustomStateClassificationProcessor,
-                            CustomObjectClassificationProcessor,
-                        ),
-                    )
-                    and processor.model_config.name == model_name
-                ):
-                    processor.shutdown()
-                else:
-                    remaining.append(processor)
-            self.realtime_processors = remaining
-
+            self._remove_custom_classification_processor(model_name)
             logger.info(
                 f"Successfully removed classification processor for model: {model_name}"
             )
             return
 
         self.config.classification.custom[model_name] = model_config
+
+        # A disabled model must not run; tear down any existing processor and
+        # do not register a new one.
+        if not model_config.enabled:
+            self._remove_custom_classification_processor(model_name)
+            logger.info(f"Disabled classification processor for model: {model_name}")
+            return
 
         # Check if processor already exists
         for processor in self.realtime_processors:
@@ -702,7 +715,11 @@ class EmbeddingMaintainer(threading.Thread):
             and "license_plate" not in camera_config.objects.track
         )
 
-        if not dedicated_lpr_enabled and len(self.config.classification.custom) == 0:
+        has_enabled_custom = any(
+            c.enabled for c in self.config.classification.custom.values()
+        )
+
+        if not dedicated_lpr_enabled and not has_enabled_custom:
             # no active features that use this data
             return
 

--- a/frigate/test/test_classification_enabled.py
+++ b/frigate/test/test_classification_enabled.py
@@ -1,0 +1,106 @@
+"""Tests that disabled custom classification models are not registered or run."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Mock TFLite before importing the maintainer / classification modules
+_MOCK_MODULES = [
+    "tflite_runtime",
+    "tflite_runtime.interpreter",
+    "ai_edge_litert",
+    "ai_edge_litert.interpreter",
+]
+for mod in _MOCK_MODULES:
+    if mod not in sys.modules:
+        sys.modules[mod] = MagicMock()
+
+from frigate.data_processing.real_time.custom_classification import (  # noqa: E402
+    CustomObjectClassificationProcessor,
+)
+from frigate.embeddings.maintainer import EmbeddingMaintainer  # noqa: E402
+
+
+class TestCustomClassificationEnabledGating(unittest.TestCase):
+    """A model with enabled: false must not keep a processor registered."""
+
+    def _make_maintainer(self) -> EmbeddingMaintainer:
+        # Bypass the heavy __init__; only the attributes touched by the
+        # config update path are needed for these tests.
+        maintainer = EmbeddingMaintainer.__new__(EmbeddingMaintainer)
+        maintainer.realtime_processors = []
+        maintainer.config = MagicMock()
+        maintainer.config.classification.custom = {}
+        maintainer.requestor = MagicMock()
+        maintainer.metrics = MagicMock()
+        maintainer.event_metadata_publisher = MagicMock()
+        return maintainer
+
+    def _make_model_config(self, name: str, enabled: bool) -> MagicMock:
+        model_config = MagicMock()
+        model_config.name = name
+        model_config.enabled = enabled
+        model_config.state_config = None
+        return model_config
+
+    def _make_processor(self, name: str) -> MagicMock:
+        processor = MagicMock(spec=CustomObjectClassificationProcessor)
+        processor.model_config = MagicMock()
+        processor.model_config.name = name
+        return processor
+
+    def test_disabled_update_tears_down_existing_processor(self):
+        """Toggling a running model to disabled shuts down and drops its processor."""
+        maintainer = self._make_maintainer()
+        processor = self._make_processor("atli")
+        maintainer.realtime_processors = [processor]
+
+        maintainer._handle_custom_classification_update(
+            "config/classification/custom/atli",
+            self._make_model_config("atli", enabled=False),
+        )
+
+        processor.shutdown.assert_called_once()
+        self.assertEqual(maintainer.realtime_processors, [])
+
+    def test_disabled_update_does_not_register_processor(self):
+        """A disabled model that has no processor is never registered."""
+        maintainer = self._make_maintainer()
+
+        maintainer._handle_custom_classification_update(
+            "config/classification/custom/atli",
+            self._make_model_config("atli", enabled=False),
+        )
+
+        self.assertEqual(maintainer.realtime_processors, [])
+
+    def test_disabled_update_leaves_other_processors_untouched(self):
+        """Disabling one model must not affect other running processors."""
+        maintainer = self._make_maintainer()
+        other = self._make_processor("simbi")
+        maintainer.realtime_processors = [other]
+
+        maintainer._handle_custom_classification_update(
+            "config/classification/custom/atli",
+            self._make_model_config("atli", enabled=False),
+        )
+
+        other.shutdown.assert_not_called()
+        self.assertEqual(maintainer.realtime_processors, [other])
+
+    def test_removed_model_tears_down_processor(self):
+        """A None payload (model deleted) still shuts down its processor."""
+        maintainer = self._make_maintainer()
+        processor = self._make_processor("atli")
+        maintainer.realtime_processors = [processor]
+
+        maintainer._handle_custom_classification_update(
+            "config/classification/custom/atli", None
+        )
+
+        processor.shutdown.assert_called_once()
+        self.assertEqual(maintainer.realtime_processors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
Custom classification models set to `enabled: false` were still registered and kept running. This PR fixes the enabled flag for both startup and live config updates, tearing down any running processor when a model is disabled.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/23680
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
