### PR TITLE
Fix model lookup for cameras added at runtime

### DIFF
--- a/frigate/config/camera/updater.py
+++ b/frigate/config/camera/updater.py
@@ -96,6 +96,7 @@ class CameraConfigUpdateSubscriber:
             return
         elif update_type == CameraConfigUpdateEnum.remove:
             self.config.cameras.pop(camera, None)
+            self.config.drop_camera_model(camera)
             self.camera_configs.pop(camera, None)
             return
 

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -687,13 +687,37 @@ class FrigateConfig(FrigateBaseModel):
     def model_for_camera(self, camera_name: str) -> ModelConfig:
         """Get the detection model a camera runs on.
 
+        Cameras added at runtime (wizard, clone, debug replay) are inserted
+        into cameras after parse, so they miss the cache built during
+        post_validation and are resolved here on first lookup.
+
         Args:
             camera_name: Name of the camera
 
         Returns:
             The model matching the camera's detect scene
         """
-        return self._camera_models[camera_name]
+        model = self._camera_models.get(camera_name)
+
+        if model is None:
+            camera = self.cameras.get(camera_name)
+            scene = camera.detect.scene if camera is not None else SceneEnum.all
+            model = self._resolve_camera_model(camera_name, scene)
+            self._camera_models[camera_name] = model
+
+        return model
+
+    def drop_camera_model(self, camera_name: str) -> None:
+        """Forget the cached model for a camera removed at runtime.
+
+        A later re-add resolves fresh, so a camera recreated under the same
+        name with a different detect scene doesn't inherit the removed
+        camera's model.
+
+        Args:
+            camera_name: Name of the removed camera
+        """
+        self._camera_models.pop(camera_name, None)
 
     def devices_for_model(self, model: ModelConfig) -> list[DeviceSpec]:
         """Get the parsed hardware devices a model runs on.

--- a/frigate/test/test_camera_config_updater.py
+++ b/frigate/test/test_camera_config_updater.py
@@ -9,6 +9,32 @@ from frigate.config.camera.updater import (
     CameraConfigUpdateSubscriber,
 )
 from frigate.const import SUB_CACHE_TAG
+from frigate.detectors.detector_config import SceneEnum
+
+
+def _build_scene_frigate_config(scene: str | None) -> FrigateConfig:
+    detect = {"height": 1080, "width": 1920, "fps": 5}
+    if scene is not None:
+        detect["scene"] = scene
+    return FrigateConfig(
+        **{
+            "mqtt": {"host": "mqtt"},
+            "models": [
+                {"devices": ["cpu"]},
+                {"scene": "outdoor", "devices": ["openvino:CPU"]},
+            ],
+            "cameras": {
+                "front_door": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}
+                        ]
+                    },
+                    "detect": detect,
+                }
+            },
+        }
+    )
 
 
 def _build_camera_config(sub_enabled: bool) -> CameraConfig:
@@ -85,6 +111,32 @@ class TestRecordUpdateRecreatesFfmpegCmds(unittest.TestCase):
         )
 
         assert not _has_sub_output(camera_config)
+
+    @patch("frigate.detectors.detector_config.load_labels")
+    def test_removed_camera_readded_without_scene_gets_fresh_model(self, mock_labels):
+        mock_labels.return_value = {}
+        config = _build_scene_frigate_config("outdoor")
+        subscriber = CameraConfigUpdateSubscriber(
+            config, {}, [CameraConfigUpdateEnum.add, CameraConfigUpdateEnum.remove]
+        )
+        assert config.model_for_camera("front_door").scene == SceneEnum.outdoor
+
+        subscriber.subscriber.check_for_update.side_effect = [
+            ("config/cameras/front_door/remove", config.cameras["front_door"]),
+            (None, None),
+        ]
+        subscriber.check_for_updates()
+
+        # recreating the camera through the wizard leaves the scene unset,
+        # so the removed camera's cached model must not carry over
+        readded = _build_scene_frigate_config(None).cameras["front_door"]
+        subscriber.subscriber.check_for_update.side_effect = [
+            ("config/cameras/front_door/add", readded),
+            (None, None),
+        ]
+        subscriber.check_for_updates()
+
+        assert config.model_for_camera("front_door").scene == SceneEnum.all
 
     def test_unchanged_record_update_keeps_existing_cmds(self):
         camera_config = _build_camera_config(sub_enabled=False)

--- a/frigate/test/test_config.py
+++ b/frigate/test/test_config.py
@@ -180,6 +180,50 @@ class TestConfig(unittest.TestCase):
         assert frigate_config.model_for_camera("back").scene == SceneEnum.all
 
     @patch("frigate.detectors.detector_config.load_labels")
+    def test_model_for_camera_resolves_camera_added_after_parse(self, mock_labels):
+        mock_labels.return_value = {}
+        config = {
+            "models": [
+                {"devices": ["cpu"], "width": 320},
+                {"scene": "outdoor", "devices": ["openvino:CPU"], "width": 416},
+            ],
+        }
+
+        frigate_config = FrigateConfig(**(deep_merge(deepcopy(config), self.minimal)))
+
+        # runtime camera adds (wizard, clone, debug replay) insert an already
+        # resolved camera into the shared config without re-running parse
+        added = deepcopy(self.minimal)
+        added["cameras"]["new_cam"] = {
+            "detect": {"height": 1080, "width": 1920, "fps": 5, "scene": "outdoor"},
+            "ffmpeg": {
+                "inputs": [
+                    {"path": "rtsp://10.0.0.2:554/video", "roles": ["detect"]},
+                ]
+            },
+        }
+        new_config = FrigateConfig(**(deep_merge(deepcopy(config), added)))
+        frigate_config.cameras["new_cam"] = new_config.cameras["new_cam"]
+
+        assert frigate_config.model_for_camera("new_cam").scene == SceneEnum.outdoor
+        assert frigate_config.model_for_camera("new_cam").width == 416
+
+    @patch("frigate.detectors.detector_config.load_labels")
+    def test_model_for_camera_unknown_camera_uses_default_model(self, mock_labels):
+        mock_labels.return_value = {}
+        config = {
+            "models": [
+                {"devices": ["cpu"], "width": 320},
+                {"scene": "outdoor", "devices": ["openvino:CPU"], "width": 416},
+            ],
+        }
+
+        frigate_config = FrigateConfig(**(deep_merge(deepcopy(config), self.minimal)))
+
+        # a caller racing a runtime remove may still name the popped camera
+        assert frigate_config.model_for_camera("removed").scene == SceneEnum.all
+
+    @patch("frigate.detectors.detector_config.load_labels")
     def test_camera_scene_without_a_model_or_a_default(self, mock_labels):
         mock_labels.return_value = {}
         config = {


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
model_for_camera reads a cache built only at config parse, so cameras added at runtime (wizard, clone, debug replay) crashed the camera maintainer, object processor, and event maintainer with a KeyError.

Unknown cameras now resolve lazily from their detect scene with the existing fallback to the all model, and a runtime remove drops the cached entry so a camera recreated under the same name doesn't inherit the removed camera's model.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
