### PR TITLE
Miscellaneous fixes (0.18 beta)

### DIFF
--- a/frigate/api/chat.py
+++ b/frigate/api/chat.py
@@ -98,11 +98,14 @@ def _resolve_zones(
     """Map zone names to their canonical config keys, case-insensitively.
 
     LLMs frequently echo a user's casing ("Front Yard") instead of the
-    configured key ("front_yard"). The downstream zone filter is a SQLite GLOB
-    over the JSON-encoded zones column, which is case-sensitive — so an
-    unnormalized name silently returns zero matches. Build a lookup over the
-    relevant cameras' configured zones and substitute when we find a match;
-    unknown names pass through so behavior matches what the model asked for.
+    configured key ("front_yard"), or fall back to a zone's friendly name
+    ("Front Walkway") instead of its ID ("front_walk"). The downstream zone
+    filter is a SQLite GLOB over the JSON-encoded zones column, which stores
+    config keys and is case-sensitive — so an unnormalized name silently
+    returns zero matches. Build a lookup over the relevant cameras' configured
+    zones, keyed by both the config key and the friendly name, and substitute
+    when we find a match; unknown names pass through so behavior matches what
+    the model asked for.
     """
     if not zones:
         return zones
@@ -112,8 +115,11 @@ def _resolve_zones(
         camera_config = config.cameras.get(camera_id)
         if camera_config is None:
             continue
-        for zone_name in camera_config.zones.keys():
+        for zone_name, zone_config in camera_config.zones.items():
             lookup.setdefault(zone_name.lower(), zone_name)
+            lookup.setdefault(
+                zone_config.get_formatted_name(zone_name).lower(), zone_name
+            )
 
     return [lookup.get(z.lower(), z) for z in zones]
 

--- a/frigate/api/chat.py
+++ b/frigate/api/chat.py
@@ -7,7 +7,7 @@ import operator
 import time
 from datetime import datetime
 from functools import reduce
-from typing import Any
+from typing import Any, Literal
 
 import cv2
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
@@ -37,6 +37,7 @@ from frigate.api.defs.response.chat_response import (
 from frigate.api.defs.tags import Tags
 from frigate.api.event import _build_attribute_filter_clause, events
 from frigate.config import FrigateConfig
+from frigate.config.classification import SemanticSearchModelEnum
 from frigate.genai.prompts import (
     build_chat_system_prompt,
     get_attribute_classifications,
@@ -86,8 +87,21 @@ def get_tools(request: Request) -> JSONResponse:
     tools = get_tool_definitions(
         semantic_search_enabled=semantic_search_enabled,
         attribute_classifications=attribute_classifications,
+        embeddings_language=_embeddings_language(config),
     )
     return JSONResponse(content={"tools": tools})
+
+
+def _embeddings_language(config: FrigateConfig) -> Literal["english", "multi"]:
+    """Return the language capability of the configured embeddings model.
+
+    JinaV1 is English-only; every other option (JinaV2 or a GenAI embeddings
+    provider) handles multiple languages.
+    """
+    if config.semantic_search.model == SemanticSearchModelEnum.jinav1:
+        return "english"
+
+    return "multi"
 
 
 def _resolve_zones(
@@ -1140,6 +1154,7 @@ async def chat_completion(
     tools = get_tool_definitions(
         semantic_search_enabled=semantic_search_enabled,
         attribute_classifications=attribute_classifications,
+        embeddings_language=_embeddings_language(config),
     )
     conversation = []
 

--- a/frigate/genai/prompts.py
+++ b/frigate/genai/prompts.py
@@ -682,14 +682,17 @@ def build_chat_system_prompt(
             if camera_config.friendly_name
             else camera_id.replace("_", " ").title()
         )
-        zone_names = list(camera_config.zones.keys())
+        zone_descriptors = [
+            f"{zone_config.get_formatted_name(zone_name)} (ID: {zone_name})"
+            for zone_name, zone_config in camera_config.zones.items()
+        ]
         if not has_speed_zone:
             has_speed_zone = any(
                 zone.distances for zone in camera_config.zones.values()
             )
-        if zone_names:
+        if zone_descriptors:
             cameras_info.append(
-                f"  - {friendly_name} (ID: {camera_id}, zones: {', '.join(zone_names)})"
+                f"  - {friendly_name} (ID: {camera_id}, zones: {', '.join(zone_descriptors)})"
             )
         else:
             cameras_info.append(f"  - {friendly_name} (ID: {camera_id})")
@@ -699,7 +702,7 @@ def build_chat_system_prompt(
         cameras_section = (
             "\n\nAvailable cameras:\n"
             + "\n".join(cameras_info)
-            + "\n\nWhen users refer to cameras by their friendly name (e.g., 'Back Deck Camera'), use the corresponding camera ID (e.g., 'back_deck_cam') in tool calls."
+            + "\n\nWhen users refer to cameras or zones by their friendly name (e.g., 'Back Deck Camera', 'Front Walkway'), use the corresponding ID (e.g., 'back_deck_cam', 'front_walk') in tool calls. Tool results also identify zones by their ID, so when presenting cameras or zones back to the user, translate the ID to its friendly name."
         )
 
     speed_units_section = ""

--- a/frigate/genai/prompts.py
+++ b/frigate/genai/prompts.py
@@ -6,7 +6,7 @@ transport.
 """
 
 import datetime
-from typing import Any
+from typing import Any, Literal
 
 from playhouse.shortcuts import model_to_dict
 
@@ -249,6 +249,7 @@ def get_attribute_classifications(config: FrigateConfig) -> list[dict[str, Any]]
 def get_tool_definitions(
     semantic_search_enabled: bool = False,
     attribute_classifications: list[dict[str, Any]] | None = None,
+    embeddings_language: Literal["english", "multi"] = "multi",
 ) -> list[dict[str, Any]]:
     """
     Get OpenAI-compatible tool definitions for Frigate.
@@ -258,7 +259,9 @@ def get_tool_definitions(
     tool exposes an additional `semantic_query` parameter for descriptive
     queries (e.g. "person riding a lawn mower") and find_similar_objects is
     included. When attribute classification models are configured, an
-    `attribute` parameter is exposed for filtering by their labels.
+    `attribute` parameter is exposed for filtering by their labels. When the
+    embeddings model only understands English (JinaV1), the `semantic_query`
+    description instructs the model to write the query in English.
     """
     search_objects_properties: dict[str, Any] = {
         "camera": {
@@ -349,6 +352,14 @@ def get_tool_definitions(
                 "When set, combine with label/time/camera/zone filters as "
                 "usual (e.g. label='person', semantic_query='riding a lawn "
                 "mower', after='2024-05-01T00:00:00Z')."
+                + (
+                    " The configured embeddings model only understands "
+                    "English, so always write semantic_query in English, "
+                    "translating the user's description if they phrased it "
+                    "in another language."
+                    if embeddings_language == "english"
+                    else ""
+                )
             ),
         }
 

--- a/web/src/components/config-form/section-configs/detect.ts
+++ b/web/src/components/config-form/section-configs/detect.ts
@@ -169,6 +169,13 @@ const detect: SectionConfigOverrides = {
       resolution: ["width", "height", "fps"],
       tracking: ["min_initialized", "max_disappeared"],
     },
+    uiSchema: {
+      annotation_offset: {
+        "ui:options": {
+          signed: true,
+        },
+      },
+    },
     hiddenFields: ["enabled_in_config"],
     advancedFields: [
       "min_initialized",

--- a/web/src/components/config-form/section-configs/record.ts
+++ b/web/src/components/config-form/section-configs/record.ts
@@ -57,6 +57,7 @@ const record: SectionConfigOverrides = {
           "ui:options": {
             suppressMultiSchema: true,
             ffmpegPresetField: "hwaccel_args",
+            ffmpegGlobalFieldPath: "export.hwaccel_args",
           },
         },
       },

--- a/web/src/components/config-form/theme/utils/index.ts
+++ b/web/src/components/config-form/theme/utils/index.ts
@@ -17,3 +17,4 @@ export {
   isSubtreeModified,
 } from "./overrides";
 export { getSizedFieldClassName } from "./fieldSizing";
+export { getNumericInputMode } from "./inputMode";

--- a/web/src/components/config-form/theme/utils/inputMode.ts
+++ b/web/src/components/config-form/theme/utils/inputMode.ts
@@ -1,0 +1,51 @@
+import type { RJSFSchema } from "@rjsf/utils";
+
+type NumericInputOptions = {
+  signed?: boolean;
+};
+
+/**
+ * Derive the on-screen keyboard hint for a schema field.
+ *
+ * Numeric config fields render as text inputs because RJSF's NumberField
+ * relies on the widget echoing raw strings back, so that trailing "." and "0"
+ * characters survive while a value is being typed. That means the numeric
+ * keypad has to be requested explicitly. Desktop browsers ignore inputMode, so
+ * this only affects virtual keyboards.
+ *
+ * Fields accepting negative values opt out, since the iOS numeric and decimal
+ * keypads have no minus key. Most numeric fields declare no minimum even
+ * though they are non-negative, so signed fields are marked explicitly with
+ * ui:options.signed.
+ *
+ * Args:
+ *     schema: The JSON schema for the field being rendered
+ *     options: The resolved ui:options for the field
+ *
+ * Returns:
+ *     The inputMode to apply, or undefined to leave the keyboard alone
+ */
+export function getNumericInputMode(
+  schema: RJSFSchema,
+  options: unknown,
+): "numeric" | "decimal" | undefined {
+  const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+  const isInteger = types.includes("integer");
+
+  if (!isInteger && !types.includes("number")) {
+    return undefined;
+  }
+
+  const numericOptions =
+    typeof options === "object" && options !== null
+      ? (options as NumericInputOptions)
+      : undefined;
+
+  const minimum = schema.minimum ?? schema.exclusiveMinimum;
+
+  if (numericOptions?.signed || (minimum ?? 0) < 0) {
+    return undefined;
+  }
+
+  return isInteger ? "numeric" : "decimal";
+}

--- a/web/src/components/config-form/theme/widgets/FfmpegArgsWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/FfmpegArgsWidget.tsx
@@ -120,6 +120,12 @@ export function FfmpegArgsWidget(props: WidgetProps) {
     id,
   } = props;
   const presetField = options?.ffmpegPresetField as PresetField | undefined;
+  // Path to this field within its config section. This is usually the same as
+  // the preset field, but the two diverge when the field sits below the
+  // section root: record.export.hwaccel_args uses the hwaccel_args preset list
+  // while living at export.hwaccel_args inside the record section.
+  const globalFieldPath =
+    (options?.ffmpegGlobalFieldPath as string | undefined) ?? presetField;
   const allowInherit = options?.allowInherit === true;
   const hideDescription = options?.hideDescription === true;
   const useSplitLayout = options?.splitLayout !== false;
@@ -131,11 +137,18 @@ export function FfmpegArgsWidget(props: WidgetProps) {
 
   // Extract the global value for this specific field to detect inheritance
   const globalFieldValue = useMemo(() => {
-    if (!showUseGlobalSetting || !formContext?.globalValue || !presetField) {
+    if (
+      !showUseGlobalSetting ||
+      !formContext?.globalValue ||
+      !globalFieldPath
+    ) {
       return undefined;
     }
-    return get(formContext.globalValue as Record<string, unknown>, presetField);
-  }, [showUseGlobalSetting, formContext?.globalValue, presetField]);
+    return get(
+      formContext.globalValue as Record<string, unknown>,
+      globalFieldPath,
+    );
+  }, [showUseGlobalSetting, formContext?.globalValue, globalFieldPath]);
 
   const { data } = useSWR<FfmpegPresetResponse>("ffmpeg/presets");
 

--- a/web/src/components/config-form/theme/widgets/TextWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/TextWidget.tsx
@@ -2,7 +2,7 @@
 import type { WidgetProps } from "@rjsf/utils";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { getSizedFieldClassName } from "../utils";
+import { getNumericInputMode, getSizedFieldClassName } from "../utils";
 
 export function TextWidget(props: WidgetProps) {
   const {
@@ -28,6 +28,7 @@ export function TextWidget(props: WidgetProps) {
       id={id}
       className={cn(fieldClassName)}
       type="text"
+      inputMode={getNumericInputMode(schema, options)}
       value={value ?? ""}
       disabled={disabled || readonly}
       placeholder={placeholder || (options.placeholder as string) || ""}

--- a/web/src/components/overlay/ObjectTrackOverlay.tsx
+++ b/web/src/components/overlay/ObjectTrackOverlay.tsx
@@ -127,8 +127,12 @@ export default function ObjectTrackOverlay({
     },
   );
 
-  const getZonesFriendlyNames = (zones: string[], config: FrigateConfig) => {
-    return zones?.map((zone) => resolveZoneName(config, zone)) ?? [];
+  const getZonesFriendlyNames = (
+    zones: string[],
+    config: FrigateConfig,
+    cameraId?: string,
+  ) => {
+    return zones?.map((zone) => resolveZoneName(config, zone, cameraId)) ?? [];
   };
 
   const timelineResults = useMemo(() => {
@@ -151,7 +155,7 @@ export default function ObjectTrackOverlay({
         data: {
           ...event.data,
           zones_friendly_names: config
-            ? getZonesFriendlyNames(event.data?.zones, config)
+            ? getZonesFriendlyNames(event.data?.zones, config, event.camera)
             : [],
         },
       }));

--- a/web/src/components/overlay/detail/ObjectPath.tsx
+++ b/web/src/components/overlay/detail/ObjectPath.tsx
@@ -61,7 +61,11 @@ export function ObjectPath({
                 ...pos.lifecycle_item?.data,
                 zones_friendly_names: pos.lifecycle_item?.data.zones.map(
                   (zone) => {
-                    return resolveZoneName(config, zone);
+                    return resolveZoneName(
+                      config,
+                      zone,
+                      pos.lifecycle_item?.camera,
+                    );
                   },
                 ),
               },

--- a/web/src/components/overlay/detail/TrackingDetails.tsx
+++ b/web/src/components/overlay/detail/TrackingDetails.tsx
@@ -301,11 +301,19 @@ export function TrackingDetails({
     [recordings, actualVideoStart],
   );
 
-  eventSequence?.map((event) => {
-    event.data.zones_friendly_names = event.data?.zones?.map((zone) => {
-      return resolveZoneName(config, zone);
-    });
-  });
+  const sequence = useMemo(
+    () =>
+      eventSequence?.map((item) => ({
+        ...item,
+        data: {
+          ...item.data,
+          zones_friendly_names: item.data?.zones?.map((zone) =>
+            resolveZoneName(config, zone, item.camera),
+          ),
+        },
+      })),
+    [eventSequence, config],
+  );
 
   // Use manualOverride (set when seeking in image mode) if present so
   // lifecycle rows and overlays follow image-mode seeks. Otherwise fall
@@ -849,9 +857,9 @@ export function TrackingDetails({
             </div>
 
             <div className="mt-2">
-              {!eventSequence ? (
+              {!sequence ? (
                 <ActivityIndicator className="size-2" size={2} />
-              ) : eventSequence.length === 0 ? (
+              ) : sequence.length === 0 ? (
                 <div className="py-2 text-muted-foreground">
                   {t("detail.noObjectDetailData", { ns: "views/events" })}
                 </div>
@@ -871,7 +879,7 @@ export function TrackingDetails({
                     />
                   )}
                   <div className="space-y-2">
-                    {eventSequence.map((item, idx) => {
+                    {sequence.map((item, idx) => {
                       return (
                         <div
                           key={`${item.timestamp}-${item.source_id ?? ""}-${idx}`}

--- a/web/src/components/timeline/DetailStream.tsx
+++ b/web/src/components/timeline/DetailStream.tsx
@@ -1032,7 +1032,7 @@ function ObjectTimeline({
         data: {
           ...event.data,
           zones_friendly_names: event.data?.zones?.map((zone) =>
-            resolveZoneName(config, zone),
+            resolveZoneName(config, zone, event.camera),
           ),
         },
       }));


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
- Resolve zone friendly names against the correct camera
  - Zone name lookups passed no camera, so `resolveZoneName` scanned every camera and returned the first match on a zone key. This would report the wrong friendly name when two cameras share a key. 
  - All four call sites now pass the item's own camera, and `TrackingDetails` builds the names in a memo instead of mutating the SWR cache mid-render.
- Render zones with friendly name and ID in the chat prompt so the model correctly uses both.
- Show a numeric keyboard on mobile for number-specific fields in the Settings UI
- Instruct model to only use English for semantic search tool when JinaV1 is configured semantic search model
- Resolve export hwaccel args global value against the correct config path
  - The camera-level export hwaccel args field looked up the global value at `record.hwaccel_args` instead of `record.export.hwaccel_args`, so it never detected inheritance and showed the resolved preset instead of "Inherit from global".
  - Split global hwaccel args lookup path out from the preset-list key, which only matched by coincidence in the ffmpeg section, and points the record section at its real path.



## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
