### PR TITLE
fix(mqtt): allow TLS without a custom CA certificate

### DIFF
--- a/docs/docs/configuration/advanced/reference.md
+++ b/docs/docs/configuration/advanced/reference.md
@@ -37,7 +37,11 @@ mqtt:
   # NOTE: MQTT password can be specified with an environment variable or docker secrets that must begin with 'FRIGATE_'.
   #       e.g. password: '{FRIGATE_MQTT_PASSWORD}'
   password: password
-  # Optional: tls_ca_certs for enabling TLS using self-signed certs (default: None)
+  # Optional: tls_ca_certs for verifying a broker certificate signed by a private
+  # certificate authority, for example a self-signed one (default: None)
+  # NOTE: setting any of the tls_ options below enables TLS. Leave tls_ca_certs unset
+  #       if the broker certificate is signed by a public CA such as Let's Encrypt,
+  #       and the system certificate store is used instead.
   tls_ca_certs: /path/to/ca.crt
   # Optional: tls_client_cert and tls_client key in order to use self-signed client
   # certificates (default: None)

--- a/frigate/comms/mqtt.py
+++ b/frigate/comms/mqtt.py
@@ -334,7 +334,16 @@ class MqttClient(Communicator):
             f"{self.mqtt_config.topic_prefix}/restart", self.on_mqtt_command
         )
 
-        if self.mqtt_config.tls_ca_certs is not None:
+        # any tls_* option turns TLS on. tls_ca_certs is passed through as-is
+        # so that leaving it unset means "use the system trust store" instead
+        # of skipping TLS entirely
+        tls_enabled = (
+            self.mqtt_config.tls_ca_certs is not None
+            or self.mqtt_config.tls_client_cert is not None
+            or self.mqtt_config.tls_insecure is not None
+        )
+
+        if tls_enabled:
             if (
                 self.mqtt_config.tls_client_cert is not None
                 and self.mqtt_config.tls_client_key is not None
@@ -346,8 +355,10 @@ class MqttClient(Communicator):
                 )
             else:
                 self.client.tls_set(self.mqtt_config.tls_ca_certs)
