### PR TITLE
fix(web): preserve requested URL after native login

### DIFF
--- a/web/e2e/specs/auth.spec.ts
+++ b/web/e2e/specs/auth.spec.ts
@@ -9,6 +9,55 @@
 import { test, expect } from "../fixtures/frigate-test";
 import { viewerProfile } from "../fixtures/mock-data/profile";
 
+test.describe("Auth — native login redirect @high", () => {
+  for (const { name, startPath, expectedPath } of [
+    {
+      name: "returns to the requested same-origin URL",
+      startPath: "/explore?cameras=driveway&labels=person",
+      expectedPath: "/explore?cameras=driveway&labels=person",
+    },
+    {
+      name: "rejects an external redirect URL",
+      startPath: "/login?redirect=https://example.com/explore",
+      expectedPath: "/",
+    },
+  ]) {
+    test(name, async ({ page }) => {
+      let authenticated = false;
+
+      await page.route("**/api/profile", (route) =>
+        route.fulfill(
+          authenticated
+            ? {
+                json: {
+                  username: "admin",
+                  role: "admin",
+                  allowed_cameras: [],
+                },
+              }
+            : { status: 401, json: {} },
+        ),
+      );
+      await page.route("**/api/login", async (route) => {
+        authenticated = true;
+        await route.fulfill({ json: {} });
+      });
+      await page.route("**/api/auth/first_time_login", (route) =>
+        route.fulfill({ json: { admin_first_time_login: false } }),
+      );
+
+      await page.goto(startPath);
+      await page.locator('input[name="user"]').fill("admin");
+      await page.locator('input[name="password"]').fill("password");
+      await page.getByRole("button", { name: /login/i }).click();
+
+      await expect(page).toHaveURL(
+        (url) => `${url.pathname}${url.search}` === expectedPath,
+      );
+    });
+  }
+});
+
 test.describe("Auth — admin access @high", () => {
   test("admin /system renders general tab", async ({ frigateApp }) => {
     await frigateApp.goto("/system");

--- a/web/e2e/specs/auth.spec.ts
+++ b/web/e2e/specs/auth.spec.ts
@@ -9,7 +9,7 @@
 import { test, expect } from "../fixtures/frigate-test";
 import { viewerProfile } from "../fixtures/mock-data/profile";
 
-test.describe("Auth — native login redirect @high", () => {
+test.describe("Auth: native login redirect @high", () => {
   for (const { name, startPath, expectedPath } of [
     {
       name: "returns to the requested same-origin URL",

--- a/web/src/api/auth-redirect.ts
+++ b/web/src/api/auth-redirect.ts
@@ -1,6 +1,8 @@
 // Module-level flag to prevent multiple simultaneous redirects
 // (eg, when multiple SWR queries fail with 401 at once, or when
 // both ApiProvider and ProtectedRoute try to redirect)
+import { baseUrl } from "./baseUrl";
+
 let _isRedirectingToLogin = false;
 
 export function isRedirectingToLogin(): boolean {
@@ -9,4 +11,13 @@ export function isRedirectingToLogin(): boolean {
 
 export function setRedirectingToLogin(value: boolean): void {
   _isRedirectingToLogin = value;
+}
+
+export function getLoginUrl(): string {
+  const loginUrl = new URL("login", baseUrl);
+  loginUrl.searchParams.set(
+    "redirect",
+    `${window.location.pathname}${window.location.search}`,
+  );
+  return loginUrl.href;
 }

--- a/web/src/api/index.tsx
+++ b/web/src/api/index.tsx
@@ -3,7 +3,11 @@ import { SWRConfig } from "swr";
 import { WsProvider } from "./WsProvider";
 import axios from "axios";
 import { ReactNode } from "react";
-import { isRedirectingToLogin, setRedirectingToLogin } from "./auth-redirect";
+import {
+  getLoginUrl,
+  isRedirectingToLogin,
+  setRedirectingToLogin,
+} from "./auth-redirect";
 
 axios.defaults.baseURL = `${baseUrl}api/`;
 
@@ -31,7 +35,8 @@ export function ApiProvider({ children, options }: ApiProviderType) {
             [401, 302, 307].includes(error.response.status)
           ) {
             // redirect to the login page if not already there
-            const loginPage = error.response.headers.get("location") ?? "login";
+            const loginPage =
+              error.response.headers.get("location") ?? getLoginUrl();
             if (window.location.href !== loginPage && !isRedirectingToLogin()) {
               setRedirectingToLogin(true);
               window.location.href = loginPage;

--- a/web/src/components/auth/AuthForm.tsx
+++ b/web/src/components/auth/AuthForm.tsx
@@ -29,6 +29,23 @@ import { Card, CardContent } from "@/components/ui/card";
 
 interface UserAuthFormProps extends React.HTMLAttributes<HTMLDivElement> {}
 
+function getLoginRedirect(): string {
+  const redirect = new URLSearchParams(window.location.search).get("redirect");
+
+  if (!redirect) {
+    return baseUrl;
+  }
+
+  try {
+    const redirectUrl = new URL(redirect, baseUrl);
+    return redirectUrl.origin === window.location.origin
+      ? redirectUrl.href
+      : baseUrl;
+  } catch {
+    return baseUrl;
+  }
+}
+
 export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
   const { t } = useTranslation(["components/auth", "common"]);
   const { getLocaleDocUrl } = useDocDomain();
@@ -69,7 +86,7 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
         username: profileRes.data.username,
         role: profileRes.data.role || "viewer",
       });
-      window.location.href = baseUrl;
+      window.location.href = getLoginRedirect();
     } catch (error) {
       if (axios.isAxiosError(error)) {
         const err = error as AxiosError;

--- a/web/src/components/auth/ProtectedRoute.tsx
+++ b/web/src/components/auth/ProtectedRoute.tsx
@@ -3,10 +3,10 @@ import { Navigate, Outlet } from "react-router-dom";
 import { AuthContext } from "@/context/auth-context";
 import ActivityIndicator from "../indicators/activity-indicator";
 import {
+  getLoginUrl,
   isRedirectingToLogin,
   setRedirectingToLogin,
 } from "@/api/auth-redirect";
-import { baseUrl } from "@/api/baseUrl";
 
 export default function ProtectedRoute({
   requiredRoles,
@@ -25,7 +25,7 @@ export default function ProtectedRoute({
       !isRedirectingToLogin()
     ) {
       setRedirectingToLogin(true);
-      window.location.href = `${baseUrl}login`;
+      window.location.href = getLoginUrl();
     }
   }, [auth.isLoading, auth.isAuthenticated, auth.user]);
 


### PR DESCRIPTION
## Proposed change

- Preserve the current path and query when native authentication redirects a protected page to login.
- Return to that URL after login only when it resolves to the same Frigate origin. Direct login and external redirect values continue to land at home.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: Fixes #24165

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: OpenAI Codex (gpt-5.6-terra)

**How AI was used**: Assisted with implementation and regression testing.

**Extent of AI involvement**: Assisted with the shared login redirect and browser coverage.

**Human oversight**: I reviewed the diff and verified the native login flow with local build, lint, and browser tests.

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
