### PR TITLE
Swap nginx-vod-module to a maintained fork

### DIFF
--- a/docker/main/build_nginx.sh
+++ b/docker/main/build_nginx.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 NGINX_VERSION="1.27.4"
-VOD_MODULE_VERSION="1.31"
+VOD_MODULE_VERSION="v1.9.1"
 SECURE_TOKEN_MODULE_VERSION="1.5"
 SET_MISC_MODULE_VERSION="v0.33"
 NGX_DEVEL_KIT_VERSION="v0.3.3"
@@ -31,24 +31,24 @@ wget -nv https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
 tar -zxf nginx-${NGINX_VERSION}.tar.gz -C /tmp/nginx --strip-components=1
 rm nginx-${NGINX_VERSION}.tar.gz
 mkdir /tmp/nginx-vod-module
-wget -nv https://github.com/kaltura/nginx-vod-module/archive/refs/tags/${VOD_MODULE_VERSION}.tar.gz
+wget -nv https://github.com/dio-az/nginx-vod-module/archive/refs/tags/${VOD_MODULE_VERSION}.tar.gz
 tar -zxf ${VOD_MODULE_VERSION}.tar.gz -C /tmp/nginx-vod-module --strip-components=1
 rm ${VOD_MODULE_VERSION}.tar.gz
     # Patch MAX_CLIPS to allow more clips to be added than the default 128
 sed -i 's/MAX_CLIPS (128)/MAX_CLIPS (1080)/g' /tmp/nginx-vod-module/vod/media_set.h
 patch -d /tmp/nginx-vod-module/ -p1 << 'EOF'
---- a/vod/avc_hevc_parser.c       2022-06-27 11:38:10.000000000 +0000
-+++ b/vod/avc_hevc_parser.c       2023-01-16 11:25:10.900521298 +0000
-@@ -3,6 +3,9 @@
+--- a/vod/avc_hevc_parser.c
++++ b/vod/avc_hevc_parser.c
+@@ -2,6 +2,9 @@
+
  bool_t
- avc_hevc_parser_rbsp_trailing_bits(bit_reader_state_t* reader)
- {
+ avc_hevc_parser_rbsp_trailing_bits(bit_reader_state_t* reader) {
 +	// https://github.com/blakeblackshear/frigate/issues/4572
 +	return TRUE;
 +
  	uint32_t one_bit;
 
- 	if (reader->stream.eof_reached)
+ 	if (reader->stream.eof_reached) {
 EOF
 
 

--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -122,6 +122,10 @@ http {
             # Smaller segments, faster generation, better browser compatibility
             vod_hls_container_format fmp4;
 
+            # fMP4 playlists use EXT-X-MAP, which requires HLS protocol
+            # version 6 (RFC 8216 section 7); the module default is 4
+            vod_hls_version 6;
+
             secure_token $args;
             secure_token_types application/vnd.apple.mpegurl;
 
@@ -130,14 +134,6 @@ http {
             expires off;
 
             keepalive_disable safari;
-
-            # vod module returns 502 for non-existent media
-            # https://github.com/kaltura/nginx-vod-module/issues/468
-            error_page 502 =404 /vod-not-found;
-        }
-
-        location = /vod-not-found {
-            return 404;
         }
 
         location /stream/ {

--- a/web/src/components/player/GenericVideoPlayer.tsx
+++ b/web/src/components/player/GenericVideoPlayer.tsx
@@ -32,8 +32,8 @@ export function GenericVideoPlayer({
     const checkSourceExists = async (url: string) => {
       try {
         const response = await fetch(url, { method: "HEAD" });
-        // nginx vod module returns 502 for non existent media
-        // https://github.com/kaltura/nginx-vod-module/issues/468
+        // missing media is a 404; 502 still covers a failed or
+        // unreachable mapping request, which is equally unplayable
         setSourceExists(response.status !== 502 && response.status !== 404);
       } catch (error) {
         setSourceExists(false);


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
Kaltura's nginx-vod-module hasn't had a real commit since March 2024. This PR moves Frigate to https://github.com/dio-az/nginx-vod-module, pinned to tag `v1.9.1` on its `v1.x` line. That line keeps muxed fMP4 and is Kaltura's code with fixes backported, so the mapping JSON, manifest routes, players, and every ffmpeg consumer are unchanged. The fork's `main` branch drops muxed tracks for CMAF, which is a much bigger migration, so we should not switch to it as it removes too much functionality we currently use.

The fork provides a number of minor improvements for Frigate specifically:

- Accurate `BANDWIDTH` in the master playlist, which the adaptive quality governor reads
- Upstream 404s map to 404 instead of a blanket 502
- Correct segment durations for sources with a nonzero first frame offset
- Modern HLS playlists, including `EXT-X-INDEPENDENT-SEGMENTS`
- Builds against nginx 1.29, so future nginx bumps aren't blocked by the module

Two specific changes were made to the nginx.conf file, specifically:
- `vod_hls_version 6` which is now explicit because the fork replaced Kaltura's automatic version calculation with a directive defaulting to 4 that only warns when fmp4 needs 6, so playlists were being stamped `EXT-X-VERSION:4` while carrying `EXT-X-MAP`. 
- The `error_page 502 =404` hack was removed. https://github.com/kaltura/nginx-vod-module/issues/468 is a `vod_mode remote` bug and we're `mapped`, so those 502s were really `_vod_response` returning 404 upstream. The fork maps it through correctly, and the hack was masking real 5xx as "no recordings".

The `MAX_CLIPS` patch is unchanged. The HEVC workaround for https://github.com/blakeblackshear/frigate/issues/4572 is rewritten for the fork's reformatted source.


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: closes https://github.com/blakeblackshear/frigate/issues/23852
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
