### PR TITLE
fix(audio): correct sodeling typo to yodeling

### DIFF
--- a/audio-labelmap.txt
+++ b/audio-labelmap.txt
@@ -24,7 +24,7 @@ yell
 sigh
 singing
 choir
-sodeling
+yodeling
 chant
 mantra
 child_singing

--- a/web/public/locales/en/audio.json
+++ b/web/public/locales/en/audio.json
@@ -426,7 +426,6 @@
   "radio": "Radio",
   "field_recording": "Field Recording",
   "scream": "Scream",
-  "sodeling": "Sodeling",
   "chird": "Chird",
   "change_ringing": "Change Ringing",
   "shofar": "Shofar",


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change
Fixes a typo: the audio class "sodeling" should be "yodeling".

- `audio-labelmap.txt`: corrected the label at its existing index (mapping order unchanged).
- `web/public/locales/en/audio.json`: removed the duplicate/misspelled `sodeling` key; the correct `yodeling` key already exists.

**Breaking change**: Configs that explicitly reference `sodeling` will need to be updated to `yodeling`, since matching is exact-string. This label is rarely used, so I think it's fine to fix now ahead of 0.18, but happy to add a note to the release notes if maintainers want.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information
- Related Weblate comment: https://hosted.weblate.org/translate/frigate-nvr/audio/en/?checksum=0ae63a252469deb4

## AI disclosure
- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude Sonnet 5

**How AI was used**: Used to check spelling and grammar of the label fix and PR description wording.

**Extent of AI involvement**: Minor wording suggestions only; the change itself and this description were written by me.

**Human oversight**: I reviewed, tested, and wrote this PR description myself.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
