### PR TITLE
Fix motion search timestamps at recording boundaries

### DIFF
--- a/frigate/jobs/motion_search_batch.py
+++ b/frigate/jobs/motion_search_batch.py
@@ -71,5 +71,6 @@ def stream_time_to_absolute(
     idx = bisect_right(offsets, stream_time) - 1
     if idx < 0:
         idx = 0
-    stream_offset, abs_start, _duration = time_map[idx]
-    return abs_start + (stream_time - stream_offset)
+    stream_offset, abs_start, duration = time_map[idx]
+    segment_time = min(max(stream_time - stream_offset, 0.0), duration)
+    return abs_start + segment_time

--- a/frigate/test/test_motion_search_batch.py
+++ b/frigate/test/test_motion_search_batch.py
@@ -53,6 +53,11 @@ class TestTimestampMapping(unittest.TestCase):
         self.assertAlmostEqual(stream_time_to_absolute(time_map, 12.0), 1012.0)
 
     def test_past_end_clamps(self):
+        run = [_Seg("a", 1000.0, 1010.0), _Seg("b", 1010.0, 1020.0)]
+        time_map = build_segment_time_map(run)
+        self.assertAlmostEqual(stream_time_to_absolute(time_map, 25.0), 1020.0)
+
+    def test_before_start_clamps(self):
         run = [_Seg("a", 1000.0, 1010.0)]
         time_map = build_segment_time_map(run)
-        self.assertAlmostEqual(stream_time_to_absolute(time_map, 9.9), 1009.9)
+        self.assertAlmostEqual(stream_time_to_absolute(time_map, -1.0), 1000.0)


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

- **Fix motion search timestamps at recording boundaries**
  - Update `stream_time_to_absolute()` so timestamps stay within the selected recording segment.
  - This handles small timestamp differences caused by keyframe PTS values and fixed-cadence rounding.

- **How it works**
  - The stream time is converted into a position relative to the selected segment.
  - The relative time is then limited to the segment duration:

    ```python
    segment_time = min(
        max(stream_time - stream_offset, 0.0),
        duration,
    )
    ```

- **Example: timestamp after the recording**
  - Assume the recording contains two segments:
    - Segment A: `1000–1010`
    - Segment B: `1010–1020`
  - A stream time of `25` previously returned `1025`, even though the recording ends at `1020`.
  - With the new clamp, the result is limited to `1020`.

- **Example: timestamp before the recording**
  - For a segment from `1000` to `1010`, a stream time of `-1` previously returned `999`.
  - The new logic limits it to the segment start, so the result is `1000`.

- **Valid timestamps are not affected**
  - A stream time of `12` still maps to `1012`, as expected.

- **Tests**
  - Add coverage for timestamps before the first segment.
  - Add coverage for timestamps after the final segment.
  - All motion search batch helper tests pass.
  
<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): OpenAI Codex

**How AI was used** (e.g., code generation, code review, debugging, documentation): mapping the relevant code flow and identify inconsistencies between the docstring, tests, and timestamp-mapping implementation.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): assisted with analyzing `stream_time_to_absolute()` and suggesting the boundary-clamping fix and related regression cases.

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

I manually reviewed the changes in `frigate/jobs/motion_search_batch.py` and `frigate/test/test_motion_search_batch.py`. I checked the timestamp calculations for values before the first segment, within the recording, and after the final segment.

I also ran the following checks locally:

```powershell
python -m unittest frigate.test.test_motion_search_batch
python -m ruff check frigate/jobs/motion_search_batch.py frigate/test/test_motion_search_batch.py
python -m ruff format --check frigate/jobs/motion_search_batch.py frigate/test/test_motion_search_batch.py
```

Results:

- All 7 unit tests passed.
- Ruff reported no linting issues.
- Both changed files were already correctly formatted.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
