### PR TITLE
Add native OpenID Connect authentication with group-to-role mapping

### DIFF
--- a/docs/docs/configuration/authentication.md
+++ b/docs/docs/configuration/authentication.md
@@ -141,7 +141,7 @@ Changing the secret will invalidate current tokens.
 
 ## Proxy configuration
 
-Frigate can be configured to leverage features of common upstream authentication proxies such as Authelia, Authentik, oauth2_proxy, or traefik-forward-auth. Frigate does not implement OIDC, SAML, or LDAP natively; as an NVR focused on recording and object detection, it relies on robust, battle-tested proxies to handle those protocols and passes the authenticated user and role through via headers (see below).
+Frigate can be configured to leverage features of common upstream authentication proxies such as Authelia, Authentik, oauth2_proxy, or traefik-forward-auth. Frigate also has native OpenID Connect (OIDC) support (see the [OpenID Connect](#openid-connect-oidc) section below) for deployments that do not want an additional proxy in front of Frigate. SAML and LDAP are still expected to be handled by an upstream proxy.
 
 If you are leveraging the authentication of an upstream proxy, you likely want to disable Frigate's authentication as there is no correspondence between users in Frigate's database and users authenticated via the proxy. Optionally, if communication between the reverse proxy and Frigate is over an untrusted network, you should set an `auth_secret` in the `proxy` config and configure the proxy to send the secret value as a header named `X-Proxy-Secret`. Assuming this is an untrusted network, you will also want to [configure a real TLS certificate](tls.md) to ensure the traffic can't simply be sniffed to steal the secret.
 
@@ -307,6 +307,113 @@ Frigate gracefully performs login page redirection that should work with most au
 ### Custom logout url
 
 If your reverse proxy has a dedicated logout url, you can specify using the `logout_url` config option. This will update the link for the `Logout` link in the UI.
+
+## OpenID Connect (OIDC)
+
+Frigate can authenticate users directly against an OpenID Connect provider (Authentik, Keycloak, Zitadel, Okta, Auth0, Google Workspace, and other standards-compliant identity providers). When enabled a **Sign in with SSO** button appears on the login page and the existing local admin login remains available as a fallback.
+
+Frigate implements the authorization code flow with PKCE and validates the returned ID token against the provider's published JWKS. On a successful login Frigate maps the user's group claims to a Frigate role, creates or updates a matching row in the user table (so features like notification tokens work), and issues the same `frigate_token` JWT cookie used by native login.
+
+### Prerequisites
+
+Register Frigate as a confidential client in your identity provider with:
+
+- Grant type: `authorization_code`
+- Response type: `code`
+- Redirect URI: `https://<your-frigate-host>/api/oidc/callback`
+- Recommended scopes: `openid`, `email`, `profile`, and whatever scope emits the user's groups (for example `groups`)
+
+### Minimal configuration
+
+```yaml
+auth:
+  enabled: true # native login must remain enabled so Frigate can issue its own session cookie
+  oidc:
+    enabled: true
+    issuer: https://idp.example.com
+    client_id: frigate
+    client_secret: "{FRIGATE_OIDC_SECRET}" # or the literal value; env substitution is supported
+```
+
+Frigate fetches `<issuer>/.well-known/openid-configuration` at startup of the flow, so only the issuer URL is required — the authorization, token, JWKS, and (optional) end-session endpoints are discovered automatically.
+
+### Group to role mapping
+
+The `group_map` block translates provider group claims into Frigate roles. The mapping semantics mirror the `role_map` under `proxy.header_map`: any match wins, but if the `admin` mapping matches Frigate resolves the session to `admin` to prevent an accidental downgrade when a user belongs to both an admin group and a lower-privilege group.
+
+```yaml
+auth:
+  roles:
+    operator:
+      - front_door
+      - garage
+  oidc:
+    enabled: true
+    issuer: https://idp.example.com
+    client_id: frigate
+    client_secret: "{FRIGATE_OIDC_SECRET}"
+    groups_claim: groups # ID token claim to read; may be a list or a delimited string
+    group_map:
+      admin:
+        - frigate-admins
+      viewer:
+        - frigate-users
+      operator:
+        - frigate-operators
+    default_role: viewer # fallback role when no group_map entry matches
+```
+
+If the user's groups claim contains none of the mapped values, Frigate assigns `default_role`. If `default_role` is unset or invalid, `viewer` is used.
+
+### Username and email
+
+Frigate reads the username from the claim named by `username_claim` (default `preferred_username`), falling back to `email` and then `sub`. Non-alphanumeric characters other than `.` and `_` are replaced with `.` so the value fits the user table's format, and the result is truncated to 30 characters. The `email` claim, when present, is stored on the user row.
+
+The stable identity used to link a returning user to their existing row is the ID token's `sub` claim, stored on the user row's `external_id` column. Renaming the username in the identity provider does not create a duplicate row.
+
+### Auto-provisioning
+
+By default (`auto_provision: true`), Frigate creates or updates a user row on every successful OIDC login. Set `auto_provision: false` to require that the user already exists in Frigate's database, matched either by `external_id` or `username`. This is useful when you want to explicitly onboard OIDC users through **Settings > Users** before granting access.
+
+### Redirect URI
+
+Frigate derives the redirect URI at request time as `<scheme>://<host>/api/oidc/callback`, honoring `X-Forwarded-Proto` and `X-Forwarded-Host` when set by a trusted proxy. If your setup needs a fixed value (for example when the public URL differs from the request host), set `auth.oidc.redirect_uri` to the absolute URL.
+
+### Logout
+
+If `auth.oidc.end_session_endpoint` is set, Frigate redirects to that URL from `/api/logout` after clearing the local session cookie. Leave it unset to keep the default behavior of redirecting back to the login page.
+
+### Full example
+
+```yaml
+auth:
+  enabled: true
+  roles:
+    operator:
+      - front_door
+      - garage
+  oidc:
+    enabled: true
+    issuer: https://idp.example.com
+    client_id: frigate
+    client_secret: "{FRIGATE_OIDC_SECRET}"
+    redirect_uri: https://frigate.example.com/api/oidc/callback
+    scopes:
+      - openid
+      - email
+      - profile
+      - groups
+    username_claim: preferred_username
+    groups_claim: groups
+    group_map:
+      admin:
+        - frigate-admins
+      operator:
+        - frigate-operators
+    default_role: viewer
+    auto_provision: true
+    end_session_endpoint: https://idp.example.com/oidc/logout
+```
 
 ## User Roles
 

--- a/docs/static/frigate-api.yaml
+++ b/docs/static/frigate-api.yaml
@@ -91,7 +91,7 @@ paths:
       description: |-
         **Access:** Public — no authentication required.
 
-        Logs out the current user by clearing the session cookie. After logout, subsequent requests will require re-authentication.
+        Logs out the current user by clearing the session cookie. When OIDC end-session is configured, the browser is redirected to the provider's end-session endpoint.
       operationId: logout_logout_get
       responses:
         '200':
@@ -134,6 +134,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security: []
+      x-required-role: public
+  /oidc/config:
+    get:
+      tags:
+        - Auth
+      summary: Get OIDC availability
+      description: |-
+        **Access:** Public — no authentication required.
+
+        Returns whether OIDC single sign-on is configured so the login page can render an SSO button.
+      operationId: oidc_config_oidc_config_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+      security: []
+      x-required-role: public
+  /oidc/login:
+    get:
+      tags:
+        - Auth
+      summary: Start OIDC login
+      description: |-
+        **Access:** Public — no authentication required.
+
+        Redirects the browser to the configured OIDC provider to begin the authorization code flow.
+      operationId: oidc_login_oidc_login_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+      security: []
+      x-required-role: public
+  /oidc/callback:
+    get:
+      tags:
+        - Auth
+      summary: Complete OIDC login
+      description: |-
+        **Access:** Public — no authentication required.
+
+        Callback endpoint invoked by the OIDC provider with the authorization code.
+      operationId: oidc_callback_oidc_callback_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
       security: []
       x-required-role: public
   /users:

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -31,6 +31,23 @@ from frigate.api.media_auth import (
     deny_response_for_media_uri,
     is_role_restricted,
 )
+from frigate.api.oidc import (
+    STATE_COOKIE_NAME,
+    STATE_TTL_SECONDS,
+    OidcError,
+    build_authorization_url,
+    decode_state_cookie,
+    encode_state_cookie,
+    exchange_code_for_tokens,
+    generate_nonce,
+    generate_pkce_pair,
+    generate_state,
+    get_discovery,
+    resolve_oidc_role,
+    resolve_username,
+    sanitize_username,
+    verify_id_token,
+)
 from frigate.config import AuthConfig, NetworkingConfig, ProxyConfig
 from frigate.const import CONFIG_DIR, JWT_SECRET_ENV_VAR, PASSWORD_HASH_ALGORITHM
 from frigate.models import User
@@ -67,6 +84,9 @@ def require_admin_by_default():
         "/auth/first_time_login",
         "/login",
         "/logout",
+        "/oidc/config",
+        "/oidc/login",
+        "/oidc/callback",
         # Authenticated user endpoints (allow_any_authenticated)
         "/profile",
         "/profiles",
@@ -826,12 +846,16 @@ def profile(request: Request):
     "/logout",
     dependencies=[Depends(allow_public())],
     summary="Logout user",
-    description="Logs out the current user by clearing the session cookie. After logout, subsequent requests will require re-authentication.",
+    description="Logs out the current user by clearing the session cookie. When OIDC end-session is configured, the browser is redirected to the provider's end-session endpoint.",
 )
 def logout(request: Request):
     auth_config: AuthConfig = request.app.frigate_config.auth
-    response = RedirectResponse("/login", status_code=303)
+    target = "/login"
+    if auth_config.oidc.enabled and auth_config.oidc.end_session_endpoint:
+        target = auth_config.oidc.end_session_endpoint
+    response = RedirectResponse(target, status_code=303)
     response.delete_cookie(auth_config.cookie_name)
+    response.delete_cookie(STATE_COOKIE_NAME, path="/")
     return response
 
 
@@ -884,6 +908,293 @@ def login(request: Request, body: AppPostLoginBody):
 
         return response
     return JSONResponse(content={"message": "Login failed"}, status_code=401)
+
+
+def _resolve_oidc_redirect_uri(request: Request) -> str:
+    oidc = request.app.frigate_config.auth.oidc
+    if oidc.redirect_uri:
+        return oidc.redirect_uri
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    forwarded_host = request.headers.get("x-forwarded-host")
+    scheme = forwarded_proto or request.url.scheme
+    host = forwarded_host or request.headers.get("host") or request.url.netloc
+    return f"{scheme}://{host}/api/oidc/callback"
+
+
+def _issue_oidc_session(
+    request: Request,
+    username: str,
+    role: str,
+    response: Response,
+) -> None:
+    """Issue the standard frigate_token JWT cookie for an OIDC-authenticated user."""
+    JWT_COOKIE_NAME = request.app.frigate_config.auth.cookie_name
+    JWT_COOKIE_SECURE = request.app.frigate_config.auth.cookie_secure
+    JWT_SESSION_LENGTH = request.app.frigate_config.auth.session_length
+    expiration = int(time.time()) + JWT_SESSION_LENGTH
+    encoded_jwt = create_encoded_jwt(username, role, expiration, request.app.jwt_token)
+    set_jwt_cookie(
+        response, JWT_COOKIE_NAME, encoded_jwt, expiration, JWT_COOKIE_SECURE
+    )
+
+
+def _upsert_oidc_user(
+    username: str,
+    role: str,
+    external_id: str,
+    email: str | None,
+) -> None:
+    """Insert or update the Frigate user row for an OIDC login.
+
+    The external_id (the id_token 'sub' claim) is the stable identity: if a
+    user with the same external_id already exists we update it, otherwise a
+    new row is created with a null password_hash. Notification tokens default
+    to an empty list on first insert.
+    """
+    existing = User.select().where(User.external_id == external_id).first()
+    if existing is not None:
+        # Keep the existing username as the primary key even if the IdP claim
+        # changes; only refresh mutable attributes.
+        User.update(
+            {
+                User.role: role,
+                User.email: email,
+            }
+        ).where(User.external_id == external_id).execute()
+        return
+
+    # No row keyed on external_id yet. Fall back to matching by username so a
+    # pre-existing local admin can be linked to their OIDC identity on first
+    # login without losing their notification tokens.
+    match_by_name = User.select().where(User.username == username).first()
+    if match_by_name is not None:
+        User.update(
+            {
+                User.role: role,
+                User.email: email,
+                User.external_id: external_id,
+            }
+        ).where(User.username == username).execute()
+        return
+
+    User.insert(
+        {
+            User.username: username,
+            User.role: role,
+            User.password_hash: None,
+            User.external_id: external_id,
+            User.email: email,
+            User.notification_tokens: [],
+        }
+    ).execute()
+
+
+@router.get(
+    "/oidc/config",
+    dependencies=[Depends(allow_public())],
+    summary="Get OIDC availability",
+    description="Returns whether OIDC single sign-on is configured so the login page can render an SSO button.",
+)
+def oidc_config(request: Request):
+    oidc = request.app.frigate_config.auth.oidc
+    return JSONResponse(content={"enabled": bool(oidc.enabled)})
+
+
+@router.get(
+    "/oidc/login",
+    dependencies=[Depends(allow_public())],
+    summary="Start OIDC login",
+    description="Redirects the browser to the configured OIDC provider to begin the authorization code flow.",
+)
+async def oidc_login(request: Request):
+    auth_config: AuthConfig = request.app.frigate_config.auth
+    if not auth_config.oidc.enabled:
+        return JSONResponse(content={"message": "OIDC is not enabled"}, status_code=404)
+    if request.app.jwt_token is None:
+        return JSONResponse(
+            content={"message": "OIDC requires auth.enabled to be true"},
+            status_code=400,
+        )
+
+    try:
+        discovery = await get_discovery(auth_config.oidc)
+    except OidcError as err:
+        logger.error("OIDC discovery failed: %s", err)
+        return JSONResponse(
+            content={"message": "OIDC provider is not reachable"},
+            status_code=502,
+        )
+
+    state = generate_state()
+    nonce = generate_nonce()
+    verifier, challenge = generate_pkce_pair()
+    redirect_uri = _resolve_oidc_redirect_uri(request)
+    return_to = request.query_params.get("return_to", "/")
+
+    try:
+        authorization_url = build_authorization_url(
+            discovery, auth_config.oidc, redirect_uri, state, nonce, challenge
+        )
+    except OidcError as err:
+        logger.error("Failed to build OIDC authorization URL: %s", err)
+        return JSONResponse(
+            content={"message": "OIDC provider configuration is invalid"},
+            status_code=502,
+        )
+
+    cookie_value = encode_state_cookie(
+        request.app.jwt_token, state, nonce, verifier, return_to
+    )
+    response = RedirectResponse(authorization_url, status_code=302)
+    response.set_cookie(
+        key=STATE_COOKIE_NAME,
+        value=cookie_value,
+        httponly=True,
+        secure=auth_config.cookie_secure,
+        max_age=STATE_TTL_SECONDS,
+        samesite="lax",
+        path="/",
+    )
+    return response
+
+
+@router.get(
+    "/oidc/callback",
+    dependencies=[Depends(allow_public())],
+    summary="Complete OIDC login",
+    description="Callback endpoint invoked by the OIDC provider with the authorization code.",
+)
+async def oidc_callback(request: Request):
+    auth_config: AuthConfig = request.app.frigate_config.auth
+    if not auth_config.oidc.enabled:
+        return JSONResponse(content={"message": "OIDC is not enabled"}, status_code=404)
+    if request.app.jwt_token is None:
+        return JSONResponse(
+            content={"message": "OIDC requires auth.enabled to be true"},
+            status_code=400,
+        )
+
+    error = request.query_params.get("error")
+    if error:
+        description = request.query_params.get("error_description", "")
+        logger.warning("OIDC provider returned error: %s %s", error, description)
+        return _oidc_failure_response(
+            request, "The identity provider rejected the login."
+        )
+
+    code = request.query_params.get("code")
+    returned_state = request.query_params.get("state")
+    if not code or not returned_state:
+        return _oidc_failure_response(
+            request, "The identity provider response was incomplete."
+        )
+
+    encoded_state = request.cookies.get(STATE_COOKIE_NAME)
+    if not encoded_state:
+        return _oidc_failure_response(
+            request, "The login session expired. Please try again."
+        )
+
+    try:
+        state_claims = decode_state_cookie(request.app.jwt_token, encoded_state)
+    except OidcError as err:
+        logger.warning("Rejecting OIDC callback: %s", err)
+        return _oidc_failure_response(
+            request, "The login session is invalid. Please try again."
+        )
+
+    if not secrets.compare_digest(state_claims.get("state", ""), returned_state):
+        logger.warning("Rejecting OIDC callback: state parameter mismatch")
+        return _oidc_failure_response(
+            request, "The login session did not match. Please try again."
+        )
+
+    redirect_uri = _resolve_oidc_redirect_uri(request)
+    try:
+        discovery = await get_discovery(auth_config.oidc)
+        tokens = await exchange_code_for_tokens(
+            discovery,
+            auth_config.oidc,
+            code,
+            redirect_uri,
+            state_claims.get("cv", ""),
+        )
+        claims = await verify_id_token(
+            tokens["id_token"], auth_config.oidc, state_claims.get("nonce", "")
+        )
+    except OidcError as err:
+        logger.error("OIDC callback failed: %s", err)
+        return _oidc_failure_response(
+            request, "Sign-in failed. Please try again or contact your administrator."
+        )
+
+    external_id = str(claims.get("sub") or "")
+    if not external_id:
+        logger.error("OIDC id_token missing 'sub' claim")
+        return _oidc_failure_response(
+            request, "The identity provider did not return a stable user identifier."
+        )
+
+    try:
+        raw_username = resolve_username(claims, auth_config.oidc)
+        username = sanitize_username(raw_username)
+    except OidcError as err:
+        logger.error("OIDC username resolution failed: %s", err)
+        return _oidc_failure_response(
+            request, "The identity provider did not return a usable username."
+        )
+
+    config_roles = set(auth_config.roles.keys())
+    role = resolve_oidc_role(claims, auth_config.oidc, config_roles)
+    email = claims.get("email")
+    if email is not None:
+        email = str(email)
+
+    if auth_config.oidc.auto_provision:
+        try:
+            _upsert_oidc_user(username, role, external_id, email)
+        except Exception:
+            logger.exception("Failed to auto-provision OIDC user %s", username)
+            return _oidc_failure_response(
+                request,
+                "Unable to provision the user account. Please contact your administrator.",
+            )
+    else:
+        # Require an existing local user matched by external_id or username.
+        existing = (
+            User.select()
+            .where((User.external_id == external_id) | (User.username == username))
+            .first()
+        )
+        if existing is None:
+            logger.warning(
+                "Rejecting OIDC login for %s: auto_provision is disabled and no matching user exists",
+                username,
+            )
+            return _oidc_failure_response(
+                request, "This account is not authorized to sign in."
+            )
+        role = existing.role
+        username = existing.username
+
+    return_to = state_claims.get("rt") or "/"
+    if not return_to.startswith("/"):
+        return_to = "/"
+    response = RedirectResponse(return_to, status_code=303)
+    response.delete_cookie(STATE_COOKIE_NAME, path="/")
+    _issue_oidc_session(request, username, role, response)
+    if role == "admin":
+        auth_config.admin_first_time_login = False
+    return response
+
+
+def _oidc_failure_response(request: Request, message: str) -> RedirectResponse:
+    """Redirect back to /login with an inline error message via query string."""
+    from urllib.parse import quote
+
+    response = RedirectResponse(f"/login?oidc_error={quote(message)}", status_code=303)
+    response.delete_cookie(STATE_COOKIE_NAME, path="/")
+    return response
 
 
 @router.get(

--- a/frigate/api/oidc.py
+++ b/frigate/api/oidc.py
@@ -1,0 +1,374 @@
+"""OpenID Connect helpers for Frigate authentication.
+
+Implements the pieces of the OIDC authorization code flow (with PKCE) that
+Frigate needs to accept SSO logins from an external identity provider:
+
+    * discovery document fetch + short-lived in-memory cache
+    * JWKS fetch + cache
+    * PKCE / state / nonce generation and short-lived signed cookies
+    * ID token verification via joserfc against the provider's JWKS
+    * group claim -> Frigate role resolution mirroring resolve_role semantics
+
+The endpoints in frigate/api/auth.py compose these helpers.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode
+
+import aiohttp
+from joserfc import jwt
+from joserfc.errors import JoseError
+from joserfc.jwk import KeySet
+
+from frigate.config.auth import OidcConfig
+
+logger = logging.getLogger(__name__)
+
+
+DISCOVERY_TTL_SECONDS = 60 * 60
+JWKS_TTL_SECONDS = 60 * 60
+STATE_COOKIE_NAME = "frigate_oidc_state"
+STATE_TTL_SECONDS = 600
+STATE_JWT_TYPE = "frigate-oidc-state"
+SUPPORTED_ID_TOKEN_ALGS = (
+    "RS256",
+    "RS384",
+    "RS512",
+    "PS256",
+    "PS384",
+    "PS512",
+    "ES256",
+    "ES384",
+    "ES512",
+    "EdDSA",
+)
+
+
+class OidcError(Exception):
+    """Raised when the OIDC flow fails in a user-visible way."""
+
+
+@dataclass
+class _CacheEntry:
+    value: Any
+    expires_at: float
+
+
+_cache: dict[str, _CacheEntry] = {}
+
+
+def _cache_get(key: str) -> Any | None:
+    entry = _cache.get(key)
+    if entry is None:
+        return None
+    if entry.expires_at <= time.time():
+        _cache.pop(key, None)
+        return None
+    return entry.value
+
+
+def _cache_set(key: str, value: Any, ttl: int) -> None:
+    _cache[key] = _CacheEntry(value=value, expires_at=time.time() + ttl)
+
+
+def _clear_cache_for(prefix: str) -> None:
+    for key in list(_cache):
+        if key.startswith(prefix):
+            _cache.pop(key, None)
+
+
+async def _http_get_json(url: str) -> dict:
+    timeout = aiohttp.ClientTimeout(total=10)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.get(url) as response:
+            response.raise_for_status()
+            return await response.json(content_type=None)
+
+
+async def _http_post_form(url: str, data: dict, auth: aiohttp.BasicAuth) -> dict:
+    timeout = aiohttp.ClientTimeout(total=10)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.post(url, data=data, auth=auth) as response:
+            if response.status >= 400:
+                body = await response.text()
+                logger.debug(
+                    "OIDC token endpoint responded %s: %s", response.status, body
+                )
+                raise OidcError(f"Token endpoint returned status {response.status}")
+            return await response.json(content_type=None)
+
+
+async def get_discovery(config: OidcConfig) -> dict:
+    """Fetch and cache the OpenID Connect discovery document."""
+    if not config.issuer:
+        raise OidcError("OIDC issuer is not configured")
+    cache_key = f"discovery:{config.issuer}"
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+    url = config.issuer.rstrip("/") + "/.well-known/openid-configuration"
+    try:
+        doc = await _http_get_json(url)
+    except Exception as err:
+        raise OidcError(f"Failed to fetch OIDC discovery document: {err}") from err
+    _cache_set(cache_key, doc, DISCOVERY_TTL_SECONDS)
+    return doc
+
+
+async def get_jwks(config: OidcConfig) -> KeySet:
+    """Fetch and cache the provider's JWKS as a joserfc KeySet."""
+    discovery = await get_discovery(config)
+    jwks_uri = discovery.get("jwks_uri")
+    if not jwks_uri:
+        raise OidcError("OIDC discovery document is missing jwks_uri")
+    cache_key = f"jwks:{jwks_uri}"
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+    try:
+        raw = await _http_get_json(jwks_uri)
+    except Exception as err:
+        raise OidcError(f"Failed to fetch OIDC JWKS: {err}") from err
+    try:
+        key_set = KeySet.import_key_set(raw)
+    except Exception as err:
+        raise OidcError(f"Failed to parse OIDC JWKS: {err}") from err
+    _cache_set(cache_key, key_set, JWKS_TTL_SECONDS)
+    return key_set
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    """Return (code_verifier, code_challenge) for PKCE S256."""
+    verifier = _b64url(secrets.token_bytes(64))
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+def generate_state() -> str:
+    return _b64url(secrets.token_bytes(32))
+
+
+def generate_nonce() -> str:
+    return _b64url(secrets.token_bytes(32))
+
+
+def encode_state_cookie(
+    jwt_key,
+    state: str,
+    nonce: str,
+    code_verifier: str,
+    return_to: str,
+    ttl: int = STATE_TTL_SECONDS,
+) -> str:
+    """Sign the transient OIDC state into a short-lived cookie value."""
+    claims = {
+        "typ": STATE_JWT_TYPE,
+        "state": state,
+        "nonce": nonce,
+        "cv": code_verifier,
+        "rt": return_to,
+        "exp": int(time.time()) + ttl,
+        "iat": int(time.time()),
+    }
+    return jwt.encode({"alg": "HS256"}, claims, jwt_key)
+
+
+def decode_state_cookie(jwt_key, encoded: str) -> dict:
+    """Verify and decode the state cookie; raises OidcError on failure."""
+    try:
+        token = jwt.decode(encoded, jwt_key)
+    except JoseError as err:
+        raise OidcError(f"Invalid OIDC state cookie: {err}") from err
+    claims = token.claims
+    if claims.get("typ") != STATE_JWT_TYPE:
+        raise OidcError("OIDC state cookie has an unexpected type")
+    if int(claims.get("exp", 0)) <= int(time.time()):
+        raise OidcError("OIDC state cookie has expired")
+    return claims
+
+
+def build_authorization_url(
+    discovery: dict,
+    config: OidcConfig,
+    redirect_uri: str,
+    state: str,
+    nonce: str,
+    code_challenge: str,
+) -> str:
+    authorization_endpoint = discovery.get("authorization_endpoint")
+    if not authorization_endpoint:
+        raise OidcError("OIDC discovery document is missing authorization_endpoint")
+    params = {
+        "response_type": "code",
+        "client_id": config.client_id,
+        "redirect_uri": redirect_uri,
+        "scope": " ".join(config.scopes),
+        "state": state,
+        "nonce": nonce,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    separator = "&" if "?" in authorization_endpoint else "?"
+    return f"{authorization_endpoint}{separator}{urlencode(params)}"
+
+
+async def exchange_code_for_tokens(
+    discovery: dict,
+    config: OidcConfig,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+) -> dict:
+    token_endpoint = discovery.get("token_endpoint")
+    if not token_endpoint:
+        raise OidcError("OIDC discovery document is missing token_endpoint")
+
+    form = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "code_verifier": code_verifier,
+        "client_id": config.client_id,
+    }
+    # basic auth is the more compatible client authentication method
+    auth = aiohttp.BasicAuth(login=config.client_id, password=config.client_secret)
+    try:
+        payload = await _http_post_form(token_endpoint, form, auth)
+    except OidcError:
+        raise
+    except Exception as err:
+        raise OidcError(f"Failed to reach OIDC token endpoint: {err}") from err
+
+    if "id_token" not in payload:
+        raise OidcError("Token response did not include an id_token")
+    return payload
+
+
+async def verify_id_token(
+    id_token: str,
+    config: OidcConfig,
+    expected_nonce: str,
+) -> dict:
+    """Verify signature and standard claims of the id_token; return claims dict."""
+    key_set = await get_jwks(config)
+    try:
+        token = jwt.decode(id_token, key_set, algorithms=list(SUPPORTED_ID_TOKEN_ALGS))
+    except JoseError as err:
+        raise OidcError(f"Failed to verify id_token signature: {err}") from err
+
+    claims = dict(token.claims)
+    now = int(time.time())
+
+    issuer = (config.issuer or "").rstrip("/")
+    token_iss = str(claims.get("iss", "")).rstrip("/")
+    if not token_iss or token_iss != issuer:
+        raise OidcError("id_token issuer does not match configured issuer")
+
+    aud = claims.get("aud")
+    audiences = aud if isinstance(aud, list) else [aud]
+    if config.client_id not in audiences:
+        raise OidcError("id_token audience does not include the configured client_id")
+
+    exp = int(claims.get("exp", 0))
+    if exp <= now:
+        raise OidcError("id_token has expired")
+
+    iat = int(claims.get("iat", 0))
+    # allow small clock skew
+    if iat and iat > now + 60:
+        raise OidcError("id_token was issued in the future")
+
+    if expected_nonce and claims.get("nonce") != expected_nonce:
+        raise OidcError("id_token nonce does not match")
+
+    return claims
+
+
+def _coerce_groups(raw: Any, separators: str) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [str(item).strip() for item in raw if str(item).strip()]
+    text = str(raw)
+    if not separators:
+        return [text.strip()] if text.strip() else []
+    result: list[str] = [text]
+    for sep in separators:
+        expanded: list[str] = []
+        for item in result:
+            expanded.extend(item.split(sep))
+        result = expanded
+    return [item.strip() for item in result if item.strip()]
+
+
+def resolve_oidc_role(
+    claims: dict,
+    oidc: OidcConfig,
+    config_roles: set[str],
+) -> str:
+    """Map an id_token's groups claim onto a configured Frigate role.
+
+    Mirrors the semantics of frigate.api.auth.resolve_role:
+    admin membership short-circuits to admin; otherwise the first matching
+    role is used; otherwise falls back to oidc.default_role (or 'viewer').
+    """
+    default_role = oidc.default_role if oidc.default_role in config_roles else "viewer"
+    if not config_roles:
+        default_role = "viewer"
+
+    groups = _coerce_groups(
+        claims.get(oidc.groups_claim), oidc.allowed_group_separators
+    )
+    if not groups or not oidc.group_map:
+        return default_role
+
+    matched = {
+        role
+        for role, required_groups in oidc.group_map.items()
+        if any(group in groups for group in required_groups)
+    }
+
+    if "admin" in matched and "admin" in config_roles:
+        return "admin"
+
+    if matched:
+        return next((r for r in config_roles if r in matched), default_role)
+
+    return default_role
+
+
+def resolve_username(claims: dict, oidc: OidcConfig) -> str:
+    """Pick a username from the id_token claims with sensible fallbacks."""
+    for key in (oidc.username_claim, "preferred_username", "email", "sub"):
+        if not key:
+            continue
+        value = claims.get(key)
+        if value:
+            return str(value)
+    raise OidcError("id_token does not contain a username claim")
+
+
+def sanitize_username(username: str) -> str:
+    """Reduce an arbitrary claim value to a database-safe username.
+
+    The user table's username field is a 30-character primary key restricted to
+    ``[A-Za-z0-9._]`` by the create endpoint. OIDC usernames often carry other
+    characters (``@``, ``-``, ``+``) that we accept but rewrite to ``.``.
+    """
+    safe = "".join(ch if ch.isalnum() or ch in "._" else "." for ch in username)
+    safe = safe.strip(".")
+    if not safe:
+        raise OidcError("id_token username claim is empty after sanitization")
+    return safe[:30]

--- a/frigate/config/auth.py
+++ b/frigate/config/auth.py
@@ -1,8 +1,99 @@
 from pydantic import Field, field_validator, model_validator
 
 from .base import FrigateBaseModel
+from .env import EnvString
 
-__all__ = ["AuthConfig"]
+__all__ = ["AuthConfig", "OidcConfig"]
+
+
+class OidcConfig(FrigateBaseModel):
+    enabled: bool = Field(
+        default=False,
+        title="Enable OpenID Connect",
+        description="Enable Single Sign-On via an OpenID Connect identity provider.",
+    )
+    issuer: str | None = Field(
+        default=None,
+        title="Issuer URL",
+        description=(
+            "Issuer URL of the OIDC provider. Frigate will fetch discovery metadata "
+            "from '{issuer}/.well-known/openid-configuration'."
+        ),
+    )
+    client_id: EnvString | None = Field(
+        default=None,
+        title="Client ID",
+        description="OIDC client identifier issued by the provider.",
+    )
+    client_secret: EnvString | None = Field(
+        default=None,
+        title="Client secret",
+        description="OIDC client secret issued by the provider.",
+    )
+    redirect_uri: str | None = Field(
+        default=None,
+        title="Redirect URI override",
+        description=(
+            "Optional absolute URL for the OIDC callback. When unset it is derived "
+            "from the incoming request as '{scheme}://{host}/api/oidc/callback'."
+        ),
+    )
+    scopes: list[str] = Field(
+        default_factory=lambda: ["openid", "email", "profile", "groups"],
+        title="Requested scopes",
+        description="Scopes requested from the OIDC provider.",
+    )
+    username_claim: str = Field(
+        default="preferred_username",
+        title="Username claim",
+        description=(
+            "ID token claim that supplies the Frigate username. Falls back to 'email' "
+            "and then 'sub' when the configured claim is missing."
+        ),
+    )
+    groups_claim: str = Field(
+        default="groups",
+        title="Groups claim",
+        description="ID token claim (list or delimited string) that supplies the user's groups.",
+    )
+    group_map: dict[str, list[str]] = Field(
+        default_factory=dict,
+        title="Group to role mapping",
+        description=(
+            "Map Frigate roles to lists of provider group values. When a user's "
+            "groups claim matches any entry the corresponding role is granted. The "
+            "admin role is prioritized to avoid accidental downgrade."
+        ),
+    )
+    default_role: str | None = Field(
+        default="viewer",
+        title="Default role",
+        description="Role assigned when no group_map entry matches. Must be a configured role.",
+    )
+    auto_provision: bool = Field(
+        default=True,
+        title="Auto-provision users",
+        description=(
+            "Create or update the Frigate user row on successful OIDC login. When "
+            "disabled a matching user must already exist in the database."
+        ),
+    )
+    end_session_endpoint: str | None = Field(
+        default=None,
+        title="End-session endpoint override",
+        description=(
+            "Optional URL to redirect to on logout. When unset Frigate uses the "
+            "'end_session_endpoint' advertised by discovery, when available."
+        ),
+    )
+    allowed_group_separators: str = Field(
+        default=",",
+        title="Group value separator",
+        description=(
+            "When the groups claim is a string instead of a list it is split on any "
+            "character in this string."
+        ),
+    )
 
 
 class AuthConfig(FrigateBaseModel):
@@ -67,6 +158,11 @@ class AuthConfig(FrigateBaseModel):
             "When true the UI may show a help link on the login page informing users how to sign in after an admin password reset. "
         ),
     )
