### PR TITLE
Miscellaneous fixes (0.18 beta)

### DIFF
--- a/docs/docs/configuration/profiles.md
+++ b/docs/docs/configuration/profiles.md
@@ -232,6 +232,21 @@ No. Only one profile can be active at a time. Activating a new profile automatic
 
 When you delete a base zone or mask in the Frigate UI, any profile overrides for that entry are deleted automatically as part of the same operation. If you remove a base entry by editing your config file directly and leave a profile override behind, the config will fail validation at startup until the orphaned override is removed as well.
 
+### How do I make a YAML profile track no objects at all?
+
+Set the tracked object list explicitly to an empty list in the profile:
+
+```yaml
+cameras:
+  front_door:
+    profiles:
+      home:
+        objects:
+          track: []
+```
+
+Leaving the `objects` section empty (or omitting `track`) does not clear the list. Empty sections set no fields, so the profile inherits the full tracked object list from the base config, including anything set at the global level. The same applies to other lists, such as `audio.listen`.
+
 ### Why are some settings missing when I configure a profile override?
 
 Fields that require a Frigate restart to take effect cannot be overridden by profiles, since profiles are applied at runtime without restarting. Those fields are hidden when editing a profile override and can only be changed on the base configuration.

--- a/docs/docs/troubleshooting/recordings.md
+++ b/docs/docs/troubleshooting/recordings.md
@@ -428,3 +428,19 @@ You'll want to:
 - [Tune your motion detection settings](/configuration/motion_detection) either by editing your config file or by using the UI's Motion Tuner.
 
 </FaqItem>
+
+<FaqItem id="my-timeline-previews-are-black-after-restarting-frigate-or-recreating-the-container" question="My timeline previews are black after restarting Frigate or recreating the container. Why?">
+
+The scrubbing previews (the timelapse clips shown when dragging the History timeline, the secondary-camera previews, and the preview that plays when hovering a review card) are not recorded continuously. Frigate caches low-resolution preview frames in `/tmp/cache` throughout each hour and only assembles them into a finished preview clip **at the top of the hour**.
+
+In the recommended configuration, `/tmp/cache` is a small in-memory (`tmpfs`) area. When Frigate starts, it tries to restore the current hour's cached frames, so a **soft restart from the UI** preserves them. But if you recreate the Docker container or stop Frigate forcibly by any other means partway through an hour, the in-memory cache is discarded, so no preview clip is produced for that partial hour.
+
+This is expected behavior, not a bug:
+
+- Previews for hours that already completed and were written to disk are unaffected.
+- The next full hour after a restart will generate previews normally.
+- This is unrelated to `shm_size`; increasing shared memory does not change it.
+
+To avoid the gap, use the **Restart Frigate** button in the UI's Settings menu rather than recreating the container when possible.
+
+</FaqItem>

--- a/docs/docs/usage/exports.md
+++ b/docs/docs/usage/exports.md
@@ -34,7 +34,7 @@ All of your exports live on the **Exports** page, reachable from the main naviga
 - **Rename** it, and
 - **Delete** it: deleting is the only way an export is removed.
 
-You can also select multiple exports at once to **delete** them in bulk, or to **add them to** (or **remove them from**) a [case](#cases).
+You can also select multiple exports at once to **delete** them in bulk, or to **add them to** (or **remove them from**) a [case](#cases). To download multiple exports as a zip archive, add them to a **case** and use the Download button there.
 
 ## Cases
 

--- a/docs/static/frigate-api.yaml
+++ b/docs/static/frigate-api.yaml
@@ -8244,6 +8244,11 @@ components:
       properties:
         provider:
           $ref: '#/components/schemas/GenAIProviderEnum'
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Name
         api_key:
           anyOf:
             - type: string

--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -196,7 +196,7 @@ def genai_models(request: Request):
         "before saving the configuration."
     ),
 )
-async def genai_probe(body: GenAIProbeBody):
+async def genai_probe(request: Request, body: GenAIProbeBody):
     load_providers()
 
     provider_cls = PROVIDERS.get(body.provider)
@@ -205,6 +205,13 @@ async def genai_probe(body: GenAIProbeBody):
             status_code=400,
             content={"success": False, "message": "Unknown provider"},
         )
+
+    api_key = body.api_key
+    if api_key == REDACTED_CREDENTIAL_SENTINEL:
+        saved_cfg = (
+            request.app.frigate_config.genai.get(body.name) if body.name else None
+        )
+        api_key = saved_cfg.api_key if saved_cfg else None
 
     # The OpenAI-compatible SDKs accept "timeout" as a constructor kwarg via
     # provider_options; other plugins use GenAIClient.timeout passed below.
@@ -217,7 +224,7 @@ async def genai_probe(body: GenAIProbeBody):
     try:
         transient_cfg = GenAIConfig(
             provider=body.provider,
-            api_key=body.api_key,
+            api_key=api_key,
             base_url=body.base_url,
             provider_options=probe_provider_options,
             # model is required by the schema but irrelevant for listing.

--- a/frigate/api/defs/request/app_body.py
+++ b/frigate/api/defs/request/app_body.py
@@ -14,6 +14,7 @@ class AppConfigSetBody(BaseModel):
 
 class GenAIProbeBody(BaseModel):
     provider: GenAIProviderEnum
+    name: str | None = None
     api_key: str | None = None
     base_url: str | None = None
     provider_options: dict[str, Any] = Field(default_factory=dict)

--- a/frigate/test/http_api/test_http_app.py
+++ b/frigate/test/http_api/test_http_app.py
@@ -132,6 +132,77 @@ class TestHttpApp(BaseTestHttp):
                 "models": ["fake-model-a", "fake-model-b"],
             }
 
