### PR TITLE
fix(video): release shm handle when a captured frame is skipped

### DIFF
--- a/frigate/video/ffmpeg.py
+++ b/frigate/video/ffmpeg.py
@@ -99,10 +99,14 @@ def capture_frames(
             try:
                 # add to the queue
                 frame_queue.put((frame_name, current_frame.value), False)
-                frame_manager.close(frame_name)
             except queue.Full:
                 # if the queue is full, skip this frame
                 skipped_eps.update()
+            finally:
+                # release our handle either way. on the skip path the frame is
+                # never handed to a consumer, so nothing else will close it and
+                # the mapping stays open until this ring slot comes back around.
+                frame_manager.close(frame_name)
 
             frame_index = 0 if frame_index == shm_frame_count - 1 else frame_index + 1
     finally:


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

In `capture_frames`, `frame_manager.close()` sits inside the `try` after
`frame_queue.put(..., False)`. When the put raises `queue.Full` the close is
skipped, so the capture process keeps its handle on that shm segment.

The frame was never handed to a consumer, so nothing downstream will close it
either. The mapping stays open until that ring slot comes back around and
`write()` reuses the cached handle.

This is bounded by `shm_frame_count`, so it is not the cause of the unbounded
growth reported in #19646 / #19925. It is a consistency fix: the success path
already closes every frame, and the skip path should behave the same way.

No hot-path cost. `write()` already reopens the segment on every iteration
because the success path closes it every iteration.

Credit to @justbendev, who spotted this in #19925.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #19646, #19925
- Link to discussion with maintainers (**required** for any large or "planned" features):

## AI disclosure

- [x] No AI tools were used in this PR.
- [ ] AI tools were used in this PR. Details below:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
