### PR TITLE
Docs/rpi5 hwaccel update

### DIFF
--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -33,7 +33,7 @@ Frigate supports presets for optimal hardware accelerated video decoding:
 
 **Raspberry Pi 3/4**
 
-- [Raspberry Pi 3/4](#raspberry-pi-34): Frigate can utilize the media engine to slightly accelerate video decoding of both H.264 and H.265 (HEVC) streams.
+- [Raspberry Pi 3/4](#raspberry-pi-34): Frigate can utilize the media engine to slightly accelerate H.264 video decoding on Raspberry Pi 3 and both H.264 and H.265 (HEVC) video decoding on Raspberry Pi 4.
 
 **Raspberry Pi 5**
 

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -296,14 +296,6 @@ These instructions were originally based on the [Jellyfin documentation](https:/
 Ensure you increase the allocated RAM for your GPU to at least 128 (`raspi-config` > Performance Options > GPU Memory).
 If you are using the HA App, you may need to use the full access variant and turn off _Protection mode_ for hardware acceleration.
 
-<ConfigTabs>
-<TabItem value="ui">
-
-Navigate to <NavPath path="Settings > Global configuration > FFmpeg" /> and set **Hardware acceleration arguments** to `Raspberry Pi (H.264)` (for H.264 streams) or `Raspberry Pi (H.265)` (for H.265/HEVC streams). For per-camera overrides, navigate to <NavPath path="Settings > Camera configuration > Streams (FFmpeg)" />.
-
-</TabItem>
-<TabItem value="yaml">
-
 ```yaml
 # Raspberry Pi 3/4: decode H.264 stream
 ffmpeg:
@@ -313,9 +305,6 @@ ffmpeg:
 ffmpeg:
   hwaccel_args: preset-rpi-64-h265
 ```
-
-</TabItem>
-</ConfigTabs>
 
 :::note
 

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -384,6 +384,7 @@ v4l2-ctl --list-devices
 ```
 
 :::warning Known issues
+
 On some systems running **Raspberry Pi OS Trixie with Linux kernel 6.18**, H.265 (HEVC) hardware decoding may cause **green or blank live-view previews** and **object detection may stop working**. Switching the camera from **Smart Streaming** to **Continuous Streaming** may restore the live-view preview, but it does **not** resolve the detection issue.
 
 Reports from users running **Bookworm OS with kernel 6.12** indicate that the same configuration can work correctly, including hardware decoding, detections, recordings, and live streaming.

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -385,15 +385,15 @@ v4l2-ctl --list-devices
 
 :::warning Known issues
 
-On some systems running **Raspberry Pi OS Trixie with Linux kernel 6.18**, H.265 (HEVC) hardware decoding may cause **green or blank live-view previews** and **object detection may stop working**. Switching the camera from **Smart Streaming** to **Continuous Streaming** may restore the live-view preview, but it does **not** resolve the detection issue.
+On some configurations, particularly when running **Raspberry Pi OS Trixie with Linux kernel 6.18**, H.265 (HEVC) hardware decoding may cause **green or blank live-view previews** and **object detection may stop working**. Switching the camera from **Smart Streaming** to **Continuous Streaming** may restore the live-view preview, but it does **not** resolve the detection issue.
 
-Reports from users running **Bookworm OS with kernel 6.12** indicate that the same configuration can work correctly, including hardware decoding, detections, recordings, and live streaming.
+Reports from users running **Raspberry Pi OS Bookworm with kernel 6.12** indicate that the same configuration can work correctly, including **hardware decoding, detections, recordings, and live streaming**.
 
 :::
 
 :::note
 
-If you encounter errors such as 'Cannot allocate memory', increase the **CMA** allocation in `/boot/firmware/config.txt`:
+If you encounter errors such as 'Cannot allocate memory', increase the **CMA** allocation in the **Raspberry Pi OS configuration** by editing '/boot/firmware/config.txt' and reboot the system to take effect:
 
 ```bash
 dtoverlay=vc4-kms-v3d,cma-512

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -380,14 +380,20 @@ The Raspberry Pi 5 HEVC decoder devices can be identified with:
 v4l2-ctl --list-devices
 ```
 
+:::warning Known issues
+On some systems running **Raspberry Pi OS Trixie with Linux kernel 6.18**, H.265 (HEVC) hardware decoding may cause **green or blank live-view previews** and **object detection may stop working**. Switching the camera from **Smart Streaming** to **Continuous Streaming** may restore the live-view preview, but it does **not** resolve the detection issue.
+
+Reports from users running **Bookworm OS with kernel 6.12** indicate that the same configuration can work correctly, including hardware decoding, detections, recordings, and live streaming.
+
 :::
 
-:::info Optional workaround for green or blank live view
+:::note
 
-Some users have reported a green or blank live view when using hardware decoding on Raspberry Pi 5, particularly when Smart Streaming is enabled on the camera. The issue has been observed with recent Raspberry Pi OS and Linux kernel releases and appears to be related to camera stream compatibility, browser rendering, or underlying video decoding components rather than Frigate itself.
+If you encounter errors such as 'Cannot allocate memory', increase the **CMA** allocation in `/boot/firmware/config.txt`:
 
-As a workaround, changing the camera stream mode from Smart Streaming to Continuous Streaming may resolve the issue. Several users have reported that this restores normal video playback while hardware decoding continues to function correctly. This workaround may not be required on all systems and camera models.
-
+```bash
+dtoverlay=vc4-kms-v3d,cma-512
+```
 :::
 
 # Community Supported

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -33,7 +33,7 @@ Frigate supports presets for optimal hardware accelerated video decoding:
 
 **Raspberry Pi 3/4**
 
-- [Raspberry Pi 3/4](#raspberry-pi-34): Frigate can utilize the media engine to slightly accelerate H.264 video decoding on Raspberry Pi 3 and both H.264 and H.265 (HEVC) video decoding on Raspberry Pi 4.
+- [Raspberry Pi 3/4](#raspberry-pi-34): Frigate can utilize the media engine in the Raspberry Pi 3 and 4 to slightly accelerate video decoding.
 
 **Raspberry Pi 5**
 
@@ -302,11 +302,11 @@ Navigate to <NavPath path="Settings > Global configuration > FFmpeg" /> and set 
 <TabItem value="yaml">
 
 ```yaml
-# if you want to decode a h264 stream
+# Raspberry Pi 3/4: decode H.264 stream
 ffmpeg:
   hwaccel_args: preset-rpi-64-h264
 
-# if you want to decode a h265 (hevc) stream
+# Raspberry Pi 4 only: decode H.265 (HEVC) stream
 ffmpeg:
   hwaccel_args: preset-rpi-64-h265
 ```

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -296,6 +296,8 @@ These instructions were originally based on the [Jellyfin documentation](https:/
 Ensure you increase the allocated RAM for your GPU to at least 128 (`raspi-config` > Performance Options > GPU Memory).
 If you are using the HA App, you may need to use the full access variant and turn off _Protection mode_ for hardware acceleration.
 
+To enable hardware decoding, configure Frigate as follows:
+
 ```yaml
 # Raspberry Pi 3/4: decode H.264 stream
 ffmpeg:

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -35,6 +35,9 @@ Frigate supports presets for optimal hardware accelerated video decoding:
 
 - [Raspberry Pi 3/4](#raspberry-pi-34): Frigate can utilize the media engine in the Raspberry Pi 3 and 4 to slightly accelerate video decoding.
 
+  - **Raspberry Pi 3:** H.264 only
+  - **Raspberry Pi 4:** H.264 and H.265 (HEVC)
+
 **Raspberry Pi 5**
 
 - [Raspberry Pi 5](#raspberry-pi-5): Hardware decoding is only available for H.265 (HEVC) streams. H.264 streams are decoded in software on the CPU.

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -363,7 +363,7 @@ ffmpeg:
 
 If running Frigate through Docker, you either need to run in privileged mode or map the required video and media devices into the container.
 
-```yaml {4-8}
+```yaml
 services:
   frigate:
     devices:
@@ -376,7 +376,7 @@ services:
 Device numbers may vary between Raspberry Pi OS releases and kernel versions.
 The Raspberry Pi 5 HEVC decoder devices can be identified with:
 
-```yaml
+```bash
 v4l2-ctl --list-devices
 ```
 

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -33,7 +33,11 @@ Frigate supports presets for optimal hardware accelerated video decoding:
 
 **Raspberry Pi 3/4**
 
-- [Raspberry Pi](#raspberry-pi-34): Frigate can utilize the media engine in the Raspberry Pi 3 and 4 to slightly accelerate video decoding.
+- [Raspberry Pi 3/4](#raspberry-pi-34): Frigate can utilize the media engine to slightly accelerate video decoding of both H.264 and H.265 (HEVC) streams.
+
+**Raspberry Pi 5**
+
+- [Raspberry Pi 5](#raspberry-pi-5): Hardware decoding is only available for H.265 (HEVC) streams. H.264 streams are decoded in software on the CPU.
 
 **Nvidia Jetson** <CommunityBadge />
 
@@ -344,6 +348,45 @@ done
 ```
 
 Or map in all the `/dev/video*` devices.
+
+:::
+
+## Raspberry Pi 5
+
+To enable H.265 (HEVC) hardware decoding on Raspberry Pi 5, configure Frigate as follows:
+
+```yaml
+ffmpeg:
+  hwaccel_args: -hwaccel drm
+```
+:::note
+
+If running Frigate through Docker, you either need to run in privileged mode or map the required video and media devices into the container.
+
+```yaml {4-8}
+services:
+  frigate:
+    devices:
+      - /dev/media0:/dev/media0
+      - /dev/media1:/dev/media1
+      - /dev/media2:/dev/media2
+      - /dev/video19:/dev/video19
+```
+
+Device numbers may vary between Raspberry Pi OS releases and kernel versions.
+The Raspberry Pi 5 HEVC decoder devices can be identified with:
+
+```yaml
+v4l2-ctl --list-devices
+```
+
+:::
+
+:::info Optional workaround for green or blank live view
+
+Some users have reported a green or blank live view when using hardware decoding on Raspberry Pi 5, particularly when Smart Streaming is enabled on the camera. The issue has been observed with recent Raspberry Pi OS and Linux kernel releases and appears to be related to camera stream compatibility, browser rendering, or underlying video decoding components rather than Frigate itself.
+
+As a workaround, changing the camera stream mode from Smart Streaming to Continuous Streaming may resolve the issue. Several users have reported that this restores normal video playback while hardware decoding continues to function correctly. This workaround may not be required on all systems and camera models.
 
 :::
 

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -114,11 +114,15 @@ services:
 
 The following sections contain additional setup steps that are only required if you are using specific hardware. If you are not using any of these hardware types, you can skip to the [Docker](#docker) installation section.
 
-### Raspberry Pi 3/4
+### Raspberry Pi 3/4/5
 
-By default, the Raspberry Pi limits the amount of memory available to the GPU. In order to use ffmpeg hardware acceleration, you must increase the available memory by setting `gpu_mem` to the maximum recommended value in `config.txt` as described in the [official docs](https://www.raspberrypi.org/documentation/computers/config_txt.html#memory-options).
+By default, all variants of Raspberry Pi 3 and Raspberry Pi 4 limit the amount of memory available to the GPU. In order to use ffmpeg hardware acceleration, you must increase the available memory by setting `gpu_mem` to the maximum recommended value in `config.txt` as described in the [official docs](https://www.raspberrypi.com/documentation/computers/legacy_config_txt.html#legacy-memory-options)
 
-Additionally, the USB Coral draws a considerable amount of power. If using any other USB devices such as an SSD, you will experience instability due to the Pi not providing enough power to USB devices. You will need to purchase an external USB hub with its own power supply. Some have reported success with <a href="https://amzn.to/3a2mH0P" target="_blank" rel="nofollow noopener sponsored">this</a> (affiliate link).
+Raspberry Pi 5 does not allocate GPU memory on behalf of the OS, so the above settings have no effect.
+
+Hardware acceleration support differs between Raspberry Pi generations, and Raspberry Pi 3/4 and Raspberry Pi 5 require different configuration steps. See the [Hardware Acceleration](https://docs.frigate.video/configuration/hardware_acceleration_video/) section of the Frigate documentation for the recommended Raspberry Pi FFmpeg presets and configuration examples.
+
+Additionally, USB peripherals such as external hard drives, USB Coral TPUs, and other accessories can significantly increase the total power consumption of a Raspberry Pi system. Insufficient power delivery may result in instability, unexpected reboots, USB device disconnects, and other issues. You may need to purchase an external USB hub with its own power supply. Some users have reported success with [this](https://amzn.to/3a2mH0P) (affiliate link).
 
 ### Hailo-8
 


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

This PR updates the Raspberry Pi installation and hardware acceleration documentation to better distinguish between Raspberry Pi 3/4 and Raspberry Pi 5 requirements.

- Distinguishes the installation and hardware acceleration requirements for Raspberry Pi 3/4 and Raspberry Pi 5.
- Adds a reference to the Hardware Acceleration section of the Frigate documentation.
- Adds a dedicated Raspberry Pi 5 section for H.265 (HEVC) hardware decoding configuration and Docker setup guidance.

The changes are based on testing performed on a Raspberry Pi 5 running Raspberry Pi OS Trixie, Linux kernel 6.18, and Frigate 0.17.2. Hardware decoding was verified using a 4K H.265 detect stream, and enabling -hwaccel drm significantly reduced FFmpeg CPU usage compared to software decoding.

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [X] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features): https://github.com/blakeblackshear/frigate/discussions/18431

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

ChatGPT assisted with drafting and refining documentation wording, markdown formatting, and PR description text.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
