### PR TITLE
Add indexes for time-ordered API queries

### DIFF
--- a/migrations/036_add_query_indexes.py
+++ b/migrations/036_add_query_indexes.py
@@ -1,0 +1,50 @@
+"""Add indexes for time-ordered API queries."""
+
+INDEXES = {
+    "event_camera_start_time": '"event" ("camera", "start_time" DESC)',
+    "review_segment_camera_start_time_end_time": (
+        '"reviewsegment" ("camera", "start_time" DESC, "end_time" DESC, '
+        '"severity", "id")'
+    ),
+    "review_segment_severity_start_time_camera": (
+        '"reviewsegment" ("severity", "start_time" DESC, "camera")'
+    ),
+    "review_segment_camera_severity_start_time": (
+        '"reviewsegment" ("camera", "severity", "start_time" DESC)'
+    ),
+    "timeline_timestamp": '"timeline" ("timestamp" DESC)',
+    "timeline_camera_timestamp": '"timeline" ("camera", "timestamp" DESC)',
+    "previews_camera_start_time_end_time": (
+        '"previews" ("camera", "start_time" DESC, "end_time" DESC)'
+    ),
+    "previews_start_time_end_time_camera": (
+        '"previews" ("start_time" DESC, "end_time" DESC, "camera")'
+    ),
+}
+
+ANALYZE_TABLES = (
+    "event",
+    "reviewsegment",
+    "timeline",
+    "previews",
+    "recordings",
+    "userreviewstatus",
+)
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    for name, definition in INDEXES.items():
+        migrator.sql(f'CREATE INDEX IF NOT EXISTS "{name}" ON {definition}')
+
+    # Help SQLite choose a global time index when the camera filter includes
+    # nearly every camera instead of scanning each camera index and sorting.
+    for table in ANALYZE_TABLES:
+        migrator.sql(f'ANALYZE "{table}"')
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    for name in reversed(INDEXES):
+        migrator.sql(f'DROP INDEX IF EXISTS "{name}"')
+
+    for table in ANALYZE_TABLES:
+        migrator.sql(f'ANALYZE "{table}"')


### PR DESCRIPTION
The problem was slow SQLite query performance in Frigate’s Events-related UI, especially with long retention and access to many cameras. The database was large, but size alone was not the root cause. The principal issue was SQLite choosing unsuitable query plans.

Baseline stats

-   Configured cameras: 42
-   Main SQLite database: 1.79 GiB
-   SQLite WAL: 23.2 MiB
-   Retained Event rows: 282,549
-   Review rows: 119,525
-   Recording segments: 694,995
-   Timeline rows: 972,260
-   Preview rows: 40,185
-   Thumbnail embeddings: 160,500
-   Description embeddings: 50,903

Baseline count-query performance

-   Review count: 574 ms
-   Event count: 900 ms
-   Timeline count: 2.34 seconds
-   Recording count: 6.86 seconds

Baseline UI-query performance

-   Latest 100 Events without camera filtering: 228 ms
-   Latest 100 Events for one camera: more than 8.7 seconds
-   One-camera Events from the last day, returning 9 rows: 8.34 seconds
-   Review list for the last 24 hours: more than 12 seconds
-   Daily Review summary: more than 12 seconds
-   Latest Timeline rows: more than 12 seconds
-   Recording time-range lookup: more than 12 seconds
-   Preview clips for 24 hours: 1.53 seconds for 936 rows

Index-related performance results (post change)

-   Latest 100 Events: 1.683 seconds before, 2 ms after
-   Ordered Review list: 492 ms before, 1 ms after
-   Latest 100 Timeline rows: 2.328 seconds before, 1 ms after
-   One day of Previews: 13 ms before, 4 ms after

Complete internal tuning results

-   Live sample size: 20 requests per endpoint
-   Median response times: 9.5–13.4 ms
-   p95 response times: 17.2–25.0 ms
-   HTTP results: every request returned 200 


## Proposed change
Add a new 036_add_query_indexes.py database migration containing eight indexes designed around Frigate’s existing time-ordered API queries.

  Event:
  - Add (camera, start_time DESC) for camera-filtered Event lists.

  Review:
  - Add (camera, start_time DESC, end_time DESC, severity, id) for filtered Review ranges and
    summaries.
  - Add (severity, start_time DESC, camera) for all-camera severity/time ordering.
  - Add (camera, severity, start_time DESC) for single-camera severity/time ordering.

  Timeline:
  - Add (timestamp DESC) for global Timeline queries.
  - Add (camera, timestamp DESC) for camera-specific Timeline queries.

  Previews:
  - Add (camera, start_time DESC, end_time DESC) for camera-specific ranges.
  - Add (start_time DESC, end_time DESC, camera) for global time ranges.

Run targeted ANALYZE operations for Event, ReviewSegment, Timeline, Previews, Recordings, and UserReviewStatus. This supplies SQLite with cardinality statistics so it can distinguish selective camera filters from authorization lists containing nearly every camera.

The expected result is that bounded, time-ordered requests use an ordered index instead of scanning camera-only indexes and building temporary sorting B-trees.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):


## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

I used codex for analysis and crafting of the new index. 

**How AI was used** (e.g., code generation, code review, debugging, documentation):

Review, analysis, and crafting of the indexes. 

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

Generated by Codex. 

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

Full oversight, test validation, and sign-off.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
