### PR TITLE
Sync PWA status bar theme-color with resolved app theme

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -25,8 +25,8 @@
     <link rel="icon" type="image/svg+xml" href="/images/branding/favicon.svg" />
     <link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
     <link rel="mask-icon" href="/images/branding/favicon.svg" color="#3b82f7" />
-    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   </head>
   <body>
     <div id="root"></div>

--- a/web/index.html
+++ b/web/index.html
@@ -25,7 +25,8 @@
     <link rel="icon" type="image/svg+xml" href="/images/branding/favicon.svg" />
     <link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
     <link rel="mask-icon" href="/images/branding/favicon.svg" color="#3b82f7" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   </head>
   <body>

--- a/web/login.html
+++ b/web/login.html
@@ -25,8 +25,8 @@
     <link rel="icon" type="image/svg+xml" href="/images/branding/favicon.svg" />
     <link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
     <link rel="mask-icon" href="/images/branding/favicon.svg" color="#3b82f7" />
-    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   </head>
   <body>
     <div id="root"></div>

--- a/web/login.html
+++ b/web/login.html
@@ -25,7 +25,8 @@
     <link rel="icon" type="image/svg+xml" href="/images/branding/favicon.svg" />
     <link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
     <link rel="mask-icon" href="/images/branding/favicon.svg" color="#3b82f7" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   </head>
   <body>

--- a/web/src/context/theme-provider.tsx
+++ b/web/src/context/theme-provider.tsx
@@ -54,7 +54,7 @@ const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
 
 function updateThemeMetaTags(theme: ActiveTheme): void {
   const isDark = theme === "dark";
-  const metaTags = [
+  const metaDefinitions = [
     { name: "theme-color", content: isDark ? "#000000" : "#ffffff" },
     {
       name: "apple-mobile-web-app-status-bar-style",
@@ -62,12 +62,19 @@ function updateThemeMetaTags(theme: ActiveTheme): void {
     },
   ];
 
-  for (const { name, content } of metaTags) {
-    const tag =
-      document.head.querySelector<HTMLMetaElement>(`meta[name="${name}"]`) ??
-      document.head.appendChild(document.createElement("meta"));
-    tag.name = name;
-    tag.content = content;
+  for (const { name, content } of metaDefinitions) {
+    const tags = document.head.querySelectorAll<HTMLMetaElement>(
+      `meta[name="${name}"]`,
+    );
+    const matchingTags =
+      tags.length > 0
+        ? Array.from(tags)
+        : [document.head.appendChild(document.createElement("meta"))];
+
+    for (const tag of matchingTags) {
+      tag.name = name;
+      tag.content = content;
+    }
   }
 }
 
@@ -102,15 +109,21 @@ export function ThemeProvider({
     }
   });
 
-  const systemTheme = useMemo<ActiveTheme | undefined>(() => {
-    if (theme != "system") {
-      return undefined;
-    }
+  const [systemPrefersDark, setSystemPrefersDark] = useState(
+    () => window.matchMedia("(prefers-color-scheme: dark)").matches,
+  );
 
-    return window.matchMedia("(prefers-color-scheme: dark)").matches
-      ? "dark"
-      : "light";
-  }, [theme]);
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = () => setSystemPrefersDark(mediaQuery.matches);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  const systemTheme = useMemo<ActiveTheme | undefined>(() => {
+    if (theme !== "system") return undefined;
+    return systemPrefersDark ? "dark" : "light";
+  }, [theme, systemPrefersDark]);
 
   useEffect(() => {
     //localStorage.removeItem(storageKey);

--- a/web/src/context/theme-provider.tsx
+++ b/web/src/context/theme-provider.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 
 type Theme = "dark" | "light" | "system";
+type ActiveTheme = Exclude<Theme, "system">;
 type ColorScheme =
   | "theme-blue"
   | "theme-green"
@@ -51,6 +52,25 @@ const initialState: ThemeProviderState = {
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
 
+function updateThemeMetaTags(theme: ActiveTheme): void {
+  const isDark = theme === "dark";
+  const metaTags = [
+    { name: "theme-color", content: isDark ? "#000000" : "#ffffff" },
+    {
+      name: "apple-mobile-web-app-status-bar-style",
+      content: isDark ? "black" : "default",
+    },
+  ];
+
+  for (const { name, content } of metaTags) {
+    const tag =
+      document.head.querySelector<HTMLMetaElement>(`meta[name="${name}"]`) ??
+      document.head.appendChild(document.createElement("meta"));
+    tag.name = name;
+    tag.content = content;
+  }
+}
+
 export function ThemeProvider({
   children,
   defaultTheme = "system",
@@ -82,7 +102,7 @@ export function ThemeProvider({
     }
   });
 
-  const systemTheme = useMemo<Theme | undefined>(() => {
+  const systemTheme = useMemo<ActiveTheme | undefined>(() => {
     if (theme != "system") {
       return undefined;
     }
@@ -100,6 +120,8 @@ export function ThemeProvider({
     root.classList.remove("light", "dark", "system", ...colorSchemes);
 
     root.classList.add(theme, colorScheme);
+
+    updateThemeMetaTags(systemTheme ?? (theme === "system" ? "light" : theme));
 
     if (systemTheme) {
       root.classList.add(systemTheme);


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
This PR adds an `updateThemeMetaTags` function to the theme provider that keeps the `theme-color` and `apple-mobile-web-app-status-bar-style` meta tags in sync with the resolved active theme (dark/light). This should resolve issues with the Android/iOS PWA status bar staying locked to a specific color regardless of the dark/light mode setting in Frigate itself. The existing static meta tags in `index.html` are left as the pre-hydration fallback and get overwritten once the theme effect runs.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
