### PR TITLE
Fix save_attempts trimming

### DIFF
--- a/frigate/data_processing/real_time/custom_classification.py
+++ b/frigate/data_processing/real_time/custom_classification.py
@@ -16,6 +16,7 @@ from frigate.config.classification import CustomClassificationConfig
 from frigate.const import CLIPS_DIR, MODEL_CACHE_DIR
 from frigate.log import suppress_stderr_during
 from frigate.util.builtin import EventsPerSecond, InferenceSpeed, load_labels
+from frigate.util.file import trim_oldest_files
 from frigate.util.image import calculate_region
 from frigate.util.object import box_overlaps
 
@@ -729,16 +730,4 @@ def write_classification_attempt(
     file = os.path.join(folder, f"{event_id}-{timestamp}-{label}-{score}.webp")
     os.makedirs(folder, exist_ok=True)
     cv2.imwrite(file, frame)
-
-    # delete oldest face image if maximum is reached
-    try:
-        files = sorted(
-            filter(lambda f: f.endswith(".webp"), os.listdir(folder)),
-            key=lambda f: os.path.getctime(os.path.join(folder, f)),
-            reverse=True,
-        )
-
-        if len(files) > max_files:
-            os.unlink(os.path.join(folder, files[-1]))
-    except (FileNotFoundError, OSError):
-        pass
+    trim_oldest_files(folder, max_files)

--- a/frigate/data_processing/real_time/face.py
+++ b/frigate/data_processing/real_time/face.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import shutil
-from pathlib import Path
 from typing import Any
 
 import cv2
@@ -28,6 +27,7 @@ from frigate.data_processing.common.face.recognizer import (
 )
 from frigate.types import TrackedObjectUpdateTypesEnum
 from frigate.util.builtin import EventsPerSecond, InferenceSpeed
+from frigate.util.file import trim_oldest_files
 from frigate.util.image import area
 from frigate.util.path import safe_join, sanitize_path_component
 
@@ -489,13 +489,4 @@ class FaceRealTimeProcessor(RealTimeProcessorApi):
             )
             os.makedirs(folder, exist_ok=True)
             cv2.imwrite(file, frame)
-
-            files = sorted(
-                filter(lambda f: f.endswith(".webp"), os.listdir(folder)),
-                key=lambda f: os.path.getctime(os.path.join(folder, f)),
-                reverse=True,
-            )
-
-            # delete oldest face image if maximum is reached
-            if len(files) > self.config.face_recognition.save_attempts:
-                Path(os.path.join(folder, files[-1])).unlink(missing_ok=True)
+            trim_oldest_files(folder, self.config.face_recognition.save_attempts)

--- a/frigate/test/test_file.py
+++ b/frigate/test/test_file.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import time
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
@@ -86,3 +87,52 @@ class TestFileUtils(TestCase):
                 pass
 
             assert file_util.get_event_thumbnail_bytes(event) is None
+
+
+class TestTrimOldestFiles(TestCase):
+    def _fill(self, folder: str, names: list[str]) -> None:
+        # a short gap keeps the ctime order deterministic
+        for name in names:
+            with open(os.path.join(folder, name), "wb"):
+                pass
+
+            time.sleep(0.01)
+
+    def test_trims_folder_already_over_limit(self):
+        """Verify one call trims a folder that is far over the limit."""
+        with tempfile.TemporaryDirectory() as folder:
+            self._fill(folder, [f"{i:03d}.webp" for i in range(10)])
+
+            file_util.trim_oldest_files(folder, 4)
+
+            assert sorted(os.listdir(folder)) == [
+                "006.webp",
+                "007.webp",
+                "008.webp",
+                "009.webp",
+            ]
+
+    def test_counts_every_listed_image_extension(self):
+        """Verify the trim counts the same images the train listing shows."""
+        with tempfile.TemporaryDirectory() as folder:
+            self._fill(
+                folder, ["notes.txt", "a.jpg", "b.jpeg", "c.png", "d.webp", "e.webp"]
+            )
+
+            file_util.trim_oldest_files(folder, 2)
+
+            assert sorted(os.listdir(folder)) == ["d.webp", "e.webp", "notes.txt"]
+
+    def test_file_removed_during_scan_does_not_skip_trim(self):
+        """Verify a file deleted between listing and stat still trims the rest."""
+        real_listdir = os.listdir
+
+        with tempfile.TemporaryDirectory() as folder:
+            self._fill(folder, [f"{i:03d}.webp" for i in range(10)])
+
+            with patch(
+                "os.listdir", side_effect=lambda p: real_listdir(p) + ["gone.webp"]
+            ):
+                file_util.trim_oldest_files(folder, 4)
+
+            assert len(os.listdir(folder)) == 4

