### PR TITLE
Prevent detector restart from corrupting the shared request queue

### DIFF
--- a/frigate/object_detection/base.py
+++ b/frigate/object_detection/base.py
@@ -5,7 +5,7 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from collections import deque
-from multiprocessing import Queue, Value
+from multiprocessing import Event, Queue, Value
 from multiprocessing.synchronize import Event as MpEvent
 from typing import Any
 
@@ -330,6 +330,7 @@ class ObjectDetectProcess:
         self.detection_queue = detection_queue
         self.avg_inference_speed = Value("d", 0.01)
         self.detection_start = Value("d", 0.0)
+        self.process_stop_event: MpEvent | None = None
         self.detect_process: FrigateProcess | None = None
         self.config = config
         self.detector_config = detector_config
@@ -338,11 +339,17 @@ class ObjectDetectProcess:
 
     def stop(self) -> None:
         # if the process has already exited on its own, just return
-        if self.detect_process and self.detect_process.exitcode:
+        if self.detect_process and self.detect_process.exitcode is not None:
             return
 
         if self.detect_process is None:
             return
+
+        # Retire this detector generation before waiting for it. If an in-flight
+        # inference returns during the grace period, the runner exits instead of
+        # re-entering detection_queue.get() and risking a locked queue on kill.
+        if self.process_stop_event is not None:
+            self.process_stop_event.set()
 
         logging.info("Waiting for detection process to exit gracefully...")
         self.detect_process.join(timeout=30)
@@ -353,9 +360,11 @@ class ObjectDetectProcess:
         logging.info("Detection process has exited...")
 
     def start_or_restart(self) -> None:
-        self.detection_start.value = 0.0  # type: ignore[attr-defined]
         if (self.detect_process is not None) and self.detect_process.is_alive():
             self.stop()
+
+        self.detection_start.value = 0.0  # type: ignore[attr-defined]
+        self.process_stop_event = Event()
 
         # Async path for MemryX
         if self.detector_config.type == "memryx":
@@ -367,7 +376,7 @@ class ObjectDetectProcess:
                 self.detection_start,
                 self.config,
                 self.detector_config,
-                self.stop_event,
+                self.process_stop_event,
             )
         else:
             self.detect_process = DetectorRunner(
@@ -378,7 +387,7 @@ class ObjectDetectProcess:
                 self.detection_start,
                 self.config,
                 self.detector_config,
-                self.stop_event,
+                self.process_stop_event,
             )
         self.detect_process.start()
 

