### PR TITLE
Compare a review's severity so a promotion from detection to alert always fires a notification

### DIFF
--- a/frigate/comms/webpush.py
+++ b/frigate/comms/webpush.py
@@ -421,6 +421,7 @@ class WebPushClient(Communicator):
         # Don't notify if message is an update and important fields don't have an update
         if (
             state == "update"
+            and payload["before"]["severity"] == payload["after"]["severity"]
             and len(payload["before"]["data"]["objects"])
             == len(payload["after"]["data"]["objects"])
             and len(payload["before"]["data"]["zones"])


### PR DESCRIPTION
In webpush.py add a severity comparison so that a review that is upgraded from a detection to an alert always fires a notification. Prior to this change, there was an edge case where a notification may not fire on promotion from detection to an alert if len(objects) and len(zones) were the same as they were before the promotion.

Such as the below scenario:

Camera config:
`review.alerts.labels: [person]`
`review.alerts.required_zones: [driveway]`
`review.detections: left unrestricted`

1) A person is seen on the street zone (not a required zone for alerts, so this is just a detection). objects = [person] -> len(objects) = 1. zones = [street] -> len(zones) = 1
2) A car enters the driveway zone. Cars aren't in alerts.labels, so this stays a detection too. objects = [person, car] -> len(objects) = 2. zones = [street, driveway] -> len(zones) = 2.
3) The same person then walks from street into driveway. Since person is in alerts.labels and driveway is a required zone, this now qualifies as an alert. But, the person was already counted (objects still = [person, car], len(objects) = 2), and driveway was already in the zone list from the car in step 2 (zones still = [street, driveway], len(zones) = 2)
4) The review has been upgraded to an alert. len(objects) and len(zones) are the same as when this was only a detection. **No notification is fired.**

See #24082 

_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features): https://github.com/blakeblackshear/frigate/discussions/24082

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [X] No AI tools were used in this PR.
- [ ] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [X] The code has been formatted using Ruff (`ruff format frigate`)
