### PR TITLE
Fix frozen recordings API defaults

### DIFF
--- a/docs/static/frigate-api.yaml
+++ b/docs/static/frigate-api.yaml
@@ -7194,13 +7194,17 @@ paths:
           in: query
           required: false
           schema:
-            type: number
+            anyOf:
+              - type: number
+              - type: 'null'
             title: After
         - name: before
           in: query
           required: false
           schema:
-            type: number
+            anyOf:
+              - type: number
+              - type: 'null'
             title: Before
       responses:
         '200':

--- a/frigate/api/record.py
+++ b/frigate/api/record.py
@@ -358,10 +358,13 @@ async def recordings_coverage(
 @router.get("/{camera_name}/recordings", dependencies=[Depends(require_camera_access)])
 async def recordings(
     camera_name: str,
-    after: float = (datetime.now() - timedelta(hours=1)).timestamp(),
-    before: float = datetime.now().timestamp(),
+    after: float | None = None,
+    before: float | None = None,
 ):
     """Return specific camera recordings between the given 'after'/'end' times. If not provided the last hour will be used"""
+    now = datetime.now()
+    after = after if after is not None else (now - timedelta(hours=1)).timestamp()
+    before = before if before is not None else now.timestamp()
     recordings = (
         Recordings.select(
             Recordings.id,

--- a/frigate/test/http_api/test_http_media.py
+++ b/frigate/test/http_api/test_http_media.py
@@ -1,7 +1,8 @@
 """Unit tests for recordings/media API endpoints."""
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
 import pytz
 from fastapi import Request
@@ -1837,6 +1838,27 @@ class TestHttpMedia(BaseTestHttp):
                     assert [
                         recording["id"] for recording in response.json()
                     ] == expected_ids
+
+    def test_recordings_default_range_follows_the_request_clock(self):
+        """Omitted bounds resolve at request time, not at module import time."""
+        uptime = timedelta(hours=2)
+        recorded_at = (datetime.now() + uptime).timestamp()
+
+        class UptimeDatetime(datetime):
+            """Stands in for a process that booted `uptime` ago."""
+
+            @classmethod
+            def now(cls, tz=None):
+                return datetime.now(tz) + uptime
+
+        with AuthTestClient(self.app) as client:
+            self._insert_recording("after_boot", recorded_at - 20, recorded_at - 10)
+
+            with patch("frigate.api.record.datetime", UptimeDatetime):
+                response = client.get("/front_door/recordings")
+
+            assert response.status_code == 200
+            assert [recording["id"] for recording in response.json()] == ["after_boot"]
 
     def test_vod_handles_all_range_relations(self):
         """VOD clips every interval relation with positive playback duration."""

--- a/generate_api_auth_spec.py
+++ b/generate_api_auth_spec.py
@@ -410,11 +410,10 @@ def enrich(spec: dict, access_map: dict) -> tuple[dict, list, list]:
 
 
 # Numeric defaults at or above this magnitude are treated as live Unix
-# timestamps baked into the schema at import time (e.g. the /{camera_name}
-# /recordings after/before params default to datetime.now()). They make the
-# export non-deterministic and document a meaningless frozen epoch, so they are
-# stripped. The proper fix is to default those route params to None and resolve
-# "now" inside the handler.
+# timestamps baked into the schema at import time. They make the export
+# non-deterministic and document a meaningless frozen epoch, so they are
+# stripped. No route defaults this way today, and route params that need "now"
+# resolve it inside the handler. Kept as a guard against the pattern returning.
 VOLATILE_DEFAULT_THRESHOLD = 1_000_000_000
 
 


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
`after` and `before` on `/{camera_name}/recordings` defaulted to `datetime.now()` in the function signature, so they were evaluated once at import and frozen at process start. Requests that omitted them were answered with a window ending when Frigate booted, so a long-running instance returned nothing for any recent range. Both bounds now resolve inside the handler.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/24120
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