--- a/frigate/util/file.py
+++ b/frigate/util/file.py
@@ -269,6 +269,41 @@ def delete_event_thumbnail(event: Event) -> bool:
         return True
 
 
+### Training Images
+
+TRAINING_IMAGE_EXTENSIONS = (".webp", ".png", ".jpg", ".jpeg")
+
+
+def trim_oldest_files(folder: str, max_files: int) -> None:
+    """Delete the oldest training images until at most max_files remain."""
+    try:
+        names = os.listdir(folder)
+    except OSError:
+        return
+
+    files: list[tuple[float, str]] = []
+
+    for name in names:
+        if not name.lower().endswith(TRAINING_IMAGE_EXTENSIONS):
+            continue
+
+        path = os.path.join(folder, name)
+
+        # the UI can move or delete an image between listdir and stat
+        try:
+            files.append((os.path.getctime(path), path))
+        except OSError:
+            continue
+
+    files.sort(reverse=True)
+
+    for _, path in files[max_files:]:
+        try:
+            os.unlink(path)
+        except OSError:
+            logger.debug("Unable to delete training image %s", path)
+
+
 ### File Locking
 
 


### PR DESCRIPTION
_Please read the [contributing guidelines](https://github.com/blakeblackshear/frigate/blob/dev/CONTRIBUTING.md) and the [AI policy](https://github.com/blakeblackshear/frigate/blob/dev/AI_POLICY.md) before submitting a PR. Every PR must be read and submitted by a person, and PRs that appear to be unreviewed AI output will be closed without review._

## Proposed change

<!--
  Thank you!

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc.

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.
-->
The save_attempts image trim deleted at most one file per write and only counted `.webp`, so a train folder that went over `save_attempts` (lowered limit, leftover wizard `.jpg` examples, or an image deleted from the UI mid-trim) stayed over it for good. Classification and face attempts now share a `trim_oldest_files` helper that deletes everything past the limit, counts the same extensions the train listings show, and skips files that disappear during the scan. Folders already over the limit get trimmed on the next attempt.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to discussion with maintainers (**required** for any large or "planned" features):

## For new features

<!--
  Every new feature adds scope that maintainers must test, maintain, and support long-term.
  We try to be thoughtful about what we take on, and sometimes that means saying no to
  good code if the feature isn't the right fit — or saying yes to something we weren't sure
  about. These calls are sometimes subjective, and we won't always get them right. We're
  happy to discuss and reconsider.

  Linking to an existing feature request or discussion with community interest helps us
  understand demand, but a great idea is a great idea even without a crowd behind it.

  You can delete this section for bugfixes and non-feature changes.
-->

- [ ] There is an existing feature request or discussion with community interest for this change.
  - Link:

## AI disclosure

<!--
  We welcome contributions that use AI tools, but we need to understand your relationship
  with the code you're submitting. See our AI usage policy in CONTRIBUTING.md for details.

  Be honest — this won't disqualify your PR. Trust matters more than method.
-->

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor):

**How AI was used** (e.g., code generation, code review, debugging, documentation):

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes):

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
