### PR TITLE
Add a deny option for the proxy default role

### DIFF
--- a/docs/docs/configuration/authentication.md
+++ b/docs/docs/configuration/authentication.md
@@ -216,9 +216,9 @@ A default role can be provided. Any value in the mapped `role` header will overr
 
 Navigate to <NavPath path="Settings > System > Proxy" /> and set the default role.
 
-| Field            | Description                                                   |
-| ---------------- | ------------------------------------------------------------- |
-| **Default role** | Fallback role when no role header is present (e.g., `viewer`) |
+| Field            | Description                                                                                          |
+| ---------------- | ---------------------------------------------------------------------------------------------------- |
+| **Default role** | Fallback role when no role header is present (e.g., `viewer`), or `None (deny access)` to reject unmapped users |
 
 </TabItem>
 <TabItem value="yaml">
@@ -231,6 +231,14 @@ proxy:
 
 </TabItem>
 </ConfigTabs>
+
+Setting `default_role` to `none` denies access instead of falling back to a role. Any proxy-authenticated user whose headers do not match an explicit `role_map` entry receives a 403 response. This is useful when the upstream proxy authenticates a broader set of users than should reach Frigate, so that only mapped groups are allowed in.
+
+```yaml
+proxy:
+  ...
+  default_role: none
+```
 
 ## Role mapping
 
@@ -257,7 +265,7 @@ In this example:
 - If the proxy passes a role header containing `sysadmins` or `access-level-security`, the user is assigned the `admin` role.
 - If the proxy passes a role header containing `camera-viewer`, the user is assigned the `viewer` role.
 - If the proxy passes a role header containing `operators`, the user is assigned the `operator` custom role.
-- If no mapping matches, Frigate falls back to `default_role` if configured.
+- If no mapping matches, Frigate falls back to `default_role` if configured, or denies access if `default_role` is `none`.
 - If `role_map` is not defined, Frigate assumes the role header directly contains `admin`, `viewer`, or a custom role name.
 
 **Note on matching semantics:**
@@ -331,7 +339,7 @@ Frigate supports user roles to control access to certain features in the UI and 
 
 - **admin**: Full access to all features, including user management and configuration.
 - **viewer**: Read-only access to the UI and API, including viewing cameras, review items, and historical footage. Configuration editor and settings in the UI are inaccessible.
-- **Custom Roles**: Arbitrary role names (alphanumeric, dots/underscores) with specific camera permissions. These extend the system for granular access (e.g., "operator" for select cameras).
+- **Custom Roles**: Arbitrary role names (alphanumeric, dots/underscores) with specific camera permissions. These extend the system for granular access (e.g., "operator" for select cameras). The names `admin`, `viewer`, and `none` are reserved and cannot be used.
 
 ### Custom Roles and Camera Access
 

--- a/docs/static/frigate-api.yaml
+++ b/docs/static/frigate-api.yaml
@@ -62,6 +62,9 @@ paths:
                 type: string
         '401':
           description: Authentication Failed
+        '403':
+          description: Access Denied (proxy user resolved to a default role of 
+            'none')
       security: []
       x-required-role: public
   /profile:

--- a/frigate/api/auth.py
+++ b/frigate/api/auth.py
@@ -497,6 +497,7 @@ def resolve_role(
                      Admin matches short-circuit to admin.
                  - If no role_map is configured, treat the header as role names directly.
       2. If no valid role is found, return proxy_config.default_role if it's valid in config_roles, else 'viewer'.
+         The literal value 'none' is a valid default and means access should be denied.
 
     Args:
         headers (dict): Incoming request headers (case-insensitive).
@@ -509,10 +510,17 @@ def resolve_role(
     default_role = proxy_config.default_role
     role_header = proxy_config.header_map.role
 
-    # Validate default_role against config; fallback to 'viewer' if invalid
-    validated_default = default_role if default_role in config_roles else "viewer"
+    # Validate default_role against config; fallback to 'viewer' if invalid.
+    # "none" is a sentinel meaning "deny access when no mapping matches"; it is
+    # reserved in AuthConfig.validate_roles so it is never a configured role.
+    validated_default = (
+        default_role
+        if default_role in config_roles or default_role == "none"
+        else "viewer"
+    )
     if not config_roles:
-        validated_default = "viewer"  # Edge case: no roles defined
+        # Edge case: no roles defined
+        validated_default = "none" if default_role == "none" else "viewer"
 
     if not role_header:
         logger.debug(
@@ -617,6 +625,9 @@ def resolve_role(
             },
         },
         401: {"description": "Authentication Failed"},
+        403: {
+            "description": "Access Denied (proxy user resolved to a default role of 'none')"
+        },
     },
 )
 def auth(request: Request):
@@ -665,6 +676,10 @@ def auth(request: Request):
         # parse header and resolve a valid role
         config_roles_set = set(auth_config.roles.keys())
         role = resolve_role(request.headers, proxy_config, config_roles_set)
+
+        if role == "none":
+            logger.debug("Resolved role is 'none', denying access")
+            return Response("", status_code=403)
 
         success_response.headers["remote-role"] = role
 

--- a/frigate/config/auth.py
+++ b/frigate/config/auth.py
@@ -78,9 +78,11 @@ class AuthConfig(FrigateBaseModel):
                     f"Invalid role name '{role}'. Must be alphanumeric with underscores."
                 )
 
-        # 'none' is the deny sentinel for proxy.default_role, not a real role
-        reserved_roles = {"admin", "viewer", "none"}
-        used_reserved = sorted(v.keys() & reserved_roles)
+        # 'none' is the deny sentinel for proxy.default_role, where it is matched
+        # case-insensitively, so every casing of it has to be reserved here
+        used_reserved = sorted(
+            r for r in v if r in ("admin", "viewer") or r.lower() == "none"
+        )
         if used_reserved:
             raise ValueError(
                 f"Reserved role name(s) {', '.join(used_reserved)} cannot be used as custom roles."

--- a/frigate/config/auth.py
+++ b/frigate/config/auth.py
@@ -78,8 +78,9 @@ class AuthConfig(FrigateBaseModel):
                     f"Invalid role name '{role}'. Must be alphanumeric with underscores."
                 )
 
-        # Ensure 'admin' and 'viewer' are not used as custom role names
-        reserved_roles = {"admin", "viewer"}
+        # Ensure built-in role names and the 'none' deny sentinel used by
+        # proxy.default_role are not used as custom role names
+        reserved_roles = {"admin", "viewer", "none"}
         if v.keys() & reserved_roles:
             raise ValueError(
                 f"Reserved roles {reserved_roles} cannot be used as custom roles."

--- a/frigate/config/auth.py
+++ b/frigate/config/auth.py
@@ -78,12 +78,12 @@ class AuthConfig(FrigateBaseModel):
                     f"Invalid role name '{role}'. Must be alphanumeric with underscores."
                 )
 
-        # Ensure built-in role names and the 'none' deny sentinel used by
-        # proxy.default_role are not used as custom role names
+        # 'none' is the deny sentinel for proxy.default_role, not a real role
         reserved_roles = {"admin", "viewer", "none"}
-        if v.keys() & reserved_roles:
+        used_reserved = sorted(v.keys() & reserved_roles)
+        if used_reserved:
             raise ValueError(
-                f"Reserved roles {reserved_roles} cannot be used as custom roles."
+                f"Reserved role name(s) {', '.join(used_reserved)} cannot be used as custom roles."
             )
 
         # Ensure no role has an empty camera list

