### PR TITLE
Decay enrichment inference-time gauges to 0 when idle

### DIFF
--- a/frigate/data_processing/common/license_plate/mixin.py
+++ b/frigate/data_processing/common/license_plate/mixin.py
@@ -59,6 +59,16 @@ class LicensePlateProcessingMixin:
         self.plates_det_second = EventsPerSecond()
         self.plates_det_second.start()
         self.event_metadata_publisher = EventMetadataPublisher()
+
+    def refresh_idle_metrics(self) -> None:
+        rec_eps = self.plates_rec_second.eps()
+        self.metrics.alpr_pps.value = rec_eps
+        if rec_eps == 0:
+            self.metrics.alpr_speed.value = 0.0
+        det_eps = self.plates_det_second.eps()
+        self.metrics.yolov9_lpr_pps.value = det_eps
+        if det_eps == 0:
+            self.metrics.yolov9_lpr_speed.value = 0.0
         self.ctc_decoder = CTCDecoder(
             character_dict_path=os.path.join(
                 MODEL_CACHE_DIR, "paddleocr-onnx", "ppocr_keys_v1.txt"

--- a/frigate/data_processing/post/api.py
+++ b/frigate/data_processing/post/api.py
@@ -63,3 +63,15 @@ class PostProcessorApi(ABC):
             payload: The updated configuration object.
         """
         pass
+
+    def refresh_idle_metrics(self) -> None:
+        """Decay this processor's rate/speed gauges toward 0 while idle.
+
+        process_data() only runs when there is a description to generate, so the
+        rate gauge and the inference-speed EMA hold their last value when the
+        processor is idle and the UI shows a stale inference time forever. The
+        maintainer calls this every loop iteration; processors with gauges
+        override it to re-read EventsPerSecond.eps() and zero the speed once the
+        rate reaches 0. Default is a no-op.
+        """
+        pass

--- a/frigate/data_processing/post/object_descriptions.py
+++ b/frigate/data_processing/post/object_descriptions.py
@@ -57,6 +57,12 @@ class ObjectDescriptionProcessor(PostProcessorApi):
         self.object_desc_dps = EventsPerSecond()
         self.object_desc_dps.start()
 
+    def refresh_idle_metrics(self) -> None:
+        eps = self.object_desc_dps.eps()
+        self.metrics.object_desc_dps.value = eps
+        if eps == 0:
+            self.metrics.object_desc_speed.value = 0.0
+
     def __handle_frame_update(
         self, camera: str, data: dict, yuv_frame: np.ndarray
     ) -> None:

--- a/frigate/data_processing/post/review_descriptions.py
+++ b/frigate/data_processing/post/review_descriptions.py
@@ -59,6 +59,12 @@ class ReviewDescriptionProcessor(PostProcessorApi):
         self.review_desc_dps = EventsPerSecond()
         self.review_desc_dps.start()
 
+    def refresh_idle_metrics(self) -> None:
+        eps = self.review_desc_dps.eps()
+        self.metrics.review_desc_dps.value = eps
+        if eps == 0:
+            self.metrics.review_desc_speed.value = 0.0
+
     def calculate_frame_count(
         self,
         camera: str,

--- a/frigate/data_processing/real_time/api.py
+++ b/frigate/data_processing/real_time/api.py
@@ -80,6 +80,19 @@ class RealTimeProcessorApi(ABC):
         """
         pass
 
+    def refresh_idle_metrics(self) -> None:
+        """Decay this processor's rate/speed gauges toward 0 while idle.
+
+        process_frame() only runs on object updates, so the rate gauge (an
+        EventsPerSecond value) and the inference-speed gauge (an EMA that only
+        changes on update) both hold their last value when the processor stops
+        receiving frames. The UI then shows a stale inference time forever. The
+        maintainer calls this every loop iteration; processors with gauges
+        override it to re-read EventsPerSecond.eps() (which decays on its own)
+        and zero the speed once the rate reaches 0. Default is a no-op.
+        """
+        pass
+
     def drain_results(self) -> list[dict[str, Any]]:
         """Return pending results that need IPC side-effects.
 

--- a/frigate/data_processing/real_time/custom_classification.py
+++ b/frigate/data_processing/real_time/custom_classification.py
@@ -97,6 +97,15 @@ class CustomStateClassificationProcessor(DeferredRealtimeProcessorApi):
         if self.inference_speed:
             self.inference_speed.update(duration)
 
+    def refresh_idle_metrics(self) -> None:
+        name = self.model_config.name
+        if not self.metrics or name not in self.metrics.classification_cps:
+            return
+        eps = self.classifications_per_second.eps()
+        self.metrics.classification_cps[name].value = eps
+        if eps == 0 and name in self.metrics.classification_speeds:
+            self.metrics.classification_speeds[name].value = 0.0
+
     def _should_save_image(
         self, camera: str, detected_state: str, score: float = 1.0
     ) -> bool:
@@ -443,6 +452,15 @@ class CustomObjectClassificationProcessor(DeferredRealtimeProcessorApi):
         self.classifications_per_second.update()
         if self.inference_speed:
             self.inference_speed.update(duration)
+
+    def refresh_idle_metrics(self) -> None:
+        name = self.model_config.name
+        if not self.metrics or name not in self.metrics.classification_cps:
+            return
+        eps = self.classifications_per_second.eps()
+        self.metrics.classification_cps[name].value = eps
+        if eps == 0 and name in self.metrics.classification_speeds:
+            self.metrics.classification_speeds[name].value = 0.0
 
     def get_weighted_score(
         self,

--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -177,6 +177,12 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
         self.faces_per_second.update()
         self.inference_speed.update(duration)
 
+    def refresh_idle_metrics(self) -> None:
+        eps = self.faces_per_second.eps()
+        self.metrics.face_rec_fps.value = eps
+        if eps == 0:
+            self.metrics.face_rec_speed.value = 0.0
+
     def process_frame(self, obj_data: dict[str, Any], frame: np.ndarray) -> None:
         """Look for faces in image."""
         self.metrics.face_rec_fps.value = self.faces_per_second.eps()

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -281,6 +281,9 @@ class EmbeddingMaintainer(threading.Thread):
         # recordings data
         self.recordings_available_through: dict[str, float] = {}
 
+        # throttle for decaying idle enrichment metrics
+        self._last_metrics_refresh = 0.0
+
     def run(self) -> None:
         """Maintain a SQLite-vec database for semantic search."""
         while not self.stop_event.is_set():
@@ -295,6 +298,7 @@ class EmbeddingMaintainer(threading.Thread):
             self._expire_dedicated_lpr()
             self._process_finalized()
             self._process_event_metadata()
+            self._refresh_idle_metrics()
 
         # Shutdown deferred processors
         for processor in self.realtime_processors:
@@ -311,6 +315,24 @@ class EmbeddingMaintainer(threading.Thread):
         self.embeddings_responder.stop()
         self.requestor.stop()
         logger.info("Exiting embeddings maintenance...")
+
+    def _refresh_idle_metrics(self) -> None:
+        """Let each processor decay its rate/speed gauges while idle.
+
+        Processors only touch their metrics inside process_frame/process_data,
+        so without this their gauges freeze at the last value when no objects
+        are being processed and the UI keeps showing a stale inference time.
+        Throttled to once per second — eps() decays over a 10s window, so a
+        finer cadence is unnecessary.
+        """
+        now = datetime.datetime.now().timestamp()
+        if now - self._last_metrics_refresh < 1.0:
+            return
+        self._last_metrics_refresh = now
+        for processor in self.realtime_processors:
+            processor.refresh_idle_metrics()
+        for processor in self.post_processors:
+            processor.refresh_idle_metrics()
 
     def _check_enrichment_config_updates(self) -> None:
         """Check for enrichment config updates and delegate to processors."""

--- a/frigate/test/test_idle_metrics.py
+++ b/frigate/test/test_idle_metrics.py
@@ -1,0 +1,148 @@
+"""Enrichment rate/speed gauges must decay to 0 when the processor goes idle.
+
+process_frame()/process_data() only run on object updates, so without an
+explicit idle refresh the rate gauge (EventsPerSecond) and the inference-speed
+gauge (an EMA that only changes on update) both hold their last value forever
+when nothing is being processed, and the UI shows a stale inference time. The
+maintainer calls refresh_idle_metrics() every loop; these tests exercise the
+real override on each processor with a mock self so the heavy model init is
+skipped.
+"""
+
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# TFLite is imported at module load by custom_classification
+for _mod in (
+    "tflite_runtime",
+    "tflite_runtime.interpreter",
+    "ai_edge_litert",
+    "ai_edge_litert.interpreter",
+):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+# isort: off
+# Import order is load-bearing: the maintainer must be imported first so that it
+# pulls in every processor module in the order that resolves the license-plate
+# <-> embeddings circular import. Alphabetical sorting would import the mixin
+# first and re-trigger the cycle, so import sorting is disabled for this block.
+from frigate.embeddings.maintainer import EmbeddingMaintainer  # noqa: E402,F401
+from frigate.data_processing.common.license_plate.mixin import (  # noqa: E402
+    LicensePlateProcessingMixin,
+)
+from frigate.data_processing.post.api import PostProcessorApi  # noqa: E402
+from frigate.data_processing.post.object_descriptions import (  # noqa: E402
+    ObjectDescriptionProcessor,
+)
+from frigate.data_processing.post.review_descriptions import (  # noqa: E402
+    ReviewDescriptionProcessor,
+)
+from frigate.data_processing.real_time.api import RealTimeProcessorApi  # noqa: E402
+from frigate.data_processing.real_time.custom_classification import (  # noqa: E402
+    CustomObjectClassificationProcessor,
+    CustomStateClassificationProcessor,
+)
+from frigate.data_processing.real_time.face import FaceRealTimeProcessor  # noqa: E402
+
+# isort: on
+
+
+class TestIdleMetricsBaseDefault(unittest.TestCase):
+    def test_base_defaults_are_noops(self):
+        # A processor without gauges must not crash when refreshed.
+        RealTimeProcessorApi.refresh_idle_metrics(MagicMock())
+        PostProcessorApi.refresh_idle_metrics(MagicMock())
+
+
+class TestFaceIdleMetrics(unittest.TestCase):
+    def _make(self, eps):
+        s = MagicMock()
+        s.faces_per_second.eps.return_value = eps
+        s.metrics.face_rec_fps = SimpleNamespace(value=99.0)
+        s.metrics.face_rec_speed = SimpleNamespace(value=42.0)
+        return s
+
+    def test_zeros_speed_when_idle(self):
+        s = self._make(0.0)
+        FaceRealTimeProcessor.refresh_idle_metrics(s)
+        self.assertEqual(s.metrics.face_rec_fps.value, 0.0)
+        self.assertEqual(s.metrics.face_rec_speed.value, 0.0)
+
+    def test_keeps_speed_when_active(self):
+        s = self._make(3.0)
+        FaceRealTimeProcessor.refresh_idle_metrics(s)
+        self.assertEqual(s.metrics.face_rec_fps.value, 3.0)
+        self.assertEqual(s.metrics.face_rec_speed.value, 42.0)  # untouched
+
+
+class TestClassificationIdleMetrics(unittest.TestCase):
+    def _make(self, eps):
+        s = MagicMock()
+        s.model_config.name = "brana"
+        s.metrics.classification_cps = {"brana": SimpleNamespace(value=99.0)}
+        s.metrics.classification_speeds = {"brana": SimpleNamespace(value=42.0)}
+        s.classifications_per_second.eps.return_value = eps
+        return s
+
+    def test_state_zeros_speed_when_idle(self):
+        s = self._make(0.0)
+        CustomStateClassificationProcessor.refresh_idle_metrics(s)
+        self.assertEqual(s.metrics.classification_cps["brana"].value, 0.0)
+        self.assertEqual(s.metrics.classification_speeds["brana"].value, 0.0)
+
+    def test_object_keeps_speed_when_active(self):
+        s = self._make(2.0)
+        CustomObjectClassificationProcessor.refresh_idle_metrics(s)
+        self.assertEqual(s.metrics.classification_cps["brana"].value, 2.0)
+        self.assertEqual(s.metrics.classification_speeds["brana"].value, 42.0)
+
+    def test_unknown_model_is_ignored(self):
+        s = MagicMock()
+        s.model_config.name = "missing"
+        s.metrics.classification_cps = {}
+        s.metrics.classification_speeds = {}
+        # must not raise
+        CustomStateClassificationProcessor.refresh_idle_metrics(s)
+
+
+class TestLicensePlateIdleMetrics(unittest.TestCase):
+    def test_zeros_both_speeds_when_idle(self):
+        s = MagicMock()
+        s.plates_rec_second.eps.return_value = 0.0
+        s.plates_det_second.eps.return_value = 0.0
+        s.metrics.alpr_pps = SimpleNamespace(value=99.0)
+        s.metrics.alpr_speed = SimpleNamespace(value=42.0)
+        s.metrics.yolov9_lpr_pps = SimpleNamespace(value=99.0)
+        s.metrics.yolov9_lpr_speed = SimpleNamespace(value=42.0)
+        LicensePlateProcessingMixin.refresh_idle_metrics(s)
+        self.assertEqual(s.metrics.alpr_pps.value, 0.0)
+        self.assertEqual(s.metrics.alpr_speed.value, 0.0)
+        self.assertEqual(s.metrics.yolov9_lpr_pps.value, 0.0)
+        self.assertEqual(s.metrics.yolov9_lpr_speed.value, 0.0)
+
+
+class TestDescriptionIdleMetrics(unittest.TestCase):
+    def test_review_zeros_speed_when_idle(self):
+        s = MagicMock()
+        s.review_desc_dps.eps.return_value = 0.0
+        s.metrics.review_desc_dps = SimpleNamespace(value=99.0)
+        s.metrics.review_desc_speed = SimpleNamespace(value=42.0)
+        ReviewDescriptionProcessor.refresh_idle_metrics(s)
+        self.assertEqual(s.metrics.review_desc_dps.value, 0.0)
+        self.assertEqual(s.metrics.review_desc_speed.value, 0.0)
+
+    def test_object_keeps_speed_when_active(self):
+        s = MagicMock()
+        s.object_desc_dps.eps.return_value = 1.5
+        s.metrics.object_desc_dps = SimpleNamespace(value=99.0)
+        s.metrics.object_desc_speed = SimpleNamespace(value=42.0)
+        ObjectDescriptionProcessor.refresh_idle_metrics(s)
+        self.assertEqual(s.metrics.object_desc_dps.value, 1.5)
+        self.assertEqual(s.metrics.object_desc_speed.value, 42.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Proposed change

The Enrichments panel keeps showing a non-zero "Average Inference Time" for an enrichment long after it goes idle, even though its "Inferences Per Second" correctly drops to 0.

Enrichment rate gauges use `EventsPerSecond` (a 10s sliding window that decays on its own) while the paired inference-time gauge uses `InferenceSpeed` (an EMA that only changes on update). Both are only touched inside `process_frame` / `process_data`, which run on object updates, so when a processor goes idle its inference time freezes at the last value and the UI shows work happening forever.

Add a `refresh_idle_metrics()` hook (no-op default on both processor base classes) that re-reads `eps()` and zeros the speed once the rate reaches 0. The maintainer calls it once per second for every realtime and post processor.
Implemented for face recognition, custom classification (state + object), license plate (recognition + detection) and review/object descriptions.

BEFORE:

<img width="940" height="537" alt="Screenshot 2026-07-15 at 16 46 50" src="https://github.com/user-attachments/assets/028f6e80-29fe-4119-890a-81be2f7c9a23" />


AFTER:

<img width="987" height="577" alt="Screenshot 2026-07-15 at 15 49 44" src="https://github.com/user-attachments/assets/40539ebb-8567-4835-ac03-126cc74874c2" />


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes: 
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features): n/a (bugfix)

## AI disclosure

- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude

**How AI was used**: root-cause analysis, code generation, unit-test generation, running the test suite and Ruff.

**Extent of AI involvement**: investigation, benchmarking, code generation, validation

**Human oversight**: Bug reproduced and fix behavior validated on my own live NVR. The code is covered by unit tests and ruff.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys
- [x] The code has been formatted using Ruff (`ruff format frigate`)