### PR TITLE
Drop surplus frames before hwdownload in intel-qsv scale presets

### DIFF
--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -121,8 +121,8 @@ PRESETS_HW_ACCEL_SCALE = {
     "preset-rpi-64-h264": "-r {0} -vf fps={0},scale={1}:{2}",
     "preset-rpi-64-h265": "-r {0} -vf fps={0},scale={1}:{2}",
     FFMPEG_HWACCEL_VAAPI: "-r {0} -vf fps={0},scale_vaapi=w={1}:h={2},hwdownload,format=nv12",
-    "preset-intel-qsv-h264": "-r {0} -vf vpp_qsv=w={1}:h={2}:format=nv12,hwdownload,format=nv12,fps={0},format=yuv420p",
-    "preset-intel-qsv-h265": "-r {0} -vf vpp_qsv=w={1}:h={2}:format=nv12,hwdownload,format=nv12,fps={0},format=yuv420p",
+    "preset-intel-qsv-h264": "-r {0} -vf fps={0},vpp_qsv=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
+    "preset-intel-qsv-h265": "-r {0} -vf fps={0},vpp_qsv=w={1}:h={2}:format=nv12,hwdownload,format=nv12,format=yuv420p",
     FFMPEG_HWACCEL_NVIDIA: "-r {0} -vf fps={0},scale_cuda=w={1}:h={2},hwdownload,format=nv12",
     "preset-jetson-h264": "-r {0}",  # scaled in decoder
     "preset-jetson-h265": "-r {0}",  # scaled in decoder

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -77,6 +77,26 @@ class TestFfmpegPresets(unittest.TestCase):
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
 
+    def test_ffmpeg_hwaccel_qsv_scale_preset(self):
+        self.default_ffmpeg["cameras"]["back"]["ffmpeg"]["hwaccel_args"] = (
+            "preset-intel-qsv-h264"
+        )
+        self.default_ffmpeg["cameras"]["back"]["detect"] = {
+            "height": 1920,
+            "width": 2560,
+            "fps": 10,
+        }
+        frigate_config = FrigateConfig(**self.default_ffmpeg)
+        assert "preset-intel-qsv-h264" not in (
+            " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
+        )
+        # fps decimation must come before vpp_qsv so surplus frames are
+        # dropped before the expensive hwdownload
+        assert (
+            "fps=10,vpp_qsv=w=2560:h=1920:format=nv12,hwdownload,format=nv12,format=yuv420p"
+            in (" ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"]))
+        )
+
     def test_default_ffmpeg_input_arg_preset(self):
         frigate_config = FrigateConfig(**self.default_ffmpeg)
 


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

### Problem
The intel-qsv scale presets decimate to detect fps only at the end of the filter chain, after `hwdownload`:

```
vpp_qsv=w=..:h=..:format=nv12,hwdownload,format=nv12,fps={fps},format=yuv420p
```

Every decoded frame is transferred from GPU to system memory and only then dropped, so `hwdownload` pays for the camera's native frame rate instead of the detect fps. (#22548 moved decimation to the software `fps` filter because `vpp_qsv=framerate=` performs no frame dropping on the Linux media driver, it only relabels PTS, but placed the filter after the download.)

### Fix
Move `fps={fps}` to the front of the chain, before `vpp_qsv`. The `fps` filter only manipulates timestamps, so it works on QSV hardware frames and drops surplus frames while they are still on the GPU. This also matches what the **vaapi** and **cuda** presets already do (`fps=..,scale_vaapi/scale_cuda=..,hwdownload,..`); the qsv preset was the odd one out.

### Results
Measured on Intel UHD 630 (i3-8300T), 4K H.264 camera at 15 fps, detect fps 10, ffmpeg 7.0

| chain | pipe output | ffmpeg CPU (one core) |
|---|---|---|
| `fps` after `hwdownload` (current dev) | 10 fps | 35 % |
| `fps` before `vpp_qsv` (this PR) | 10 fps | 30 % |

CPU numbers are process CPU time / elapsed over ~8 min of real camera runtime each, same static scene. Output verified frame-exact in both cases (`dup=1 drop=0`, no skipped frames in Frigate).

### Migration
None.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR is related to issue: none; follows up on the decimation change in #22548

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Claude Code)

**How AI was used**: investigation, benchmarking, code generation, validation

**Extent of AI involvement**: identified that `vpp_qsv=framerate=` only relabels PTS on the Linux media driver, benchmarked the filter-chain variants with real ffmpeg on real hardware, and generated the change

**Human oversight**: I directed and reviewed all changes; measurements ran on my own NVR with real camera streams, and both variants were exercised in production there.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)