### PR TITLE
Don't require a restart to enable GenAI descriptions

### DIFF
--- a/frigate/app.py
+++ b/frigate/app.py
@@ -103,21 +103,9 @@ class FrigateApp:
         self.detection_shms: list[mp.shared_memory.SharedMemory] = []
         self.log_queue: Queue = mp.Queue()
         self.camera_metrics: DictProxy = self.metrics_manager.dict()
-        self.embeddings_metrics: DataProcessorMetrics | None = (
-            DataProcessorMetrics(
-                self.metrics_manager, list(config.classification.custom.keys())
-            )
-            if (
-                config.semantic_search.enabled
-                or any(
-                    c.objects.genai.enabled or c.review.genai.enabled
-                    for c in config.cameras.values()
-                )
-                or config.lpr.enabled
-                or config.face_recognition.enabled
-                or len(config.classification.custom) > 0
-            )
-            else None
+
+        self.embeddings_metrics = DataProcessorMetrics(
+            self.metrics_manager, list(config.classification.custom.keys())
         )
         self.ptz_metrics: dict[str, PTZMetrics] = {}
         self.processes: dict[str, int] = {}

--- a/frigate/data_processing/post/object_descriptions.py
+++ b/frigate/data_processing/post/object_descriptions.py
@@ -63,8 +63,10 @@ class ObjectDescriptionProcessor(PostProcessorApi):
         """Handle an update to a frame for an object."""
         camera_config = self.config.cameras[camera]
 
-        # no need to save our own thumbnails if genai is not enabled
-        # or if the object has become stationary
+        if not camera_config.objects.genai.enabled:
+            return
+
+        # no need to save our own thumbnails if the object has become stationary
         if not data["stationary"]:
             if data["id"] not in self.tracked_events:
                 self.tracked_events[data["id"]] = []

--- a/frigate/embeddings/__init__.py
+++ b/frigate/embeddings/__init__.py
@@ -33,7 +33,7 @@ class EmbeddingProcess(FrigateProcess):
     def __init__(
         self,
         config: FrigateConfig,
-        metrics: DataProcessorMetrics | None,
+        metrics: DataProcessorMetrics,
         stop_event: MpEvent,
     ) -> None:
         super().__init__(

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -95,7 +95,7 @@ class EmbeddingMaintainer(threading.Thread):
     def __init__(
         self,
         config: FrigateConfig,
-        metrics: DataProcessorMetrics | None,
+        metrics: DataProcessorMetrics,
         stop_event: MpEvent,
     ) -> None:
         super().__init__(name="embeddings_maintainer")

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -78,6 +78,16 @@ logger = logging.getLogger(__name__)
 
 MAX_THUMBNAILS = 10
 
+GENAI_UPDATE_TOPICS = frozenset(
+    {
+        CameraConfigUpdateEnum.add.name,
+        CameraConfigUpdateEnum.objects.name,
+        CameraConfigUpdateEnum.object_genai.name,
+        CameraConfigUpdateEnum.review.name,
+        CameraConfigUpdateEnum.review_genai.name,
+    }
+)
+
 
 class EmbeddingMaintainer(threading.Thread):
     """Handle embedding queue and post event updates."""
@@ -220,16 +230,6 @@ class EmbeddingMaintainer(threading.Thread):
         # post processors
         self.post_processors: list[PostProcessorApi] = []
 
-        if any(c.review.genai.enabled_in_config for c in self.config.cameras.values()):
-            self.post_processors.append(
-                ReviewDescriptionProcessor(
-                    self.config,
-                    self.requestor,
-                    self.metrics,
-                    self.genai_manager,
-                )
-            )
-
         if self.config.lpr.enabled:
             self.post_processors.append(
                 LicensePlatePostProcessor(
@@ -252,9 +252,9 @@ class EmbeddingMaintainer(threading.Thread):
                 )
             )
 
-        semantic_trigger_processor: SemanticTriggerProcessor | None = None
+        self.semantic_trigger_processor: SemanticTriggerProcessor | None = None
         if self.config.semantic_search.enabled:
-            semantic_trigger_processor = SemanticTriggerProcessor(
+            self.semantic_trigger_processor = SemanticTriggerProcessor(
                 db,
                 self.config,
                 self.requestor,
@@ -262,9 +262,49 @@ class EmbeddingMaintainer(threading.Thread):
                 metrics,
                 self.embeddings,
             )
-            self.post_processors.append(semantic_trigger_processor)
+            self.post_processors.append(self.semantic_trigger_processor)
 
-        if any(c.objects.genai.enabled_in_config for c in self.config.cameras.values()):
+        self._sync_genai_processors()
+
+        self.stop_event = stop_event
+
+        # recordings data
+        self.recordings_available_through: dict[str, float] = {}
+
+    def _sync_genai_processors(self) -> None:
+        """Create GenAI post processors for cameras that have GenAI enabled.
+
+        Called at startup and again after camera config updates so enabling
+        GenAI on the first camera does not require a restart. Processors are
+        never removed once created.
+
+        A profile can turn GenAI on without setting enabled_in_config, so both
+        flags are checked.
+        """
+        cameras = self.config.cameras.values()
+
+        if any(
+            c.review.genai.enabled or c.review.genai.enabled_in_config for c in cameras
+        ) and not any(
+            isinstance(p, ReviewDescriptionProcessor) for p in self.post_processors
+        ):
+            logger.debug("Initializing review description processor")
+            self.post_processors.append(
+                ReviewDescriptionProcessor(
+                    self.config,
+                    self.requestor,
+                    self.metrics,
+                    self.genai_manager,
+                )
+            )
+
+        if any(
+            c.objects.genai.enabled or c.objects.genai.enabled_in_config
+            for c in cameras
+        ) and not any(
+            isinstance(p, ObjectDescriptionProcessor) for p in self.post_processors
+        ):
+            logger.debug("Initializing object description processor")
             self.post_processors.append(
                 ObjectDescriptionProcessor(
                     self.config,
@@ -272,19 +312,21 @@ class EmbeddingMaintainer(threading.Thread):
                     self.requestor,
                     self.metrics,
                     self.genai_manager,
-                    semantic_trigger_processor,
+                    self.semantic_trigger_processor,
                 )
             )
 
-        self.stop_event = stop_event
+    def _check_camera_config_updates(self) -> None:
+        """Apply camera config updates and register newly enabled processors."""
+        updated_topics = self.config_updater.check_for_updates()
 
-        # recordings data
-        self.recordings_available_through: dict[str, float] = {}
+        if updated_topics.keys() & GENAI_UPDATE_TOPICS:
+            self._sync_genai_processors()
 
     def run(self) -> None:
         """Maintain a SQLite-vec database for semantic search."""
         while not self.stop_event.is_set():
-            self.config_updater.check_for_updates()
+            self._check_camera_config_updates()
             self._check_enrichment_config_updates()
             self._process_requests()
             self._process_updates()

--- a/frigate/stats/util.py
+++ b/frigate/stats/util.py
@@ -62,7 +62,7 @@ def get_latest_version(config: FrigateConfig) -> str:
 def stats_init(
     config: FrigateConfig,
     camera_metrics: DictProxy,
-    embeddings_metrics: DataProcessorMetrics | None,
+    embeddings_metrics: DataProcessorMetrics,
     detectors: dict[str, ObjectDetectProcess],
     processes: dict[str, int],
 ) -> StatsTrackingTypes:

--- a/frigate/test/test_genai_processor_sync.py
+++ b/frigate/test/test_genai_processor_sync.py
@@ -1,0 +1,213 @@
+"""Tests for GenAI enablement gating in the embeddings maintainer.
+
+Covers creating post processors when GenAI is enabled at runtime, and the
+per-camera gating those processors apply once they exist.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Mock TFLite before importing the maintainer
+_MOCK_MODULES = [
+    "tflite_runtime",
+    "tflite_runtime.interpreter",
+    "ai_edge_litert",
+    "ai_edge_litert.interpreter",
+]
+for mod in _MOCK_MODULES:
+    if mod not in sys.modules:
+        sys.modules[mod] = MagicMock()
+
+# imported from the maintainer to avoid tripping the circular import between
+# the maintainer and the processor modules
+from frigate.embeddings.maintainer import (  # noqa: E402
+    EmbeddingMaintainer,
+    ObjectDescriptionProcessor,
+    PostProcessDataEnum,
+    ReviewDescriptionProcessor,
+)
+
+
+class TestGenAIProcessorSync(unittest.TestCase):
+    """Enabling GenAI on the first camera must not require a restart."""
+
+    def _make_maintainer(
+        self,
+        review: bool = False,
+        objects: bool = False,
+        review_in_config: bool | None = None,
+        objects_in_config: bool | None = None,
+    ) -> EmbeddingMaintainer:
+        # Bypass the heavy __init__; only the attributes touched by
+        # _sync_genai_processors are needed for these tests.
+        maintainer = EmbeddingMaintainer.__new__(EmbeddingMaintainer)
+        maintainer.post_processors = []
+        maintainer.config = MagicMock()
+        maintainer.config.cameras = {
+            "front": self._make_camera(
+                review,
+                objects,
+                review if review_in_config is None else review_in_config,
+                objects if objects_in_config is None else objects_in_config,
+            )
+        }
+        maintainer.config_updater = MagicMock()
+        maintainer.embeddings = None
+        maintainer.requestor = MagicMock()
+        maintainer.metrics = MagicMock()
+        maintainer.genai_manager = MagicMock()
+        maintainer.semantic_trigger_processor = None
+        return maintainer
+
+    def _make_camera(
+        self,
+        review: bool,
+        objects: bool,
+        review_in_config: bool,
+        objects_in_config: bool,
+    ) -> MagicMock:
+        camera = MagicMock()
+        camera.review.genai.enabled = review
+        camera.review.genai.enabled_in_config = review_in_config
+        camera.objects.genai.enabled = objects
+        camera.objects.genai.enabled_in_config = objects_in_config
+        return camera
+
+    def _processor_types(self, maintainer: EmbeddingMaintainer) -> list[type]:
+        return [type(p) for p in maintainer.post_processors]
+
+    def test_no_processors_when_genai_disabled(self):
+        """A config with no GenAI cameras registers neither processor."""
+        maintainer = self._make_maintainer()
+
+        maintainer._sync_genai_processors()
+
+        self.assertEqual(maintainer.post_processors, [])
+
+    def test_review_processor_added_when_enabled_after_startup(self):
+        """Enabling review GenAI on the first camera registers the processor."""
+        maintainer = self._make_maintainer()
+        maintainer._sync_genai_processors()
+
+        camera = maintainer.config.cameras["front"]
+        camera.review.genai.enabled = True
+        camera.review.genai.enabled_in_config = True
+        maintainer._sync_genai_processors()
+
+        self.assertEqual(
+            self._processor_types(maintainer), [ReviewDescriptionProcessor]
+        )
+
+    def test_object_processor_added_when_enabled_after_startup(self):
+        """Enabling object GenAI on the first camera registers the processor."""
+        maintainer = self._make_maintainer()
+        maintainer._sync_genai_processors()
+
+        camera = maintainer.config.cameras["front"]
+        camera.objects.genai.enabled = True
+        camera.objects.genai.enabled_in_config = True
+        maintainer._sync_genai_processors()
+
+        self.assertEqual(
+            self._processor_types(maintainer), [ObjectDescriptionProcessor]
+        )
+
+    def test_processor_added_when_only_enabled_by_profile(self):
+        """A profile enables GenAI without setting enabled_in_config."""
+        maintainer = self._make_maintainer(
+            review=True, objects=True, review_in_config=False, objects_in_config=False
+        )
+
+        maintainer._sync_genai_processors()
+
+        self.assertEqual(
+            self._processor_types(maintainer),
+            [ReviewDescriptionProcessor, ObjectDescriptionProcessor],
+        )
+
+    def test_processors_are_not_duplicated(self):
+        """Repeated config updates must not register a second processor."""
+        maintainer = self._make_maintainer(review=True, objects=True)
+
+        maintainer._sync_genai_processors()
+        maintainer._sync_genai_processors()
+
+        self.assertEqual(
+            self._processor_types(maintainer),
+            [ReviewDescriptionProcessor, ObjectDescriptionProcessor],
+        )
+
+    def test_genai_topic_triggers_sync(self):
+        """A camera config update on a GenAI topic registers the processor."""
+        maintainer = self._make_maintainer(review=True)
+        maintainer.config_updater.check_for_updates.return_value = {"review": ["front"]}
+
+        maintainer._check_camera_config_updates()
+
+        self.assertEqual(
+            self._processor_types(maintainer), [ReviewDescriptionProcessor]
+        )
+
+    def test_unrelated_topic_does_not_sync(self):
+        """An unrelated camera config update must not register processors."""
+        maintainer = self._make_maintainer(review=True)
+        maintainer.config_updater.check_for_updates.return_value = {"motion": ["front"]}
+
+        maintainer._check_camera_config_updates()
+
+        self.assertEqual(maintainer.post_processors, [])
+
+
+class TestObjectDescriptionCameraGating(unittest.TestCase):
+    """One camera enabling object descriptions must not enlist the others."""
+
+    def _make_processor(self, enabled: bool) -> ObjectDescriptionProcessor:
+        config = MagicMock()
+        camera = MagicMock()
+        camera.objects.genai.enabled = enabled
+        camera.objects.genai.send_triggers.after_significant_updates = None
+        config.cameras = {"front": camera}
+
+        genai_manager = MagicMock()
+        genai_manager.description_client = MagicMock()
+
+        return ObjectDescriptionProcessor(
+            config, None, MagicMock(), MagicMock(), genai_manager, None
+        )
+
+    def _update(self, processor: ObjectDescriptionProcessor) -> None:
+        processor.process_data(
+            {
+                "camera": "front",
+                "data": {
+                    "id": "1234.5-abcdef",
+                    "box": (0, 0, 10, 10),
+                    "stationary": False,
+                },
+                "state": "update",
+                "yuv_frame": MagicMock(),
+            },
+            PostProcessDataEnum.tracked_object,
+        )
+
+    @patch("frigate.data_processing.post.object_descriptions.create_thumbnail")
+    def test_disabled_camera_collects_no_thumbnails(self, mock_create_thumbnail):
+        """A camera with object descriptions off does no thumbnail work."""
+        processor = self._make_processor(enabled=False)
+
+        self._update(processor)
+
+        mock_create_thumbnail.assert_not_called()
+        self.assertEqual(processor.tracked_events, {})
+
+    @patch("frigate.data_processing.post.object_descriptions.create_thumbnail")
+    def test_enabled_camera_collects_thumbnails(self, mock_create_thumbnail):
+        """A camera with object descriptions on still collects thumbnails."""
+        mock_create_thumbnail.return_value = b"jpg"
+        processor = self._make_processor(enabled=True)
+
+        self._update(processor)
+
+        mock_create_thumbnail.assert_called_once()
+        self.assertEqual(len(processor.tracked_events["1234.5-abcdef"]), 1)

--- a/frigate/types.py
+++ b/frigate/types.py
@@ -8,7 +8,7 @@ from frigate.object_detection.base import ObjectDetectProcess
 
 class StatsTrackingTypes(TypedDict):
     camera_metrics: dict[str, CameraMetrics]
-    embeddings_metrics: DataProcessorMetrics | None
+    embeddings_metrics: DataProcessorMetrics
     detectors: dict[str, ObjectDetectProcess]
     started: int
     latest_frigate_version: str


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR fixes a few issues with dynamic config updating and GenAI.

The review and object description processors were only created in the embedding maintainer's init, so enabling GenAI on the first camera silently did nothing until a restart. 

- Processor creation moved to `_sync_genai_processors()`, called at startup and again on add/objects/object_genai/review/review_genai camera config updates.
- Check both `enabled` as well as `enabled_in_config`. Profiles set `enabled` without `enabled_in_config`, so profile-enabled GenAI never started a processor, and a restart did not help either since profiles are re-applied after parse.
- `DataProcessorMetrics` is now always created. It was `None` whenever no enrichment was enabled at boot, and the processors dereference it, so constructing one at runtime would crash the embeddings process.
- Object descriptions now check per-camera `objects.genai.enabled` before building thumbnails, so one camera enabling descriptions no longer makes every other camera encode and retain them.
- Add backend test

Supersedes https://github.com/blakeblackshear/frigate/pull/23957

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
