### PR TITLE
Bound REGEXP evaluation with a timeout to prevent ReDoS on the database thread

### DIFF
--- a/frigate/db/sqlitevecq.py
+++ b/frigate/db/sqlitevecq.py
@@ -1,8 +1,10 @@
-import re
 import sqlite3
 from typing import Any
 
+import regex
 from playhouse.sqliteq import SqliteQueueDatabase
+
+REGEXP_TIMEOUT_SECONDS = 1.0
 
 
 class SqliteVecQueueDatabase(SqliteQueueDatabase):
@@ -34,8 +36,10 @@ class SqliteVecQueueDatabase(SqliteQueueDatabase):
             if item is None:
                 return False
             try:
-                return re.search(expr, item) is not None
-            except re.error:
+                return (
+                    regex.search(expr, item, timeout=REGEXP_TIMEOUT_SECONDS) is not None
+                )
+            except (regex.error, TimeoutError):
                 return False
 
         conn.create_function("REGEXP", 2, regexp)

--- a/frigate/test/test_sqlitevecq_regexp.py
+++ b/frigate/test/test_sqlitevecq_regexp.py
@@ -1,0 +1,54 @@
+"""Tests for the REGEXP function registered on the main Frigate database.
+
+Regression coverage for GHSA-q8jx-q884-jcq9: an attacker-controlled
+catastrophic (ReDoS) pattern reaching the REGEXP sink must not be able to
+stall the serialized database worker thread.
+"""
+
+import sqlite3
+import time
+import unittest
+
+from frigate.db.sqlitevecq import REGEXP_TIMEOUT_SECONDS, SqliteVecQueueDatabase
+
+
+class TestRegexpFunction(unittest.TestCase):
+    def setUp(self) -> None:
+        # autostart=False keeps the queue worker thread from spinning up; we
+        # only need the REGEXP registration, exercised on our own connection.
+        self.db = SqliteVecQueueDatabase(":memory:", autostart=False)
+        self.conn = sqlite3.connect(":memory:")
+        self.db._register_regexp(self.conn)
+
+    def tearDown(self) -> None:
+        self.conn.close()
+
+    def _regexp(self, value: str | None, pattern: str) -> int | None:
+        # SQLite maps "value REGEXP pattern" to regexp(pattern, value).
+        return self.conn.execute("SELECT ? REGEXP ?", (value, pattern)).fetchone()[0]
+
+    def test_normal_patterns_still_match(self) -> None:
+        self.assertTrue(self._regexp("ABC123", "^ABC"))
+        self.assertTrue(self._regexp("ABC123", "ABC.*"))
+        self.assertTrue(self._regexp("ABC123", "[0-9]+$"))
+        self.assertFalse(self._regexp("ABC123", "^XYZ"))
+
+    def test_null_value_does_not_match(self) -> None:
+        self.assertFalse(self._regexp(None, ".*"))
+
+    def test_invalid_pattern_does_not_raise(self) -> None:
+        self.assertFalse(self._regexp("ABC123", "(unclosed"))
+
+    def test_catastrophic_pattern_is_time_bounded(self) -> None:
+        # Without the timeout this evaluation backtracks for minutes to hours
+        # and wedges the whole database thread (GHSA-q8jx-q884-jcq9).
+        catastrophic = "(a{2,})+c"
+        subject = "a" * 4000
+
+        start = time.monotonic()
+        result = self._regexp(subject, catastrophic)
+        elapsed = time.monotonic() - start
+
+        # The pattern does not match; the guarantee is that it returns quickly.
+        self.assertFalse(result)
+        self.assertLess(elapsed, REGEXP_TIMEOUT_SECONDS + 2.0)


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
The `recognized_license_plate` event filter (`GET /api/events` and `/api/events/search`) treats a plate value that looks like a pattern as a regex and passes it, unbounded, into a SQLite `REGEXP` clause implemented over stdlib `re.search`. A catastrophic backtracking pattern such as `(a+)+$` against a long stored value pegs a CPU core for minutes to hours, and since `REGEXP` runs on the single serialized `SqliteQueueDatabase` worker thread, every other database operation queues behind it. Any authenticated user, down to the lowest-privileged viewer role, could freeze the whole application with one GET request

This PR swaps stdlib `re` for the `regex` module and pass a per-evaluation `timeout` in `_register_regexp`, covering both endpoints at the single sink. The regex engine aborts backtracking once the budget is exceeded and raises `TimeoutError`, caught alongside `regex.error` and treated as no match. Legitimate plate patterns complete in well under a millisecond, and regex is already present in the build, so no new dependency is added.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes  GHSA-q8jx-q884-jcq9
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
