### PR TITLE
Fix export case download with non-ascii names

### DIFF
--- a/frigate/api/export.py
+++ b/frigate/api/export.py
@@ -9,6 +9,7 @@ import zipfile
 from collections import deque
 from collections.abc import Iterator
 from pathlib import Path
+from urllib.parse import quote
 
 import psutil
 from fastapi import APIRouter, Depends, Query, Request
@@ -453,6 +454,22 @@ def _stream_case_archive(exports: list[Export]) -> Iterator[bytes]:
     yield from buffer.drain()
 
 
+def _content_disposition(filename: str, ascii_fallback: str) -> str:
+    """Build an attachment Content-Disposition that survives non-ASCII names.
+
+    Header values are encoded as latin-1, so a name outside that range cannot
+    go in filename at all. RFC 6266 handles this with a pair: a plain ASCII
+    filename for old clients, plus a percent-encoded UTF-8 filename* that
+    every current browser prefers.
+    """
+    ascii_name = filename if filename.isascii() else ascii_fallback
+
+    return (
+        f'attachment; filename="{ascii_name}"; '
+        f"filename*=UTF-8''{quote(filename, safe='')}"
+    )
+
+
 @router.get(
     "/cases/{case_id}/download",
     dependencies=[Depends(allow_any_authenticated())],
@@ -495,7 +512,9 @@ def download_export_case(
         _stream_case_archive(exports),
         media_type="application/zip",
         headers={
-            "Content-Disposition": f'attachment; filename="{archive_base}.zip"',
+            "Content-Disposition": _content_disposition(
+                f"{archive_base}.zip", f"{case_id}.zip"
+            ),
         },
     )
 

--- a/frigate/test/http_api/test_http_export.py
+++ b/frigate/test/http_api/test_http_export.py
@@ -1,5 +1,7 @@
+import io
 import os
 import tempfile
+import zipfile
 from unittest.mock import patch
 
 from frigate.jobs.export import (
@@ -1431,3 +1433,79 @@ class TestHttpExport(BaseTestHttp):
             )
 
         assert response.status_code == 403
+
+    def test_download_export_case_with_multibyte_name(self):
+        """A case name outside latin-1 must not break the response headers."""
+        case = ExportCase.create(
+            id="case_multibyte",
+            name="テスト事案",
+            description="",
+            created_at=10,
+            updated_at=10,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_path = os.path.join(tmpdir, "multibyte_export.mp4")
+            with open(video_path, "wb") as handle:
+                handle.write(b"video")
+
+            Export.create(
+                id="export_multibyte",
+                camera="front_door",
+                name="現場カメラ",
+                date=100,
+                video_path=video_path,
+                thumb_path=os.path.join(tmpdir, "multibyte_export.webp"),
+                in_progress=False,
+                export_case=case,
+            )
+
+            with AuthTestClient(self.app) as client:
+                response = client.get(f"/cases/{case.id}/download")
+
+        assert response.status_code == 200
+        # RFC 5987/6266: the UTF-8 name rides in filename*, and a latin-1 safe
+        # fallback stays in filename for old clients.
+        assert response.headers["content-disposition"] == (
+            'attachment; filename="case_multibyte.zip"; '
+            "filename*=UTF-8''%E3%83%86%E3%82%B9%E3%83%88%E4%BA%8B%E6%A1%88.zip"
+        )
+
+        archive = zipfile.ZipFile(io.BytesIO(response.content))
+        assert archive.namelist() == ["現場カメラ.mp4"]
+
+    def test_download_export_case_with_ascii_name(self):
+        """An ASCII case name still gets a plain, readable filename."""
+        case = ExportCase.create(
+            id="case_ascii",
+            name="Burglary 2026-08",
+            description="",
+            created_at=10,
+            updated_at=10,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_path = os.path.join(tmpdir, "ascii_export.mp4")
+            with open(video_path, "wb") as handle:
+                handle.write(b"video")
+
+            Export.create(
+                id="export_ascii",
+                camera="front_door",
+                name="Front door",
+                date=100,
+                video_path=video_path,
+                thumb_path=os.path.join(tmpdir, "ascii_export.webp"),
+                in_progress=False,
+                export_case=case,
+            )
+
+            with AuthTestClient(self.app) as client:
+                response = client.get(f"/cases/{case.id}/download")
+
+        assert response.status_code == 200
+        assert (
+            response.headers["content-disposition"]
+            == 'attachment; filename="Burglary 2026-08.zip"; '
+            "filename*=UTF-8''Burglary%202026-08.zip"
+        )


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
Header values are encoded as latin-1, so a case name with multi-byte characters blew up in `Content-Disposition` before any bytes were sent, and the download returned a 500. The UTF-8 name now rides in `filename*` per RFC 6266, with an ASCII fallback in `filename` for old clients.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/24099
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
