### PR TITLE
Fix stuck loading spinner after cancelling a timeline selection

### DIFF
--- a/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
+++ b/web/src/components/player/dynamic/DynamicVideoPlayer.tsx
@@ -158,6 +158,7 @@ export default function DynamicVideoPlayer({
   const [isLoading, setIsLoading] = useState(false);
   const [isBuffering, setIsBuffering] = useState(false);
   const loadingTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+  const prevCameraRef = useRef(camera);
 
   // Don't set source until recordings load - we need accurate startPosition
   // to avoid hls.js clamping to video end when startPosition exceeds duration
@@ -166,13 +167,34 @@ export default function DynamicVideoPlayer({
   // start at correct time
 
   useEffect(() => {
+    // isLoading/isBuffering only clear on playback progress, which a
+    // paused scrub never reaches. A camera switch is excluded: its old
+    // source still reads as settled while the new one is fetched
+    const scrubExit = prevCameraRef.current === camera;
+    prevCameraRef.current = camera;
+    const settled = () =>
+      sourceLoadedRef.current &&
+      (playerRef.current?.readyState ?? 0) >=
+        HTMLMediaElement.HAVE_CURRENT_DATA;
+
+    if (!isScrubbing && scrubExit && settled()) {
+      setIsLoading(false);
+      setIsBuffering(false);
+    }
+
     if (!isScrubbing) {
       // never overwrite a pending timer: an orphaned one escapes
       // onPlaying's clearTimeout and flashes loading mid-playback
       if (loadingTimeoutRef.current) {
         clearTimeout(loadingTimeoutRef.current);
       }
-      loadingTimeoutRef.current = setTimeout(() => setIsLoading(true), 1000);
+      loadingTimeoutRef.current = setTimeout(() => {
+        // re-checked here: readyState drops while a seek loads
+        if (scrubExit && settled()) {
+          return;
+        }
+        setIsLoading(true);
+      }, 1000);
     }
 
     return () => {


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
`isLoading` and `isBuffering` only clear on playback progress, and scrubbing holds the player paused, so a source rebuild during a timeline selection left them set with nothing able to clear them. Cancelling made them visible as a spinner over an already-loaded frame, which stayed until the next manual seek. Leaving a scrub now clears them when the source is loaded and the element holds a frame.

Tests already committed to dev in https://github.com/blakeblackshear/frigate/pull/24158 


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/24137#discussioncomment-18240315
- This PR is related to issue: https://github.com/blakeblackshear/frigate/pull/24158 
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
