### PR TITLE
Fix 500 when an event thumbnail file is empty

### DIFF
--- a/frigate/api/media.py
+++ b/frigate/api/media.py
@@ -1060,7 +1060,7 @@ async def event_thumbnail(
     except DoesNotExist:
         thumbnail_bytes = None
 
-    if thumbnail_bytes is None:
+    if not thumbnail_bytes:
         # see if the object is currently being tracked
         try:
             camera_states = request.app.detected_frames_processor.get_camera_states()
@@ -1076,7 +1076,7 @@ async def event_thumbnail(
                 status_code=404,
             )
 
-    if thumbnail_bytes is None:
+    if not thumbnail_bytes:
         return JSONResponse(
             content={"success": False, "message": "Event not found"},
             status_code=404,
@@ -1084,6 +1084,13 @@ async def event_thumbnail(
 
     img_as_np = np.frombuffer(thumbnail_bytes, dtype=np.uint8)
     img = cv2.imdecode(img_as_np, flags=1)
+
+    if img is None:
+        # thumbnail on disk is truncated or corrupt
+        return JSONResponse(
+            content={"success": False, "message": "Event not found"},
+            status_code=404,
+        )
 
     # android notifications prefer a 2:1 ratio
     if format == "android":

--- a/frigate/test/test_file.py
+++ b/frigate/test/test_file.py
@@ -72,6 +72,7 @@ class TestFileUtils(TestCase):
             assert rendered_image.max() > 0
 
     def test_get_event_thumbnail_bytes_ignores_empty_file(self):
+        """Verify empty thumbnail files are treated as missing."""
         event = SimpleNamespace(id="empty-thumb", camera="front_door", thumbnail=None)
 
         with (

--- a/frigate/test/test_file.py
+++ b/frigate/test/test_file.py
@@ -70,3 +70,18 @@ class TestFileUtils(TestCase):
             assert rendered_image is not None
             assert rendered_image.shape[0] == 40
             assert rendered_image.max() > 0
+
+    def test_get_event_thumbnail_bytes_ignores_empty_file(self):
+        event = SimpleNamespace(id="empty-thumb", camera="front_door", thumbnail=None)
+
+        with (
+            tempfile.TemporaryDirectory() as thumb_dir,
+            patch.object(file_util, "THUMB_DIR", thumb_dir),
+        ):
+            camera_dir = os.path.join(thumb_dir, event.camera)
+            os.makedirs(camera_dir)
+
+            with open(os.path.join(camera_dir, f"{event.id}.webp"), "wb"):
+                pass
+
+            assert file_util.get_event_thumbnail_bytes(event) is None

--- a/frigate/util/file.py
+++ b/frigate/util/file.py
@@ -20,14 +20,15 @@ logger = logging.getLogger(__name__)
 
 
 def get_event_thumbnail_bytes(event: Event) -> bytes | None:
+    # callers treat empty bytes as a valid image, so normalize them to None
     if event.thumbnail:
-        return base64.b64decode(event.thumbnail)
+        return base64.b64decode(event.thumbnail) or None
     else:
         try:
             with open(
                 os.path.join(THUMB_DIR, event.camera, f"{event.id}.webp"), "rb"
             ) as f:
-                return f.read()
+                return f.read() or None
         except Exception:
             return None
 


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
A zero-length thumbnail file on disk makes `get_event_thumbnail_bytes()` return `b""` rather than `None`, and `event_thumbnail` only checked for `None`, so `cv2.imdecode()` asserted on the empty buffer and the request 500'd. 

Empty and undecodable thumbnails now 404 the same as a missing one. 


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/24104
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
