### PR TITLE
Stop creating a config subscriber per capture thread

### DIFF
--- a/frigate/video/ffmpeg.py
+++ b/frigate/video/ffmpeg.py
@@ -54,59 +54,48 @@ def capture_frames(
     skipped_eps = EventsPerSecond()
     skipped_eps.start()
 
-    config_subscriber = CameraConfigUpdateSubscriber(
-        None, {config.name: config}, [CameraConfigUpdateEnum.enabled]
-    )
+    while not stop_event.is_set():
+        # CameraWatchdog applies enabled updates onto this same CameraConfig
+        # before it stops ffmpeg. Do not subscribe here: it would be rebuilt per
+        # ffmpeg restart and strand a pipe in the idle main process config PUB.
+        if not config.enabled:
+            logger.debug(f"Stopping capture thread for disabled {config.name}")
+            break
 
-    def get_enabled_state():
-        """Fetch the latest enabled state from ZMQ."""
-        config_subscriber.check_for_updates()
-        return config.enabled
-
-    try:
-        while not stop_event.is_set():
-            if not get_enabled_state():
-                logger.debug(f"Stopping capture thread for disabled {config.name}")
+        fps.value = frame_rate.eps()
+        skipped_fps.value = skipped_eps.eps()
+        current_frame.value = datetime.now().timestamp()
+        frame_name = f"{config.name}_frame{frame_index}"
+        frame_buffer = frame_manager.write(frame_name)
+        try:
+            frame_buffer[:] = ffmpeg_process.stdout.read(frame_size)
+        except Exception:
+            # shutdown has been initiated
+            if stop_event.is_set():
                 break
 
-            fps.value = frame_rate.eps()
-            skipped_fps.value = skipped_eps.eps()
-            current_frame.value = datetime.now().timestamp()
-            frame_name = f"{config.name}_frame{frame_index}"
-            frame_buffer = frame_manager.write(frame_name)
-            try:
-                frame_buffer[:] = ffmpeg_process.stdout.read(frame_size)
-            except Exception:
-                # shutdown has been initiated
-                if stop_event.is_set():
-                    break
+            logger.error(f"{config.name}: Unable to read frames from ffmpeg process.")
 
+            if ffmpeg_process.poll() is not None:
                 logger.error(
-                    f"{config.name}: Unable to read frames from ffmpeg process."
+                    f"{config.name}: ffmpeg process is not running. exiting capture thread..."
                 )
+                break
 
-                if ffmpeg_process.poll() is not None:
-                    logger.error(
-                        f"{config.name}: ffmpeg process is not running. exiting capture thread..."
-                    )
-                    break
+            continue
 
-                continue
+        frame_rate.update()
 
-            frame_rate.update()
+        # don't lock the queue to check, just try since it should rarely be full
+        try:
+            # add to the queue
+            frame_queue.put((frame_name, current_frame.value), False)
+            frame_manager.close(frame_name)
+        except queue.Full:
+            # if the queue is full, skip this frame
+            skipped_eps.update()
 
-            # don't lock the queue to check, just try since it should rarely be full
-            try:
-                # add to the queue
-                frame_queue.put((frame_name, current_frame.value), False)
-                frame_manager.close(frame_name)
-            except queue.Full:
-                # if the queue is full, skip this frame
-                skipped_eps.update()
-
-            frame_index = 0 if frame_index == shm_frame_count - 1 else frame_index + 1
-    finally:
-        config_subscriber.stop()
+        frame_index = 0 if frame_index == shm_frame_count - 1 else frame_index + 1
 
 
 class CameraWatchdog(threading.Thread):


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
Each ffmpeg restart spun up a new capture thread with its own zmq config subscriber, and the main process's config publisher never reaps those dead connections because it only does work when a config change is actually published. An offline camera restarting every retry_interval leaks about 16 kB per restart, so over 100 MB a day, until the next config change flushes it.

The capture thread's subscriber was actually redundant. `CameraWatchdog` already holds a long-lived subscriber over the same `CameraConfig` instance and applies enabled updates to it before stopping ffmpeg, so the capture loop reads the attribute directly.

After the change in this PR, behavior is unchanged except that a disable reaches the capture loop on the next watchdog tick (within 1s) instead of immediately, and ffmpeg's stdout now stays drained until the watchdog kills it rather than being abandoned early.

The diff is slightly confusing to read because of the indentation change, but the only real change was to remove a try/finally, remove the config subscriber, and have the check look at the prop's config object rather than the update from the subscriber.



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/24001
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
