### PR TITLE
Prevent embeddings crashes after camera removal

### DIFF
--- a/frigate/data_processing/post/object_descriptions.py
+++ b/frigate/data_processing/post/object_descriptions.py
@@ -151,7 +151,13 @@ class ObjectDescriptionProcessor(PostProcessorApi):
             logger.error(f"Event {event_id} not found for description regeneration")
             return
 
-        camera_config = self.config.cameras[str(event.camera)]
+        camera_config = self.config.cameras.get(str(event.camera))
+        if camera_config is None:
+            logger.error(
+                "Camera %s not found for description regeneration", event.camera
+            )
+            return
+
         if not camera_config.objects.genai.enabled and not force:
             logger.error(f"GenAI not enabled for camera {event.camera}")
             return

--- a/frigate/data_processing/post/review_descriptions.py
+++ b/frigate/data_processing/post/review_descriptions.py
@@ -137,7 +137,10 @@ class ReviewDescriptionProcessor(PostProcessorApi):
             return
 
         camera = data["after"]["camera"]
-        camera_config = self.config.cameras[camera]
+        camera_config = self.config.cameras.get(camera)
+
+        if camera_config is None:
+            return
 
         if not camera_config.review.genai.enabled:
             return

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -677,7 +677,8 @@ class EmbeddingMaintainer(threading.Thread):
             if not last_seen:
                 continue
 
