### PR TITLE
docs: note known preset-vaapi multi-camera instability, recommend QSV preset

### DIFF
--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -57,10 +57,16 @@ Frigate can utilize most Intel integrated GPUs and Arc GPUs to accelerate video 
 | ------------------ | ------------ | ------------------- | ------------------------------------------- |
 | gen1 - gen5        | i965         | preset-vaapi        | qsv is not supported, may not support H.265 |
 | gen6 - gen7        | iHD          | preset-vaapi        | qsv is not supported                        |
-| gen8 - gen12       | iHD          | preset-vaapi        | preset-intel-qsv-\* can also be used        |
+| gen8 - gen12       | iHD          | preset-vaapi        | preset-intel-qsv-\* can also be used, and is recommended over preset-vaapi when running multiple cameras concurrently — see note below |
 | gen13+             | iHD / Xe     | preset-intel-qsv-\* |                                             |
 | Intel Arc A-series | iHD / Xe     | preset-intel-qsv-\* |                                             |
 | Intel Arc B-series | iHD / Xe     | preset-intel-qsv-\* | Requires host kernel 6.12+                  |
+
+:::tip
+
+Generic `preset-vaapi` has a known instability with the `iHD` driver when **multiple cameras** use hardware decode concurrently, surfacing as repeated ffmpeg crashes with errors like `Failed to sync surface` / `hwdownload: Failed to download frame: -5`. This has been reported across several different Intel generations (e.g. [#23319](https://github.com/blakeblackshear/frigate/discussions/23319), [#19177](https://github.com/blakeblackshear/frigate/discussions/19177), [#16828](https://github.com/blakeblackshear/frigate/discussions/16828)). If you see this error pattern with more than one camera on `preset-vaapi`, switching to `preset-intel-qsv-h264` (or `-h265`) is a low-risk change that has resolved it in every reported case so far, using the same underlying hardware via a different ffmpeg code path.
+
+:::
 
 :::note
 


### PR DESCRIPTION
## Summary

Adds a short note to the Intel hardware acceleration docs about a known instability with generic `preset-vaapi` + the `iHD` driver when **multiple cameras** use hardware decode concurrently, and recommends `preset-intel-qsv-h264`/`-h265` as a documented working fix for gen8+ Intel CPUs.

This issue has been independently reported across several different Intel generations:
- #23319 (Iris Xe)
- #19177
- #16828

I hit the same exact failure signature (`Failed to sync surface`, `hwdownload: Failed to download frame: -5`) on an Intel Pentium Gold 8505 (Alder Lake-UP3, GT1) running 3 cameras — one camera alone on `preset-vaapi` was stable, but crashed repeatedly (900+ times over 2 days) once a second camera also used hardware decode concurrently. Switching the global `hwaccel_args` to `preset-intel-qsv-h264` resolved it completely — zero crashes in 24+ hours since, across all cameras using hardware decode.

Since the generic `preset-vaapi` preset is what's suggested for gen8-gen12 today with no mention of this instability, I think a short callout could save others the same multi-day debugging cycle.

## Test plan

- [x] Docs-only change, verified the markdown renders correctly (table + `:::tip` admonition syntax matches the existing `:::note` block immediately below it)
- [ ] Maintainer review of wording/placement

🤖 Drafted with [Claude Code](https://claude.com/claude-code)