### PR TITLE
Support end-to-end YOLO outputs

### DIFF
--- a/frigate/test/test_post_processing.py
+++ b/frigate/test/test_post_processing.py
@@ -82,6 +82,31 @@ class TestYoloNmsPostProcess(unittest.TestCase):
         np.testing.assert_allclose(detections[0], [0, 0.90, *A_ROW], atol=2e-3)
 
 
+class TestYoloEndToEndPostProcess(unittest.TestCase):
+    def test_converts_pixel_xyxy_output(self):
+        output = np.zeros((1, 300, 6), dtype=np.float32)
+        output[0, 0] = [393, 499, 484, 620, 0.90, 0]
+        output[0, 1] = [527, 499, 618, 620, 0.85, 1]
+
+        detections = kept(post_process_yolo([output], WIDTH, HEIGHT))
+
+        self.assertEqual(len(detections), 2)
+        np.testing.assert_allclose(detections[0], [0, 0.90, *A_ROW], atol=2e-3)
+        np.testing.assert_allclose(detections[1], [1, 0.85, *B_ROW], atol=2e-3)
+
+    def test_filters_and_sorts_detections(self):
+        output = np.zeros((1, 300, 6), dtype=np.float32)
+        output[0, 0] = [393, 499, 484, 620, 0.50, 0]
+        output[0, 1] = [527, 499, 618, 620, 0.90, 1]
+        output[0, 2] = [100, 100, 200, 200, 0.40, 2]
+
+        detections = kept(post_process_yolo([output], WIDTH, HEIGHT))
+
+        self.assertEqual(len(detections), 2)
+        self.assertEqual(detections[0, 0], 1)
+        self.assertEqual(detections[1, 0], 0)
+
+
 class TestMultipartYoloPostProcess(unittest.TestCase):
     def _multipart_output(self) -> list[np.ndarray]:
         """Build a 3-scale anchor-based YOLO output containing boxes A and B,

--- a/frigate/util/model.py
+++ b/frigate/util/model.py
@@ -258,9 +258,46 @@ def __post_process_nms_yolo(predictions: np.ndarray, width, height) -> np.ndarra
     return detections
 
 
-def post_process_yolo(output: list[np.ndarray], width: int, height: int) -> np.ndarray:
+def __post_process_end_to_end_yolo(
+    predictions: np.ndarray, width: int, height: int
+) -> np.ndarray:
+    """Convert end-to-end YOLO [x1, y1, x2, y2, score, class] output."""
+    predictions = np.asarray(predictions)
+    if predictions.ndim == 3 and predictions.shape[0] == 1:
+        predictions = predictions[0]
+
+    detections = np.zeros((20, 6), np.float32)
+    predictions = predictions[predictions[:, 4] > 0.4]
+    if predictions.size == 0:
+        return detections
+
+    predictions = predictions[np.argsort(predictions[:, 4])[::-1]][:20]
+    boxes = predictions[:, :4].astype(np.float32)
+    scores = predictions[:, 4]
+    class_ids = np.rint(predictions[:, 5])
+
+    boxes[:, [0, 2]] /= width
+    boxes[:, [1, 3]] /= height
+    boxes = np.clip(boxes, 0.0, 1.0)
+    count = len(predictions)
+    detections[:count, 0] = class_ids
+    detections[:count, 1] = scores
+    detections[:count, 2] = boxes[:, 1]
+    detections[:count, 3] = boxes[:, 0]
+    detections[:count, 4] = boxes[:, 3]
+    detections[:count, 5] = boxes[:, 2]
+    return detections
+
+
+def post_process_yolo(
+    output: list[np.ndarray],
+    width: int,
+    height: int,
+) -> np.ndarray:
     if len(output) > 1:
         return __post_process_multipart_yolo(output, width, height)
+    elif output[0].shape[-1] == 6:
+        return __post_process_end_to_end_yolo(output[0], width, height)
     else:
         return __post_process_nms_yolo(output[0], width, height)
 


### PR DESCRIPTION
  ## Proposed change

  This PR adds support for the single-output `[N, 6]` end-to-end detection format used by YOLO26, where each row contains `[x1, y1, x2, y2, score, class]`.

  The new post-processing path filters detections using Frigate's existing confidence threshold, sorts them by confidence, limits the output to 20 detections, converts absolute `xyxy` coordinates to
  normalized coordinates, and returns them in Frigate's expected detection order.

  Existing multipart and regular single-output YOLO post-processing paths remain unchanged. Regression tests cover confidence filtering, result ordering, and coordinate conversion.

  ## Type of change

  - [ ] Dependency upgrade
  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [x] New feature
  - [ ] Breaking change (fix/feature causing existing functionality to break)
  - [ ] Code quality improvements to existing code
  - [ ] Documentation Update

  ## Additional information

  - This PR fixes or closes issue: N/A
  - This PR is related to issue: N/A
  - Link to discussion with maintainers: N/A

  ## For new features

  - [ ] There is an existing feature request or discussion with community interest for this change.
    - Link: N/A

  ## AI disclosure

  - [ ] No AI tools were used in this PR.
  - [x] AI tools were used in this PR. Details below:

  **AI tool(s) used**: OpenAI Codex

  **How AI was used**: I asked Codex to implement support for the YOLO26 single-output end-to-end detection format and to perform formatting, type checking, unit testing, and model-output validation.

  **Extent of AI involvement**: Codex implemented the end-to-end YOLO post-processing path and its regression tests, and assisted with debugging and validation.

  **Human oversight**: I defined the intended YOLO26 behavior and reviewed the scope and reported validation results. Codex performed the local validation commands. I did not independently rerun the
  commands.

  ## Checklist

  - [x] The code change is tested and works locally.
  - [x] Local tests pass. 
  - [x] There is no commented out code in this PR.
  - [x] I can explain every line of code in this PR if asked.
  - [x] UI changes including text have used i18n keys and have been added to the `en` locale. **Not applicable; this PR has no UI changes.**
  - [x] The code has been formatted using Ruff (`ruff format frigate`)