--- a/frigate/test/test_detector_restart.py
+++ b/frigate/test/test_detector_restart.py
@@ -1,0 +1,234 @@
+import multiprocessing as mp
+import sys
+import threading
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import numpy as np
+
+from frigate.object_detection.base import DetectorRunner, ObjectDetectProcess
+
+
+def detector_returning_from_inference(
+    detection_queue: mp.Queue,
+    inference_started: mp.Event,
+    release_inference: mp.Event,
+    process_stop_event: mp.Event,
+) -> None:
+    detection_queue.get(timeout=5)
+    inference_started.set()
+    release_inference.wait(5)
+
+    if process_stop_event.is_set():
+        return
+
+    detection_queue.get(timeout=5)
+
+
+def receive_one_request(detection_queue: mp.Queue, result_pipe) -> None:
+    result_pipe.send(detection_queue.get(timeout=5))
+    result_pipe.close()
+
+
+class ProcessThatExitsAfterRetirement:
+    def __init__(self, calls: list[str]) -> None:
+        self.calls = calls
+        self.exitcode: int | None = None
+
+    def is_alive(self) -> bool:
+        return self.exitcode is None
+
+    def join(self, timeout: int | None = None) -> None:
+        self.calls.append(f"join:{timeout}")
+        self.exitcode = 0
+
+    def kill(self) -> None:
+        self.calls.append("kill")
+
+
+class ProcessThatNeedsKilling(ProcessThatExitsAfterRetirement):
+    def join(self, timeout: int | None = None) -> None:
+        self.calls.append(f"join:{timeout}")
+
+    def kill(self) -> None:
+        self.calls.append("kill")
+        self.exitcode = -9
+
+
+class TestDetectorGenerationShutdown(unittest.TestCase):
+    def test_stop_retires_generation_before_waiting_for_process(self) -> None:
+        calls: list[str] = []
+        detector = ObjectDetectProcess.__new__(ObjectDetectProcess)
+        detector.detect_process = ProcessThatExitsAfterRetirement(calls)
+        detector.process_stop_event = Mock()
+        detector.process_stop_event.set.side_effect = lambda: calls.append("retire")
+
+        detector.stop()
+
+        self.assertEqual(calls, ["retire", "join:30"])
+        detector.process_stop_event.set.assert_called_once_with()
+
+    def test_stop_force_kills_only_after_retirement_timeout(self) -> None:
+        calls: list[str] = []
+        detector = ObjectDetectProcess.__new__(ObjectDetectProcess)
+        detector.detect_process = ProcessThatNeedsKilling(calls)
+        detector.process_stop_event = Mock()
+        detector.process_stop_event.set.side_effect = lambda: calls.append("retire")
+
+        detector.stop()
+
+        self.assertEqual(calls, ["retire", "join:30", "kill", "join:None"])
+
+    @patch("frigate.object_detection.base.Event")
+    @patch("frigate.object_detection.base.DetectorRunner")
+    def test_restart_uses_a_fresh_generation_stop_event(
+        self,
+        detector_runner: Mock,
+        event: Mock,
+    ) -> None:
+        calls: list[str] = []
+        old_stop_event = Mock()
+        new_stop_event = event.return_value
+
+        detector = ObjectDetectProcess.__new__(ObjectDetectProcess)
+        detector.name = "test"
+        detector.cameras = ["front"]
+        detector.detection_queue = Mock()
+        detector.avg_inference_speed = Mock()
+        detector.detection_start = SimpleNamespace(value=123.0)
+        detector.process_stop_event = old_stop_event
+        detector.detect_process = ProcessThatExitsAfterRetirement(calls)
+        detector.config = Mock()
+        detector.detector_config = SimpleNamespace(type="onnx")
+        detector.stop_event = Mock()
+
+        def retire_old() -> None:
+            self.assertEqual(detector.detection_start.value, 123.0)
+            calls.append("retire-old")
+
+        old_stop_event.set.side_effect = retire_old
+
+        detector.start_or_restart()
+
+        self.assertEqual(calls, ["retire-old", "join:30"])
+        self.assertIs(detector.process_stop_event, new_stop_event)
+        self.assertEqual(detector.detection_start.value, 0.0)
+        detector_runner.assert_called_once_with(
+            "frigate.detector:test",
+            detector.detection_queue,
+            detector.cameras,
+            detector.avg_inference_speed,
+            detector.detection_start,
+            detector.config,
+            detector.detector_config,
+            new_stop_event,
+        )
+        detector_runner.return_value.start.assert_called_once_with()
+
+    @patch("frigate.object_detection.base.ObjectDetectorPublisher")
+    @patch("frigate.object_detection.base.LocalObjectDetector")
+    @patch("frigate.object_detection.base.SharedMemoryFrameManager")
+    def test_retired_runner_exits_before_reentering_detection_queue(
+        self,
+        frame_manager: Mock,
+        local_detector: Mock,
+        publisher: Mock,
+    ) -> None:
+        stop_event = Mock()
+        stop_event.is_set.side_effect = [False, True]
+        detection_queue = Mock()
+        detection_queue.get.return_value = "front"
+        frame_manager.return_value.get.return_value = np.zeros(
+            (1, 4, 4, 3), dtype=np.uint8
+        )
+        local_detector.return_value.detect_raw.return_value = np.zeros(
+            (20, 6), dtype=np.float32
+        )
+
+        runner = DetectorRunner.__new__(DetectorRunner)
+        runner.pre_run_setup = Mock()
+        runner.config = SimpleNamespace(logger=Mock())
+        runner.detector_config = SimpleNamespace(
+            model=SimpleNamespace(height=4, width=4)
+        )
+        runner.cameras = []
+        runner.stop_event = stop_event
+        runner.detection_queue = detection_queue
+        runner.avg_speed = SimpleNamespace(value=0.01)
+        runner.start_time = SimpleNamespace(value=0.0)
+        runner.outputs = {"front": {"np": np.zeros((20, 6), dtype=np.float32)}}
+
+        runner.run()
+
+        detection_queue.get.assert_called_once_with(timeout=1)
+        publisher.return_value.publish.assert_called_once_with("front")
+        publisher.return_value.stop.assert_called_once_with()
+
+    @unittest.skipUnless(sys.platform.startswith("linux"), "requires POSIX queue")
+    def test_replacement_can_reuse_queue_after_inflight_inference_returns(
+        self,
+    ) -> None:
+        ctx = mp.get_context("fork")
+        detection_queue = ctx.Queue()
+        inference_started = ctx.Event()
+        release_inference = ctx.Event()
+        process_stop_event = ctx.Event()
+        old_process = ctx.Process(
+            target=detector_returning_from_inference,
+            args=(
+                detection_queue,
+                inference_started,
+                release_inference,
+                process_stop_event,
+            ),
+        )
+        replacement = None
+        stop_thread = None
+
+        try:
+            old_process.start()
+            detection_queue.put("inflight-request")
+            self.assertTrue(inference_started.wait(5))
+
+            detector = ObjectDetectProcess.__new__(ObjectDetectProcess)
+            detector.detect_process = old_process
+            detector.process_stop_event = process_stop_event
+
+            stop_thread = threading.Thread(target=detector.stop)
+            stop_thread.start()
+            self.assertTrue(process_stop_event.wait(5))
+            release_inference.set()
+            stop_thread.join(5)
+
+            self.assertFalse(stop_thread.is_alive())
+            self.assertEqual(old_process.exitcode, 0)
+
+            receiver, sender = ctx.Pipe(duplex=False)
+            replacement = ctx.Process(
+                target=receive_one_request,
+                args=(detection_queue, sender),
+            )
+            replacement.start()
+            sender.close()
+            detection_queue.put("replacement-request")
+
+            self.assertTrue(receiver.poll(5))
+            self.assertEqual(receiver.recv(), "replacement-request")
+            replacement.join(5)
+            self.assertEqual(replacement.exitcode, 0)
+        finally:
+            release_inference.set()
+            if stop_thread is not None:
+                stop_thread.join(1)
+            if old_process.is_alive():
+                old_process.kill()
+                old_process.join(5)
+            if replacement is not None and replacement.is_alive():
+                replacement.kill()
+                replacement.join(5)
+            detection_queue.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Proposed change