--- a/frigate/config/proxy.py
+++ b/frigate/config/proxy.py
@@ -43,7 +43,7 @@ class ProxyConfig(FrigateBaseModel):
     default_role: str | None = Field(
         default="viewer",
         title="Default role",
-        description="Default role assigned to proxy-authenticated users when no role mapping applies.",
+        description="Default role assigned to proxy-authenticated users when no role mapping applies. Set to 'none' to deny access to unmapped users.",
     )
     separator: str | None = Field(
         default=",",

--- a/frigate/config/proxy.py
+++ b/frigate/config/proxy.py
@@ -51,6 +51,16 @@ class ProxyConfig(FrigateBaseModel):
         description="Character used to split multiple values provided in proxy headers.",
     )
 
+    @field_validator("default_role", mode="before")
+    @classmethod
+    def normalize_deny_sentinel(cls, v):
+        # Fail closed on capitalization: an unnormalized "None" would miss the
+        # sentinel and fall back to viewer, granting the access it was meant to
+        # deny. Other role names stay case-sensitive.
+        if isinstance(v, str) and v.strip().lower() == "none":
+            return "none"
+        return v
+
     @field_validator("separator", mode="before")
     @classmethod
     def validate_separator_length(cls, v):

--- a/frigate/test/test_proxy_auth.py
+++ b/frigate/test/test_proxy_auth.py
@@ -170,6 +170,31 @@ class TestDefaultRoleNone(unittest.TestCase):
         role = resolve_role(headers, self.proxy_config, set())
         self.assertEqual(role, "none")
 
+    def test_default_role_none_is_case_insensitive(self):
+        """Capitalized spellings must deny, not fall back to viewer."""
+        for spelling in ("None", "NONE", "nOnE", " none "):
+            with self.subTest(default_role=spelling):
+                config = ProxyConfig(
+                    auth_secret=None,
+                    default_role=spelling,
+                    separator="|",
+                    header_map=HeaderMappingConfig(
+                        user="x-remote-user",
+                        role="x-remote-role",
+                        role_map={"admin": ["group_admin"]},
+                    ),
+                )
+                self.assertEqual(config.default_role, "none")
+                role = resolve_role(
+                    {"x-remote-role": "group_unknown"}, config, self.config_roles
+                )
+                self.assertEqual(role, "none")
+
+    def test_other_role_names_stay_case_sensitive(self):
+        """Only the deny sentinel is normalized; role names are untouched."""
+        config = ProxyConfig(default_role="Operator")
+        self.assertEqual(config.default_role, "Operator")
+
 
 class TestReservedRoleNames(unittest.TestCase):
     def test_reserved_names_rejected(self):
@@ -182,6 +207,12 @@ class TestReservedRoleNames(unittest.TestCase):
     def test_custom_role_still_allowed(self):
         config = AuthConfig(roles={"operator": ["front_door"]})
         self.assertEqual(config.roles["operator"], ["front_door"])
+
+    def test_error_names_the_offending_role(self):
+        """The message must say which name to rename, in a stable order."""
+        with self.assertRaises(ValidationError) as ctx:
+            AuthConfig(roles={"none": ["front_door"], "admin": ["front_door"]})
+        self.assertIn("admin, none", str(ctx.exception))
 
 
 class TestProxyAuthSecretEnvString(unittest.TestCase):

--- a/frigate/test/test_proxy_auth.py
+++ b/frigate/test/test_proxy_auth.py
@@ -214,6 +214,18 @@ class TestReservedRoleNames(unittest.TestCase):
             AuthConfig(roles={"none": ["front_door"], "admin": ["front_door"]})
         self.assertIn("admin, none", str(ctx.exception))
 
+    def test_none_reserved_in_every_casing(self):
+        """proxy.default_role folds case, so a 'None' role would be unreachable."""
+        for name in ("None", "NONE", "nOnE"):
+            with self.subTest(role=name):
+                with self.assertRaises(ValidationError):
+                    AuthConfig(roles={name: ["front_door"]})
+
+    def test_case_variant_of_a_normal_role_still_allowed(self):
+        """Only 'none' folds case; other role names are untouched."""
+        config = AuthConfig(roles={"Operator": ["front_door"]})
+        self.assertEqual(config.roles["Operator"], ["front_door"])
+
 
 class TestProxyAuthSecretEnvString(unittest.TestCase):
     def setUp(self):

