### PR TITLE
Make face detection_threshold effective below 0.5

### DIFF
--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -127,7 +127,7 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
             os.path.join(MODEL_CACHE_DIR, "facedet/facedet.onnx"),
             config="",
             input_size=(320, 320),
-            score_threshold=0.5,
+            score_threshold=min(0.5, self.face_config.detection_threshold),
             nms_threshold=0.3,
         )
         self.faces_per_second.start()


### PR DESCRIPTION
## Proposed change

When `face_recognition.detection_threshold` is set below `0.5`, the value is silently ignored because YuNet's internal `score_threshold` is hardcoded to `0.5` in the `FaceDetectorYN.create()` call. The configured threshold is only applied afterwards as a post-filter, on
results that already survived the internal `0.5` cutoff.

On cameras with low-resolution detect streams (e.g. a 736x416 substream), real faces routinely score 0.3–0.5 in YuNet, so face recognition never runs on them — even though the embedding model handles such crops well.

This changes the internal threshold to `min(0.5, detection_threshold)`, so a configured value below `0.5` is respected. Behaviour is unchanged for the default and for any value at or above `0.5`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR is related to issue:
- Link to discussion with maintainers:

## AI disclosure

- [x] AI tools were used in this PR. Details below:

**AI tool(s) used:** Claude (Claude Code)

**How AI was used:** Debugging and root-cause analysis.

**Extent of AI involvement:** The single-line change.

**Human oversight:** I deployed the equivalent change on my own Frigate 0.17.2 installation, ran before/after walk-up tests on my camera, and reviewed the final diff.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented-out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the en locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)