### PR TITLE
Fix hardware stats crash when audio transcription is enabled

### DIFF
--- a/frigate/stats/hardware.py
+++ b/frigate/stats/hardware.py
@@ -427,13 +427,15 @@ class HardwareStats:
             if config.lpr.enabled and (config.lpr.device or "AUTO") != "CPU":
                 names.add(gpu)
 
-        # audio transcription runs on CUDA only
-        transcription_configs = [config.audio_transcription] + [
-            camera.audio_transcription for camera in config.cameras.values()
-        ]
+        # audio transcription runs on CUDA only, and the device is global only
+        transcription = config.audio_transcription
+        transcription_enabled = transcription.enabled or any(
+            camera.audio_transcription.enabled for camera in config.cameras.values()
+        )
 
         if (
-            any(c.enabled and c.device == "GPU" for c in transcription_configs)
+            transcription_enabled
+            and transcription.device == "GPU"
             and "onnx:nvidia" in _present_hardware()
             and _gpu_device_nodes_exist("nvidia")
         ):


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
`_scan_enrichments` read `.device` off both the global and per-camera transcription configs, but `CameraAudioTranscriptionConfig` has no `device` field, so any camera with `audio_transcription.enabled` crashed Frigate at startup in `StatsEmitter`. `device` is a global setting, so this PR reads it from `config.audio_transcription` only, with the per-camera configs used just to check whether transcription is on anywhere.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
