### PR TITLE
Fix ZMQ detector: recover from failed model init instead of silently serving zero detections

### DIFF
--- a/frigate/detectors/plugins/zmq_ipc.py
+++ b/frigate/detectors/plugins/zmq_ipc.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 from typing import Any, Literal
 
 import numpy as np
@@ -13,6 +14,8 @@ from frigate.detectors.detector_config import BaseDetectorConfig
 logger = logging.getLogger(__name__)
 
 DETECTOR_KEY = "zmq"
+
+NOT_READY_LOG_INTERVAL_S = 60.0
 
 
 class ZmqDetectorConfig(BaseDetectorConfig):
@@ -37,6 +40,11 @@ class ZmqDetectorConfig(BaseDetectorConfig):
         default=0,
         title="ZMQ socket linger in milliseconds",
         description="Socket linger period in milliseconds.",
+    )
+    reinit_backoff_ms: int = Field(
+        default=5000,
+        title="ZMQ model re-initialization backoff in milliseconds",
+        description="Minimum interval between model re-initialization attempts in milliseconds.",
     )
 
 
@@ -65,6 +73,8 @@ class ZmqIpcDetector(DetectionApi):
     - On initialization, sends model request to check if model is available
     - If model not available, sends model data via ZMQ
     - Only starts inference after model is ready