--- a/frigate/test/test_proxy_auth.py
+++ b/frigate/test/test_proxy_auth.py
@@ -1,7 +1,9 @@
 import unittest
 
+from pydantic import ValidationError
+
 from frigate.api.auth import resolve_role
-from frigate.config import HeaderMappingConfig, ProxyConfig
+from frigate.config import AuthConfig, HeaderMappingConfig, ProxyConfig
 from frigate.config.env import FRIGATE_ENV_VARS
 
 
@@ -92,6 +94,94 @@ class TestProxyRoleResolution(unittest.TestCase):
         headers = {"x-remote-role": "group_unknown"}
         role = resolve_role(headers, self.proxy_config, self.config_roles)
         self.assertEqual(role, self.proxy_config.default_role)
+
+
+class TestDefaultRoleNone(unittest.TestCase):
+    def setUp(self):
+        self.proxy_config = ProxyConfig(
+            auth_secret=None,
+            default_role="none",
+            separator="|",
+            header_map=HeaderMappingConfig(
+                user="x-remote-user",
+                role="x-remote-role",
+                role_map={
+                    "admin": ["group_admin"],
+                    "viewer": ["group_viewer"],
+                },
+            ),
+        )
+        self.config_roles = list(["admin", "viewer"])
+
+    def test_default_role_none_no_match(self):
+        """Unmatched groups resolve to 'none' when default_role is 'none'."""
+        headers = {"x-remote-role": "group_unknown"}
+        role = resolve_role(headers, self.proxy_config, self.config_roles)
+        self.assertEqual(role, "none")
+
+    def test_default_role_none_with_match(self):
+        """Matched groups still resolve normally when default_role is 'none'."""
+        headers = {"x-remote-role": "group_admin"}
+        role = resolve_role(headers, self.proxy_config, self.config_roles)
+        self.assertEqual(role, "admin")
+
+    def test_default_role_none_missing_header(self):
+        """A missing role header resolves to 'none'."""
+        headers = {}
+        role = resolve_role(headers, self.proxy_config, self.config_roles)
+        self.assertEqual(role, "none")
+
+    def test_default_role_none_empty_header(self):
+        """An empty role header resolves to 'none'."""
+        headers = {"x-remote-role": ""}
+        role = resolve_role(headers, self.proxy_config, self.config_roles)
+        self.assertEqual(role, "none")
+
+    def test_default_role_none_no_role_map(self):
+        """An invalid direct role name resolves to 'none' without a role_map."""
+        config = ProxyConfig(
+            auth_secret=None,
+            default_role="none",
+            separator="|",
+            header_map=HeaderMappingConfig(
+                user="x-remote-user",
+                role="x-remote-role",
+                role_map=None,
+            ),
+        )
+        headers = {"x-remote-role": "notarole"}
+        role = resolve_role(headers, config, self.config_roles)
+        self.assertEqual(role, "none")
+
+    def test_default_role_none_no_role_header_configured(self):
+        """Proxy configs without a role header resolve to 'none'."""
+        config = ProxyConfig(
+            auth_secret=None,
+            default_role="none",
+            separator="|",
+            header_map=HeaderMappingConfig(user="x-remote-user"),
+        )
+        role = resolve_role({}, config, self.config_roles)
+        self.assertEqual(role, "none")
+
+    def test_default_role_none_no_roles_configured(self):
+        """'none' survives the empty config_roles edge case."""
+        headers = {"x-remote-role": "group_admin"}
+        role = resolve_role(headers, self.proxy_config, set())
+        self.assertEqual(role, "none")
+
+
+class TestReservedRoleNames(unittest.TestCase):
+    def test_reserved_names_rejected(self):
+        """admin, viewer, and the 'none' deny sentinel cannot be custom roles."""
+        for name in ("admin", "viewer", "none"):
+            with self.subTest(role=name):
+                with self.assertRaises(ValidationError):
+                    AuthConfig(roles={name: ["front_door"]})
+
+    def test_custom_role_still_allowed(self):
+        config = AuthConfig(roles={"operator": ["front_door"]})
+        self.assertEqual(config.roles["operator"], ["front_door"])
 
 
 class TestProxyAuthSecretEnvString(unittest.TestCase):

