### PR TITLE
Declare httpx[http2] dependency in requirements

### DIFF
--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -20,7 +20,6 @@ apt-get -qq install --no-install-recommends -y \
     libgl1 \
     libglib2.0-0 \
     libusb-1.0.0 \
-    python3-h2 \
     libgomp1  # memryx detector
 
 update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1

--- a/docker/main/requirements-wheels.txt
+++ b/docker/main/requirements-wheels.txt
@@ -2,6 +2,7 @@ aiofiles == 24.1.*
 click == 8.1.*
 # FastAPI
 aiohttp == 3.12.*
+httpx[http2] == 0.28.*
 starlette == 0.47.*
 starlette-context == 0.4.*
 fastapi[standard-no-fastapi-cloud-cli] == 0.116.*


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

Declare explicit dependency on httpx[http2] in `requirements-wheel.txt`. There are various consumers of httpx, but it has not been explicitly tracked as a dependency. Folds in the install of the Debian `python3-h2` package into requiremennts.txt style declaration.

```
$ rg -l httpx frigate
frigate/api/camera.py
frigate/genai/plugins/llama_cpp.py
frigate/genai/plugins/ollama.py
frigate/genai/plugins/openai.py
frigate/test/test_genai_providers.py
```

I *think* it currently leaks in via `google-genai`and `openai`  fwiw.

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [x] No AI tools were used in this PR.
- [ ] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