+    def test_genai_probe_resolves_sentinel_to_saved_api_key(self):
+        # After a save the UI's api_key field holds the redaction sentinel;
+        # the probe must substitute the saved key for the named entry instead
+        # of sending the literal sentinel to the provider (GH discussion 23754).
+        probed_keys: list[str | None] = []
+
+        class CapturingClient(GenAIClient):
+            def list_models(self):
+                probed_keys.append(self.genai_config.api_key)
+                return ["fake-model"]
+
+        self.minimal_config["genai"] = {
+            "llm": {
+                "provider": "openai",
+                "api_key": "sk-saved",
+                "base_url": "https://example.invalid",
+                "model": "fake-model",
+            }
+        }
+        app = super().create_app()
+
+        with (
+            AuthTestClient(app) as client,
+            patch.dict(
+                frigate.genai.PROVIDERS,
+                {GenAIProviderEnum.openai: CapturingClient},
+            ),
+        ):
+            response = client.post(
+                "/genai/probe",
+                json={
+                    "provider": "openai",
+                    "name": "llm",
+                    "api_key": REDACTED_CREDENTIAL_SENTINEL,
+                    "base_url": "https://example.invalid",
+                },
+            )
+            assert response.status_code == 200
+            assert response.json()["success"] is True
+            assert probed_keys == ["sk-saved"]
+
+    def test_genai_probe_sentinel_without_saved_entry_sends_no_key(self):
+        # If the sentinel arrives for an entry that has no saved config, the
+        # probe must drop the key entirely rather than leak the sentinel.
+        probed_keys: list[str | None] = []
+
+        class CapturingClient(GenAIClient):
+            def list_models(self):
+                probed_keys.append(self.genai_config.api_key)
+                return ["fake-model"]
+
+        app = super().create_app()
+
+        with (
+            AuthTestClient(app) as client,
+            patch.dict(
+                frigate.genai.PROVIDERS,
+                {GenAIProviderEnum.openai: CapturingClient},
+            ),
+        ):
+            response = client.post(
+                "/genai/probe",
+                json={
+                    "provider": "openai",
+                    "name": "llm",
+                    "api_key": REDACTED_CREDENTIAL_SENTINEL,
+                },
+            )
+            assert response.status_code == 200
+            assert probed_keys == [None]
+
     def test_genai_probe_empty_list_is_treated_as_failure(self):
         # The plugin's list_models() returns [] on connection failure rather
         # than raising. The endpoint should surface that as success=false so

--- a/web/src/components/config-form/theme/widgets/GenAIModelWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/GenAIModelWidget.tsx
@@ -160,6 +160,7 @@ export function GenAIModelWidget(props: WidgetProps) {
     try {
       const res = await axios.post<ProbeResponse>("genai/probe", {
         provider: formProvider,
+        name: providerKey,
         api_key:
           typeof formEntry.api_key === "string" ? formEntry.api_key : null,
         base_url:

--- a/web/src/components/overlay/ExportDialog.tsx
+++ b/web/src/components/overlay/ExportDialog.tsx
@@ -444,10 +444,10 @@ export function ExportContent({
     }
 
     setRange({
-      before: latestTime,
-      after: latestTime - 3600,
+      before: currentTime + 1800,
+      after: currentTime - 1800,
     });
-  }, [activeTab, latestTime, range, setRange]);
+  }, [activeTab, currentTime, range, setRange]);
 
   const { data: events, isLoading: isEventsLoading } = useSWR<Event[]>(
     activeTab === "multi" && debouncedRange
@@ -817,7 +817,19 @@ export function ExportContent({
 
       <Tabs
         value={activeTab}
-        onValueChange={(value) => setActiveTab(value as ExportTab)}
+        onValueChange={(value) => {
+          const tab = value as ExportTab;
+          if (tab === "multi") {
+            setRange({
+              before: currentTime + 1800,
+              after: currentTime - 1800,
+            });
+          } else {
+            onSelectTime(selectedOption);
+          }
+
+          setActiveTab(tab);
+        }}
         className={cn("w-full", !isDesktop && "flex min-h-0 flex-1 flex-col")}
       >
         <TabsList className="grid w-full grid-cols-2">


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
- Resolve saved credential sentinel to the stored api key in genai probe
  - The GenAI model probe sent the form's api_key verbatim, so after saving, the untouched field held the redaction sentinel and the literal string `__FRIGATE_SAVED_CREDENTIAL__` was sent to the provider as the bearer key (#23754). The probe body now includes the config entry name, and the backend substitutes the saved api_key when it receives the sentinel (dropping the key entirely if no saved entry exists), so testing a saved provider works without retyping the key. The saved YAML and runtime clients were never affected; only the model-list probe leaked the sentinel.
- Center the one hour multi-camera export time range on the timeline handlebar instead of the past hour from when the History screen was opened
- Docs updates 


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
