### PR TITLE
Catch RuntimeError in jsmpeg BroadcastThread send loop

### DIFF
--- a/frigate/output/camera.py
+++ b/frigate/output/camera.py
@@ -131,7 +131,11 @@ class BroadcastThread(threading.Thread):
                             ws.send(buf, binary=True)
                         except ValueError:
                             pass
-                        except (BrokenPipeError, ConnectionResetError) as e:
+                        except (
+                            BrokenPipeError,
+                            ConnectionResetError,
+                            RuntimeError,
+                        ) as e:
                             logger.debug(f"Websocket unexpectedly closed {e}")
             elif self.converter.process.poll() is not None:
                 break

--- a/frigate/output/camera.py
+++ b/frigate/output/camera.py
@@ -122,21 +122,19 @@ class BroadcastThread(threading.Thread):
                     ws_iter = iter(websockets.values())
 
                 for ws in ws_iter:
-                    if (
-                        not ws.terminated
-                        and ws.environ["PATH_INFO"] == f"/{self.camera}"
-                        and ws_has_camera_access(ws, self.camera, self.config)
-                    ):
-                        try:
-                            ws.send(buf, binary=True)
-                        except ValueError:
-                            pass
-                        except (
-                            BrokenPipeError,
-                            ConnectionResetError,
-                            RuntimeError,
-                        ) as e:
-                            logger.debug(f"Websocket unexpectedly closed {e}")
+                    try:
+                        if (
+                            ws.terminated
+                            or ws.environ["PATH_INFO"] != f"/{self.camera}"
+                            or not ws_has_camera_access(ws, self.camera, self.config)
+                        ):
+                            continue
+
+                        ws.send(buf, binary=True)
+                    except Exception as e:
+                        # ws4py tears the client down on another thread, so the
+                        # exception type depends on timing; don't stop the loop.
+                        logger.debug(f"Websocket unexpectedly closed {e}")
             elif self.converter.process.poll() is not None:
                 break
 