Prevent detector-only recovery from corrupting the shared multiprocessing request queue by retiring each detector generation before waiting for it or force-killing it.

### What failed

When the detector watchdog finds an inference running for more than ten seconds, it calls `ObjectDetectProcess.start_or_restart()`. The current restart path waits up to 30 seconds for the old detector, but it does not ask that detector generation to stop before waiting.

If the inference returns during that window, the old runner continues its loop and enters another `multiprocessing.Queue.get()`. At the end of the 30-second window the parent still force-kills it. Killing a process while it owns the queue reader lock can leave the shared detection queue unusable for the replacement process.

The resulting state is silent and persistent:

- the replacement detector process is alive and initializes its backend;
- camera frames continue to arrive;
- camera processors enqueue requests and wait for detector responses;
- the replacement detector never receives another request;
- `detection_start` remains zero, so the stuck-inference watchdog cannot fire again;
- the container can remain healthy while object detection is unavailable.

## Runtime evidence

I preserved the failed instance and collected process-level evidence before restarting anything:

- Frigate `0.17.2-3d4dd3a`, ONNX/CUDA, Quadro P400;
- the watchdog waited 30 seconds and logged `Force killing...` on two observed detector restarts;
- the replacement detector logged that the ONNX model was loaded successfully;
- `camera_fps` remained about 5.1 while `process_fps` remained 0.1 and `detection_fps` remained 0;
- the replacement detector main thread stayed in `futex_wait_queue` in 10/10 samples;
- a camera processor feeder thread stayed in `pipe_write` in 10/10 samples;
- the blocked write was 31 bytes, matching the framed camera connection ID written to the detection queue;
- the blocked pipe was open in both the camera processor and replacement detector;
- GPU use was about 1%, and the host had no NVIDIA Xid, GPU reset, or OOM record.

The earlier router outage was about 5.5 hours before the detector restart. I cannot establish a causal relationship, and this PR does not claim one. I also have not identified why the original inference exceeded ten seconds. This change addresses the reproducible failure in the detector restart path after that timeout.

