### PR TITLE
Improve Debug Replay error message

### DIFF
--- a/docs/static/frigate-api.yaml
+++ b/docs/static/frigate-api.yaml
@@ -7109,7 +7109,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/DebugReplayStartResponse'
         '400':
-          description: Invalid camera, time range, or no recordings
+          description: Invalid camera or time range
+        '404':
+          description: No recordings in the requested time range
         '409':
           description: A replay session is already active
         '422':

--- a/frigate/api/debug_replay.py
+++ b/frigate/api/debug_replay.py
@@ -13,6 +13,7 @@ from frigate.api.auth import require_role
 from frigate.api.defs.tags import Tags
 from frigate.jobs.debug_replay import (
     ExportDebugReplaySource,
+    NoRecordingsError,
     RecordingDebugReplaySource,
     start_debug_replay_job,
 )
@@ -74,7 +75,8 @@ class DebugReplayStopResponse(BaseModel):
     response_model=DebugReplayStartResponse,
     status_code=202,
     responses={
-        400: {"description": "Invalid camera, time range, or no recordings"},
+        400: {"description": "Invalid camera or time range"},
+        404: {"description": "No recordings in the requested time range"},
         409: {"description": "A replay session is already active"},
     },
     dependencies=[Depends(require_role(["admin"]))],
@@ -112,6 +114,14 @@ async def start_debug_replay(request: Request, body: DebugReplayStartBody):
                 "message": "A replay session is already active",
             },
             status_code=409,
+        )
+    except NoRecordingsError:
+        return JSONResponse(
+            content={
+                "success": False,
+                "message": "No recordings found in the selected time range",
+            },
+            status_code=404,
         )
     except ValueError:
         logger.exception("Rejected debug replay start request")

--- a/frigate/jobs/debug_replay.py
+++ b/frigate/jobs/debug_replay.py
@@ -115,6 +115,10 @@ def query_recordings(source_camera: str, start_ts: float, end_ts: float) -> Mode
     return cast(ModelSelect, query)
 
 
+class NoRecordingsError(ValueError):
+    """Raised when no recordings exist in the requested time range."""
+
+
 class DebugReplaySource(ABC):
     """Abstract source for a debug replay session.
 
@@ -187,7 +191,7 @@ class RecordingDebugReplaySource(DebugReplaySource):
             raise ValueError("End time must be after start time")
 
         if not query_recordings(self._camera, self._start_ts, self._end_ts).count():
-            raise ValueError(
+            raise NoRecordingsError(
                 f"No recordings found for camera '{self._camera}' in the specified time range"
             )
 

--- a/frigate/test/http_api/test_debug_replay_api.py
+++ b/frigate/test/http_api/test_debug_replay_api.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+from frigate.jobs.debug_replay import NoRecordingsError
 from frigate.models import Event, Recordings, ReviewSegment
 from frigate.test.http_api.base_http_test import AuthTestClient, BaseTestHttp
 
@@ -65,6 +66,32 @@ class TestDebugReplayAPI(BaseTestHttp):
         # Message is hard-coded so we don't echo exception text back to clients
         # (CodeQL: information exposure through an exception).
         self.assertEqual(body["message"], "Invalid debug replay parameters")
+
+    def test_start_returns_404_when_no_recordings(self):
+        with patch(
+            "frigate.api.debug_replay.start_debug_replay_job",
+            side_effect=NoRecordingsError(
+                "No recordings found for camera 'front' in the specified time range"
+            ),
+        ):
+            with AuthTestClient(self.app) as client:
+                resp = client.post(
+                    "/debug_replay/start",
+                    json={
+                        "camera": "front",
+                        "start_time": 100,
+                        "end_time": 200,
+                    },
+                )
+
+        self.assertEqual(resp.status_code, 404)
+        body = resp.json()
+        self.assertFalse(body["success"])
+        # Message is hard-coded so we don't echo exception text back to clients
+        # (CodeQL: information exposure through an exception).
+        self.assertEqual(
+            body["message"], "No recordings found in the selected time range"
+        )
 
     def test_start_returns_409_when_session_already_active(self):
         with patch(

--- a/frigate/test/test_debug_replay_job.py
+++ b/frigate/test/test_debug_replay_job.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 from frigate.debug_replay import DebugReplayManager
 from frigate.jobs.debug_replay import (
     DebugReplayJob,
+    NoRecordingsError,
     RecordingDebugReplaySource,
     cancel_debug_replay_job,
     get_active_runner,
@@ -129,7 +130,7 @@ class TestStartDebugReplayJob(unittest.TestCase):
         empty_qs = MagicMock()
         empty_qs.count.return_value = 0
         with patch("frigate.jobs.debug_replay.query_recordings", return_value=empty_qs):
-            with self.assertRaises(ValueError):
+            with self.assertRaises(NoRecordingsError):
                 start_debug_replay_job(
                     source=RecordingDebugReplaySource(
                         source_camera="front",

--- a/web/public/locales/en/views/replay.json
+++ b/web/public/locales/en/views/replay.json
@@ -21,6 +21,7 @@
     "toast": {
       "error": "Failed to start debug replay: {{error}}",
       "alreadyActive": "A replay session is already active",
+      "noRecordings": "No recordings found in the selected time range",
       "stopError": "Failed to stop debug replay: {{error}}",
       "goToReplay": "Go to Replay"
     }

--- a/web/src/components/overlay/DebugReplayDialog.tsx
+++ b/web/src/components/overlay/DebugReplayDialog.tsx
@@ -217,7 +217,11 @@ export default function DebugReplayDialog({
           error.response?.data?.detail ||
           "Unknown error";
 
-        if (error.response?.status === 409) {
+        if (error.response?.status === 404) {
+          toast.error(t("dialog.toast.noRecordings"), {
+            position: "top-center",
+          });
+        } else if (error.response?.status === 409) {
           toast.error(t("dialog.toast.alreadyActive"), {
             position: "top-center",
             closeButton: true,


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
Starting a debug replay over a timespan with no recordings previously failed with a generic "Invalid debug replay parameters" toast, which read as user error. The API now returns a distinct 404 for this case and the dialog shows a translated "No recordings found in the selected time range" message.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