--- a/frigate/test/test_output_camera.py
+++ b/frigate/test/test_output_camera.py
@@ -1,0 +1,119 @@
+"""Tests for the jsmpeg BroadcastThread.
+
+Regression coverage for a client closing while the broadcast loop is between
+the `terminated` check and the send, which used to raise out of run() and
+silently stop jsmpeg live view for the camera until restart. See
+https://github.com/blakeblackshear/frigate/pull/24225
+"""
+
+import threading
+import unittest
+from types import SimpleNamespace
+
+from frigate.config import FrigateConfig
+from frigate.output.camera import BroadcastThread
+
+
+class FakeConverter:
+    """Yields one buffer, then reports the ffmpeg process as exited."""
+
+    def __init__(self, buf: bytes):
+        self.bufs = [buf]
+        self.process = SimpleNamespace(poll=lambda: 0)
+
+    def read(self, _size: int) -> bytes:
+        return self.bufs.pop(0) if self.bufs else b""
+
+
+class FakeWebSocket:
+    def __init__(self, camera: str, error: Exception | None = None):
+        self.terminated = False
+        self.environ: dict[str, str] | None = {
+            "PATH_INFO": f"/{camera}",
+            "HTTP_REMOTE_ROLE": "admin",
+        }
+        self.error = error
+        self.sent: list[bytes] = []
+
+    def send(self, payload: bytes, binary: bool = False) -> None:
+        if self.error is not None:
+            raise self.error
+        self.sent.append(payload)
+
+
+class TestBroadcastThread(unittest.TestCase):
+    def setUp(self):
+        self.config = FrigateConfig(
+            mqtt={"host": "mqtt"},
+            cameras={
+                "front_door": {
+                    "ffmpeg": {
+                        "inputs": [
+                            {"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}
+                        ]
+                    },
+                    "detect": {"height": 1080, "width": 1920, "fps": 5},
+                }
+            },
+        )
+
+    def _broadcast(self, *websockets: FakeWebSocket) -> BroadcastThread:
+        server = SimpleNamespace(
+            manager=SimpleNamespace(
+                lock=threading.Lock(),
+                websockets={id(ws): ws for ws in websockets},
+            )
+        )
+        return BroadcastThread(
+            "front_door",
+            FakeConverter(b"frame"),
+            server,
+            threading.Event(),
+            self.config,
+        )
+
+    def _assert_broadcast_survives(self, closing: FakeWebSocket) -> None:
+        # The closing client comes first so the loop hits it before the
+        # healthy one. run() rather than start() so an escaping exception
+        # fails the test instead of being swallowed by the thread.
+        healthy = FakeWebSocket("front_door")
+
+        self._broadcast(closing, healthy).run()
+
+        self.assertEqual(closing.sent, [])
+        self.assertEqual(healthy.sent, [b"frame"])
+
+    # ws4py's terminate() runs on the manager thread and, after setting the
+    # terminated flags, closes the socket and clears `stream` and `environ`.
+    # A client that closes while the broadcast loop is between the
+    # `terminated` check and the send therefore raises one of several
+    # exceptions, depending on where terminate() has got to.
+
+    def test_client_terminated_before_send(self):
+        self._assert_broadcast_survives(
+            FakeWebSocket(
+                "front_door", RuntimeError("Cannot send on a terminated websocket")
+            )
+        )
+
+    def test_client_stream_cleared_before_send(self):
+        self._assert_broadcast_survives(
+            FakeWebSocket(
+                "front_door",
+                AttributeError("'NoneType' object has no attribute 'binary_message'"),
+            )
+        )
+
+    def test_client_environ_cleared_before_path_check(self):
+        closing = FakeWebSocket("front_door")
+        closing.environ = None
+        self._assert_broadcast_survives(closing)
+
+    def test_frame_goes_only_to_matching_camera(self):
+        front = FakeWebSocket("front_door")
+        back = FakeWebSocket("back_door")
+
+        self._broadcast(front, back).run()
+
+        self.assertEqual(front.sent, [b"frame"])
+        self.assertEqual(back.sent, [])


### PR DESCRIPTION
## Proposed change

When a client closes between the `ws.terminated` check and the `ws.send()` a RuntimeError error is raised which isn't caught. This causes the thread to exit and the jsmpeg live view for that camera to stay black until a frigate restart.

Log output from the container:
```
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "/opt/frigate/frigate/output/camera.py", line 125, in run
    ws.send(buf, binary=True)
  File "/usr/local/lib/python3.11/dist-packages/ws4py/websocket.py", line 303, in send
    self._write(m)
  File "/usr/local/lib/python3.11/dist-packages/ws4py/websocket.py", line 283, in _write
    raise RuntimeError("Cannot send on a terminated websocket")
RuntimeError: Cannot send on a terminated websocket
```

I haven't tried to reproduce the issue or the fix since it is a tricky race condition but here is a (AI generated) test case that fails on 77a66e75c61862b048a07c1295877f4b31343504 and passes after this fix. I can add it to the test setup if desired.

<details><summary>Test case</summary>

```python
"""Tests for the jsmpeg BroadcastThread."""

import threading
import unittest
from types import SimpleNamespace

from frigate.config import FrigateConfig
from frigate.output.camera import BroadcastThread


class FakeConverter:
    """Yields one buffer, then reports the ffmpeg process as exited."""

    def __init__(self, buf: bytes):
        self.bufs = [buf]
        self.process = SimpleNamespace(poll=lambda: 0)

    def read(self, _size: int) -> bytes:
        return self.bufs.pop(0) if self.bufs else b""


class FakeWebSocket:
    def __init__(self, camera: str, error: Exception | None = None):
        self.terminated = False
        self.environ = {"PATH_INFO": f"/{camera}", "HTTP_REMOTE_ROLE": "admin"}
        self.error = error
        self.sent: list[bytes] = []

    def send(self, payload: bytes, binary: bool = False) -> None:
        if self.error is not None:
            raise self.error
        self.sent.append(payload)


class TestBroadcastThread(unittest.TestCase):
    def setUp(self):
        self.config = FrigateConfig(
            mqtt={"host": "mqtt"},
            cameras={
                "front_door": {
                    "ffmpeg": {
                        "inputs": [
                            {"path": "rtsp://10.0.0.1:554/video", "roles": ["detect"]}
                        ]
                    },
                    "detect": {"height": 1080, "width": 1920, "fps": 5},
                }
            },
        )

    def _broadcast(self, *websockets: FakeWebSocket) -> BroadcastThread:
        server = SimpleNamespace(
            manager=SimpleNamespace(
                lock=threading.Lock(),
                websockets={id(ws): ws for ws in websockets},
            )
        )
        return BroadcastThread(
            "front_door",
            FakeConverter(b"frame"),
            server,
            threading.Event(),
            self.config,
        )

    def test_send_error_on_one_client_does_not_stop_broadcast(self):
        # ws4py raises RuntimeError when a client closes between the
        # `terminated` check and the send. The other clients must still get
        # the frame and run() must return normally.
        closing = FakeWebSocket(
            "front_door", RuntimeError("Cannot send on a terminated websocket")
        )
        healthy = FakeWebSocket("front_door")

        # run() rather than start() so an escaping exception fails the test
        # instead of being swallowed by the thread.
        self._broadcast(closing, healthy).run()

        self.assertEqual(closing.sent, [])
        self.assertEqual(healthy.sent, [b"frame"])

    def test_frame_goes_only_to_matching_camera(self):
        front = FakeWebSocket("front_door")
        back = FakeWebSocket("back_door")

        self._broadcast(front, back).run()

        self.assertEqual(front.sent, [b"frame"])
        self.assertEqual(back.sent, [])

```

</details>

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude Code (Fable 5.1)

**How AI was used**:  Claude identified the issue and suggested this fix from frigate log output

**Human oversight**: The patch make sense to me and although I haven't been to reproce the exact production issue with or without this patch I believe it fixes the issue.

## Checklist

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
