### PR TITLE
fix: clamp YuNet bbox before uint16 cast to prevent negative-coordina…

### DIFF
--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -162,11 +162,16 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
             if potential_face[-1] < threshold:
                 continue
 
-            raw_bbox = potential_face[0:4].astype(np.uint16)
-            x: int = int(max(raw_bbox[0], 0) / scale_factor)
-            y: int = int(max(raw_bbox[1], 0) / scale_factor)
-            w: int = int(raw_bbox[2] / scale_factor)
-            h: int = int(raw_bbox[3] / scale_factor)
+            # YuNet can return slightly negative x/y when the face extends to the
+            # image border. Clamp to zero BEFORE any integer cast: casting a
+            # negative float to np.uint16 wraps it (e.g. -7.5 -> 65529), and the
+            # subsequent max(..., 0) never has a chance to correct it. The wrapped
+            # value is used as a slice index, producing an empty crop that crashes
+            # cv2.Laplacian with "!_src.empty()" in get_blur_confidence_reduction.
+            x: int = int(max(potential_face[0], 0) / scale_factor)
+            y: int = int(max(potential_face[1], 0) / scale_factor)
+            w: int = int(max(potential_face[2], 0) / scale_factor)
+            h: int = int(max(potential_face[3], 0) / scale_factor)
             bbox = (x, y, x + w, y + h)
 
             if face is None or area(bbox) > area(face):  # type: ignore[unreachable]


### PR DESCRIPTION
## Proposed change

`cv2.FaceDetectorYN` (YuNet) can return slightly negative `x`/`y` when a detected face runs to the edge of the image — a face flush with the top of the frame comes back with something like `y = -7.5`.

`__detect_face` casts the raw box to `np.uint16` before clamping:

```python
raw_bbox = potential_face[0:4].astype(np.uint16)
x: int = int(max(raw_bbox[0], 0) / scale_factor)
y: int = int(max(raw_bbox[1], 0) / scale_factor)
w: int = int(raw_bbox[2] / scale_factor)
h: int = int(raw_bbox[3] / scale_factor)
```

The cast wraps the negative value round to the top of the range, so the `max(..., 0)` on the next line never fires — by then it's looking at a large positive number, not a negative one. (`w`/`h` are not negative; the clamp is applied to all four only to keep the assignments parallel.)

```
-7.5  →  uint16  →  65529  →  max(65529, 0) = 65529
```

That value is then used as a slice index, so the crop comes back empty, and the empty array reaches `cv2.Laplacian` in `get_blur_confidence_reduction`:

```
cv2.error: (-215:Assertion failed) !_src.empty() in function 'Laplacian'
```

This fixes it by clamping the raw floats before any integer cast.

The live camera path survives the bug today because `process_frame` clamps against the frame bounds and has an `if face_frame.size == 0` guard — the face is just silently dropped, which shows up as `Empty face crop for <id>` in debug logs. `handle_request` has neither, so `POST /api/faces/recognize` returns a 500 for any image where the detected box touches the border. Face-library images are tight crops, so this is common.

Reproduced on 0.18.0-rc2 (`0.18.0-77a66e7`). All 86 images in my face library were POSTed to `/api/faces/recognize`, first on stock rc2 and then with this change applied, restarting Frigate between the two runs:

```
                 stock rc2        with this change
person 1     ok=7   fail=3        ok=10  fail=0
person 2     ok=32  fail=5        ok=37  fail=0
person 3     ok=6   fail=4        ok=10  fail=0
person 4     ok=4   fail=3        ok=7   fail=0
person 5     ok=13  fail=2        ok=15  fail=0
person 6     ok=6   fail=1        ok=7   fail=0

TOTAL        ok=68  fail=18       ok=86  fail=0
```

All 18 failures return `{"success":false,"message":"Could not process request. Try
restarting Frigate."}` with the `Laplacian` traceback in the log, and all 18 return a name
and score after the change. Nothing that worked before regressed.

So roughly one in five images in a real library hits it. It affects both axes — in my library about twice as many on y as on x — e.g. `(65530, 20, 65919, 459)` for a face flush with the left edge, and `(4, 65529, 354, 65968)` for one flush with the top.

This is the same fix as #23544, which was auto-closed by the template bot on the day it was opened and never reviewed. Credit to @yaseenisolated for the original diagnosis and patch — I've resubmitted it with the template filled in and confirmed the bug is still present in rc2.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: n/a
- This PR is related to issue: #23544 (same fix, auto-closed for template formatting before review)
- Link to discussion with maintainers (**required** for any large or "planned" features): n/a

## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used**: Claude

**How AI was used**: debugging and investigation — tracing the crash from the log
traceback to the cast, confirming the wrap arithmetic, and checking whether the bug was
already reported. Drafting this description.

**Extent of AI involvement**: the four changed lines of code are @yaseenisolated's from #23544, unchanged. I updated the explanatory comment to name the actual crash site in current code — `cv2.Laplacian` in `get_blur_confidence_reduction`, not `cv2.cvtColor` in `align_face` — and to use the values from my own reproduction. AI was used to confirm the diagnosis on my own hardware and to write this description.

**Human oversight**: Reproduced on my own install (0.18.0-rc2, `0.18.0-77a66e7`). I ran the before/after on my own host — commands driven by Claude, results checked by me — POSTing all 86 images in my face library to `/api/faces/recognize` on stock rc2, then applying this change, restarting Frigate, and running the identical set again: 18 failures went to 0, I checked each of the 18 individually rather than just the totals, and nothing that previously worked regressed. Container was restored to stock afterwards and verified by checksum against the released image.

I did not run the Python test suite locally — no test imports `face.py` or exercises `__detect_face`, so nothing covers the changed lines; CI will confirm. I understand the change: the clamp has to happen on the raw float, because casting a negative value to `uint16` wraps it to a large positive number and the existing `max(..., 0)` can then never fire.

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)