+    oidc: OidcConfig = Field(
+        default_factory=OidcConfig,
+        title="OpenID Connect",
+        description="Configuration for Single Sign-On via an OIDC provider.",
+    )
 
     @field_validator("roles")
     @classmethod
@@ -99,5 +195,39 @@ class AuthConfig(FrigateBaseModel):
         # Ensure admin and viewer are never overridden
         self.roles["admin"] = []
         self.roles["viewer"] = []
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_oidc(self):
+        oidc = self.oidc
+        if not oidc.enabled:
+            return self
+
+        missing = [
+            name
+            for name, value in (
+                ("issuer", oidc.issuer),
+                ("client_id", oidc.client_id),
+                ("client_secret", oidc.client_secret),
+            )
+            if not value
+        ]
+        if missing:
+            raise ValueError(
+                f"OIDC is enabled but the following auth.oidc fields are missing: {', '.join(missing)}"
+            )
+
+        valid_roles = set(self.roles.keys()) | {"admin", "viewer"}
+        for role in oidc.group_map.keys():
+            if role not in valid_roles:
+                raise ValueError(
+                    f"auth.oidc.group_map role '{role}' is not a configured role. Known roles: {sorted(valid_roles)}"
+                )
+
+        if oidc.default_role is not None and oidc.default_role not in valid_roles:
+            raise ValueError(
+                f"auth.oidc.default_role '{oidc.default_role}' is not a configured role. Known roles: {sorted(valid_roles)}"
+            )
 
         return self

