### PR TITLE
Avoid killing a detector after stuck inference recovers

### DIFF
--- a/frigate/object_detection/base.py
+++ b/frigate/object_detection/base.py
@@ -353,9 +353,23 @@ class ObjectDetectProcess:
         logging.info("Detection process has exited...")
 
     def start_or_restart(self) -> None:
-        self.detection_start.value = 0.0  # type: ignore[attr-defined]
         if (self.detect_process is not None) and self.detect_process.is_alive():
-            self.stop()
+            logging.info("Waiting for detection process to exit gracefully...")
+            self.detect_process.join(timeout=30)
+            if self.detect_process.exitcode is None:
+                # detection_start is set only after detection_queue.get()
+                # returns. If it was reset during the grace period, the process
+                # recovered and may be waiting on the shared queue again.
+                if self.detection_start.value == 0.0:  # type: ignore[attr-defined]
+                    logging.info("Detection process recovered before restart")
+                    return
+
+                logging.info("Detection process didn't exit. Force killing...")
+                self.detect_process.kill()
+                self.detect_process.join()
+            logging.info("Detection process has exited...")
+
+        self.detection_start.value = 0.0  # type: ignore[attr-defined]
 
         # Async path for MemryX
         if self.detector_config.type == "memryx":

--- a/frigate/test/test_detector_restart.py
+++ b/frigate/test/test_detector_restart.py
@@ -1,0 +1,76 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+from frigate.object_detection.base import ObjectDetectProcess
+
+
+def _make_detector(
+    detection_start: SimpleNamespace,
+    process: Mock,
+    stop_event: Mock,
+) -> ObjectDetectProcess:
+    detector = ObjectDetectProcess.__new__(ObjectDetectProcess)
+    detector.name = "test"
+    detector.cameras = ["front"]
+    detector.detection_queue = Mock()
+    detector.avg_inference_speed = Mock()
+    detector.detection_start = detection_start
+    detector.detect_process = process
+    detector.config = Mock()
+    detector.detector_config = SimpleNamespace(type="onnx")
+    detector.stop_event = stop_event
+    return detector
+
+
+class TestDetectorRestart(unittest.TestCase):
+    @patch("frigate.object_detection.base.DetectorRunner")
+    def test_restart_is_abandoned_when_inference_recovers(
+        self, detector_runner: Mock
+    ) -> None:
+        detection_start = SimpleNamespace(value=123.0)
+        process = Mock(exitcode=None)
+        process.is_alive.return_value = True
+        process.join.side_effect = lambda timeout=None: setattr(
+            detection_start, "value", 0.0
+        )
+        detector = _make_detector(detection_start, process, Mock())
+
+        detector.start_or_restart()
+
+        process.join.assert_called_once_with(timeout=30)
+        process.kill.assert_not_called()
+        self.assertIs(detector.detect_process, process)
+        detector_runner.assert_not_called()
+
+    @patch("frigate.object_detection.base.DetectorRunner")
+    def test_restart_force_kills_detector_that_remains_stuck(
+        self, detector_runner: Mock
+    ) -> None:
+        detection_start = SimpleNamespace(value=123.0)
+        process = Mock(exitcode=None)
+        process.is_alive.return_value = True
+        process.kill.side_effect = lambda: setattr(process, "exitcode", -9)
+        stop_event = Mock()
+        detector = _make_detector(detection_start, process, stop_event)
+
+        detector.start_or_restart()
+
+        process.join.assert_has_calls([call(timeout=30), call()])
+        process.kill.assert_called_once_with()
+        self.assertEqual(detection_start.value, 0.0)
+        detector_runner.assert_called_once_with(
+            "frigate.detector:test",
+            detector.detection_queue,
+            detector.cameras,
+            detector.avg_inference_speed,
+            detection_start,
+            detector.config,
+            detector.detector_config,
+            stop_event,
+        )
+        detector_runner.return_value.start.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Proposed change

Avoid force-killing a detector when an inference has already recovered during the watchdog's existing 30-second grace period.

### What failed

When `detection_start` shows that an inference has been running for more than ten seconds, the watchdog calls `ObjectDetectProcess.start_or_restart()`.

The previous restart path cleared `detection_start`, waited up to 30 seconds, and then force-killed the old process if it was still alive. A detector process is expected to stay alive indefinitely, so recovering from the inference did not make that process exit.

If the inference returned during the grace period, the runner published its result, cleared `detection_start`, and could enter the next `multiprocessing.Queue.get()`. The parent would still kill it at the end of the grace period. Terminating a process while it is reading from a shared `multiprocessing.Queue` can leave the queue's reader lock unusable by the replacement process.

