### PR TITLE
Miscellaneous fixes

### DIFF
--- a/web/e2e/fixtures/frigate-test.ts
+++ b/web/e2e/fixtures/frigate-test.ts
@@ -54,8 +54,11 @@ export class FrigateApp {
     });
 
     await this.ws.install(this.page);
-    await this.media.install();
     await this.api.install(overrides);
+    // media goes last so its per-event routes win over the broader
+    // `**/api/events**` list route, which otherwise answers thumbnail and
+    // snapshot requests with the events JSON
+    await this.media.install();
   }
 
   /** Navigate to a page. Always call installDefaults() first. */

--- a/web/e2e/fixtures/mock-data/config.ts
+++ b/web/e2e/fixtures/mock-data/config.ts
@@ -52,6 +52,9 @@ function deepMerge<T extends Record<string, unknown>>(
 export const BASE_CONFIG = {
   ...configSnapshot,
   version: "0.15.0-test",
+  // injected by the /config endpoint rather than the Pydantic model, so it
+  // is absent from the snapshot
+  plus: { enabled: false },
   cameras: {
     ...configSnapshot.cameras,
     front_door: {

--- a/web/e2e/helpers/api-mocker.ts
+++ b/web/e2e/helpers/api-mocker.ts
@@ -251,7 +251,7 @@ export class MediaMocker {
 
     // Event thumbnails. The explore grid and detail dialog request .webp,
     // everything else requests .jpg.
-    await this.page.route("**/api/events/*/thumbnail.@(jpg|webp)**", (route) =>
+    await this.page.route("**/api/events/*/thumbnail.{jpg,webp}**", (route) =>
       route.fulfill({
         contentType: "image/png",
         body: PLACEHOLDER_PNG,

--- a/web/e2e/helpers/api-mocker.ts
+++ b/web/e2e/helpers/api-mocker.ts
@@ -249,8 +249,9 @@ export class MediaMocker {
       }),
     );
 
-    // Event thumbnails
-    await this.page.route("**/api/events/*/thumbnail.jpg**", (route) =>
+    // Event thumbnails. The explore grid and detail dialog request .webp,
+    // everything else requests .jpg.
+    await this.page.route("**/api/events/*/thumbnail.@(jpg|webp)**", (route) =>
       route.fulfill({
         contentType: "image/png",
         body: PLACEHOLDER_PNG,

--- a/web/e2e/specs/explore.spec.ts
+++ b/web/e2e/specs/explore.spec.ts
@@ -263,3 +263,71 @@ test.describe("Explore — mobile @high @mobile", () => {
     await expect(searchInput).toBeFocused();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Frigate+ submission — desktop only
+// The detail dialog's previous/next arrows only render on desktop.
+// ---------------------------------------------------------------------------
+
+test.describe("Explore — Frigate+ submission (desktop) @high", () => {
+  test.skip(
+    ({ frigateApp }) => frigateApp.isMobile,
+    "Detail dialog navigation arrows are desktop-only",
+  );
+
+  test("in-flight submission does not mark the next tracked object as submitted", async ({
+    frigateApp,
+  }) => {
+    await frigateApp.installDefaults({ config: { plus: { enabled: true } } });
+    const page = frigateApp.page;
+
+    // Hold the submission open so it is still in flight while the user moves
+    // on to the next tracked object.
+    let releaseSubmission: () => void = () => {};
+    const submissionHeld = new Promise<void>((resolve) => {
+      releaseSubmission = resolve;
+    });
+    let submissions = 0;
+    await page.route("**/api/events/*/plus", async (route) => {
+      submissions += 1;
+      await submissionHeld;
+      await route.fulfill({ json: { success: true } });
+    });
+
+    await frigateApp.goto("/explore?labels=person");
+
+    const firstResult = page.locator("[data-start]").first();
+    await expect(firstResult).toBeVisible({ timeout: 10_000 });
+    await firstResult.click();
+
+    // The label being confirmed is rendered in a <code> tag inside the
+    // "Is this object a <label>?" question.
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.locator("code")).toHaveText("person");
+
+    await dialog.getByRole("button", { name: "Yes", exact: true }).click();
+    await expect.poll(() => submissions, { timeout: 5_000 }).toBe(1);
+
+    await page.getByRole("button", { name: "Next tracked object" }).click();
+    await expect(dialog.locator("code")).toHaveText("car");
+
+    const submissionLanded = page.waitForResponse(/\/api\/events\/.*\/plus/);
+    releaseSubmission();
+    await submissionLanded;
+    // two frames is enough for React to flush the response handler's state
+    // updates, so the assertions below can't pass by racing ahead of them
+    await page.evaluate(
+      () =>
+        new Promise((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(resolve)),
+        ),
+    );
+
+    // The car was never submitted, so its question must be untouched.
+    expect(submissions).toBe(1);
+    await expect(dialog.getByText("Submitted")).toHaveCount(0);
+    await expect(
+      dialog.getByRole("button", { name: "Yes", exact: true }),
+    ).toBeVisible();
+  });
+});

--- a/web/src/components/overlay/detail/SearchDetailDialog.tsx
+++ b/web/src/components/overlay/detail/SearchDetailDialog.tsx
@@ -1240,10 +1240,14 @@ function ObjectDetailsTab({
     search?.plus_id ? "submitted" : "reviewing",
   );
 
-  useEffect(
-    () => setState(search?.plus_id ? "submitted" : "reviewing"),
-    [search],
-  );
+  // a submission request outlives the object it was made for, so the
+  // response handler needs to know which object is on screen now
+  const displayedIdRef = useRef(search?.id);
+
+  useEffect(() => {
+    displayedIdRef.current = search?.id;
+    setState(search?.plus_id ? "submitted" : "reviewing");
+  }, [search]);
 
   const onSubmitToPlus = useCallback(
     async (falsePositive: boolean) => {
@@ -1251,10 +1255,12 @@ function ObjectDetailsTab({
         return;
       }
 
+      const eventId = search.id;
+
       try {
         const resp = falsePositive
-          ? await axios.put(`events/${search.id}/false_positive`)
-          : await axios.post(`events/${search.id}/plus`, {
+          ? await axios.put(`events/${eventId}/false_positive`)
+          : await axios.post(`events/${eventId}/plus`, {
               include_annotation: 1,
             });
 
@@ -1262,12 +1268,15 @@ function ObjectDetailsTab({
           throw new Error();
         }
 
-        setState("submitted");
+        if (displayedIdRef.current === eventId) {
+          setState("submitted");
+        }
+
         mutate(
           (key) => isEventsKey(key),
           (currentData: SearchResult[][] | SearchResult[] | undefined) =>
             mapSearchResults(currentData, (event) =>
-              event.id === search.id
+              event.id === eventId
                 ? { ...event, plus_id: "new_upload" }
                 : event,
             ),
@@ -1278,7 +1287,12 @@ function ObjectDetailsTab({
           },
         );
       } catch {
-        setState("reviewing");
+        if (displayedIdRef.current === eventId) {
+          setState("reviewing");
+        }
+
+        // the toast is not object specific, so it is always shown to avoid
+        // silently dropping a failed submission
         toast.error(
           t("explore.plus.review.toast.error", { ns: "components/dialog" }),
           { position: "top-center" },

--- a/web/src/lib/const.ts
+++ b/web/src/lib/const.ts
@@ -31,6 +31,7 @@ export const supportedLanguageKeys = [
   "zh-CN",
   "zh-Hant",
   "yue-Hant",
+  "ko",
   "ja",
   "vi",
   "th",


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
- Submitting to Frigate+ and then moving to the next tracked object would mark that next object as Submitted once the first request finally landed, because the awaited response handler wrote `setState` into whatever object the dialog was showing by then. The fix is just to capture the event id up front and only update the local submission state when that object is still on screen. 
- Add Korean to languages menu


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes https://github.com/blakeblackshear/frigate/discussions/23599
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [x] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