--- a/frigate/models.py
+++ b/frigate/models.py
@@ -147,9 +147,11 @@ class User(Model):
         max_length=20,
         default="admin",
     )
-    password_hash = CharField(null=False, max_length=120)
+    password_hash = CharField(null=True, max_length=120)
     password_changed_at = DateTimeField(null=True)
     notification_tokens = JSONField()
+    external_id = CharField(null=True, unique=True, max_length=255)
+    email = CharField(null=True, max_length=255)
 
     @classmethod
     def get_allowed_cameras(

--- a/frigate/test/test_oidc.py
+++ b/frigate/test/test_oidc.py
@@ -1,0 +1,329 @@
+"""Unit tests for the OIDC helper module and config validators."""
+
+import time
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from joserfc import jwt
+from joserfc.jwk import OctKey, RSAKey
+from pydantic import ValidationError
+
+from frigate.api import oidc as oidc_module
+from frigate.api.oidc import (
+    OidcError,
+    _coerce_groups,
+    decode_state_cookie,
+    encode_state_cookie,
+    resolve_oidc_role,
+    resolve_username,
+    sanitize_username,
+    verify_id_token,
+)
+from frigate.config.auth import AuthConfig, OidcConfig
+
+
+class TestOidcConfigValidation(unittest.TestCase):
+    def test_disabled_requires_nothing(self):
+        AuthConfig(oidc=OidcConfig(enabled=False))
+
+    def test_enabled_requires_client_and_issuer(self):
+        with self.assertRaises(ValidationError):
+            AuthConfig(oidc=OidcConfig(enabled=True))
+
+    def test_enabled_ok_with_all_fields(self):
+        AuthConfig(
+            oidc=OidcConfig(
+                enabled=True,
+                issuer="https://idp.example.com",
+                client_id="frigate",
+                client_secret="s3cret",
+            )
+        )
+
+    def test_group_map_role_must_be_configured(self):
+        with self.assertRaises(ValidationError):
+            AuthConfig(
+                oidc=OidcConfig(
+                    enabled=True,
+                    issuer="https://idp.example.com",
+                    client_id="frigate",
+                    client_secret="s3cret",
+                    group_map={"nonexistent": ["g1"]},
+                )
+            )
+
+    def test_group_map_accepts_admin_and_custom_role(self):
+        AuthConfig(
+            oidc=OidcConfig(
+                enabled=True,
+                issuer="https://idp.example.com",
+                client_id="frigate",
+                client_secret="s3cret",
+                group_map={"admin": ["idp-admins"]},
+            ),
+            roles={"operator": ["front_door"]},
+        )
+        AuthConfig(
+            oidc=OidcConfig(
+                enabled=True,
+                issuer="https://idp.example.com",
+                client_id="frigate",
+                client_secret="s3cret",
+                group_map={"operator": ["ops"]},
+            ),
+            roles={"operator": ["front_door"]},
+        )
+
+    def test_default_role_must_be_configured(self):
+        with self.assertRaises(ValidationError):
+            AuthConfig(
+                oidc=OidcConfig(
+                    enabled=True,
+                    issuer="https://idp.example.com",
+                    client_id="frigate",
+                    client_secret="s3cret",
+                    default_role="unknown",
+                )
+            )
+
+
+class TestGroupCoercion(unittest.TestCase):
+    def test_list_passthrough(self):
+        self.assertEqual(_coerce_groups(["a", "b"], ","), ["a", "b"])
+
+    def test_list_strips_and_drops_empty(self):
+        self.assertEqual(_coerce_groups(["a", "  ", " b "], ","), ["a", "b"])
+
+    def test_string_split(self):
+        self.assertEqual(_coerce_groups("a,b, c", ","), ["a", "b", "c"])
+
+    def test_string_multiple_separators(self):
+        self.assertEqual(_coerce_groups("a|b,c", ",|"), ["a", "b", "c"])
+
+    def test_string_no_separator_returns_single(self):
+        self.assertEqual(_coerce_groups("solo", ""), ["solo"])
+
+    def test_none_returns_empty(self):
+        self.assertEqual(_coerce_groups(None, ","), [])
+
+
+class TestResolveOidcRole(unittest.TestCase):
+    def _config(self, **overrides):
+        base = dict(
+            enabled=True,
+            issuer="https://idp.example.com",
+            client_id="frigate",
+            client_secret="s3cret",
+            groups_claim="groups",
+            group_map={"admin": ["sysadmins"], "viewer": ["watchers"]},
+            default_role="viewer",
+        )
+        base.update(overrides)
+        return OidcConfig(**base)
+
+    def test_admin_short_circuit(self):
+        oidc = self._config(group_map={"admin": ["sysadmins"], "viewer": ["sysadmins"]})
+        role = resolve_oidc_role({"groups": ["sysadmins"]}, oidc, {"admin", "viewer"})
+        self.assertEqual(role, "admin")
+
+    def test_no_match_falls_back_to_default(self):
+        oidc = self._config()
+        role = resolve_oidc_role({"groups": ["random"]}, oidc, {"admin", "viewer"})
+        self.assertEqual(role, "viewer")
+
+    def test_missing_groups_claim_returns_default(self):
+        oidc = self._config()
+        role = resolve_oidc_role({}, oidc, {"admin", "viewer"})
+        self.assertEqual(role, "viewer")
+
+    def test_default_role_falls_back_to_viewer_when_invalid(self):
+        oidc = self._config(default_role="viewer")
+        role = resolve_oidc_role({"groups": []}, oidc, set())
+        self.assertEqual(role, "viewer")
+
+    def test_custom_role_match(self):
+        oidc = self._config(group_map={"operator": ["ops"]})
+        role = resolve_oidc_role(
+            {"groups": ["ops"]}, oidc, {"admin", "viewer", "operator"}
+        )
+        self.assertEqual(role, "operator")
+
+    def test_string_group_claim_split(self):
+        oidc = self._config(
+            group_map={"admin": ["sysadmins"]}, allowed_group_separators=","
+        )
+        role = resolve_oidc_role(
+            {"groups": "watchers,sysadmins"}, oidc, {"admin", "viewer"}
+        )
+        self.assertEqual(role, "admin")
+
+
+class TestResolveUsername(unittest.TestCase):
+    def test_prefers_configured_claim(self):
+        oidc = OidcConfig(
+            enabled=True,
+            issuer="https://idp.example.com",
+            client_id="frigate",
+            client_secret="s3cret",
+            username_claim="preferred_username",
+        )
+        self.assertEqual(
+            resolve_username({"preferred_username": "alice", "email": "a@x"}, oidc),
+            "alice",
+        )
+
+    def test_falls_back_to_email_then_sub(self):
+        oidc = OidcConfig(
+            enabled=True,
+            issuer="https://idp.example.com",
+            client_id="frigate",
+            client_secret="s3cret",
+            username_claim="preferred_username",
+        )
+        self.assertEqual(
+            resolve_username({"email": "a@x", "sub": "123"}, oidc),
+            "a@x",
+        )
+        self.assertEqual(resolve_username({"sub": "123"}, oidc), "123")
+
+    def test_missing_all_claims_raises(self):
+        oidc = OidcConfig(
+            enabled=True,
+            issuer="https://idp.example.com",
+            client_id="frigate",
+            client_secret="s3cret",
+        )
+        with self.assertRaises(OidcError):
+            resolve_username({}, oidc)
+
+
+class TestSanitizeUsername(unittest.TestCase):
+    def test_replaces_illegal_chars(self):
+        self.assertEqual(sanitize_username("alice@example.com"), "alice.example.com")
+
+    def test_strips_trailing_dots(self):
+        self.assertEqual(sanitize_username("bob..."), "bob")
+
+    def test_truncates_to_30(self):
+        long = "a" * 60
+        self.assertEqual(len(sanitize_username(long)), 30)
+
+    def test_empty_after_sanitize_raises(self):
+        with self.assertRaises(OidcError):
+            sanitize_username("@@@")
+
+
+class TestStateCookieRoundTrip(unittest.TestCase):
+    def setUp(self):
+        self.key = OctKey.import_key(b"a" * 64)
+
+    def test_round_trip_ok(self):
+        encoded = encode_state_cookie(
+            self.key, "state123", "nonce456", "verifier", "/live"
+        )
+        claims = decode_state_cookie(self.key, encoded)
+        self.assertEqual(claims["state"], "state123")
+        self.assertEqual(claims["nonce"], "nonce456")
+        self.assertEqual(claims["cv"], "verifier")
+        self.assertEqual(claims["rt"], "/live")
+
+    def test_expired_cookie_rejected(self):
+        encoded = encode_state_cookie(self.key, "s", "n", "v", "/", ttl=1)
+        # rewind the clock by patching time inside the module
+        with patch.object(oidc_module.time, "time", return_value=time.time() + 3600):
+            with self.assertRaises(OidcError):
+                decode_state_cookie(self.key, encoded)
+
+    def test_wrong_type_rejected(self):
+        bad = jwt.encode(
+            {"alg": "HS256"},
+            {"typ": "other", "exp": int(time.time()) + 60},
+            self.key,
+        )
+        with self.assertRaises(OidcError):
+            decode_state_cookie(self.key, bad)
+
+    def test_tampered_signature_rejected(self):
+        encoded = encode_state_cookie(self.key, "s", "n", "v", "/")
+        other = OctKey.import_key(b"b" * 64)
+        with self.assertRaises(OidcError):
+            decode_state_cookie(other, encoded)
+
+
+class TestVerifyIdToken(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        try:
+            self.rsa_key = RSAKey.generate_key(2048, auto_kid=True)
+        except TypeError:
+            # older joserfc signature
+            self.rsa_key = RSAKey.generate_key(2048)
+        self.kid = getattr(self.rsa_key, "kid", None) or "test"
+        self.public_jwks = {"keys": [self.rsa_key.as_dict(private=False)]}
+        self.config = OidcConfig(
+            enabled=True,
+            issuer="https://idp.example.com",
+            client_id="frigate",
+            client_secret="s3cret",
+        )
+
+    def _make_id_token(self, **claim_overrides):
+        now = int(time.time())
+        claims = {
+            "iss": "https://idp.example.com",
+            "aud": "frigate",
+            "sub": "user-1",
+            "exp": now + 300,
+            "iat": now,
+            "nonce": "the-nonce",
+        }
+        claims.update(claim_overrides)
+        return jwt.encode({"alg": "RS256", "kid": self.kid}, claims, self.rsa_key)
+
+    async def _verify(self, token, nonce="the-nonce"):
+        with patch(
+            "frigate.api.oidc.get_jwks",
+            new=AsyncMock(
+                return_value=oidc_module.KeySet.import_key_set(self.public_jwks)
+            ),
+        ):
+            return await verify_id_token(token, self.config, nonce)
+
+    async def test_valid_token_returns_claims(self):
+        token = self._make_id_token()
+        claims = await self._verify(token)
+        self.assertEqual(claims["sub"], "user-1")
+        self.assertEqual(claims["nonce"], "the-nonce")
+
+    async def test_wrong_issuer_rejected(self):
+        token = self._make_id_token(iss="https://other.example.com")
+        with self.assertRaises(OidcError):
+            await self._verify(token)
+
+    async def test_wrong_audience_rejected(self):
+        token = self._make_id_token(aud="different-client")
+        with self.assertRaises(OidcError):
+            await self._verify(token)
+
+    async def test_expired_token_rejected(self):
+        token = self._make_id_token(exp=int(time.time()) - 10)
+        with self.assertRaises(OidcError):
+            await self._verify(token)
+
+    async def test_nonce_mismatch_rejected(self):
+        token = self._make_id_token(nonce="not-the-nonce")
+        with self.assertRaises(OidcError):
+            await self._verify(token)
+
+    async def test_issuer_trailing_slash_normalized(self):
+        token = self._make_id_token(iss="https://idp.example.com/")
+        claims = await self._verify(token)
+        self.assertEqual(claims["sub"], "user-1")
+
+    async def test_audience_as_list(self):
+        token = self._make_id_token(aud=["frigate", "another"])
+        claims = await self._verify(token)
+        self.assertEqual(claims["sub"], "user-1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/migrations/036_add_oidc_user_fields.py
+++ b/migrations/036_add_oidc_user_fields.py
@@ -1,0 +1,44 @@
+"""Peewee migrations -- 036_add_oidc_user_fields.py.
+
+Add optional external_id and email columns to the user table and drop the
+NOT NULL constraint on password_hash so users authenticated via OIDC (which
+do not have a local password) can be auto-provisioned.
+"""
+
+import peewee as pw
+
+SQL = pw.SQL
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    # SQLite cannot ALTER an existing column, so drop NOT NULL by rebuilding
+    # the table. peewee-migrate's change_fields does the round-trip safely.
+    migrator.change_fields(
+        "user",
+        password_hash=pw.CharField(null=True, max_length=120),
+    )
+    migrator.sql(
+        """
+        ALTER TABLE user ADD COLUMN external_id VARCHAR(255) NULL
+        """
+    )
+    migrator.sql(
+        """
+        ALTER TABLE user ADD COLUMN email VARCHAR(255) NULL
+        """
+    )
+    migrator.sql(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS user_external_id ON user (external_id)
+        """
+    )
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.sql("DROP INDEX IF EXISTS user_external_id")
+    migrator.sql("ALTER TABLE user DROP COLUMN email")
+    migrator.sql("ALTER TABLE user DROP COLUMN external_id")
+    migrator.change_fields(
+        "user",
+        password_hash=pw.CharField(null=False, max_length=120),
+    )

--- a/web/public/locales/en/components/auth.json
+++ b/web/public/locales/en/components/auth.json
@@ -11,6 +11,10 @@
       "loginFailed": "Login failed",
       "unknownError": "Unknown error. Check logs.",
       "webUnknownError": "Unknown error. Check console logs."
+    },
+    "oidc": {
+      "button": "Sign in with SSO",
+      "divider": "or"
     }
   }
 }

--- a/web/public/locales/en/config/global.json
+++ b/web/public/locales/en/config/global.json
@@ -69,6 +69,62 @@
     "admin_first_time_login": {
       "label": "First-time admin flag",
       "description": "When true the UI may show a help link on the login page informing users how to sign in after an admin password reset. "
+    },
+    "oidc": {
+      "label": "OpenID Connect",
+      "description": "Configuration for Single Sign-On via an OIDC provider.",
+      "enabled": {
+        "label": "Enable OpenID Connect",
+        "description": "Enable Single Sign-On via an OpenID Connect identity provider."
+      },
+      "issuer": {
+        "label": "Issuer URL",
+        "description": "Issuer URL of the OIDC provider. Frigate will fetch discovery metadata from '{issuer}/.well-known/openid-configuration'."
+      },
+      "client_id": {
+        "label": "Client ID",
+        "description": "OIDC client identifier issued by the provider."
+      },
+      "client_secret": {
+        "label": "Client secret",
+        "description": "OIDC client secret issued by the provider."
+      },
+      "redirect_uri": {
+        "label": "Redirect URI override",
+        "description": "Optional absolute URL for the OIDC callback. When unset it is derived from the incoming request as '{scheme}://{host}/api/oidc/callback'."
+      },
+      "scopes": {
+        "label": "Requested scopes",
+        "description": "Scopes requested from the OIDC provider."
+      },
+      "username_claim": {
+        "label": "Username claim",
+        "description": "ID token claim that supplies the Frigate username. Falls back to 'email' and then 'sub' when the configured claim is missing."
+      },
+      "groups_claim": {
+        "label": "Groups claim",
+        "description": "ID token claim (list or delimited string) that supplies the user's groups."
+      },
+      "group_map": {
+        "label": "Group to role mapping",
+        "description": "Map Frigate roles to lists of provider group values. When a user's groups claim matches any entry the corresponding role is granted. The admin role is prioritized to avoid accidental downgrade."
+      },
+      "default_role": {
+        "label": "Default role",
+        "description": "Role assigned when no group_map entry matches. Must be a configured role."
+      },
+      "auto_provision": {
+        "label": "Auto-provision users",
+        "description": "Create or update the Frigate user row on successful OIDC login. When disabled a matching user must already exist in the database."
+      },
+      "end_session_endpoint": {
+        "label": "End-session endpoint override",
+        "description": "Optional URL to redirect to on logout. When unset Frigate uses the 'end_session_endpoint' advertised by discovery, when available."
+      },
+      "allowed_group_separators": {
+        "label": "Group value separator",
+        "description": "When the groups claim is a string instead of a list it is split on any character in this string."
+      }
     }
   },
   "database": {

--- a/web/src/components/auth/AuthForm.tsx
+++ b/web/src/components/auth/AuthForm.tsx
@@ -40,6 +40,24 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
   const { data } = useSWR("/auth/first_time_login", fetcher);
   const showFirstTimeLink = data?.admin_first_time_login === true;
 
+  const { data: oidcConfig } = useSWR<{ enabled: boolean }>(
+    "/oidc/config",
+    fetcher,
+  );
+  const oidcEnabled = oidcConfig?.enabled === true;
+
+  React.useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const oidcError = params.get("oidc_error");
+    if (oidcError) {
+      toast.error(oidcError, { position: "top-center" });
+      params.delete("oidc_error");
+      const next = params.toString();
+      const url = `${window.location.pathname}${next ? `?${next}` : ""}${window.location.hash}`;
+      window.history.replaceState(null, "", url);
+    }
+  }, []);
+
   const formSchema = z.object({
     user: z.string().min(1, t("form.errors.usernameRequired")),
     password: z.string().min(1, t("form.errors.passwordRequired")),
@@ -98,6 +116,26 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
 
   return (
     <div className={cn("grid gap-6", className)} {...props}>
+      {oidcEnabled && (
+        <div className="flex flex-col gap-4">
+          <Button
+            variant="select"
+            type="button"
+            className="w-full"
+            aria-label={t("form.oidc.button")}
+            onClick={() => {
+              window.location.href = `${baseUrl}api/oidc/login`;
+            }}
+          >
+            {t("form.oidc.button")}
+          </Button>
+          <div className="flex items-center gap-3 text-xs uppercase text-muted-foreground">
+            <span className="h-px flex-1 bg-border" />
+            {t("form.oidc.divider")}
+            <span className="h-px flex-1 bg-border" />
+          </div>
+        </div>
+      )}
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
           <FormField


### PR DESCRIPTION
## Proposed change

Adds a first-class OpenID Connect (OIDC) login flow so Frigate can authenticate users directly against an external identity provider (Keycloak, Authentik, Zitadel, Okta, Auth0, Google Workspace, etc.) without requiring a reverse-proxy auth layer.

**What lands:**

- **New `auth.oidc` config block** with `enabled`, `issuer`, `client_id`, `client_secret`, `redirect_uri`, `scopes`, `username_claim`, `groups_claim`, `group_map`, `default_role`, `auto_provision`, `end_session_endpoint`. Cross-field validator enforces provider fields when enabled and requires every mapped role to already exist in `auth.roles` (or be `admin`/`viewer`). `client_id`/`client_secret` accept `{FRIGATE_*}` env substitution via `EnvString`.
- **Authorization code + PKCE flow** with signed state/nonce cookies. ID tokens are verified against the provider's JWKS via `joserfc` (already a project dep). No new Python dependencies — `joserfc` and `aiohttp` are already pinned in `docker/main/requirements-wheels.txt`.
- **Group claim -> Frigate role resolution** mirrors the existing `proxy.header_map.role_map` semantics, including the admin short-circuit so a user in both an admin group and a lower-privilege group is not accidentally downgraded.
- **User auto-provisioning** on first login, linked on the ID token `sub` via a new `external_id` column so renaming a user in the IdP does not create duplicate rows. A pre-existing local user whose username matches the IdP claim is linked in place instead of duplicated. `auto_provision: false` requires the user to be onboarded manually.
- **New endpoints**: `GET /oidc/config` (public — advertises SSO availability to the UI), `GET /oidc/login` (starts flow), `GET /oidc/callback` (exchanges code, verifies token, issues the standard `frigate_token` JWT cookie). `/logout` honors `end_session_endpoint` when configured. All three paths added to the global `require_admin_by_default` exempt list.
- **Migration 036** makes `password_hash` nullable and adds `external_id` (unique) and `email` columns.
- **Frontend**: 'Sign in with SSO' button appears on the login page when OIDC is enabled, with an inline error toast surfacing callback failures via `?oidc_error=` cleanup.
- **Docs**: new '## OpenID Connect (OIDC)' section in `docs/docs/configuration/authentication.md` with prerequisites, minimal + full YAML examples, group-mapping semantics, auto-provisioning, and logout behavior. The 'Frigate does not implement OIDC' line under the proxy section has been updated.
- **Generated files regenerated**: `docs/static/frigate-api.yaml` (spec) and `web/public/locales/en/config/global.json` (config translations).

**Backwards compatibility:** OIDC is off by default. Native password login continues to work unchanged when OIDC is enabled — the SSO button appears alongside the existing form. The `frigate_token` JWT cookie issued on OIDC callback is the same cookie native login uses, so every downstream authorization check (`require_role`, `require_camera_access`, `/profile`) works without modification.

**Security notes:** PKCE S256 for all authorization requests. State + nonce are stored in a short-lived HttpOnly JWT cookie signed with the existing `FRIGATE_JWT_SECRET`, verified on callback. ID token signature is verified against the provider's JWKS; `iss`, `aud`, `exp`, `iat`, and `nonce` claims are all validated. Only asymmetric signing algorithms are accepted for ID tokens (`RS*/PS*/ES*/EdDSA`); HS256 is intentionally rejected to prevent JWKS-key-confusion. Cache TTL for discovery + JWKS is 1 hour.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features): _no prior discussion — happy to open one and let this PR sit until maintainers weigh in on scope/direction_

## For new features

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link: _none yet — see note above_

## AI disclosure

- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Opus 4.7 via Claude Code)

**How AI was used**: Codebase exploration to map the existing auth/proxy/role architecture, initial implementation of the OIDC config model, client helpers, endpoints, unit tests, frontend SSO button, and documentation section. Also drove ruff formatting, test execution inside the `frigate:latest` image, and the OpenAPI spec regeneration.

**Extent of AI involvement**: Generated the initial implementation across all files listed above. Design decisions (dedicated `auth.oidc.group_map` vs reusing `proxy.header_map.role_map`, auto-provisioning users into the DB vs headers-only, SSO button vs auto-redirect, no new Python dependencies) were made interactively by the human author.

**Human oversight**: Read every generated file, ran all 36 unit tests inside the built Frigate image, ran ruff format + lint, ran the OpenAPI `--check` regeneration guard. Reviewed the security surface (PKCE, nonce, JWKS-based verification, algorithm allowlist, state cookie signing). End-to-end testing against a real IdP is next.

## Checklist

- [x] The code change is tested and works locally. _(36 unit tests pass inside \`frigate:latest\`; end-to-end IdP test pending)_
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the \`en\` locale.
- [x] The code has been formatted using Ruff (\`ruff format frigate\`)