### PR TITLE
Docs update hardware decoding rpi 3/4/5

### DIFF
--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -33,7 +33,7 @@ Frigate supports presets for optimal hardware accelerated video decoding:
 
 **Raspberry Pi 3/4**
 
-- [Raspberry Pi](#raspberry-pi-34): Frigate can utilize the media engine in the Raspberry Pi 3 and 4 to slightly accelerate video decoding.
+- [Raspberry Pi 3/4](#raspberry-pi-34): Frigate can utilize the media engine in the Raspberry Pi 3 and 4 to slightly accelerate video decoding.
 
   - **Raspberry Pi 3:** H.264 only
   - **Raspberry Pi 4:** H.264 and H.265 (HEVC)

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -388,10 +388,9 @@ v4l2-ctl --list-devices
 
 :::warning Known issues
 
-On some configurations, particularly **RPi Trixie OS with Linux kernel 6.18 and Frigate releases up to 0.17.x (bundled with FFmpeg 5)**, enabling **H.265 (HEVC) hardware decoding** with may cause **green or blank live-view previews** and **object detection to stop working correctly**. 
-Similar reports have also been observed on **Home Assistant OS 18.x**, which uses the **Linux 6.18 kernel series**.
+On some configurations, particularly **RPi Trixie OS with Linux kernel 6.18**, enabling **H.265 (HEVC) hardware decoding** may cause **green or blank live-view previews** and **object detection to stop working correctly**. Similar reports have also been observed on **Home Assistant OS 18.x**, which uses the **Linux 6.18 kernel series**.
 
-The latest known configuration reported to work reliably is **RPi Bookworm OS with Linux kernel 6.12 and Frigate up to 0.17.2**, as well as **Home Assistant OS 17.x**, where HEVC hardware decoding has been reported to work correctly without causing the issues described above.
+The latest known configuration reported to work reliably is **RPi Bookworm OS with Linux kernel 6.12**, where HEVC hardware decoding has been reported to work correctly without causing the issues described above.
 
 :::
 

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -35,6 +35,13 @@ Frigate supports presets for optimal hardware accelerated video decoding:
 
 - [Raspberry Pi](#raspberry-pi-34): Frigate can utilize the media engine in the Raspberry Pi 3 and 4 to slightly accelerate video decoding.
 
+  - **Raspberry Pi 3:** H.264 only
+  - **Raspberry Pi 4:** H.264 and H.265 (HEVC)
+
+**Raspberry Pi 5**
+
+- [Raspberry Pi 5](#raspberry-pi-5): Hardware decoding is only available for H.265 (HEVC) streams. H.264 streams are decoded in software on the CPU.
+
 **Nvidia Jetson** <CommunityBadge />
 
 - [Jetson](#nvidia-jetson): Frigate can utilize the media engine in Jetson hardware to accelerate video decoding.
@@ -298,11 +305,11 @@ Navigate to <NavPath path="Settings > Global configuration > FFmpeg" /> and set 
 <TabItem value="yaml">
 
 ```yaml
-# if you want to decode a h264 stream
+# if you want to decode a h264 stream on Raspberry Pi 3/4:
 ffmpeg:
   hwaccel_args: preset-rpi-64-h264
 
-# if you want to decode a h265 (hevc) stream
+# if you want to decode a h265 (hevc) stream on Raspberry Pi 4:
 ffmpeg:
   hwaccel_args: preset-rpi-64-h265
 ```
@@ -344,6 +351,57 @@ done
 ```
 
 Or map in all the `/dev/video*` devices.
+
+:::
+
+## Raspberry Pi 5
+
+H.265 (HEVC) hardware decoding can be enabled globally or per camera by configuring Frigate as follows:
+
+```yaml
+ffmpeg:
+  hwaccel_args: -hwaccel drm
+```
+
+:::note
+
+If running Frigate through Docker, you either need to run in privileged mode or map the required video and media devices into the container.
+
+```yaml
+services:
+  frigate:
+    devices:
+      - /dev/media0:/dev/media0
+      - /dev/media1:/dev/media1
+      - /dev/media2:/dev/media2
+      - /dev/video19:/dev/video19
+```
+
+Device numbers may vary between Raspberry Pi OS releases and kernel versions.
+The Raspberry Pi 5 HEVC decoder devices can be identified with:
+
+```bash
+v4l2-ctl --list-devices
+```
+
+:::
+
+:::warning Known issues
+
+On some configurations, particularly **RPi Trixie OS with Linux kernel 6.18 and Frigate releases up to 0.17.x (bundled with FFmpeg 5)**, enabling **H.265 (HEVC) hardware decoding** with may cause **green or blank live-view previews** and **object detection to stop working correctly**. 
+Similar reports have also been observed on **Home Assistant OS 18.x**, which uses the **Linux 6.18 kernel series**.
+
+The latest known configuration reported to work reliably is **RPi Bookworm OS with Linux kernel 6.12 and Frigate up to 0.17.2**, as well as **Home Assistant OS 17.x**, where HEVC hardware decoding has been reported to work correctly without causing the issues described above.
+
+:::
+
+:::note
+
+If you encounter errors such as 'cannot allocate memory' or 'alloc failed', increase the **CMA** allocation in the **Raspberry Pi OS configuration** by editing '/boot/firmware/config.txt' and reboot the system to take effect:
+
+```bash
+dtoverlay=vc4-kms-v3d,cma-512
+```
 
 :::
 

--- a/docs/docs/frigate/installation.md
+++ b/docs/docs/frigate/installation.md
@@ -114,11 +114,15 @@ services:
 
 The following sections contain additional setup steps that are only required if you are using specific hardware. If you are not using any of these hardware types, you can skip to the [Docker](#docker) installation section.
 
-### Raspberry Pi 3/4
+### Raspberry Pi 3/4/5
 
-By default, the Raspberry Pi limits the amount of memory available to the GPU. In order to use ffmpeg hardware acceleration, you must increase the available memory by setting `gpu_mem` to the maximum recommended value in `config.txt` as described in the [official docs](https://www.raspberrypi.org/documentation/computers/config_txt.html#memory-options).
+By default, the Raspberry Pi 3/4 limits the amount of memory available to the GPU. In order to use ffmpeg hardware acceleration, you must increase the available memory by setting `gpu_mem` to the maximum recommended value in `config.txt` as described in the [official docs](https://www.raspberrypi.com/documentation/computers/legacy_config_txt.html#legacy-memory-options).
 
-Additionally, the USB Coral draws a considerable amount of power. If using any other USB devices such as an SSD, you will experience instability due to the Pi not providing enough power to USB devices. You will need to purchase an external USB hub with its own power supply. Some have reported success with <a href="https://amzn.to/3a2mH0P" target="_blank" rel="nofollow noopener sponsored">this</a> (affiliate link).
+Raspberry Pi 5 does not allocate GPU memory on behalf of the OS, so the above settings have no effect.
+
+Hardware acceleration support differs between Raspberry Pi generations, and Raspberry Pi 3/4 and Raspberry Pi 5 require different configuration steps. See the [Hardware Acceleration](https://docs.frigate.video/configuration/hardware_acceleration_video/) section of the Frigate documentation for the recommended Raspberry Pi FFmpeg presets and configuration examples.
+
+Additionally, USB peripherals such as external hard drives, USB Coral TPUs, and other accessories can significantly increase the total power consumption of a Raspberry Pi system. Insufficient power delivery may result in instability, unexpected reboots, USB device disconnects, and other issues. You may need to purchase an external USB hub with its own power supply. Some users have reported success with [this](https://amzn.to/3a2mH0P) (affiliate link).
 
 ### Hailo-8
 


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

This PR updates the Raspberry Pi installation and hardware acceleration documentation to better distinguish between Raspberry Pi 3/4 and Raspberry Pi 5 requirements.

- Distinguishes the installation and hardware acceleration requirements for Raspberry Pi 3/4 and Raspberry Pi 5.
- Adds a dedicated Raspberry Pi 5 section for H.265 (HEVC) hardware decoding configuration and Docker setup guidance.
- Documents currently known compatibility issues related to H.265 hardware decoding on some Raspberry Pi OS / kernel combinations.

The changes are based on testing performed on Raspberry Pi 5 systems running RPi Bookworm OS (kernel 6.12) and RPi Trixie OS (kernel 6.18) with Frigate 0.17.2.

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features): https://github.com/blakeblackshear/frigate/discussions/18431

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): ChatGPT

**How AI was used** (e.g., code generation, code review, debugging, documentation): Assisted with documentation wording, grammar, and formatting

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

I manually reviewed all changes, tested the Raspberry Pi 5 configurations on Bookworm (kernel 6.12) and Trixie (kernel 6.18), and verified the documented behavior

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