-            if now - last_seen > self.config.cameras[data["camera"]].lpr.expire_time:
+            camera_config = self.config.cameras.get(data["camera"])
+            if camera_config is None or now - last_seen > camera_config.lpr.expire_time:
                 to_remove.append(id)
         for id in to_remove:
             self.event_metadata_publisher.publish(

--- a/frigate/embeddings/maintainer.py
+++ b/frigate/embeddings/maintainer.py
@@ -585,6 +585,13 @@ class EmbeddingMaintainer(threading.Thread):
             for processor in self.realtime_processors:
                 processor.expire_object(event_id, camera)
 
+            if camera not in self.config.cameras:
+                for processor in self.post_processors:
+                    if isinstance(processor, ObjectDescriptionProcessor):
+                        processor.cleanup_event(event_id)
+                self.detected_license_plates.pop(event_id, None)
+                continue
+
             thumbnail: bytes | None = None
 
             if updated_db:

--- a/frigate/test/test_genai_processor_sync.py
+++ b/frigate/test/test_genai_processor_sync.py
@@ -260,6 +260,20 @@ class TestRemovedCameraUpdates(unittest.TestCase):
 
         mock_run_analysis.assert_not_called()
 
+    def test_lpr_state_is_expired_without_camera_config(self):
+        maintainer = EmbeddingMaintainer.__new__(EmbeddingMaintainer)
+        maintainer.config = MagicMock()
+        maintainer.config.cameras = {}
+        maintainer.detected_license_plates = {
+            "event-id": {"camera": "removed", "last_seen": 1}
+        }
+        maintainer.event_metadata_publisher = MagicMock()
+
+        maintainer._expire_dedicated_lpr()
+
+        self.assertEqual(maintainer.detected_license_plates, {})
+        maintainer.event_metadata_publisher.publish.assert_called_once()
+
     def test_regenerate_is_ignored_without_camera_config(self):
         processor = ObjectDescriptionProcessor.__new__(ObjectDescriptionProcessor)
         processor.config = MagicMock()

--- a/frigate/test/test_genai_processor_sync.py
+++ b/frigate/test/test_genai_processor_sync.py
@@ -27,6 +27,7 @@ from frigate.embeddings.maintainer import (  # noqa: E402
     PostProcessDataEnum,
     ReviewDescriptionProcessor,
 )
+from frigate.models import Event  # noqa: E402
 
 
 class TestGenAIProcessorSync(unittest.TestCase):
@@ -211,3 +212,70 @@ class TestObjectDescriptionCameraGating(unittest.TestCase):
 
         mock_create_thumbnail.assert_called_once()
         self.assertEqual(len(processor.tracked_events["1234.5-abcdef"]), 1)
+
+
+class TestRemovedCameraUpdates(unittest.TestCase):
+    """Queued updates for removed cameras must be ignored safely."""
+
+    def test_finalized_event_cleans_up_without_camera_config(self):
+        maintainer = EmbeddingMaintainer.__new__(EmbeddingMaintainer)
+        maintainer.config = MagicMock()
+        maintainer.config.cameras = {}
+        maintainer.event_end_subscriber = MagicMock()
+        maintainer.event_end_subscriber.check_for_update.side_effect = [
+            ("event-id", "removed", True),
+            None,
+        ]
+        maintainer.realtime_processors = []
+
+        object_processor = ObjectDescriptionProcessor.__new__(
+            ObjectDescriptionProcessor
+        )
+        object_processor.cleanup_event = MagicMock()
+        maintainer.post_processors = [object_processor]
+        maintainer.detected_license_plates = {"event-id": {"camera": "removed"}}
+
+        with patch.object(Event, "get") as mock_get_event:
+            maintainer._process_finalized()
+
+        object_processor.cleanup_event.assert_called_once_with("event-id")
+        self.assertEqual(maintainer.detected_license_plates, {})
+        mock_get_event.assert_not_called()
+
+    def test_review_update_is_ignored_without_camera_config(self):
+        processor = ReviewDescriptionProcessor.__new__(ReviewDescriptionProcessor)
+        processor.config = MagicMock()
+        processor.config.cameras = {}
+        processor.metrics = MagicMock()
+        processor.review_desc_dps = MagicMock()
+        processor.genai_manager = MagicMock()
+        processor.genai_manager.description_client = MagicMock()
+
+        with patch(
+            "frigate.data_processing.post.review_descriptions.run_analysis"
+        ) as mock_run_analysis:
+            processor.process_data(
+                {"after": {"camera": "removed"}}, PostProcessDataEnum.review
+            )
+
+        mock_run_analysis.assert_not_called()
+
+    def test_regenerate_is_ignored_without_camera_config(self):
+        processor = ObjectDescriptionProcessor.__new__(ObjectDescriptionProcessor)
+        processor.config = MagicMock()
+        processor.config.cameras = {}
+
+        event = MagicMock()
+        event.camera = "removed"
+        with patch.object(Event, "get", return_value=event):
+            with self.assertLogs(
+                "frigate.data_processing.post.object_descriptions", level="ERROR"
+            ) as logs:
+                processor.handle_request(
+                    "regenerate_description",
+                    {"event_id": "event-id", "source": "thumbnail", "force": False},
+                )
+
+        self.assertIn(
+            "Camera removed not found for description regeneration", logs.output[0]
+        )


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

Prevent the embeddings process from accessing camera configuration that has already been removed.

Camera configuration updates are applied before queued event finalization and review updates are processed. If a camera is removed while one of those messages is still queued, post-processors can attempt to access the deleted camera configuration and raise an uncaught `KeyError`.

This change:

- Skips finalized event post-processing when the associated camera no longer exists.
- Cleans up retained object-description and dedicated LPR state for removed cameras.
- Safely expires dedicated LPR entries when their camera configuration no longer exists.
- Ignores queued review description updates for removed cameras.
- Handles description regeneration requests for events whose camera has been removed.
- Adds regression coverage for each affected entry point.

The centralized finalization guard protects the license plate, semantic trigger, and object description post-processors without adding duplicate checks to each processor.

This follows the separate fix identified during the review of #23964:
https://github.com/blakeblackshear/frigate/pull/23964#discussion_r3767013177

No configuration, API, or user-facing behavior is changed.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: OpenAI Codex

**How AI was used**: Used to trace dynamic camera removal through the embeddings and GenAI post-processing lifecycle, implement the guards and state cleanup, add regression coverage, review the final diff, and assist with validation.

**Extent of AI involvement**: Assisted with the implementation of the removed-camera guards, cleanup behavior, and validation.

**Human oversight**: I reviewed the final four-file diff and verified that the changes follow the existing post-processing lifecycle and project conventions. The changes were validated using targeted tests, the complete backend test suite, Ruff, and Git diff checks.

## Testing

- Full backend test suite: 891 tests
- Targeted GenAI, classification, and sqlite-vector test suite: 34 tests
- Ruff lint checks passed.
- Ruff formatting checks passed.
- Git diff checks passed.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)