### PR TITLE
Fix LPR vehicle message for multiple models

### DIFF
--- a/frigate/camera/state.py
+++ b/frigate/camera/state.py
@@ -63,7 +63,7 @@ class CameraState:
         self.lpr_min_obj_area: int = 0
         self.lp_objects = {
             label
-            for label, attributes in config.model.attributes_map.items()
+            for label, attributes in self.model.attributes_map.items()
             if "license_plate" in attributes
         }
 

--- a/frigate/test/http_api/test_http_export.py
+++ b/frigate/test/http_api/test_http_export.py
@@ -1530,7 +1530,7 @@ class TestHttpExport(BaseTestHttp):
         )
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            video_path = os.path.join(tmpdir, "multibyte_export.mp4")
+            video_path = os.path.join(tmpdir, "現場カメラ.mp4")
             with open(video_path, "wb") as handle:
                 handle.write(b"video")
 

--- a/web/src/components/config-form/section-configs/lpr.ts
+++ b/web/src/components/config-form/section-configs/lpr.ts
@@ -1,3 +1,4 @@
+import { getModelForCamera } from "@/utils/modelUtil";
 import type { SectionConfigOverrides } from "./types";
 
 const lpr: SectionConfigOverrides = {
@@ -21,12 +22,10 @@ const lpr: SectionConfigOverrides = {
           if (ctx.level !== "camera" || !ctx.fullCameraConfig) return false;
           if (ctx.fullCameraConfig.type === "lpr") return false;
           const tracked = ctx.fullCameraConfig.objects?.track ?? [];
-          const vehicles = Object.entries(
-            ctx.fullConfig.model?.attributes_map ?? {},
-          )
-            .filter(([, attributes]) => attributes.includes("license_plate"))
-            .map(([label]) => label);
-          return !tracked.some((o) => vehicles.includes(o));
+          const model = getModelForCamera(ctx.fullConfig, ctx.cameraName);
+          return !tracked.some((o) =>
+            model?.attributes_map?.[o]?.includes("license_plate"),
+          );
         },
       },
     ],


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
The lookup added in https://github.com/blakeblackshear/frigate/pull/24097 reads `FrigateConfig.model`, which became `models[]` in https://github.com/blakeblackshear/frigate/pull/23995, so it didn't compile on 0.19 after rebasing. Each camera has its own detector/model pair now, so this uses `getModelForCamera` to check the scene the camera is assigned to.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
