### PR TITLE
Convert face crops to RGB before embedding

### DIFF
--- a/frigate/embeddings/onnx/base_embedding.py
+++ b/frigate/embeddings/onnx/base_embedding.py
@@ -57,6 +57,12 @@ class BaseEmbedding(ABC):
     def _preprocess_inputs(self, raw_inputs: Any) -> Any:
         pass
 
+    @staticmethod
+    def _bgr_to_rgb(frame: Any) -> Any:
+        if isinstance(frame, np.ndarray) and frame.ndim == 3:
+            return np.ascontiguousarray(frame[:, :, ::-1])
+        return frame
+
     def _process_image(self, image, output: str = "RGB") -> Image.Image:
         if isinstance(image, str):
             if image.startswith("http"):

--- a/frigate/embeddings/onnx/face_embedding.py
+++ b/frigate/embeddings/onnx/face_embedding.py
@@ -73,7 +73,13 @@ class FaceNetEmbedding(BaseEmbedding):
             self.tensor_output_details = self.runner.get_output_details()
 
     def _preprocess_inputs(self, raw_inputs):
-        pil = self._process_image(raw_inputs[0])
+        frame = raw_inputs[0]
+
+        # convert the BGR face crop to the RGB order the model expects
+        if isinstance(frame, np.ndarray) and frame.ndim == 3:
+            frame = np.ascontiguousarray(frame[:, :, ::-1])
+
+        pil = self._process_image(frame)
 
         # handle images larger than input size
         width, height = pil.size
@@ -159,7 +165,13 @@ class ArcfaceEmbedding(BaseEmbedding):
             )
 
     def _preprocess_inputs(self, raw_inputs):
-        pil = self._process_image(raw_inputs[0])
+        frame = raw_inputs[0]
+
+        # convert the BGR face crop to the RGB order the model expects
+        if isinstance(frame, np.ndarray) and frame.ndim == 3:
+            frame = np.ascontiguousarray(frame[:, :, ::-1])
+
+        pil = self._process_image(frame)
 
         # handle images larger than input size
         width, height = pil.size

--- a/frigate/embeddings/onnx/face_embedding.py
+++ b/frigate/embeddings/onnx/face_embedding.py
@@ -73,13 +73,7 @@ class FaceNetEmbedding(BaseEmbedding):
             self.tensor_output_details = self.runner.get_output_details()
 
     def _preprocess_inputs(self, raw_inputs):
-        frame = raw_inputs[0]
-
-        # convert the BGR face crop to the RGB order the model expects
-        if isinstance(frame, np.ndarray) and frame.ndim == 3:
-            frame = np.ascontiguousarray(frame[:, :, ::-1])
-
-        pil = self._process_image(frame)
+        pil = self._process_image(self._bgr_to_rgb(raw_inputs[0]))
 
         # handle images larger than input size
         width, height = pil.size
@@ -165,13 +159,7 @@ class ArcfaceEmbedding(BaseEmbedding):
             )
 
     def _preprocess_inputs(self, raw_inputs):
-        frame = raw_inputs[0]
-
-        # convert the BGR face crop to the RGB order the model expects
-        if isinstance(frame, np.ndarray) and frame.ndim == 3:
-            frame = np.ascontiguousarray(frame[:, :, ::-1])
-
-        pil = self._process_image(frame)
+        pil = self._process_image(self._bgr_to_rgb(raw_inputs[0]))
 
         # handle images larger than input size
         width, height = pil.size


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

### Problem
Face crops are OpenCV BGR arrays. `_process_image()` hands the ndarray straight to PIL, so both the FaceNet and ArcFace embedders receive BGR while they expect from training data the RGB order.

The error applies to enrollment and recognition alike, so it partially cancels out, which is why it went unnoticed, but it still costs accuracy.

### Fix
Convert BGR -> RGB for ndarray inputs in both `_preprocess_inputs` methods.(`custom_classification.py` already handles channel order explicitly; the face path predates it.)

### Results
Measured on a 2-person library + 29 low-quality camera crops:

| model | person separation (RGB) | (BGR) |
|---|---|---|
| arcface (large) | 0.501 | 0.480 |
| facenet (small, default) | 0.464 | 0.382 |

For facenet, cross-person similarity drops from 0.154 to 0.100 in fewer wrong-person matches.

Local tests: 781/785 pass, the 4 failures are the known go2rtc environment errors, identical on clean `dev`.

### Migration
None. Embeddings are rebuilt from the stored crops at startup.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR is related to issue:

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Claude Code)

**How AI was used**: investigation, code generation, validation benchmarking, debugging

**Extent of AI involvement**: identified the channel-order mismatch, generated the fix, built/ran the validation benchmarks (RGB vs BGR A/B on a real face library with both embedding models)

**Human oversight**: I directed and reviewed all changes; validation ran on my own NVR data with personally verified ground truth.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)