The detailed sanitized timeline and process observations are in this PR comment: https://github.com/blakeblackshear/frigate/pull/24142#issuecomment-5478719234

## Reproduction

I reproduced the queue failure in an isolated Linux container with the same lifecycle:

1. The old consumer receives a request and simulates an in-flight inference.
2. The inference returns and the old consumer enters its next queue read.
3. The old consumer is force-killed while holding the queue reader lock.
4. A replacement consumer starts with the same queue.
5. A new request is submitted, but the replacement times out.

Result before the fix:

```text
vulnerable replacement status=timeout value=None
```

With a detector-generation retirement event set before releasing the in-flight inference, the old consumer exits before another queue read and the replacement receives the request:

```text
safe replacement status=received value='replacement-request'
```

Python documents the underlying constraint: terminating a process while it is using a `multiprocessing.Queue` can corrupt the queue or deadlock other processes.

## Fix

Each detector generation now gets its own stop event.

On detector restart:

1. `stop()` sets the current generation's event before waiting.
2. If the in-flight inference returns during the 30-second grace period, the runner sees the event at the top of the loop and exits without another `detection_queue.get()`.
3. If inference does not return, the existing force-kill remains available, but the process is still inside `detect_raw()` rather than holding the queue reader lock.
4. After the old process exits, `detection_start` is cleared and a fresh event is created for the replacement generation.

The event is passed through the existing runner `stop_event` interface, so synchronous and asynchronous detector loops use the same lifecycle rule. The application-wide stop event remains separate; retiring one detector does not stop the rest of Frigate.

This also avoids clearing the shared `detection_start` while the old detector can still read it. Current `dev` already uses a local monotonic value for inference duration, but ordering the reset after shutdown keeps the shared state owned by the active generation.

## Why the original readiness patch was removed

The first revision of this PR added an alive-but-not-ready startup timeout. More complete logs showed that the replacement detector loaded its ONNX model in about 167 seconds, so that timeout would not have fired. The persistent failure happened after initialization in the request queue.

That speculative change and its tests have been removed. The final diff only addresses the reproduced queue lifecycle failure.

## Tests

The new tests cover:

1. A detector generation is retired before the parent begins its graceful wait.
2. Force-kill happens only after retirement and the existing 30-second timeout.
3. A replacement receives a fresh generation stop event.
4. `detection_start` is not reset while the old generation is still running.
5. A retired synchronous runner exits before re-entering the detection queue.
6. A Linux process-level test returns an in-flight inference, retires the old process, and verifies that a real replacement process can consume from the same real `multiprocessing.Queue`.

Validation completed before the final push:

- Isolated Linux vulnerable/safe reproduction: expected timeout before the lifecycle change; request received with retirement.
- `python3 -u -m unittest frigate.test.test_detector_restart frigate.test.test_object_detector`: 9 tests passed.
- Focused mypy for `base.py` and `test_detector_restart.py`: no issues.
- Focused Ruff format and lint: passed.
- `git diff --check`: passed.

The repository's full devcontainer test and check jobs are left to the PR workflow because the production `stable-tensorrt` image is not the `dev` branch devcontainer and produced unrelated dependency/version failures when used as one.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing code to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation update

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below.

**AI tool used:** GPT-5.6 Sol

**How AI was used:** I used GPT-5.6 Sol to correlate the production logs, `/api/stats`, GPU state, Linux process wait channels, pipe file descriptors, and the Frigate detector lifecycle. It generated the isolated reproduction, implemented the detector-generation stop event, and wrote the regression tests under my direction.

**Human oversight:** I required the first speculative readiness patch to be discarded after the evidence contradicted it. I reviewed the final boundary: retire only the detector generation being replaced, preserve the existing timeout and force-kill fallback, do not infer detector health from event counts, and do not claim that the earlier network outage caused the original inference stall. A Frigate maintainer has agreed to review this AI-assisted contribution.

## Checklist

- [x] The failure mechanism is reproduced independently of the production camera and GPU.
- [x] The same reproduction succeeds after applying the lifecycle change.
- [x] Focused unit, process-level, type, format, and lint checks pass.
- [x] There is no commented-out code.
- [x] I can explain the lifecycle and every changed production line.
- [x] No UI or user-visible text is changed.
