### PR TITLE
Performance: avoid unnecessary scans in timeline and VOD queries

### DIFF
--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -574,11 +574,11 @@ async def vod_ts(
             Recordings.start_time,
         )
         .where(
-            Recordings.start_time.between(start_ts, end_ts)
-            | Recordings.end_time.between(start_ts, end_ts)
-            | ((start_ts > Recordings.start_time) & (end_ts < Recordings.end_time))
+            Recordings.camera == camera_name,
+            Recordings.start_time >= start_ts - MAX_SEGMENT_DURATION,
+            Recordings.start_time <= end_ts,
+            Recordings.end_time >= start_ts,
         )
-        .where(Recordings.camera == camera_name)
         .order_by(Recordings.start_time.asc())
         .iterator()
     )

--- a/frigate/api/record.py
+++ b/frigate/api/record.py
@@ -25,7 +25,7 @@ from frigate.api.defs.query.recordings_query_parameters import (
 )
 from frigate.api.defs.response.generic_response import GenericResponse
 from frigate.api.defs.tags import Tags
-from frigate.const import RECORD_DIR
+from frigate.const import MAX_SEGMENT_DURATION, RECORD_DIR
 from frigate.models import Event, Recordings
 from frigate.util.time import get_dst_transitions
 
@@ -243,6 +243,7 @@ async def recordings(
         )
         .where(
             Recordings.camera == camera_name,
+            Recordings.start_time >= after - MAX_SEGMENT_DURATION,
             Recordings.end_time >= after,
             Recordings.start_time <= before,
         )

--- a/frigate/test/http_api/test_http_media.py
+++ b/frigate/test/http_api/test_http_media.py
@@ -1,11 +1,13 @@
 """Unit tests for recordings/media API endpoints."""
 
 from datetime import UTC, datetime
+from unittest.mock import patch
 
 import pytz
 from fastapi import Request
 
 from frigate.api.auth import get_allowed_cameras_for_filter, get_current_user
+from frigate.const import MAX_SEGMENT_DURATION
 from frigate.models import Recordings
 from frigate.test.http_api.base_http_test import AuthTestClient, BaseTestHttp
 
@@ -403,6 +405,55 @@ class TestHttpMedia(BaseTestHttp):
             assert len(summary) == 1
             assert "2024-03-10" in summary
             assert summary["2024-03-10"] is True
+
+    def test_recordings_returns_overlapping_segment(self):
+        """Recordings include a segment that overlaps the requested range."""
+        after = 1000
+        before = 1100
+
+        with AuthTestClient(self.app) as client:
+            super().insert_mock_recording("too_old", after - 10, after - 1)
+            super().insert_mock_recording(
+                "overlap",
+                after - MAX_SEGMENT_DURATION + 1,
+                after,
+            )
+            super().insert_mock_recording("too_new", before + 1, before + 10)
+
+            response = client.get(
+                "/front_door/recordings",
+                params={"after": after, "before": before},
+            )
+
+            assert response.status_code == 200
+            assert [recording["id"] for recording in response.json()] == ["overlap"]
+
+    def test_vod_returns_overlapping_segment(self):
+        """VOD mapping includes a segment that overlaps the requested range."""
+        start = 1000
+        end = 1100
+
+        with (
+            AuthTestClient(self.app) as client,
+            patch(
+                "frigate.api.media.get_keyframe_before",
+                return_value=None,
+            ),
+        ):
+            super().insert_mock_recording("too_old", start - 10, start - 1)
+            super().insert_mock_recording(
+                "overlap",
+                start - MAX_SEGMENT_DURATION + 2,
+                start + 1,
+            )
+            super().insert_mock_recording("too_new", end + 1, end + 10)
+
+            response = client.get(f"/vod/front_door/start/{start}/end/{end}")
+
+            assert response.status_code == 200
+            assert [
+                clip["path"] for clip in response.json()["sequences"][0]["clips"]
+            ] == ["overlap"]
 
     def test_recordings_unavailable_reports_gap_between_recordings(self):
         """A gap between two recordings is reported as an unavailable segment."""


### PR DESCRIPTION
The recording timeline and VOD queries were scanning more recording history than needed. This change adds a lower `start_time` bound based on `MAX_SEGMENT_DURATION` and replaces the VOD overlap expression with equivalent inclusive conditions.

Recording segments longer than or equal to 600 s are already rejected before they are stored, so an older segment cannot overlap the requested range.

On my database containing about 183 000 recording segments, the timeline query dropped from 51-59 ms to 1.8-2.1 ms, and the VOD mapping query dropped from 57-66 ms to 1.4-1.6 ms.

HTTP tests cover overlapping segments and recordings outside the requested range.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
- Related work: #23586 applies a similar lower bound to `/recordings/unavailable`. This PR covers the separate recording timeline and VOD queries and does not modify that endpoint.

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Codex

**How AI was used**: I used Codex while investigating the queries, comparing their results and query plans and code review.

**Human oversight**: I tested the change on my Frigate instance by opening the recording timeline and starting VOD playback. Both continued to work as expected, and I noticed a clear improvement in loading time.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
