### PR TITLE
Fix Content-Type for `webp`, `png`, and `jpeg` files in `/clips/`

### DIFF
--- a/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
+++ b/docker/main/rootfs/usr/local/nginx/conf/nginx.conf
@@ -150,7 +150,9 @@ http {
             include auth_request.conf;
             types {
                 video/mp4 mp4;
-                image/jpeg jpg;
+                image/jpeg jpg jpeg;
+                image/png png;
+                image/webp webp;
             }
 
             expires 7d;


### PR DESCRIPTION
## Proposed change

Several image types under `/clips/` are served with the wrong `Content-Type`, so clients that trust it cannot render them.

The `location /clips/` block in `docker/main/rootfs/usr/local/nginx/conf/nginx.conf` declares a location-local `types` block containing only `video/mp4 mp4` and `image/jpeg jpg`. An inner `types` block **replaces** the global `include mime.types` rather than extending it, so any extension not listed falls through to `default_type application/octet-stream` (line 16 of the same file).

Several file types written under `CLIPS_DIR` are missing from that list:

- `.webp`: review thumbnails (`review/thumb-{camera}-{id}.webp`, `frigate/review/maintainer.py`), clean snapshots (`frigate/util/file.py`), trigger images (`frigate/embeddings/embeddings.py`), face images (`frigate/api/classification.py`), and GenAI request thumbnails (`frigate/data_processing/post/review_descriptions.py`)
- `.png`: clean snapshots (`frigate/util/file.py`) and classification training images (`frigate/api/classification.py`)
- `.jpeg`: face library and classification dataset/train images, which `frigate/api/classification.py` explicitly accepts alongside `.jpg`, `.png` and `.webp`

All of these are currently served as `application/octet-stream`. The bytes are correct; only the declared type is wrong.

Affects any consumer that checks `Content-Type` before rendering, including the Home Assistant integration's `ReviewClipsProxyView`, which proxies `clips/{path}` through without rewriting the header. Frigate's own UI is unaffected because every `/clips/` consumer in the web app is an `<img src>` (`ClassificationCard.tsx`, `ImagePicker.tsx`, `ModelSelectionView.tsx`, `Step3ChooseExamples.tsx`) and no `X-Content-Type-Options: nosniff` header is set, so browsers sniff the format. That is why this has gone unnoticed.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): Claude

**How AI was used** (e.g., code generation, code review, documentation): Root-cause analysis, fix creation, testing.

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): Generated entire fix and tested.

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions:
 - Reviewed the diff by hand. The full Python test suite was also run against this change (958 tests, all passing).
 - AI testing: The nginx behaviour was verified: a minimal nginx container was run with the original and patched `types` blocks side by side, serving real `.webp`, `.png`, `.jpg`, `.jpeg` and `.mp4` files, and `curl -I` confirmed `.webp`, `.png` and `.jpeg` return `application/octet-stream` before the change and the correct image type after, with `.jpg` and `.mp4` unchanged. The set of extensions written under `CLIPS_DIR` was cross-checked against the Python source, and the claim about the Home Assistant integration was checked against `ReviewClipsProxyView` in `frigate-hass-integration`.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass** <!-- N/A: no Python or TypeScript changed; no test in the suite covers nginx.conf -->
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale. <!-- N/A: no UI change -->
- [ ] The code has been formatted using Ruff (`ruff format frigate`) <!-- N/A: no Python changed -->