-        if self.mqtt_config.tls_insecure is not None:
-            self.client.tls_insecure_set(self.mqtt_config.tls_insecure)
+
+            # must come after tls_set, which is what creates the ssl context
+            if self.mqtt_config.tls_insecure is not None:
+                self.client.tls_insecure_set(self.mqtt_config.tls_insecure)
         if self.mqtt_config.user is not None:
             self.client.username_pw_set(
                 self.mqtt_config.user, password=self.mqtt_config.password

--- a/frigate/test/test_mqtt_tls.py
+++ b/frigate/test/test_mqtt_tls.py
@@ -1,0 +1,91 @@
+"""Tests for MQTT TLS setup."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from frigate.comms.mqtt import MqttClient
+
+
+def _start_client(
+    *,
+    tls_ca_certs: str | None = None,
+    tls_client_cert: str | None = None,
+    tls_client_key: str | None = None,
+    tls_insecure: bool | None = None,
+) -> MagicMock:
+    """Start an MqttClient against a mocked paho client and hand the mock back
+    so the tls calls it received can be inspected."""
+    config = MagicMock()
+    config.cameras = {}
+    config.notifications.enabled_in_config = False
+    config.mqtt.topic_prefix = "frigate"
+    config.mqtt.client_id = "frigate"
+    config.mqtt.user = None
+    config.mqtt.tls_ca_certs = tls_ca_certs
+    config.mqtt.tls_client_cert = tls_client_cert
+    config.mqtt.tls_client_key = tls_client_key
+    config.mqtt.tls_insecure = tls_insecure
+
+    with patch("frigate.comms.mqtt.mqtt.Client") as client_cls:
+        paho_client = client_cls.return_value
+
+        def tls_insecure_set(value: bool) -> None:
+            # paho refuses this until tls_set has built the ssl context
+            if not paho_client.tls_set.called:
+                raise ValueError(
+                    "Must configure SSL context before using tls_insecure_set."
+                )
+
+        paho_client.tls_insecure_set.side_effect = tls_insecure_set
+
+        MqttClient(config).subscribe(MagicMock())
+
+    return paho_client
+
+
+class TestMqttTls(unittest.TestCase):
+    def test_tls_untouched_when_no_tls_option_is_set(self):
+        paho_client = _start_client()
+
+        paho_client.tls_set.assert_not_called()
+        paho_client.tls_insecure_set.assert_not_called()
+
+    def test_ca_certs_are_passed_through(self):
+        paho_client = _start_client(tls_ca_certs="/path/to/ca.crt")
+
+        paho_client.tls_set.assert_called_once_with("/path/to/ca.crt")
+
+    def test_client_certs_are_passed_with_ca_certs(self):
+        paho_client = _start_client(
+            tls_ca_certs="/path/to/ca.crt",
+            tls_client_cert="/path/to/client.crt",
+            tls_client_key="/path/to/client.key",
+        )
+
+        paho_client.tls_set.assert_called_once_with(
+            "/path/to/ca.crt", "/path/to/client.crt", "/path/to/client.key"
+        )
+
+    def test_tls_insecure_alone_enables_tls(self):
+        """tls_insecure on its own must still turn TLS on, otherwise paho
+        raises because there is no ssl context to apply it to."""
+        paho_client = _start_client(tls_insecure=True)
+
+        paho_client.tls_set.assert_called_once_with(None)
+        paho_client.tls_insecure_set.assert_called_once_with(True)
+
+    def test_client_certs_without_ca_certs_use_system_trust_store(self):
+        """A broker with a publicly trusted cert needs no ca_certs, so None is
+        forwarded to paho and it falls back to the system certificates."""
+        paho_client = _start_client(
+            tls_client_cert="/path/to/client.crt",
+            tls_client_key="/path/to/client.key",
+        )
+
+        paho_client.tls_set.assert_called_once_with(
+            None, "/path/to/client.crt", "/path/to/client.key"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Proposed change

Frigate only calls paho's `tls_set()` when `tls_ca_certs` is set, so there is no way to talk to a broker over TLS when the broker certificate is signed by a public CA such as Let's Encrypt. The workaround people have landed on in #2471 is to point `tls_ca_certs` at `/etc/ssl/certs/ca-certificates.crt`, which is just the system trust store paho would have used on its own. paho's `tls_set()` falls back to `load_default_certs()` when `ca_certs` is None, so this change enables TLS when any of the `tls_` options is set and passes `tls_ca_certs` straight through. Leaving it unset now means "use the system certificates" instead of "do not use TLS at all".

The same block had a second problem. `tls_insecure_set()` was called outside the `tls_ca_certs` check, and paho raises `ValueError: Must configure SSL context before using tls_insecure_set.` when no SSL context exists yet. That means a config with `tls_insecure` but no `tls_ca_certs` threw out of the dispatcher setup and Frigate did not start. That call now sits inside the TLS branch, after `tls_set()` has built the context. `tls_set()` already calls `tls_insecure_set(False)` itself, so keeping the explicit call after it is still correct for anyone who wants `tls_insecure: true`.

No new config option, and no schema or UI change. I added `frigate/test/test_mqtt_tls.py` covering the four cases (no TLS options, CA only, client certs without a CA, and `tls_insecure` on its own), and updated the comments for `tls_ca_certs` in the config reference so it reads as optional and only needed for a private CA.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #2471
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

Not a new feature, this is a bugfix, so there is nothing to link here.

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): Claude Code

**How AI was used** (e.g., code generation, code review, debugging, documentation): code generation for the rewritten TLS block, the new test module, and the doc comment wording.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): it wrote the change to `_start()` and the test file from the approach I described, which is about a dozen lines of source plus the tests.

**Human oversight**: I read through paho's `client.py` myself to confirm that `tls_set(None)` calls `load_default_certs()` and that `tls_insecure_set()` raises when `_ssl_context` is None, which is what the fix relies on. I went over the diff line by line, ran the new tests against the old code to check they actually fail (the `tls_insecure` one raises the ValueError, the client cert one shows `tls_set` never being called) and against the new code to check they pass, and ran `ruff format --check` and `ruff check`. I could not run the whole suite locally since most of it needs dependencies that will not install on my machine, so I only ran the two MQTT test modules.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)