### PR TITLE
Move fps after hwdownload for NVIDIA and VAAPI

### DIFF
--- a/frigate/ffmpeg_presets.py
+++ b/frigate/ffmpeg_presets.py
@@ -120,10 +120,11 @@ PRESETS_HW_ACCEL_DECODE["preset-rk-h265"] = PRESETS_HW_ACCEL_DECODE[
 PRESETS_HW_ACCEL_SCALE = {
     "preset-rpi-64-h264": "-r {0} -vf fps={0},scale={1}:{2}",
     "preset-rpi-64-h265": "-r {0} -vf fps={0},scale={1}:{2}",
-    FFMPEG_HWACCEL_VAAPI: "-r {0} -vf fps={0},scale_vaapi=w={1}:h={2},hwdownload,format=nv12",
+    # fps runs on the CPU, so it goes after hwdownload (same order as QSV below).
+    FFMPEG_HWACCEL_VAAPI: "-r {0} -vf scale_vaapi=w={1}:h={2},hwdownload,format=nv12,fps={0}",
     "preset-intel-qsv-h264": "-r {0} -vf vpp_qsv=w={1}:h={2}:format=nv12,hwdownload,format=nv12,fps={0},format=yuv420p",
     "preset-intel-qsv-h265": "-r {0} -vf vpp_qsv=w={1}:h={2}:format=nv12,hwdownload,format=nv12,fps={0},format=yuv420p",
-    FFMPEG_HWACCEL_NVIDIA: "-r {0} -vf fps={0},scale_cuda=w={1}:h={2},hwdownload,format=nv12",
+    FFMPEG_HWACCEL_NVIDIA: "-r {0} -vf scale_cuda=w={1}:h={2},hwdownload,format=nv12,fps={0}",
     "preset-jetson-h264": "-r {0}",  # scaled in decoder
     "preset-jetson-h265": "-r {0}",  # scaled in decoder
     FFMPEG_HWACCEL_RKMPP: "-r {0} -vf scale_rkrga=w={1}:h={2}:format=yuv420p:force_original_aspect_ratio=0,hwmap=mode=read,format=yuv420p",

--- a/frigate/test/test_ffmpeg_presets.py
+++ b/frigate/test/test_ffmpeg_presets.py
@@ -73,7 +73,7 @@ class TestFfmpegPresets(unittest.TestCase):
         assert "preset-nvidia-h264" not in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
-        assert "fps=10,scale_cuda=w=2560:h=1920,hwdownload,format=nv12" in (
+        assert "scale_cuda=w=2560:h=1920,hwdownload,format=nv12,fps=10" in (
             " ".join(frigate_config.cameras["back"].ffmpeg_cmds[0]["cmd"])
         )
 


### PR DESCRIPTION
## Proposed change

This was largely done with Claude
This PR moves fps after hwdownload for the NVIDIA and VAAPI presets, matching the other presets.
It turns out that fps is a CPU-based filter. When it runs before the hardware scaling step, ffmpeg has to insert a format conversion between the GPU frames and the fps filter. That conversion can fail during initialization with:

```
“Impossible to convert between the formats supported by the filter Parsed_fps_0 and the filter auto_scale_0.”
```
As a result, the detection process crashes and the camera gets stuck in a restart loop.

Note that this does make frames leave the GPU at full camera rate.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: A similar change was done in this PR: https://github.com/blakeblackshear/frigate/pull/22548


## AI disclosure

- [ ] No AI tools were used in this PR.
- [x] AI tools were used in this PR. Details below:

**AI tool(s) used** (e.g., Claude, Copilot, ChatGPT, Cursor): Claude

**How AI was used** (e.g., code generation, code review, debugging, documentation):  Diagnosing, fixing, and verification

**Extent of AI involvement** (e.g., generated entire implementation, assisted with specific functions, suggested fixes): Entirely done with AI

**Human oversight**: Describe what manual review, testing, and validation you performed on the AI-generated portions.
The diff is pretty simple.  It seems to have fixed the issue in my environment.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I can explain every line of code in this PR if asked.
- [n/a] UI changes including text have used i18n keys and have been added to the `en` locale.
- [x] The code has been formatted using Ruff (`ruff format frigate`)
