### PR TITLE
Use extended graph optimization for jinav2

### DIFF
--- a/frigate/detectors/detection_runners.py
+++ b/frigate/detectors/detection_runners.py
@@ -25,25 +25,31 @@ def is_arm64_platform() -> bool:
     return machine in ("aarch64", "arm64", "armv8", "armv7l")
 
 
-def get_ort_session_options(
-    is_complex_model: bool = False,
-) -> ort.SessionOptions | None:
+def get_ort_session_options(model_type: str | None = None) -> ort.SessionOptions | None:
     """Get ONNX Runtime session options with appropriate settings.
 
     Args:
-        is_complex_model: Whether the model needs basic optimization to avoid graph fusion issues.
+        model_type: Model being loaded, used to pin its graph optimization level.
 
     Returns:
-        SessionOptions with appropriate optimization level, or None for default settings.
+        SessionOptions with a pinned optimization level, or None for default settings.
     """
-    if is_complex_model:
-        sess_options = ort.SessionOptions()
-        sess_options.graph_optimization_level = (
-            ort.GraphOptimizationLevel.ORT_ENABLE_BASIC
-        )
-        return sess_options
+    # Import here to avoid circular imports
+    from frigate.embeddings.types import EnrichmentModelTypeEnum
 
-    return None
+    if model_type == EnrichmentModelTypeEnum.jina_v2.value:
+        # below EXTENDED the CUDA EP returns an identical vector for every image,
+        # and ORT_ENABLE_ALL fails to build on CPU with a SimplifiedLayerNormFusion error
+        level = ort.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
+    elif model_type == EnrichmentModelTypeEnum.jina_v1.value:
+        # aggressive optimizations create or expect nodes that don't exist
+        level = ort.GraphOptimizationLevel.ORT_ENABLE_BASIC
+    else:
+        return None
+
+    sess_options = ort.SessionOptions()
+    sess_options.graph_optimization_level = level
+    return sess_options
 
 
 # Import OpenVINO only when needed to avoid circular dependencies
@@ -114,21 +120,6 @@ class BaseModelRunner(ABC):
 
 class ONNXModelRunner(BaseModelRunner):
     """Run ONNX models using ONNX Runtime."""
-
-    @staticmethod
-    def is_cpu_complex_model(model_type: str) -> bool:
-        """Check if model needs basic optimization level to avoid graph fusion issues.
-
-        Some models (like Jina-CLIP) have issues with aggressive optimizations like
-        SimplifiedLayerNormFusion that create or expect nodes that don't exist.
-        """
-        # Import here to avoid circular imports
-        from frigate.embeddings.types import EnrichmentModelTypeEnum
-
-        return model_type in [
-            EnrichmentModelTypeEnum.jina_v1.value,
-            EnrichmentModelTypeEnum.jina_v2.value,
-        ]
 
     @staticmethod
     def is_migraphx_complex_model(model_type: str) -> bool:
@@ -626,9 +617,7 @@ def get_optimized_runner(
     return ONNXModelRunner(
         ort.InferenceSession(
             model_path,
-            sess_options=get_ort_session_options(
-                ONNXModelRunner.is_cpu_complex_model(model_type)
-            ),
+            sess_options=get_ort_session_options(model_type),
             providers=providers,
             provider_options=options,
         ),

--- a/frigate/test/test_detection_runners.py
+++ b/frigate/test/test_detection_runners.py
@@ -1,0 +1,41 @@
+"""Tests for ONNX Runtime session option selection."""
+
+import unittest
+
+import onnxruntime as ort
+
+from frigate.detectors.detection_runners import get_ort_session_options
+from frigate.detectors.detector_config import ModelTypeEnum
+from frigate.embeddings.types import EnrichmentModelTypeEnum
+
+
+class TestGetOrtSessionOptions(unittest.TestCase):
+    def test_jina_v2_uses_extended(self):
+        """jina-clip-v2 returns an identical vector for every image on the CUDA
+        execution provider at anything below EXTENDED."""
+        options = get_ort_session_options(EnrichmentModelTypeEnum.jina_v2.value)
+
+        self.assertIsNotNone(options)
+        self.assertEqual(
+            options.graph_optimization_level,
+            ort.GraphOptimizationLevel.ORT_ENABLE_EXTENDED,
+        )
+
+    def test_jina_v1_uses_basic(self):
+        options = get_ort_session_options(EnrichmentModelTypeEnum.jina_v1.value)
+
+        self.assertIsNotNone(options)
+        self.assertEqual(
+            options.graph_optimization_level,
+            ort.GraphOptimizationLevel.ORT_ENABLE_BASIC,
+        )
+
+    def test_other_models_use_defaults(self):
+        for model_type in [
+            None,
+            EnrichmentModelTypeEnum.paddleocr.value,
+            EnrichmentModelTypeEnum.arcface.value,
+            ModelTypeEnum.rfdetr.value,
+        ]:
+            with self.subTest(model_type=model_type):
+                self.assertIsNone(get_ort_session_options(model_type))


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
jina-clip-v2 returned an identical vector for every image under the CUDA execution provider, so thumbnail search returned the same results no matter what you searched for. Building the session at `ORT_ENABLE_EXTENDED` instead of `ORT_ENABLE_BASIC` fixes it, verified on two NVIDIA GPUs and bit-identical to the old output on CPU.

Anyone running `jinav2` with `model_size: large` on a GPU will need to reindex their embeddings after this.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: Fixes https://github.com/blakeblackshear/frigate/discussions/24058
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
