### PR TITLE
Set GPU_QUEUE_THROTTLE to low for OpenVINO

### DIFF
--- a/frigate/detectors/detection_runners.py
+++ b/frigate/detectors/detection_runners.py
@@ -314,6 +314,12 @@ class OpenVINOModelRunner(BaseModelRunner):
         if device in ["GPU", "AUTO", "NPU"]:
             self.ov_core.set_property(device, {"PERFORMANCE_HINT": "LATENCY"})
 
+        if device in ["GPU", "AUTO"]:
+            try:
+                self.ov_core.set_property("GPU", {"GPU_QUEUE_THROTTLE": "LOW"})
+            except Exception as e:
+                logger.debug(f"GPU_QUEUE_THROTTLE not supported: {e}")
+
         if device == "NPU" and OpenVINOModelRunner.is_detection_model(model_type):
             try:
                 self.ov_core.set_property(device, {"NPU_TURBO": "YES"})


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

After investigation from some reports of higher CPU usage on OpenVINO in 0.18 compared to 0.17, the GPU_QUEUE_THROTTLE property was discovered which allows us to improve performance for Frigate's use case

|                        | **0.17.2** | **0.18 ** | **this PR**        |
|------------------------|-----------|--------------|--------------------------------|
| inf/s                  | 183.2     | 222.2        | **211.4** (+15.4% vs 0.17)    |
| CPU-ms per inference   | 1.66      | 4.51         | **1.48** (-10.8% vs 0.17)     |
| J per inference (pkg)  | 0.146     | 0.150        | **0.139** (-5.0% vs 0.17)     |
| latency mean ms        | 5.46      | 4.50         | 4.73                           |

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [ ] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
