### PR TITLE
Dynamically resolve Intel NPU

### DIFF
--- a/frigate/test/test_gpu_stats.py
+++ b/frigate/test/test_gpu_stats.py
@@ -1,7 +1,12 @@
 import unittest
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
-from frigate.util.services import get_amd_gpu_stats, get_intel_gpu_stats
+from frigate.util.services import (
+    get_amd_gpu_stats,
+    get_intel_gpu_stats,
+    get_openvino_npu_stats,
+)
 
 
 class TestGpuStats(unittest.TestCase):
@@ -16,6 +21,38 @@ class TestGpuStats(unittest.TestCase):
         sp.return_value = process
         amd_stats = get_amd_gpu_stats()
         assert amd_stats == {"gpu": "4.17%", "mem": "60.37%"}
+
+    @patch("frigate.util.services.time.sleep")
+    @patch("frigate.util.services.time.time", side_effect=[0.0, 1.0])
+    @patch(
+        "builtins.open",
+        side_effect=[StringIO("1000"), StringIO("1250")],
+    )
+    def test_openvino_npu_stats_runtime_active_time(self, open_file, time, sleep):
+        assert get_openvino_npu_stats() == {"npu": "25.0", "mem": "-%"}
+
+        assert open_file.call_args_list[0].args[0].endswith("runtime_active_time")
+
+    @patch("frigate.util.services.time.sleep")
+    @patch("frigate.util.services.time.time", side_effect=[0.0, 1.0])
+    @patch(
+        "builtins.open",
+        side_effect=[
+            FileNotFoundError,
+            StringIO("1000000"),
+            StringIO("1250000"),
+        ],
+    )
+    def test_openvino_npu_stats_busy_time_fallback(self, open_file, time, sleep):
+        assert get_openvino_npu_stats() == {"npu": "25.0", "mem": "-%"}
+
+        assert open_file.call_args_list[0].args[0].endswith("runtime_active_time")
+        assert open_file.call_args_list[1].args[0].endswith("npu_busy_time_us")
+
+    @patch("builtins.open", side_effect=FileNotFoundError)
+    def test_openvino_npu_stats_unavailable(self, open_file):
+        assert get_openvino_npu_stats() is None
+        assert open_file.call_count == 2
 
     @patch("frigate.stats.intel_gpu_info.intel_gpu_name_resolver.get_names")
     @patch("frigate.util.services.time.sleep")

--- a/frigate/test/test_gpu_stats.py
+++ b/frigate/test/test_gpu_stats.py
@@ -25,34 +25,84 @@ class TestGpuStats(unittest.TestCase):
     @patch("frigate.util.services.time.sleep")
     @patch("frigate.util.services.time.time", side_effect=[0.0, 1.0])
     @patch(
+        "frigate.util.services.os.readlink",
+        return_value="/sys/bus/pci/drivers/intel_vpu",
+    )
+    @patch(
+        "frigate.util.services.glob.glob",
+        return_value=["/sys/class/accel/accel0"],
+    )
+    @patch(
         "builtins.open",
         side_effect=[StringIO("1000"), StringIO("1250")],
     )
-    def test_openvino_npu_stats_runtime_active_time(self, open_file, time, sleep):
+    def test_openvino_npu_stats_discovers_accel0(
+        self, open_file, glob, readlink, time, sleep
+    ):
         assert get_openvino_npu_stats() == {"npu": "25.0", "mem": "-%"}
 
-        assert open_file.call_args_list[0].args[0].endswith("runtime_active_time")
+        open_file.assert_any_call(
+            "/sys/class/accel/accel0/device/power/runtime_active_time"
+        )
 
     @patch("frigate.util.services.time.sleep")
     @patch("frigate.util.services.time.time", side_effect=[0.0, 1.0])
     @patch(
-        "builtins.open",
+        "frigate.util.services.os.readlink",
         side_effect=[
-            FileNotFoundError,
-            StringIO("1000000"),
-            StringIO("1250000"),
+            "/sys/bus/pci/drivers/other",
+            "/sys/bus/pci/drivers/intel_vpu",
         ],
     )
-    def test_openvino_npu_stats_busy_time_fallback(self, open_file, time, sleep):
+    @patch(
+        "frigate.util.services.glob.glob",
+        return_value=[
+            "/sys/class/accel/accel0",
+            "/sys/class/accel/accel1",
+        ],
+    )
+    @patch(
+        "builtins.open",
+        side_effect=[StringIO("1000"), StringIO("1250")],
+    )
+    def test_openvino_npu_stats_skips_non_intel_accelerator(
+        self, open_file, glob, readlink, time, sleep
+    ):
         assert get_openvino_npu_stats() == {"npu": "25.0", "mem": "-%"}
 
-        assert open_file.call_args_list[0].args[0].endswith("runtime_active_time")
-        assert open_file.call_args_list[1].args[0].endswith("npu_busy_time_us")
+        open_file.assert_any_call(
+            "/sys/class/accel/accel1/device/power/runtime_active_time"
+        )
 
-    @patch("builtins.open", side_effect=FileNotFoundError)
-    def test_openvino_npu_stats_unavailable(self, open_file):
+    @patch(
+        "frigate.util.services.os.readlink",
+        return_value="/sys/bus/pci/drivers/other",
+    )
+    @patch(
+        "frigate.util.services.glob.glob",
+        return_value=["/sys/class/accel/accel0"],
+    )
+    @patch("builtins.open")
+    def test_openvino_npu_stats_no_intel_accelerator(self, open_file, glob, readlink):
         assert get_openvino_npu_stats() is None