--- a/web/public/locales/en/config/global.json
+++ b/web/public/locales/en/config/global.json
@@ -212,7 +212,7 @@
     },
     "default_role": {
       "label": "Default role",
-      "description": "Default role assigned to proxy-authenticated users when no role mapping applies."
+      "description": "Default role assigned to proxy-authenticated users when no role mapping applies. Set to 'none' to deny access to unmapped users."
     },
     "separator": {
       "label": "Separator character",

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -1738,7 +1738,8 @@
     },
     "defaultRole": {
       "admin": "Admin",
-      "viewer": "Viewer"
+      "viewer": "Viewer",
+      "none": "None (deny access)"
     }
   },
   "globalConfig": {

--- a/web/src/components/config-form/theme/widgets/DefaultRoleWidget.tsx
+++ b/web/src/components/config-form/theme/widgets/DefaultRoleWidget.tsx
@@ -12,6 +12,7 @@ import type { ConfigFormContext } from "@/types/configForm";
 import { getSizedFieldClassName } from "../utils";
 
 const BUILT_IN_ROLES = ["admin", "viewer"];
+const NONE_ROLE = "none";
 
 export function DefaultRoleWidget(props: WidgetProps) {
   const { id, value, disabled, readonly, onChange, schema, options, registry } =
@@ -25,13 +26,15 @@ export function DefaultRoleWidget(props: WidgetProps) {
     const configured = Object.keys(formContext?.fullConfig?.auth?.roles ?? {});
     // Keep admin/viewer first, then any custom roles in config order.
     const custom = configured.filter((r) => !BUILT_IN_ROLES.includes(r));
-    return [...BUILT_IN_ROLES, ...custom];
+    return [...BUILT_IN_ROLES, ...custom, NONE_ROLE];
   }, [formContext]);
 
   const selectedValue = typeof value === "string" && value ? value : "viewer";
 
   const getLabel = (role: string) =>
-    BUILT_IN_ROLES.includes(role) ? t(`configForm.defaultRole.${role}`) : role;
+    BUILT_IN_ROLES.includes(role) || role === NONE_ROLE
+      ? t(`configForm.defaultRole.${role}`)
+      : role;
 
   return (
     <Select


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR adds `none` as a valid value for `proxy.default_role`. With it set, a proxy-authenticated user whose headers don't match a `role_map` entry gets a 403 instead of silently falling back to `viewer`. This is for setups where the upstream proxy authenticates a wider set of people than should reach Frigate, so only mapped groups get in. Note that this only applies to proxy-only mode where `auth.enabled` is false. `default_role` isn't part of Frigate's own authentication path.

- Resolve `none` in `resolve_role()` rather than coercing it to `viewer`, including the case where no roles are defined
- Return a 403 from `/auth` when the resolved role is `none`, before the media and go2rtc stream checks
- Reserve `none` alongside `admin` and `viewer` in `AuthConfig.validate_roles()` so it can't collide with a custom role name
- Add `None (deny access)` to the default role dropdown in Settings -> System -> Proxy
- Add tests

Note: `none` in any casing joins `admin` and `viewer` as a reserved role name, so a config with a custom role named `none` or `None` won't load until it's renamed. The validation error names the role.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [x] Documentation Update

## Additional information

- This PR fixes or closes issue: closes https://github.com/blakeblackshear/frigate/issues/22758, closes https://github.com/blakeblackshear/frigate/discussions/24103
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