The observed result was a replacement detector that was alive and had loaded its ONNX model, while camera requests stopped reaching it. Camera input continued, but `detection_fps` stayed at zero and the detector watchdog could not fire again because `detection_start` remained zero.

## Runtime evidence and scope

The failed instance showed two watchdog restarts ending in `Force killing...`. Afterward:

- the replacement ONNX detector reported a successful model load;
- camera FPS remained around 5.1 while process FPS was around 0.1 and detection FPS was zero;
- the replacement detector was repeatedly sampled in `futex_wait_queue`;
- a camera processor feeder thread was repeatedly sampled in `pipe_write` to the detection queue;
- GPU use was around 1%, with no NVIDIA Xid, GPU reset, or host OOM evidence.

The earlier router outage was about 5.5 hours before the detector restart. I cannot establish that it caused the original long inference, and this PR does not make that claim. The original reason for the inference exceeding ten seconds is still unknown. This PR only addresses the reproducible failure in the recovery path afterward.

Detailed sanitized production observations are available here: https://github.com/blakeblackshear/frigate/pull/24142#issuecomment-5478719234

## Targeted fix

This revision uses an existing `DetectorRunner` invariant:

1. The runner reads a request from `detection_queue`.
2. Only after `Queue.get()` returns does it set `detection_start` to a nonzero timestamp.
3. It resets `detection_start` to zero after publishing the result.

`start_or_restart()` now leaves that value intact while waiting for the old process:

- If it becomes zero during the grace period, the inference recovered and the runner may be waiting on the shared queue again. The restart is abandoned without killing the process.
- If it remains nonzero, the process is already past `Queue.get()`. The existing force-kill and replacement behavior is retained.
- If a recovered detector has already accepted another request, `detection_start` is nonzero again, so it is also past the queue read before any kill occurs.

The production change is 16 additions and 2 deletions in `ObjectDetectProcess.start_or_restart()`.

This revision deliberately does not change:

- application-wide stop-event behavior;
- normal application shutdown or `ObjectDetectProcess.stop()`;
- `DetectorRunner` or `AsyncDetectorRunner` loop behavior;
- the MemryX detector path;
- detector startup arguments;
- camera, recording, event, alert, classification, or UI code;
- per-frame inference behavior or performance.

The earlier per-generation stop event and lifecycle lock have been removed. They fixed the reproduction but changed more core lifecycle behavior than this failure required.

## Reproduction and tests

The focused regression models an inference completing during the timed join.

Against the code before this PR, it fails because the recovered process is still force-killed:

```text
Expected 'join' to be called once. Called 2 times.
Calls: [call(timeout=30), call()].
```

With this revision, the same test passes and verifies that the old process is neither killed nor replaced. A second test verifies that a detector whose `detection_start` remains nonzero is still force-killed and replaced using the unchanged application stop event.

Final validation in a Linux build of the repository's development container, with go2rtc running:

- focused detector restart tests: 2 passed;
- full unittest suite: 958 passed;
- Ruff 0.15.20 format and lint: 335 files checked, all passed;
- mypy: no issues in 336 source files;
- API authorization specification: up to date;
- `git diff --check`: passed.

No NVIDIA or MemryX hardware canary was run. The updated code no longer changes either backend's event or shutdown semantics, but the original production incident involved an ONNX/CUDA detector.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing code to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation update

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below.

**AI tool used:** GPT-5.6 Sol

**How AI was used:** I used GPT-5.6 Sol to correlate the production logs, Linux process wait channels, pipe state, GPU state, and the detector lifecycle. It assisted with the controlled reproduction, implementation, and regression tests under my direction.

**Human oversight:** I rejected the earlier readiness-timeout approach when production evidence showed that the replacement detector had loaded successfully. After maintainer feedback, I also rejected the broader generation-event and lifecycle-lock implementation, re-audited its shutdown and MemryX implications, and reduced the production change to the existing `detection_start` invariant described above. I reviewed the final diff and reran the complete repository checks before updating the PR.

## Checklist

- [x] The recovered-inference behavior fails against the previous implementation.
- [x] The same regression passes after the targeted change.
- [x] A still-stuck detector retains the existing force-kill and replacement behavior.
- [x] Application shutdown and asynchronous detector behavior are unchanged.
- [x] Focused tests, full unittest, type, format, lint, and API specification checks pass.
- [x] There is no commented-out code or user-visible text change.
