### PR TITLE
Fix VOD recording selection at time boundaries

### DIFF
--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -573,11 +573,7 @@ async def vod_ts(
             Recordings.end_time,
             Recordings.start_time,
         )
-        .where(
-            Recordings.start_time.between(start_ts, end_ts)
-            | Recordings.end_time.between(start_ts, end_ts)
-            | ((start_ts > Recordings.start_time) & (end_ts < Recordings.end_time))
-        )
+        .where((Recordings.start_time < end_ts) & (Recordings.end_time > start_ts))
         .where(Recordings.camera == camera_name)
         .order_by(Recordings.start_time.asc())
         .iterator()

--- a/frigate/test/http_api/test_http_media.py
+++ b/frigate/test/http_api/test_http_media.py
@@ -1,6 +1,7 @@
 """Unit tests for recordings/media API endpoints."""
 
 from datetime import UTC, datetime
+from unittest.mock import patch
 
 import pytz
 from fastapi import Request
@@ -43,6 +44,43 @@ class TestHttpMedia(BaseTestHttp):
         """Clean up after tests."""
         self.app.dependency_overrides.clear()
         super().tearDown()
+
+    def test_vod_excludes_recording_ending_at_requested_start(self):
+        """A recording with no overlap must not be included in the VOD mapping."""
+        with AuthTestClient(self.app) as client:
+            Recordings.insert_many(
+                [
+                    {
+                        "id": "recording_a",
+                        "path": "/media/recordings/a.mp4",
+                        "camera": "front_door",
+                        "start_time": 1000.0,
+                        "end_time": 1010.0,
+                        "duration": 10.0,
+                    },
+                    {
+                        "id": "recording_b",
+                        "path": "/media/recordings/b.mp4",
+                        "camera": "front_door",
+                        "start_time": 1010.0,
+                        "end_time": 1020.0,
+                        "duration": 10.0,
+                    },
+                ]
+            ).execute()
+
+            with patch("frigate.api.media.get_keyframe_before", return_value=8000):
+                response = client.get(
+                    "/vod/front_door/start/1010/end/1020",
+                    headers={
+                        "remote-user": "admin",
+                        "remote-role": "admin",
+                    },
+                )
+
+        assert response.status_code == 200
+        clips = response.json()["sequences"][0]["clips"]
+        assert [clip["path"] for clip in clips] == ["/media/recordings/b.mp4"]
 
     def test_recordings_summary_across_dst_spring_forward(self):
         """


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

The VOD recording query currently treats both ends of the requested time range as inclusive. This can select a recording that ends exactly at the requested start, even though it has no overlap with the requested range.

For example:

- Requested range: `1010–1020`
- Recording A: `1000–1010`
- Recording B: `1010–1020`

Recording A initially has a resulting duration of `0 ms`. However, if its `clipFrom` value is moved from `10000 ms` back to a preceding keyframe at `8000 ms`, the duration increases to `2000 ms`. The VOD response then includes the final two seconds of recording A before recording B.

This changes the query to use the standard interval-overlap condition:

`recording.start_time < requested_end and recording.end_time > requested_start`

Recordings that only touch the requested boundary are no longer selected. A regression test covers a recording that ends exactly when the requested range starts and verifies that only the overlapping recording is returned.

## Testing

- Ran the new VOD boundary regression test with Python 3.13.14:
  - `TestHttpMedia.test_vod_excludes_recording_ending_at_requested_start`
  - Result: `Ran 1 test in 3.811s — OK`
- Ran all 11 tests in `frigate.test.http_api.test_http_media`.
  - Each test used a fresh SQLite test database to avoid Windows file-lock reuse between cases.
  - Result: `11 passed, 0 failed`
- Verified that the VOD response only contains the recording that overlaps the requested range.
- Verified four valid interval-overlap cases and two boundary-only cases.
- Ran Ruff lint on both changed files.
  - Result: `All checks passed!`
- Ran Ruff formatting checks on both changed files.
  - Result: `2 files already formatted`
- Ran `git diff --check`.
  - Result: passed

A local Windows compatibility bootstrap was used for Unix-only runtime hooks and optional hardware imports. The FastAPI route, Peewee database, `vod_ts` implementation, and test assertions use the repository source unchanged.

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): OpenAI Codex

**How AI was used** (e.g., code generation, code review, debugging, documentation): was used to navigate the codebase, trace the VOD recording-selection flow, and identify the boundary condition.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): assisted with the diagnosis and suggested the interval-overlap query and regression test. The final change is limited to the recording query and its test coverage.

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.
I manually reviewed both changed files and the final diff. I checked the boundary calculation, reviewed the regression test, and verified the local test, lint, and formatting results. I understand the purpose of each changed line.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
