### PR TITLE
Stop config saves from re-broadcasting unchanged runtime toggles

### DIFF
--- a/frigate/api/config_util.py
+++ b/frigate/api/config_util.py
@@ -30,4 +30,6 @@ def swap_runtime_config(app: FastAPI, config: FrigateConfig) -> None:
         for comm in app.dispatcher.comms:
             comm.config = config
 
-        app.dispatcher.apply_runtime_state()
+        # workers still hold the live toggle values, so correct only the
+        # config object here rather than re-broadcasting every override
+        app.dispatcher.reapply_runtime_state_to_config()

--- a/frigate/comms/dispatcher.py
+++ b/frigate/comms/dispatcher.py
@@ -492,6 +492,48 @@ class Dispatcher:
         """
         self._runtime_state.clear_camera(camera)
 
+    def reapply_runtime_state_to_config(self) -> None:
+        """Re-apply persisted runtime overrides to the swapped-in config object.
+
+        After config/set (or a camera delete) parses fresh yaml and swaps the
+        config, the worker processes still hold the live toggle values and the
+        overrides are already on disk, so only the in-process config object is
+        out of date. Unlike apply_runtime_state (used at startup, where workers
+        must be told), this makes no ZMQ, MQTT, or disk writes, it just corrects
+        the config the API and dispatcher read.
+
+        The field mutations and gates mirror the _on_*_command handlers; keep
+        the two in sync if a tracked toggle is added or its gate changes.
+        """
+        state = self._runtime_state.load()
+
+        for camera_name, features in state.items():
+            camera = self.config.cameras.get(camera_name)
+
+            if camera is None:
+                continue
+
+            for topic, value in features.items():
+                if topic == "enabled":
+                    if value and not camera.enabled_in_config:
+                        continue
+                    camera.enabled = value
+                elif topic == "detect":
+                    camera.detect.enabled = value
+                    # detection requires motion, mirror the handler coupling
+                    if value and not camera.motion.enabled:
+                        camera.motion.enabled = True
+                elif topic == "snapshots":
+                    camera.snapshots.enabled = value
+                elif topic == "recordings":
+                    if value and not camera.record.enabled_in_config:
+                        continue
+                    camera.record.enabled = value
+                elif topic == "audio":
+                    if value and not camera.audio.enabled_in_config:
+                        continue
+                    camera.audio.enabled = value
+
     def _on_detect_command(self, camera_name: str, payload: str) -> None:
         """Callback for detect topic."""
         detect_settings = self.config.cameras[camera_name].detect

--- a/frigate/test/http_api/test_http_camera.py
+++ b/frigate/test/http_api/test_http_camera.py
@@ -118,7 +118,7 @@ class TestDeleteCameraRuntimeConfig(BaseTestHttp):
                 self.assertIn("back_yard", dispatcher.config.cameras)
 
                 # surviving cameras' overrides are re-layered onto the new object
-                dispatcher.apply_runtime_state.assert_called_once_with()
+                dispatcher.reapply_runtime_state_to_config.assert_called_once_with()
 
                 # the deleted camera's persisted overrides are pruned
                 dispatcher.clear_runtime_state_for_camera.assert_called_once_with(

--- a/frigate/test/http_api/test_http_config_set.py
+++ b/frigate/test/http_api/test_http_config_set.py
@@ -143,11 +143,10 @@ class TestConfigSetWildcardPropagation(BaseTestHttp):
         # front_door was turned off via the UI: the override is on disk, and
         # yaml still says enabled: true. Stand in for the real replay, which
         # reads dispatcher.config - the object the endpoint just swapped in.
-        def fake_apply():
+        def fake_reapply():
             dispatcher.config.cameras["front_door"].enabled = False
-            return {"front_door": {"enabled": False}}
 
-        dispatcher.apply_runtime_state.side_effect = fake_apply
+        dispatcher.reapply_runtime_state_to_config.side_effect = fake_reapply
 
         try:
             app, _ = self._create_app_with_dispatcher(dispatcher)
@@ -168,7 +167,7 @@ class TestConfigSetWildcardPropagation(BaseTestHttp):
 
                 # the swap must be repaired: the new config object the API and
                 # dispatcher now share has to still show front_door as off
-                dispatcher.apply_runtime_state.assert_called_once_with()
+                dispatcher.reapply_runtime_state_to_config.assert_called_once_with()
                 self.assertFalse(app.frigate_config.cameras["front_door"].enabled)
                 self.assertIs(dispatcher.config, app.frigate_config)
 
@@ -178,7 +177,7 @@ class TestConfigSetWildcardPropagation(BaseTestHttp):
                 call_names = [name for name, _, _ in dispatcher.mock_calls]
                 self.assertLess(
                     call_names.index("clear_runtime_state_for_yaml_keys"),
-                    call_names.index("apply_runtime_state"),
+                    call_names.index("reapply_runtime_state_to_config"),
                 )
         finally:
             os.unlink(config_path)
@@ -205,7 +204,7 @@ class TestConfigSetWildcardPropagation(BaseTestHttp):
                 )
 
                 self.assertEqual(resp.status_code, 200)
-                dispatcher.apply_runtime_state.assert_not_called()
+                dispatcher.reapply_runtime_state_to_config.assert_not_called()
         finally:
             os.unlink(config_path)
 

--- a/frigate/test/test_config_util.py
+++ b/frigate/test/test_config_util.py
@@ -35,7 +35,7 @@ class TestSwapRuntimeConfig(unittest.TestCase):
         swap_runtime_config(app, config)
 
         # the swap rebuilds cameras from yaml, so overrides must be re-layered
-        app.dispatcher.apply_runtime_state.assert_called_once_with()
+        app.dispatcher.reapply_runtime_state_to_config.assert_called_once_with()
 
     def test_tolerates_missing_optional_collaborators(self) -> None:
         app = MagicMock()

--- a/frigate/test/test_dispatcher_runtime_state.py
+++ b/frigate/test/test_dispatcher_runtime_state.py
@@ -253,5 +253,115 @@ class TestClearPassthrough(unittest.TestCase):
         dispatcher._runtime_state.clear_camera.assert_called_once_with("front_door")
 
 
+class TestReapplyRuntimeStateToConfig(unittest.TestCase):
+    """The silent re-apply corrects the config object with no side effects."""
+
+    def _dispatcher_with(
+        self, cameras: dict[str, MagicMock], state: dict
+    ) -> Dispatcher:
+        dispatcher = _build_dispatcher(cameras)
+        dispatcher._runtime_state = MagicMock(spec=RuntimeStatePersistence)
+        dispatcher._runtime_state.load.return_value = state
+        dispatcher.publish = MagicMock()
+        return dispatcher
+
+    def test_mutates_every_tracked_field(self) -> None:
+        cameras = {"front_door": _make_camera_mock()}
+        dispatcher = self._dispatcher_with(
+            cameras,
+            {
+                "front_door": {
+                    "enabled": False,
+                    "detect": False,
+                    "snapshots": False,
+                    "recordings": False,
+                    "audio": False,
+                }
+            },
+        )
+
+        dispatcher.reapply_runtime_state_to_config()
+
+        cam = cameras["front_door"]
+        self.assertFalse(cam.enabled)
+        self.assertFalse(cam.detect.enabled)
+        self.assertFalse(cam.snapshots.enabled)
+        self.assertFalse(cam.record.enabled)
+        self.assertFalse(cam.audio.enabled)
+
+    def test_makes_no_zmq_mqtt_or_disk_writes(self) -> None:
+        dispatcher = self._dispatcher_with(
+            {"front_door": _make_camera_mock()},
+            {"front_door": {"enabled": False}},
+        )
+
+        dispatcher.reapply_runtime_state_to_config()
+
+        dispatcher.config_updater.publish_update.assert_not_called()
+        dispatcher._runtime_state.set.assert_not_called()
+        dispatcher.publish.assert_not_called()
+
+    def test_respects_enabled_in_config_gate(self) -> None:
+        # an ON override for a camera disabled in yaml must not enable it
+        cameras = {
+            "front_door": _make_camera_mock(enabled=False, enabled_in_config=False)
+        }
+        dispatcher = self._dispatcher_with(cameras, {"front_door": {"enabled": True}})
+
+        dispatcher.reapply_runtime_state_to_config()
+
+        self.assertFalse(cameras["front_door"].enabled)
+
+    def test_respects_recordings_and_audio_gates(self) -> None:
+        # ON overrides for recordings/audio not enabled in yaml must be ignored
+        cameras = {
+            "front_door": _make_camera_mock(
+                record_enabled=False,
+                record_enabled_in_config=False,
+                audio_enabled=False,
+                audio_enabled_in_config=False,
+            )
+        }
+        dispatcher = self._dispatcher_with(
+            cameras, {"front_door": {"recordings": True, "audio": True}}
+        )
+
+        dispatcher.reapply_runtime_state_to_config()
+
+        self.assertFalse(cameras["front_door"].record.enabled)
+        self.assertFalse(cameras["front_door"].audio.enabled)
+
+    def test_applies_on_override_when_gate_passes(self) -> None:
+        # a camera off in yaml but enabled_in_config keeps its runtime-on state
+        cameras = {
+            "front_door": _make_camera_mock(enabled=False, enabled_in_config=True)
+        }
+        dispatcher = self._dispatcher_with(cameras, {"front_door": {"enabled": True}})
+
+        dispatcher.reapply_runtime_state_to_config()
+
+        self.assertTrue(cameras["front_door"].enabled)
+
+    def test_detect_on_couples_motion(self) -> None:
+        cam = _make_camera_mock(detect_enabled=False)
+        cam.motion.enabled = False
+        dispatcher = self._dispatcher_with(
+            {"front_door": cam}, {"front_door": {"detect": True}}
+        )
+
+        dispatcher.reapply_runtime_state_to_config()
+
+        self.assertTrue(cam.detect.enabled)
+        self.assertTrue(cam.motion.enabled)
+
+    def test_skips_camera_not_in_config(self) -> None:
+        dispatcher = self._dispatcher_with(
+            {"front_door": _make_camera_mock()}, {"ghost": {"enabled": False}}
+        )
+
+        # a stale entry for a deleted camera must be ignored, not raise
+        dispatcher.reapply_runtime_state_to_config()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
https://github.com/blakeblackshear/frigate/pull/23734 changed runtime camera toggles (on/off, detect, snapshots, recordings, audio) to apply by mutating the in-memory config and persisting an override to `.runtime_state.json`. `/api/config/set` and camera deletion re-parse yaml into a fresh `FrigateConfig` and swap it into the app, and to keep a runtime-off camera from silently coming back on they re-layered the overrides on top by calling `apply_runtime_state`, which replays each override **through the command handlers**. Those handlers publish a ZMQ config update, a retained MQTT `{camera}/{topic}/state` message, and a runtime-state disk write on every call, so every config save re-emitted all three for every camera with a stored toggle.

None of that was necessary. The worker processes are never handed the swapped config object; they track changes over ZMQ and already held the live toggle values from the original command, so only the freshly parsed in-process config the API and dispatcher read was actually out of date. The redundant republish churned the retained MQTT topics (visible downstream, e.g. Home Assistant), amplified disk writes during config tuning, and re-broadcast `enabled` updates that co-drained with other topics on the config socket.

This PR makes a small tweak and adds `Dispatcher.reapply_runtime_state_to_config`, a silent re-apply that corrects only the swapped-in config object, mirroring the field mutations and gates of the `_on_*_command` handlers (including the detect/motion coupling and the `enabled_in_config` gates) with no ZMQ, MQTT, or disk writes. `swap_runtime_config` now uses it for both the config-set and delete paths. `apply_runtime_state` is unchanged and still used at startup by `restore_runtime_state`, where freshly started workers genuinely must be told the overrides. The runtime-off camera still reads correctly after a save because the dispatcher's config is corrected before `handle_on_connect` reports it.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