+    - If initialization fails, it is retried with a backoff from the detect
+      path rather than requiring a full restart to recover
     """
 
     type_key = DETECTOR_KEY
@@ -76,12 +86,16 @@ class ZmqIpcDetector(DetectionApi):
         self._endpoint = detector_config.endpoint
         self._request_timeout_ms = detector_config.request_timeout_ms
         self._linger_ms = detector_config.linger_ms
+        self._reinit_backoff_ms = detector_config.reinit_backoff_ms
         self._socket = None
         self._create_socket()
 
         # Model management
         self._model_ready = False
         self._model_name = self._get_model_name()
+        self._last_init_attempt = 0.0
+        self._not_ready_last_log = 0.0
+        self._not_ready_suppressed = 0
 
         # Initialize model if needed
         self._initialize_model()
@@ -96,6 +110,14 @@ class ZmqIpcDetector(DetectionApi):
             except Exception:
                 pass
         self._socket = self._context.socket(zmq.REQ)
+        # Correlate replies with requests and relax the strict REQ state
+        # machine: a stale reply left over from an earlier request (e.g. a
+        # peer that answered after a timeout/reset cycle) is dropped by libzmq
+        # instead of being mistaken for the answer to the current request.
+        # REP peers echo the correlation envelope automatically, so this
+        # needs no server-side change.
+        self._socket.setsockopt(zmq.REQ_CORRELATE, 1)
+        self._socket.setsockopt(zmq.REQ_RELAXED, 1)
         # Apply timeouts and linger so calls don't block indefinitely
         self._socket.setsockopt(zmq.RCVTIMEO, self._request_timeout_ms)
         self._socket.setsockopt(zmq.SNDTIMEO, self._request_timeout_ms)
@@ -111,11 +133,20 @@ class ZmqIpcDetector(DetectionApi):
 
     def _initialize_model(self) -> None:
         """Initialize the model by checking availability and transferring if needed."""
+        self._last_init_attempt = time.monotonic()
+        self._model_ready = False
         try:
             logger.info(f"Initializing model: {self._model_name}")
 
-            # Check if model is available and transfer if needed
-            if self._check_and_transfer_model():
+            # Handshake on a fresh socket so nothing buffered from an earlier
+            # request generation can be mistaken for this handshake's reply.
+            self._create_socket()
+
+            # Require the ready handshake to be confirmed by a second
+            # exchange: one spurious reply (stale buffer, half-open peer)
+            # can satisfy at most one round-trip, so a peer that is really
+            # alive and loaded must answer twice in a row.
+            if self._check_and_transfer_model() and self._check_model_availability():
                 logger.info(f"Model {self._model_name} is ready")
                 self._model_ready = True
             else:
@@ -123,6 +154,38 @@ class ZmqIpcDetector(DetectionApi):
 
         except Exception as e:
             logger.error(f"Failed to initialize model: {e}")
+
+    def _recover(self) -> None:
+        """Backoff-gated re-initialization shared by every failure path.
+
+        Called whenever the plugin is not ready or a request failed. At most
+        one initialization attempt per reinit_backoff_ms, so a dead peer is
+        polled instead of hammered, and the plugin recovers by itself when
+        the peer returns instead of wedging until the next restart.
+        """
+        if (
+            time.monotonic() - self._last_init_attempt
+            >= self._reinit_backoff_ms / 1000.0
+        ):
+            try:
+                self._initialize_model()
+            except Exception:
+                pass
+
+    def _log_not_ready(self) -> None:
+        """Rate-limited not-ready warning so a wedged period cannot flood the log."""
+        now = time.monotonic()
+        if now - self._not_ready_last_log >= NOT_READY_LOG_INTERVAL_S:
+            suffix = (
+                f" ({self._not_ready_suppressed} similar warnings suppressed)"
+                if self._not_ready_suppressed
+                else ""
+            )
+            logger.warning(f"Model not ready, returning zero detections{suffix}")
+            self._not_ready_last_log = now
+            self._not_ready_suppressed = 0
+        else:
+            self._not_ready_suppressed += 1
 
     def _check_and_transfer_model(self) -> bool:
         """Check if model is available and transfer if needed in one atomic operation."""
@@ -299,8 +362,10 @@ class ZmqIpcDetector(DetectionApi):
 
     def detect_raw(self, tensor_input: np.ndarray) -> np.ndarray:
         if not self._model_ready:
-            logger.warning("Model not ready, returning zero detections")
-            return self._zero_result
+            self._recover()
+            if not self._model_ready:
+                self._log_not_ready()
+                return self._zero_result
 
         try:
             header_bytes = self._build_header(tensor_input)
@@ -316,21 +381,16 @@ class ZmqIpcDetector(DetectionApi):
             # Ensure output shape and dtype are exactly as expected
             return detections
         except zmq.Again:
-            # Timeout
-            logger.debug("ZMQ detector request timed out; resetting socket")
-            try:
-                self._create_socket()
-                self._initialize_model()
-            except Exception:
-                pass
+            # Timeout: mark not ready and require a fresh, confirmed
+            # handshake before trusting the peer again.
+            logger.debug("ZMQ detector request timed out; reinitializing")
+            self._model_ready = False
+            self._recover()
             return self._zero_result
         except zmq.ZMQError as exc:
-            logger.error(f"ZMQ detector ZMQError: {exc}; resetting socket")
-            try:
-                self._create_socket()
-                self._initialize_model()
-            except Exception:
-                pass
+            logger.error(f"ZMQ detector ZMQError: {exc}; reinitializing")
+            self._model_ready = False
+            self._recover()
             return self._zero_result
         except Exception as exc:  # noqa: BLE001
             logger.error(f"ZMQ detector unexpected error: {exc}")


### PR DESCRIPTION
## Proposed change

The zmq detector sets _model_ready only during __init__ and never retries a failed model init/transfer: one failure (e.g. detector peer unavailable or an EAGAIN timeout during a live re-init) leaves detect_raw() serving the error path -- zero detections -- until Frigate is restarted, while all health signals stay green. A stale buffered reply can also satisfy the ready handshake against a peer that's no longer alive. Due to some lucky (or unlucky depending on your view) severe weather and backup power failure on a portion of the NVR system, I experienced both ZMQ failure modes in quick succession which made it much easier to diagnose and workup solutions.

Changes, all in the zmq_ipc.py plugin:

- Retry failed initialization: every not-ready detect_raw() call and every request failure may re-attempt init, this is now rate-limited by a new reinit_backoff_ms config option (default 5000 ms), so a returning connection is picked up automatically without hammering a dead one.
- Set REQ_CORRELATE + REQ_RELAXED so libzmq drops replies that do not correlate with the current outstanding request.
- Perform the ready handshake on a fresh socket and require two consecutive successful exchanges before arming _model_ready.
- Rate-limit the not-ready warning to one line per 60 s with a suppressed count, replacing the per-frame log flood which ballooned quickly.

A standalone repro/regression harness that demonstrates both failure modes on the unpatched plugin and passes 12/12 with the patch - happy to attach it or add it to the discussion if wanted.

This issue was reported as discussion #23883: https://github.com/blakeblackshear/frigate/discussions/23883.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information
- This PR is related to: discussion #23883

## AI disclosure
- [x] AI tools were used in this PR. Details below:
- I used Claude Code CLI to assist in locating the root cause of the interruptions, run sandboxed tests to gather timing data and produce minimal changed code to the detector to address only this issue. Also used it to produce my temporary cron patch to monitor and kick-start any additional events. I directed CC during the process, controlled its scope, audited its results and directed and adjusted its testing sequence.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
