### PR TITLE
Update Intel NPU drivers to 1.28.0

### DIFF
--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -140,6 +140,7 @@ if [[ "${TARGETARCH}" == "amd64" ]]; then
     wget https://github.com/oneapi-src/level-zero/releases/download/v1.28.2/level-zero_1.28.2+u22.04_amd64.deb
     wget https://github.com/intel/linux-npu-driver/releases/download/v1.28.0/linux-npu-driver-v1.28.0.20251218-20347000698-ubuntu2404.tar.gz
     tar -xf linux-npu-driver-v1.28.0.20251218-20347000698-ubuntu2404.tar.gz --strip-components=1
+    rm linux-npu-driver-v1.28.0.20251218-20347000698-ubuntu2404.tar.gz
 
     dpkg -i *.deb
     rm *.deb

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -139,7 +139,7 @@ if [[ "${TARGETARCH}" == "amd64" ]]; then
     # npu packages
     wget https://github.com/oneapi-src/level-zero/releases/download/v1.28.2/level-zero_1.28.2+u22.04_amd64.deb
     wget https://github.com/intel/linux-npu-driver/releases/download/v1.28.0/linux-npu-driver-v1.28.0.20251218-20347000698-ubuntu2404.tar.gz
-    tar -xf linux-npu-driver-v1.28.0.20251218-20347000698-ubuntu2404.tar.gz --strip-components=1
+    tar -xf linux-npu-driver-v1.28.0.20251218-20347000698-ubuntu2404.tar.gz
     rm linux-npu-driver-v1.28.0.20251218-20347000698-ubuntu2404.tar.gz
 
     dpkg -i *.deb

--- a/docker/main/install_deps.sh
+++ b/docker/main/install_deps.sh
@@ -138,9 +138,8 @@ if [[ "${TARGETARCH}" == "amd64" ]]; then
     wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.32.7/intel-igc-core-2_2.32.7+21184_amd64.deb
     # npu packages
     wget https://github.com/oneapi-src/level-zero/releases/download/v1.28.2/level-zero_1.28.2+u22.04_amd64.deb
-    wget https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-driver-compiler-npu_1.19.0.20250707-16111289554_ubuntu22.04_amd64.deb
-    wget https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-fw-npu_1.19.0.20250707-16111289554_ubuntu22.04_amd64.deb
-    wget https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-level-zero-npu_1.19.0.20250707-16111289554_ubuntu22.04_amd64.deb
+    wget https://github.com/intel/linux-npu-driver/releases/download/v1.28.0/linux-npu-driver-v1.28.0.20251218-20347000698-ubuntu2404.tar.gz
+    tar -xf linux-npu-driver-v1.28.0.20251218-20347000698-ubuntu2404.tar.gz --strip-components=1
 
     dpkg -i *.deb
     rm *.deb


### PR DESCRIPTION
## Proposed change

Brings in support for Panther Lake NPUs. Not sure if it is the latest that could be included, but this worked in my testing on a Intel Core Ultra 7 356H.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

## AI disclosure

- [x] No AI tools were used in this PR.
- [ ] AI tools were used in this PR. Details below:

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I can explain every line of code in this PR if asked.
- [N/A] UI changes including text have used i18n keys and have been added to the `en` locale.
- [N/A] The code has been formatted using Ruff (`ruff format frigate`)
