### PR TITLE
Recreate preview output directory before writing (fix 0.18 regression: silent permanent preview loss)

### DIFF
--- a/frigate/output/preview.py
+++ b/frigate/output/preview.py
@@ -159,6 +159,13 @@ class FFMpegConverter(threading.Thread):
                 f"duration {self.frame_times[t_idx + 1] - self.frame_times[t_idx]}"
             )
 
+        # The preview directory is created once in PreviewRecorder.__init__, but
+        # record cleanup's remove_empty_directories() can delete it again while it
+        # is empty (e.g. a camera re-added after removal, or an hour with no
+        # retained previews). Recreate it here so the hourly export can never fail
+        # permanently with "No such file or directory".
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+
         try:
             p = sp.run(
                 self.ffmpeg_cmd.split(" "),


### PR DESCRIPTION
## Proposed change

Preview generation breaks permanently in 0.18 once
recording cleanup deletes an empty `clips/previews/<camera>` directory. The
directory is created only once, in `PreviewRecorder.__init__`; `FFMpegConverter`
then writes the hourly clip without ensuring it still exists. In 0.18,
`record/cleanup.py` now passes preview-parent dirs into `remove_empty_directories()`,
which `rmdir()`s the empty `previews/<camera>` — and nothing recreates it, so every
subsequent hourly export fails with `No such file or directory` and previews are
silently lost. This worked in 0.17 (cleanup there only touched the recordings tree).
Hit it by re-enabling two cameras that had previously been removed. Fix: recreate
the output directory in `FFMpegConverter.run()` before invoking ffmpeg.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## AI disclosure

- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude (Claude Code)

**How AI was used**: Diagnosed the failure from my logs, located the root cause in
`output/preview.py` and `record/cleanup.py`, identified it as a 0.17→0.18 regression,
and wrote the one-line fix.

**Extent of AI involvement**: Assisted with diagnosis and the single-line change; I
reviewed and directed it.

**Human oversight**: [EDIT TO MATCH WHAT YOU DID] Reviewed the diff; verified the
missing-directory root cause against my running 0.18.0-beta1 instance (the exact
error and the deleted dir), applied the fix, and confirmed previews generate again.
Frigate's pytest suite was not run locally; change is ruff-formatted.

## Checklist

- [ ] The code change is tested and works locally.   
- [ ] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes ... (n/a)
- [x] The code has been formatted using Ruff (`ruff format frigate`)