-        assert open_file.call_count == 2
+        open_file.assert_not_called()
+
+    @patch(
+        "frigate.util.services.os.readlink",
+        return_value="/sys/bus/pci/drivers/intel_vpu",
+    )
+    @patch(
+        "frigate.util.services.glob.glob",
+        return_value=["/sys/class/accel/accel0"],
+    )
+    @patch("builtins.open", side_effect=FileNotFoundError)
+    def test_openvino_npu_stats_runtime_counter_unavailable(
+        self, open_file, glob, readlink
+    ):
+        assert get_openvino_npu_stats() is None
+        open_file.assert_called_once_with(
+            "/sys/class/accel/accel0/device/power/runtime_active_time"
+        )
 
     @patch("frigate.stats.intel_gpu_info.intel_gpu_name_resolver.get_names")
     @patch("frigate.util.services.time.sleep")

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -670,26 +670,42 @@ def get_intel_gpu_stats(
 
 def get_openvino_npu_stats() -> dict[str, str] | None:
     """Get NPU stats using openvino."""
-    NPU_RUNTIME_PATH = "/sys/devices/pci0000:00/0000:00:0b.0/power/runtime_active_time"
+    NPU_RUNTIME_PATHS = (
+        (
+            "/sys/devices/pci0000:00/0000:00:0b.0/power/runtime_active_time",
+            1_000,  # Milliseconds per second
+        ),
+        (
+            "/sys/class/accel/accel0/device/npu_busy_time_us",
+            1_000_000,  # Microseconds per second
+        ),
+    )
+
+    for runtime_path, units_per_second in NPU_RUNTIME_PATHS:
+        try:
+            with open(runtime_path) as f:
+                initial_runtime = float(f.read().strip())
+            break
+        except (FileNotFoundError, PermissionError, ValueError):
+            continue
+    else:
+        return None
 
     try:
-        with open(NPU_RUNTIME_PATH) as f:
-            initial_runtime = float(f.read().strip())
-
         initial_time = time.time()
 
         # Sleep for 1 second to get an accurate reading
         time.sleep(1.0)
 
         # Read runtime value again
-        with open(NPU_RUNTIME_PATH) as f:
+        with open(runtime_path) as f:
             current_runtime = float(f.read().strip())
 
         current_time = time.time()
 
         # Calculate usage percentage
         runtime_diff = current_runtime - initial_runtime
-        time_diff = (current_time - initial_time) * 1000.0  # Convert to milliseconds
+        time_diff = (current_time - initial_time) * units_per_second
 
         if time_diff > 0:
             usage = min(100.0, max(0.0, (runtime_diff / time_diff * 100.0)))

--- a/frigate/util/services.py
+++ b/frigate/util/services.py
@@ -1,6 +1,7 @@
 """Utilities for services."""
 
 import asyncio
+import glob
 import json
 import logging
 import os
@@ -670,19 +671,17 @@ def get_intel_gpu_stats(
 
 def get_openvino_npu_stats() -> dict[str, str] | None:
     """Get NPU stats using openvino."""
-    NPU_RUNTIME_PATHS = (
-        (
-            "/sys/devices/pci0000:00/0000:00:0b.0/power/runtime_active_time",
-            1_000,  # Milliseconds per second
-        ),
-        (
-            "/sys/class/accel/accel0/device/npu_busy_time_us",
-            1_000_000,  # Microseconds per second
-        ),
-    )
-
-    for runtime_path, units_per_second in NPU_RUNTIME_PATHS:
+    for accel_path in sorted(glob.glob("/sys/class/accel/accel*")):
         try:
+            driver = os.path.basename(os.readlink(f"{accel_path}/device/driver"))
+        except OSError:
+            continue
+
+        if driver != "intel_vpu":
+            continue
+
+        try:
+            runtime_path = f"{accel_path}/device/power/runtime_active_time"
             with open(runtime_path) as f:
                 initial_runtime = float(f.read().strip())
             break
@@ -705,7 +704,7 @@ def get_openvino_npu_stats() -> dict[str, str] | None:
 
         # Calculate usage percentage
         runtime_diff = current_runtime - initial_runtime
-        time_diff = (current_time - initial_time) * units_per_second
+        time_diff = (current_time - initial_time) * 1000.0  # Convert to milliseconds
 
         if time_diff > 0:
             usage = min(100.0, max(0.0, (runtime_diff / time_diff * 100.0)))


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) before submitting a PR._

## Proposed change
The current NPU stats use a hard-coded PCI address 0000:00:0b.0. to get the NPU runtime stats. 
The code now discovers accelerators through /sys/class/accel/accel*.
It identifies the device bound to intel_vpu.
The existing measurement calculation is unchanged.

This'll enable the NPU usage metrics to be displayed correctly in cases like multiple pci devices, or frigate hosted in vms etc.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update


## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [X] AI tools were used in this PR. Details below:


I wrote the skeleton code, and have Codex polish it. Test cases were written using codex.

I manually reviewed every code change. I verified thru CLI that the old sysfs path was not available in my machine and the new counter returns numeric value in the correct units. 

Focussed tests and ruff passed, but I did not run the full test suite. Hw validation is not done yet.
## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
